### PR TITLE
update jackson databind nullable to 0.2.11

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/build.gradle.mustache
@@ -118,7 +118,7 @@ ext {
     jackson_annotations_version = "2.21"
     jackson_databind_version = "2.21.5"
     {{#openApiNullable}}
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.11"
     {{/openApiNullable}}
     jakarta_annotation_version = "1.3.5"
     {{#useBeanValidation}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/apache-httpclient/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/apache-httpclient/build.gradle.mustache
@@ -129,14 +129,14 @@ ext {
     jackson_annotations_version = "2.21"
     jackson_databind_version = "2.21.5"
     {{#openApiNullable}}
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.11"
     {{/openApiNullable}}
     {{/useJackson3}}
     {{#useJackson3}}
     jackson3_version = "3.1.5"
     jackson_annotations_version = "2.21"
     {{#openApiNullable}}
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.11"
     {{/openApiNullable}}
     {{/useJackson3}}
     jakarta_annotation_version = "1.3.5"

--- a/modules/openapi-generator/src/main/resources/Java/libraries/apache-httpclient/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/apache-httpclient/pom.mustache
@@ -397,14 +397,14 @@
         <jackson-annotations-version>2.21</jackson-annotations-version>
         <jackson-databind-version>2.21.5</jackson-databind-version>
         {{#openApiNullable}}
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         {{/openApiNullable}}
         {{/useJackson3}}
         {{#useJackson3}}
         <jackson3-version>3.1.5</jackson3-version>
         <jackson-annotations-version>2.21</jackson-annotations-version>
         {{#openApiNullable}}
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         {{/openApiNullable}}
         {{/useJackson3}}
         {{#useJakartaEe}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/feign/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/feign/build.gradle.mustache
@@ -108,7 +108,7 @@ ext {
     jackson_databind_version = "2.21.5"
     {{/jackson}}
     {{#openApiNullable}}
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.11"
     {{/openApiNullable}}
     jakarta_annotation_version = "1.3.5"
     feign_version = "13.5"

--- a/modules/openapi-generator/src/main/resources/Java/libraries/feign/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/feign/pom.mustache
@@ -417,7 +417,7 @@
         <gson-version>2.10.1</gson-version>
         {{/gson}}
         {{#openApiNullable}}
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         {{/openApiNullable}}
         {{#useJakartaEe}}
         <jakarta-annotation-version>2.1.1</jakarta-annotation-version>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/google-api-client/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/google-api-client/build.gradle.mustache
@@ -102,7 +102,7 @@ ext {
     jackson_annotations_version = "2.21"
     jackson_databind_version = "2.21.5"
     {{#openApiNullable}}
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.11"
     {{/openApiNullable}}
     jakarta_annotation_version = "1.3.5"
     google_api_client_version = "1.32.2"

--- a/modules/openapi-generator/src/main/resources/Java/libraries/google-api-client/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/google-api-client/pom.mustache
@@ -314,7 +314,7 @@
         <jackson-annotations-version>2.21</jackson-annotations-version>
         <jackson-databind-version>2.21.5</jackson-databind-version>
         {{#openApiNullable}}
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         {{/openApiNullable}}
         {{#joda}}
         <jodatime-version>2.9.9</jodatime-version>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/build.gradle.mustache
@@ -108,7 +108,7 @@ ext {
     jackson_annotations_version = "2.21"
     jackson_databind_version = "2.21.5"
     {{#openApiNullable}}
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.11"
     {{/openApiNullable}}
     jakarta_annotation_version = "1.3.5"
     {{#useBeanValidation}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/build.sbt.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/build.sbt.mustache
@@ -24,7 +24,7 @@ lazy val root = (project in file(".")).
       {{/joda}}
       "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % "2.21.5" % "compile",
       {{#openApiNullable}}
-      "org.openapitools" % "jackson-databind-nullable" % "0.2.10" % "compile",
+      "org.openapitools" % "jackson-databind-nullable" % "0.2.11" % "compile",
       {{/openApiNullable}}
       {{#hasOAuthMethods}}
       "com.github.scribejava" % "scribejava-apis" % "8.3.1" % "compile",

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/pom.mustache
@@ -408,7 +408,7 @@
         <jackson-version>2.21.5</jackson-version>
         <jackson-annotations-version>2.21</jackson-annotations-version>
         <jackson-databind-version>2.21.5</jackson-databind-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         {{#useJakartaEe}}
         <jakarta-annotation-version>2.1.1</jakarta-annotation-version>
         <beanvalidation-version>3.0.2</beanvalidation-version>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/build.gradle.mustache
@@ -109,7 +109,7 @@ ext {
     jackson_annotations_version = "2.21"
     {{/useJackson3}}
     {{#openApiNullable}}
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.11"
     {{/openApiNullable}}
     jakarta_annotation_version = "3.0.0"
     {{#useBeanValidation}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/build.sbt.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/build.sbt.mustache
@@ -24,7 +24,7 @@ lazy val root = (project in file(".")).
       {{/joda}}
       "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % "2.21.1" % "compile",
       {{#openApiNullable}}
-      "org.openapitools" % "jackson-databind-nullable" % "0.2.10" % "compile",
+      "org.openapitools" % "jackson-databind-nullable" % "0.2.11" % "compile",
       {{/openApiNullable}}
       {{#hasOAuthMethods}}
       "com.github.scribejava" % "scribejava-apis" % "8.3.1" % "compile",

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/pom.mustache
@@ -453,7 +453,7 @@
         <jackson3-version>3.1.5</jackson3-version>
         <jackson-annotations-version>2.21</jackson-annotations-version>
         {{/useJackson3}}
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         {{#useJakartaEe}}
         <jakarta-annotation-version>3.0.0</jakarta-annotation-version>
         <beanvalidation-version>3.1.1</beanvalidation-version>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/build.gradle.mustache
@@ -118,14 +118,14 @@ dependencies {
     implementation "com.fasterxml.jackson.core:jackson-annotations:$jackson_annotations_version"
     implementation "com.fasterxml.jackson.core:jackson-databind:$jackson_version"
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jackson_version"
-    implementation "org.openapitools:jackson-databind-nullable:0.2.10"
+    implementation "org.openapitools:jackson-databind-nullable:0.2.11"
     {{/useJackson3}}
     {{#useJackson3}}
     implementation "tools.jackson.core:jackson-core:$jackson3_version"
     implementation "com.fasterxml.jackson.core:jackson-annotations:$jackson_annotations_version"
     implementation "tools.jackson.core:jackson-databind:$jackson3_version"
     {{#openApiNullable}}
-    implementation "org.openapitools:jackson-databind-nullable:0.2.10"
+    implementation "org.openapitools:jackson-databind-nullable:0.2.11"
     {{/openApiNullable}}
     {{/useJackson3}}
     {{#useJspecify}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/pom.mustache
@@ -342,12 +342,12 @@
         {{^useJackson3}}
         <jackson-version>2.21.5</jackson-version>
         <jackson-annotations-version>2.21</jackson-annotations-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         {{/useJackson3}}
         {{#useJackson3}}
         <jackson3-version>3.1.1</jackson3-version>
         <jackson-annotations-version>2.21</jackson-annotations-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         {{/useJackson3}}
         {{#useJakartaEe}}
         <jakarta-annotation-version>2.1.1</jakarta-annotation-version>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/build.gradle.mustache
@@ -132,7 +132,7 @@ dependencies {
     implementation 'io.gsonfire:gson-fire:1.9.0'
     implementation 'jakarta.ws.rs:jakarta.ws.rs-api:2.1.6'
     {{#openApiNullable}}
-    implementation 'org.openapitools:jackson-databind-nullable:0.2.10'
+    implementation 'org.openapitools:jackson-databind-nullable:0.2.11'
     {{/openApiNullable}}
     {{#withAWSV4Signature}}
     implementation 'software.amazon.awssdk:auth:2.20.157'

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/build.sbt.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/build.sbt.mustache
@@ -16,7 +16,7 @@ lazy val root = (project in file(".")).
       "org.apache.commons" % "commons-lang3" % "3.18.0",
       "jakarta.ws.rs" % "jakarta.ws.rs-api" % "2.1.6",
       {{#openApiNullable}}
-      "org.openapitools" % "jackson-databind-nullable" % "0.2.10",
+      "org.openapitools" % "jackson-databind-nullable" % "0.2.11",
       {{/openApiNullable}}
       {{#withAWSV4Signature}}
       "software.amazon.awssdk" % "auth" % "2.20.157",

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/pom.mustache
@@ -416,7 +416,7 @@
         <gson-version>2.10.1</gson-version>
         <commons-lang3-version>3.18.0</commons-lang3-version>
         {{#openApiNullable}}
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         {{/openApiNullable}}
         {{#joda}}
         <jodatime-version>2.12.0</jodatime-version>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/rest-assured/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/rest-assured/build.gradle.mustache
@@ -109,7 +109,7 @@ ext {
     jackson_version = "2.21.5"
     jackson_databind_version = "2.21.5"
     {{#openApiNullable}}
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.11"
     {{/openApiNullable}}
 {{/jackson}}
 {{#gson}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/rest-assured/build.sbt.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/rest-assured/build.sbt.mustache
@@ -18,7 +18,7 @@ lazy val root = (project in file(".")).
       "com.fasterxml.jackson.core" % "jackson-annotations" % "2.21",
       "com.fasterxml.jackson.core" % "jackson-databind" % "2.21.5",
       {{#openApiNullable}}
-      "org.openapitools" % "jackson-databind-nullable" % "0.2.10",
+      "org.openapitools" % "jackson-databind-nullable" % "0.2.11",
       {{/openApiNullable}}
       {{#withXml}}
       "com.fasterxml.jackson.dataformat" % "jackson-dataformat-xml" % "2.13.4.1",

--- a/modules/openapi-generator/src/main/resources/Java/libraries/rest-assured/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/rest-assured/pom.mustache
@@ -354,7 +354,7 @@
         {{#jackson}}
         <jackson-version>2.21.5</jackson-version>
         <jackson-databind-version>2.21.5</jackson-databind-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         {{/jackson}}
         {{#useJakartaEe}}
         <jakarta-annotation-version>2.1.1</jakarta-annotation-version>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/restclient/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/restclient/build.gradle.mustache
@@ -111,7 +111,7 @@ ext {
     {{/useJackson3}}
     jackson_annotations_version = "2.21"
     {{#openApiNullable}}
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.11"
     {{/openApiNullable}}
     {{^useSpringBoot4}}
     spring_web_version = "6.2.16"

--- a/modules/openapi-generator/src/main/resources/Java/libraries/restclient/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/restclient/pom.mustache
@@ -370,7 +370,7 @@
 
         <jackson-annotations-version>2.21</jackson-annotations-version>
         {{#openApiNullable}}
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         {{/openApiNullable}}
         {{#joda}}
         <jodatime-version>2.14.0</jodatime-version>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/build.gradle.mustache
@@ -101,7 +101,7 @@ ext {
     jackson_version = "2.21.5"
     jackson_databind_version = "2.21.5"
     {{#openApiNullable}}
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.11"
     {{/openApiNullable}}
     jakarta_annotation_version = "1.3.5"
     threetenbp_version = "2.9.10"

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/pom.mustache
@@ -302,7 +302,7 @@
         <jackson-annotations-version>2.21</jackson-annotations-version>
         <jackson-databind-version>2.21.5</jackson-databind-version>
         {{#openApiNullable}}
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         {{/openApiNullable}}
         {{#useJakartaEe}}
         <jakarta-annotation-version>2.1.1</jakarta-annotation-version>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/build.gradle.mustache
@@ -123,7 +123,7 @@ ext {
     {{/useJackson3}}
     jackson_annotations_version = "2.21"
     {{#openApiNullable}}
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.11"
     {{/openApiNullable}}
     {{#useSpringBoot4}}
     spring_web_version = "7.0.5"

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/pom.mustache
@@ -410,7 +410,7 @@
 
         <jackson-annotations-version>2.21</jackson-annotations-version>
         {{#openApiNullable}}
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         {{/openApiNullable}}
         {{#joda}}
         <jodatime-version>2.9.9</jodatime-version>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/build.gradle.mustache
@@ -105,7 +105,7 @@ ext {
     jackson_databind_version = "2.21.5"
     javax_ws_rs_api_version = "2.1.1"
     {{#openApiNullable}}
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.11"
     {{/openApiNullable}}
     {{/jackson}}
     {{#usePlayWS}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/pom.mustache
@@ -387,7 +387,7 @@
         <jackson-version>2.21.5</jackson-version>
         <jackson-annotations-version>2.21</jackson-annotations-version>
             {{#openApiNullable}}
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
             {{/openApiNullable}}
         <javax.ws.rs-api-version>2.1.1</javax.ws.rs-api-version>
         {{/jackson}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/vertx/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/vertx/build.gradle.mustache
@@ -35,7 +35,7 @@ ext {
     vertx_version = "{{#useVertx5}}5.0.11{{/useVertx5}}{{#supportVertxFuture}}{{^useVertx5}}4.0.0{{/useVertx5}}{{/supportVertxFuture}}{{^supportVertxFuture}}{{^useVertx5}}3.5.2{{/useVertx5}}{{/supportVertxFuture}}"
     junit_version = "5.10.3"
     {{#openApiNullable}}
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.11"
     {{/openApiNullable}}
     jakarta_annotation_version = "1.3.5"
 }

--- a/modules/openapi-generator/src/main/resources/Java/libraries/vertx/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/vertx/pom.mustache
@@ -309,7 +309,7 @@
         <jackson-version>2.21.5</jackson-version>
         <jackson-annotations-version>2.21</jackson-annotations-version>
         <jackson-databind>2.21.5</jackson-databind>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         {{#useJakartaEe}}
         <jakarta-annotation-version>2.1.1</jakarta-annotation-version>
         {{/useJakartaEe}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/webclient/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/webclient/build.gradle.mustache
@@ -162,7 +162,7 @@ ext {
     {{/useSpringBoot4}}
     jackson_annotations_version = "2.21"
     {{#openApiNullable}}
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.11"
     {{/openApiNullable}}
     {{#joda}}
     jodatime_version = "2.14.0"

--- a/modules/openapi-generator/src/main/resources/Java/libraries/webclient/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/webclient/pom.mustache
@@ -197,7 +197,7 @@
         <jackson-version>2.21.5</jackson-version>
         {{/useJackson3}}
         {{#openApiNullable}}
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         {{/openApiNullable}}
         {{#useJakartaEe}}
         {{^useSpringBoot4}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/libraries/quarkus/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/libraries/quarkus/pom.mustache
@@ -51,7 +51,7 @@
     <smallrye.rest.client.version>1.2.1</smallrye.rest.client.version>
 {{/useMutiny}}
 {{#openApiNullable}}
-    <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+    <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
 {{/openApiNullable}}
   </properties>
   <dependencyManagement>

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/pom.mustache
@@ -212,7 +212,7 @@
     <jakarta.ws.rs-version>2.1.6</jakarta.ws.rs-version>
 {{/useJakartaEe}}
 {{#openApiNullable}}
-    <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+    <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
 {{/openApiNullable}}
 {{#useSwaggerV3Annotations}}
     <io.swagger.v3.annotations.version>2.2.21</io.swagger.v3.annotations.version>

--- a/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-boot/pom-sb3.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-boot/pom-sb3.mustache
@@ -191,7 +191,7 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.10</version>
+            <version>0.2.11</version>
         </dependency>
         {{/openApiNullable}}
 {{#useBeanValidation}}

--- a/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-cloud/pom-sb3.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-cloud/pom-sb3.mustache
@@ -124,7 +124,7 @@
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
         {{^parentOverridden}}
-            <version>0.2.10</version>
+            <version>0.2.11</version>
         {{/parentOverridden}}
         </dependency>
         {{/openApiNullable}}

--- a/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-http-interface/pom-sb3.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-http-interface/pom-sb3.mustache
@@ -88,7 +88,7 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.10</version>
+            <version>0.2.11</version>
         </dependency>
         {{/openApiNullable}}
         {{#useJspecify}}

--- a/modules/openapi-generator/src/main/resources/java-camel-server/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/java-camel-server/pom.mustache
@@ -116,7 +116,7 @@ Do not edit the class manually.
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.10</version>
+            <version>0.2.11</version>
         </dependency>
         {{#swagger1AnnotationLibrary}}
         <dependency>

--- a/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/mp/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/mp/pom.mustache
@@ -18,7 +18,7 @@
 
     <properties>
         {{#openApiNullable}}
-        <version.jackson.databind.nullable>0.2.10</version.jackson.databind.nullable>
+        <version.jackson.databind.nullable>0.2.11</version.jackson.databind.nullable>
         {{/openApiNullable}}
     </properties>
 

--- a/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/se/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/se/pom.mustache
@@ -19,7 +19,7 @@
 
     <properties>
 {{#openApiNullable}}
-        <version.jackson.databind.nullable>0.2.10</version.jackson.databind.nullable>
+        <version.jackson.databind.nullable>0.2.11</version.jackson.databind.nullable>
 {{/openApiNullable}}
     </properties>
 

--- a/modules/openapi-generator/src/main/resources/java-helidon/server/libraries/mp/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/java-helidon/server/libraries/mp/pom.mustache
@@ -19,7 +19,7 @@
 
     <properties>
 {{#openApiNullable}}
-        <version.jackson.databind.nullable>0.2.10</version.jackson.databind.nullable>
+        <version.jackson.databind.nullable>0.2.11</version.jackson.databind.nullable>
 {{/openApiNullable}}
     </properties>
 

--- a/modules/openapi-generator/src/main/resources/java-helidon/server/libraries/se/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/java-helidon/server/libraries/se/pom.mustache
@@ -20,7 +20,7 @@
     <properties>
         <mainClass>{{{invokerPackage}}}.Main</mainClass>
 {{#openApiNullable}}
-        <version.jackson.databind.nullable>0.2.10</version.jackson.databind.nullable>
+        <version.jackson.databind.nullable>0.2.11</version.jackson.databind.nullable>
 {{/openApiNullable}}
     </properties>
 

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-boot/buildGradle-sb3-Kts.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-boot/buildGradle-sb3-Kts.mustache
@@ -53,7 +53,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("jakarta.validation:jakarta.validation-api"){{/useBeanValidation}}
 {{#openApiNullable}}
-    implementation("org.openapitools:jackson-databind-nullable:0.2.10"){{/openApiNullable}}
+    implementation("org.openapitools:jackson-databind-nullable:0.2.11"){{/openApiNullable}}
     implementation("jakarta.annotation:jakarta.annotation-api:2.1.0")
 
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-boot/buildGradle-sb4-Kts.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-boot/buildGradle-sb4-Kts.mustache
@@ -62,7 +62,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("jakarta.validation:jakarta.validation-api"){{/useBeanValidation}}
 {{#openApiNullable}}
-    implementation("org.openapitools:jackson-databind-nullable:0.2.10"){{/openApiNullable}}
+    implementation("org.openapitools:jackson-databind-nullable:0.2.11"){{/openApiNullable}}
     implementation("jakarta.annotation:jakarta.annotation-api:3.0.0")
 
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-boot/pom-sb3.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-boot/pom-sb3.mustache
@@ -201,7 +201,7 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.10</version>
+            <version>0.2.11</version>
         </dependency>{{/openApiNullable}}
         <dependency>
             <groupId>jakarta.annotation</groupId>

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-boot/pom-sb4.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-boot/pom-sb4.mustache
@@ -207,7 +207,7 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.10</version>
+            <version>0.2.11</version>
         </dependency>{{/openApiNullable}}
         <dependency>
             <groupId>jakarta.annotation</groupId>

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-cloud/buildGradle-sb3-Kts.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-cloud/buildGradle-sb3-Kts.mustache
@@ -63,7 +63,7 @@ dependencies {
 {{#useBeanValidation}}
     implementation("jakarta.validation:jakarta.validation-api"){{/useBeanValidation}}
 {{#openApiNullable}}
-    implementation("org.openapitools:jackson-databind-nullable:0.2.10"){{/openApiNullable}}
+    implementation("org.openapitools:jackson-databind-nullable:0.2.11"){{/openApiNullable}}
     implementation("jakarta.annotation:jakarta.annotation-api:2.1.0")
 
 }

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-cloud/buildGradle-sb4-Kts.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-cloud/buildGradle-sb4-Kts.mustache
@@ -72,7 +72,7 @@ dependencies {
 {{#useBeanValidation}}
     implementation("jakarta.validation:jakarta.validation-api"){{/useBeanValidation}}
 {{#openApiNullable}}
-    implementation("org.openapitools:jackson-databind-nullable:0.2.10"){{/openApiNullable}}
+    implementation("org.openapitools:jackson-databind-nullable:0.2.11"){{/openApiNullable}}
     implementation("jakarta.annotation:jakarta.annotation-api:3.0.0")
 
 }

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-cloud/pom-sb3.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-cloud/pom-sb3.mustache
@@ -222,7 +222,7 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.10</version>
+            <version>0.2.11</version>
         </dependency>{{/openApiNullable}}
         <dependency>
             <groupId>jakarta.annotation</groupId>

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-cloud/pom-sb4.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-cloud/pom-sb4.mustache
@@ -228,7 +228,7 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.10</version>
+            <version>0.2.11</version>
         </dependency>{{/openApiNullable}}
         <dependency>
             <groupId>jakarta.annotation</groupId>

--- a/modules/openapi-generator/src/test/resources/2_0/templates/Java/libraries/jersey2/build.gradle.mustache
+++ b/modules/openapi-generator/src/test/resources/2_0/templates/Java/libraries/jersey2/build.gradle.mustache
@@ -112,7 +112,7 @@ ext {
     jackson_version = "2.21.5"
     jackson_databind_version = "2.21.5"
     {{#openApiNullable}}
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.11"
     {{/openApiNullable}}
     jakarta_annotation_version = "1.3.5"
     jersey_version = "2.27"

--- a/modules/openapi-generator/src/test/resources/2_0/templates/Java/libraries/jersey2/pom.mustache
+++ b/modules/openapi-generator/src/test/resources/2_0/templates/Java/libraries/jersey2/pom.mustache
@@ -375,7 +375,7 @@
         <jersey-version>2.30.1</jersey-version>
         <jackson-version>2.21.5</jackson-version>
         <jackson-databind-version>2.21.5</jackson-databind-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         {{#threetenbp}}
         <threetenbp-version>2.18.2</threetenbp-version>
         {{/threetenbp}}

--- a/samples/client/echo_api/java/apache-httpclient/build.gradle
+++ b/samples/client/echo_api/java/apache-httpclient/build.gradle
@@ -121,7 +121,7 @@ ext {
     jackson_version = "2.21.5"
     jackson_annotations_version = "2.21"
     jackson_databind_version = "2.21.5"
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.11"
     jakarta_annotation_version = "1.3.5"
     httpclient_version = "5.1.3"
     jodatime_version = "2.9.9"

--- a/samples/client/echo_api/java/apache-httpclient/pom.xml
+++ b/samples/client/echo_api/java/apache-httpclient/pom.xml
@@ -273,7 +273,7 @@
         <jackson-version>2.21.5</jackson-version>
         <jackson-annotations-version>2.21</jackson-annotations-version>
         <jackson-databind-version>2.21.5</jackson-databind-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <beanvalidation-version>2.0.2</beanvalidation-version>
         <junit-version>5.10.2</junit-version>

--- a/samples/client/echo_api/java/feign-gson/build.gradle
+++ b/samples/client/echo_api/java/feign-gson/build.gradle
@@ -102,7 +102,7 @@ test {
 
 ext {
     swagger_annotations_version = "1.6.11"
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.11"
     jakarta_annotation_version = "1.3.5"
     feign_version = "13.5"
     feign_form_version = "3.8.0"

--- a/samples/client/echo_api/java/feign-gson/pom.xml
+++ b/samples/client/echo_api/java/feign-gson/pom.xml
@@ -303,7 +303,7 @@
         <feign-version>13.2.1</feign-version>
         <feign-form-version>3.8.0</feign-form-version>
         <gson-version>2.10.1</gson-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <beanvalidation-version>2.0.2</beanvalidation-version>
         <junit-version>5.10.0</junit-version>

--- a/samples/client/echo_api/java/native/build.gradle
+++ b/samples/client/echo_api/java/native/build.gradle
@@ -80,7 +80,7 @@ dependencies {
     implementation "com.fasterxml.jackson.core:jackson-annotations:$jackson_annotations_version"
     implementation "com.fasterxml.jackson.core:jackson-databind:$jackson_version"
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jackson_version"
-    implementation "org.openapitools:jackson-databind-nullable:0.2.10"
+    implementation "org.openapitools:jackson-databind-nullable:0.2.11"
     implementation "jakarta.annotation:jakarta.annotation-api:$jakarta_annotation_version"
     implementation "org.apache.httpcomponents:httpmime:$httpmime_version"
     testImplementation "org.junit.jupiter:junit-jupiter-api:$junit_version"

--- a/samples/client/echo_api/java/native/pom.xml
+++ b/samples/client/echo_api/java/native/pom.xml
@@ -255,7 +255,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <jackson-version>2.21.5</jackson-version>
         <jackson-annotations-version>2.21</jackson-annotations-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <beanvalidation-version>2.0.2</beanvalidation-version>
         <httpmime-version>4.5.14</httpmime-version>

--- a/samples/client/echo_api/java/okhttp-gson-user-defined-templates/build.gradle
+++ b/samples/client/echo_api/java/okhttp-gson-user-defined-templates/build.gradle
@@ -112,7 +112,7 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.9.1'
     implementation 'io.gsonfire:gson-fire:1.9.0'
     implementation 'jakarta.ws.rs:jakarta.ws.rs-api:2.1.6'
-    implementation 'org.openapitools:jackson-databind-nullable:0.2.10'
+    implementation 'org.openapitools:jackson-databind-nullable:0.2.11'
     implementation group: 'org.apache.oltu.oauth2', name: 'org.apache.oltu.oauth2.client', version: '1.0.2'
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.18.0'
     implementation "jakarta.annotation:jakarta.annotation-api:$jakarta_annotation_version"

--- a/samples/client/echo_api/java/okhttp-gson-user-defined-templates/build.sbt
+++ b/samples/client/echo_api/java/okhttp-gson-user-defined-templates/build.sbt
@@ -15,7 +15,7 @@ lazy val root = (project in file(".")).
       "com.google.code.gson" % "gson" % "2.9.1",
       "org.apache.commons" % "commons-lang3" % "3.18.0",
       "jakarta.ws.rs" % "jakarta.ws.rs-api" % "2.1.6",
-      "org.openapitools" % "jackson-databind-nullable" % "0.2.10",
+      "org.openapitools" % "jackson-databind-nullable" % "0.2.11",
       "org.apache.oltu.oauth2" % "org.apache.oltu.oauth2.client" % "1.0.2",
       "io.gsonfire" % "gson-fire" % "1.9.0" % "compile",
       "jakarta.annotation" % "jakarta.annotation-api" % "1.3.5" % "compile",

--- a/samples/client/echo_api/java/okhttp-gson-user-defined-templates/pom.xml
+++ b/samples/client/echo_api/java/okhttp-gson-user-defined-templates/pom.xml
@@ -332,7 +332,7 @@
         <okhttp-version>4.12.0</okhttp-version>
         <gson-version>2.10.1</gson-version>
         <commons-lang3-version>3.18.0</commons-lang3-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <beanvalidation-version>2.0.2</beanvalidation-version>
         <junit-version>5.10.3</junit-version>

--- a/samples/client/echo_api/java/okhttp-gson/build.gradle
+++ b/samples/client/echo_api/java/okhttp-gson/build.gradle
@@ -112,7 +112,7 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.9.1'
     implementation 'io.gsonfire:gson-fire:1.9.0'
     implementation 'jakarta.ws.rs:jakarta.ws.rs-api:2.1.6'
-    implementation 'org.openapitools:jackson-databind-nullable:0.2.10'
+    implementation 'org.openapitools:jackson-databind-nullable:0.2.11'
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.18.0'
     implementation "jakarta.annotation:jakarta.annotation-api:$jakarta_annotation_version"
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.3'

--- a/samples/client/echo_api/java/okhttp-gson/build.sbt
+++ b/samples/client/echo_api/java/okhttp-gson/build.sbt
@@ -15,7 +15,7 @@ lazy val root = (project in file(".")).
       "com.google.code.gson" % "gson" % "2.9.1",
       "org.apache.commons" % "commons-lang3" % "3.18.0",
       "jakarta.ws.rs" % "jakarta.ws.rs-api" % "2.1.6",
-      "org.openapitools" % "jackson-databind-nullable" % "0.2.10",
+      "org.openapitools" % "jackson-databind-nullable" % "0.2.11",
       "io.gsonfire" % "gson-fire" % "1.9.0" % "compile",
       "jakarta.annotation" % "jakarta.annotation-api" % "1.3.5" % "compile",
       "com.google.code.findbugs" % "jsr305" % "3.0.2" % "compile",

--- a/samples/client/echo_api/java/okhttp-gson/pom.xml
+++ b/samples/client/echo_api/java/okhttp-gson/pom.xml
@@ -327,7 +327,7 @@
         <okhttp-version>4.12.0</okhttp-version>
         <gson-version>2.10.1</gson-version>
         <commons-lang3-version>3.18.0</commons-lang3-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <beanvalidation-version>2.0.2</beanvalidation-version>
         <junit-version>5.10.3</junit-version>

--- a/samples/client/echo_api/java/restclient/build.gradle
+++ b/samples/client/echo_api/java/restclient/build.gradle
@@ -99,7 +99,7 @@ if(hasProperty('target') && target == 'android') {
 ext {
     jackson_version = "2.21.5"
     jackson_annotations_version = "2.21"
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.11"
     spring_web_version = "6.2.16"
     jakarta_annotation_version = "2.1.1"
     bean_validation_version = "3.1.1"

--- a/samples/client/echo_api/java/restclient/pom.xml
+++ b/samples/client/echo_api/java/restclient/pom.xml
@@ -268,7 +268,7 @@
         <jakarta-annotation-version>2.1.1</jakarta-annotation-version>
 
         <jackson-annotations-version>2.21</jackson-annotations-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <beanvalidation-version>3.1.1</beanvalidation-version>
         <junit-version>5.10.2</junit-version>
     </properties>

--- a/samples/client/echo_api/java/resteasy/build.gradle
+++ b/samples/client/echo_api/java/resteasy/build.gradle
@@ -100,7 +100,7 @@ ext {
     swagger_annotations_version = "1.6.3"
     jackson_version = "2.21.5"
     jackson_databind_version = "2.21.5"
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.11"
     jakarta_annotation_version = "1.3.5"
     threetenbp_version = "2.9.10"
     resteasy_version = "4.5.11.Final"

--- a/samples/client/echo_api/java/resteasy/pom.xml
+++ b/samples/client/echo_api/java/resteasy/pom.xml
@@ -257,7 +257,7 @@
         <jackson-version>2.21.5</jackson-version>
         <jackson-annotations-version>2.21</jackson-annotations-version>
         <jackson-databind-version>2.21.5</jackson-databind-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <threetenbp-version>2.9.10</threetenbp-version>
         <maven-plugin-version>1.0.0</maven-plugin-version>

--- a/samples/client/echo_api/java/resttemplate/build.gradle
+++ b/samples/client/echo_api/java/resttemplate/build.gradle
@@ -99,7 +99,7 @@ if(hasProperty('target') && target == 'android') {
 ext {
     jackson_version = "2.21.5"
     jackson_annotations_version = "2.21"
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.11"
     spring_web_version = "5.3.33"
     jakarta_annotation_version = "1.3.5"
     bean_validation_version = "2.0.2"

--- a/samples/client/echo_api/java/resttemplate/pom.xml
+++ b/samples/client/echo_api/java/resttemplate/pom.xml
@@ -284,7 +284,7 @@
         <jackson-version>2.21.5</jackson-version>
 
         <jackson-annotations-version>2.21</jackson-annotations-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <junit-version>5.10.2</junit-version>
     </properties>
 </project>

--- a/samples/client/others/java/jersey2-oneOf-Mixed/build.gradle
+++ b/samples/client/others/java/jersey2-oneOf-Mixed/build.gradle
@@ -101,7 +101,7 @@ ext {
     jackson_version = "2.21.5"
     jackson_annotations_version = "2.21"
     jackson_databind_version = "2.21.5"
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.11"
     jakarta_annotation_version = "1.3.5"
     jersey_version = "2.35"
     junit_version = "5.8.2"

--- a/samples/client/others/java/jersey2-oneOf-Mixed/build.sbt
+++ b/samples/client/others/java/jersey2-oneOf-Mixed/build.sbt
@@ -20,7 +20,7 @@ lazy val root = (project in file(".")).
       "com.fasterxml.jackson.core" % "jackson-annotations" % "2.21" % "compile",
       "com.fasterxml.jackson.core" % "jackson-databind" % "2.21.5" % "compile",
       "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % "2.21.5" % "compile",
-      "org.openapitools" % "jackson-databind-nullable" % "0.2.10" % "compile",
+      "org.openapitools" % "jackson-databind-nullable" % "0.2.11" % "compile",
       "jakarta.annotation" % "jakarta.annotation-api" % "1.3.5" % "compile",
       "org.junit.jupiter" % "junit-jupiter-api" % "5.8.2" % "test"
     )

--- a/samples/client/others/java/jersey2-oneOf-Mixed/pom.xml
+++ b/samples/client/others/java/jersey2-oneOf-Mixed/pom.xml
@@ -333,7 +333,7 @@
         <jackson-version>2.21.5</jackson-version>
         <jackson-annotations-version>2.21</jackson-annotations-version>
         <jackson-databind-version>2.21.5</jackson-databind-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <beanvalidation-version>2.0.2</beanvalidation-version>
         <junit-version>5.14.4</junit-version>

--- a/samples/client/others/java/jersey2-oneOf-duplicates/build.gradle
+++ b/samples/client/others/java/jersey2-oneOf-duplicates/build.gradle
@@ -101,7 +101,7 @@ ext {
     jackson_version = "2.21.5"
     jackson_annotations_version = "2.21"
     jackson_databind_version = "2.21.5"
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.11"
     jakarta_annotation_version = "1.3.5"
     jersey_version = "2.35"
     junit_version = "5.8.2"

--- a/samples/client/others/java/jersey2-oneOf-duplicates/build.sbt
+++ b/samples/client/others/java/jersey2-oneOf-duplicates/build.sbt
@@ -20,7 +20,7 @@ lazy val root = (project in file(".")).
       "com.fasterxml.jackson.core" % "jackson-annotations" % "2.21" % "compile",
       "com.fasterxml.jackson.core" % "jackson-databind" % "2.21.5" % "compile",
       "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % "2.21.5" % "compile",
-      "org.openapitools" % "jackson-databind-nullable" % "0.2.10" % "compile",
+      "org.openapitools" % "jackson-databind-nullable" % "0.2.11" % "compile",
       "jakarta.annotation" % "jakarta.annotation-api" % "1.3.5" % "compile",
       "org.junit.jupiter" % "junit-jupiter-api" % "5.8.2" % "test"
     )

--- a/samples/client/others/java/jersey2-oneOf-duplicates/pom.xml
+++ b/samples/client/others/java/jersey2-oneOf-duplicates/pom.xml
@@ -333,7 +333,7 @@
         <jackson-version>2.21.5</jackson-version>
         <jackson-annotations-version>2.21</jackson-annotations-version>
         <jackson-databind-version>2.21.5</jackson-databind-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <beanvalidation-version>2.0.2</beanvalidation-version>
         <junit-version>5.14.4</junit-version>

--- a/samples/client/others/java/okhttp-gson-oneOf-array/build.gradle
+++ b/samples/client/others/java/okhttp-gson-oneOf-array/build.gradle
@@ -113,7 +113,7 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.9.1'
     implementation 'io.gsonfire:gson-fire:1.9.0'
     implementation 'jakarta.ws.rs:jakarta.ws.rs-api:2.1.6'
-    implementation 'org.openapitools:jackson-databind-nullable:0.2.10'
+    implementation 'org.openapitools:jackson-databind-nullable:0.2.11'
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.18.0'
     implementation "jakarta.annotation:jakarta.annotation-api:$jakarta_annotation_version"
     implementation "jakarta.validation:jakarta.validation-api:$bean_validation_version"

--- a/samples/client/others/java/okhttp-gson-oneOf-array/build.sbt
+++ b/samples/client/others/java/okhttp-gson-oneOf-array/build.sbt
@@ -15,7 +15,7 @@ lazy val root = (project in file(".")).
       "com.google.code.gson" % "gson" % "2.9.1",
       "org.apache.commons" % "commons-lang3" % "3.18.0",
       "jakarta.ws.rs" % "jakarta.ws.rs-api" % "2.1.6",
-      "org.openapitools" % "jackson-databind-nullable" % "0.2.10",
+      "org.openapitools" % "jackson-databind-nullable" % "0.2.11",
       "io.gsonfire" % "gson-fire" % "1.9.0" % "compile",
       "jakarta.annotation" % "jakarta.annotation-api" % "1.3.5" % "compile",
       "com.google.code.findbugs" % "jsr305" % "3.0.2" % "compile",

--- a/samples/client/others/java/okhttp-gson-oneOf-array/pom.xml
+++ b/samples/client/others/java/okhttp-gson-oneOf-array/pom.xml
@@ -334,7 +334,7 @@
         <okhttp-version>4.12.0</okhttp-version>
         <gson-version>2.10.1</gson-version>
         <commons-lang3-version>3.18.0</commons-lang3-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <beanvalidation-version>2.0.2</beanvalidation-version>
         <junit-version>5.10.3</junit-version>

--- a/samples/client/others/java/okhttp-gson-oneOf/build.gradle
+++ b/samples/client/others/java/okhttp-gson-oneOf/build.gradle
@@ -112,7 +112,7 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.9.1'
     implementation 'io.gsonfire:gson-fire:1.9.0'
     implementation 'jakarta.ws.rs:jakarta.ws.rs-api:2.1.6'
-    implementation 'org.openapitools:jackson-databind-nullable:0.2.10'
+    implementation 'org.openapitools:jackson-databind-nullable:0.2.11'
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.18.0'
     implementation "jakarta.annotation:jakarta.annotation-api:$jakarta_annotation_version"
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.3'

--- a/samples/client/others/java/okhttp-gson-oneOf/build.sbt
+++ b/samples/client/others/java/okhttp-gson-oneOf/build.sbt
@@ -15,7 +15,7 @@ lazy val root = (project in file(".")).
       "com.google.code.gson" % "gson" % "2.9.1",
       "org.apache.commons" % "commons-lang3" % "3.18.0",
       "jakarta.ws.rs" % "jakarta.ws.rs-api" % "2.1.6",
-      "org.openapitools" % "jackson-databind-nullable" % "0.2.10",
+      "org.openapitools" % "jackson-databind-nullable" % "0.2.11",
       "io.gsonfire" % "gson-fire" % "1.9.0" % "compile",
       "jakarta.annotation" % "jakarta.annotation-api" % "1.3.5" % "compile",
       "com.google.code.findbugs" % "jsr305" % "3.0.2" % "compile",

--- a/samples/client/others/java/okhttp-gson-oneOf/pom.xml
+++ b/samples/client/others/java/okhttp-gson-oneOf/pom.xml
@@ -327,7 +327,7 @@
         <okhttp-version>4.12.0</okhttp-version>
         <gson-version>2.10.1</gson-version>
         <commons-lang3-version>3.18.0</commons-lang3-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <beanvalidation-version>2.0.2</beanvalidation-version>
         <junit-version>5.10.3</junit-version>

--- a/samples/client/others/java/okhttp-gson-streaming/build.gradle
+++ b/samples/client/others/java/okhttp-gson-streaming/build.gradle
@@ -112,7 +112,7 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.9.1'
     implementation 'io.gsonfire:gson-fire:1.9.0'
     implementation 'jakarta.ws.rs:jakarta.ws.rs-api:2.1.6'
-    implementation 'org.openapitools:jackson-databind-nullable:0.2.10'
+    implementation 'org.openapitools:jackson-databind-nullable:0.2.11'
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.18.0'
     implementation "jakarta.annotation:jakarta.annotation-api:$jakarta_annotation_version"
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.3'

--- a/samples/client/others/java/okhttp-gson-streaming/build.sbt
+++ b/samples/client/others/java/okhttp-gson-streaming/build.sbt
@@ -15,7 +15,7 @@ lazy val root = (project in file(".")).
       "com.google.code.gson" % "gson" % "2.9.1",
       "org.apache.commons" % "commons-lang3" % "3.18.0",
       "jakarta.ws.rs" % "jakarta.ws.rs-api" % "2.1.6",
-      "org.openapitools" % "jackson-databind-nullable" % "0.2.10",
+      "org.openapitools" % "jackson-databind-nullable" % "0.2.11",
       "io.gsonfire" % "gson-fire" % "1.9.0" % "compile",
       "jakarta.annotation" % "jakarta.annotation-api" % "1.3.5" % "compile",
       "com.google.code.findbugs" % "jsr305" % "3.0.2" % "compile",

--- a/samples/client/others/java/okhttp-gson-streaming/pom.xml
+++ b/samples/client/others/java/okhttp-gson-streaming/pom.xml
@@ -327,7 +327,7 @@
         <okhttp-version>4.12.0</okhttp-version>
         <gson-version>2.10.1</gson-version>
         <commons-lang3-version>3.18.0</commons-lang3-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <beanvalidation-version>2.0.2</beanvalidation-version>
         <junit-version>5.10.3</junit-version>

--- a/samples/client/others/java/restclient-enum-in-multipart/build.gradle
+++ b/samples/client/others/java/restclient-enum-in-multipart/build.gradle
@@ -99,7 +99,7 @@ if(hasProperty('target') && target == 'android') {
 ext {
     jackson_version = "2.21.5"
     jackson_annotations_version = "2.21"
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.11"
     spring_web_version = "6.2.16"
     jakarta_annotation_version = "2.1.1"
     bean_validation_version = "3.1.1"

--- a/samples/client/others/java/restclient-enum-in-multipart/pom.xml
+++ b/samples/client/others/java/restclient-enum-in-multipart/pom.xml
@@ -268,7 +268,7 @@
         <jakarta-annotation-version>2.1.1</jakarta-annotation-version>
 
         <jackson-annotations-version>2.21</jackson-annotations-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <beanvalidation-version>3.1.1</beanvalidation-version>
         <junit-version>5.10.2</junit-version>
     </properties>

--- a/samples/client/others/java/restclient-sealedInterface/build.gradle
+++ b/samples/client/others/java/restclient-sealedInterface/build.gradle
@@ -99,7 +99,7 @@ if(hasProperty('target') && target == 'android') {
 ext {
     jackson_version = "2.21.5"
     jackson_annotations_version = "2.21"
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.11"
     spring_web_version = "6.2.16"
     jakarta_annotation_version = "2.1.1"
     bean_validation_version = "3.1.1"

--- a/samples/client/others/java/restclient-sealedInterface/pom.xml
+++ b/samples/client/others/java/restclient-sealedInterface/pom.xml
@@ -268,7 +268,7 @@
         <jakarta-annotation-version>2.1.1</jakarta-annotation-version>
 
         <jackson-annotations-version>2.21</jackson-annotations-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <beanvalidation-version>3.1.1</beanvalidation-version>
         <junit-version>5.10.2</junit-version>
     </properties>

--- a/samples/client/others/java/restclient-useAbstractionForFiles/build.gradle
+++ b/samples/client/others/java/restclient-useAbstractionForFiles/build.gradle
@@ -99,7 +99,7 @@ if(hasProperty('target') && target == 'android') {
 ext {
     jackson_version = "2.21.5"
     jackson_annotations_version = "2.21"
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.11"
     spring_web_version = "6.2.16"
     jakarta_annotation_version = "2.1.1"
     bean_validation_version = "3.1.1"

--- a/samples/client/others/java/restclient-useAbstractionForFiles/pom.xml
+++ b/samples/client/others/java/restclient-useAbstractionForFiles/pom.xml
@@ -268,7 +268,7 @@
         <jakarta-annotation-version>2.1.1</jakarta-annotation-version>
 
         <jackson-annotations-version>2.21</jackson-annotations-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <beanvalidation-version>3.1.1</beanvalidation-version>
         <junit-version>5.10.2</junit-version>
     </properties>

--- a/samples/client/others/java/resttemplate-list-schema-validation/build.gradle
+++ b/samples/client/others/java/resttemplate-list-schema-validation/build.gradle
@@ -99,7 +99,7 @@ if(hasProperty('target') && target == 'android') {
 ext {
     jackson_version = "2.21.5"
     jackson_annotations_version = "2.21"
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.11"
     spring_web_version = "5.3.33"
     jakarta_annotation_version = "1.3.5"
     bean_validation_version = "2.0.2"

--- a/samples/client/others/java/resttemplate-list-schema-validation/pom.xml
+++ b/samples/client/others/java/resttemplate-list-schema-validation/pom.xml
@@ -291,7 +291,7 @@
         <jackson-version>2.21.5</jackson-version>
 
         <jackson-annotations-version>2.21</jackson-annotations-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <junit-version>5.10.2</junit-version>
     </properties>
 </project>

--- a/samples/client/others/java/resttemplate-useAbstractionForFiles/build.gradle
+++ b/samples/client/others/java/resttemplate-useAbstractionForFiles/build.gradle
@@ -99,7 +99,7 @@ if(hasProperty('target') && target == 'android') {
 ext {
     jackson_version = "2.21.5"
     jackson_annotations_version = "2.21"
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.11"
     spring_web_version = "5.3.33"
     jakarta_annotation_version = "1.3.5"
     bean_validation_version = "2.0.2"

--- a/samples/client/others/java/resttemplate-useAbstractionForFiles/pom.xml
+++ b/samples/client/others/java/resttemplate-useAbstractionForFiles/pom.xml
@@ -284,7 +284,7 @@
         <jackson-version>2.21.5</jackson-version>
 
         <jackson-annotations-version>2.21</jackson-annotations-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <junit-version>5.10.2</junit-version>
     </properties>
 </project>

--- a/samples/client/others/java/webclient-sealedInterface/build.gradle
+++ b/samples/client/others/java/webclient-sealedInterface/build.gradle
@@ -119,7 +119,7 @@ ext {
     reactor_netty_version = "1.2.8"
     jackson_version = "2.21.5"
     jackson_annotations_version = "2.21"
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.11"
     junit_version = "5.10.2"
 }
 

--- a/samples/client/others/java/webclient-sealedInterface/pom.xml
+++ b/samples/client/others/java/webclient-sealedInterface/pom.xml
@@ -131,7 +131,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jackson-version>2.21.5</jackson-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <spring-boot-version>2.7.17</spring-boot-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <reactor-version>3.4.34</reactor-version>

--- a/samples/client/others/java/webclient-sealedInterface_3_1/build.gradle
+++ b/samples/client/others/java/webclient-sealedInterface_3_1/build.gradle
@@ -119,7 +119,7 @@ ext {
     reactor_netty_version = "1.2.8"
     jackson_version = "2.21.5"
     jackson_annotations_version = "2.21"
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.11"
     junit_version = "5.10.2"
 }
 

--- a/samples/client/others/java/webclient-sealedInterface_3_1/pom.xml
+++ b/samples/client/others/java/webclient-sealedInterface_3_1/pom.xml
@@ -131,7 +131,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jackson-version>2.21.5</jackson-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <spring-boot-version>2.7.17</spring-boot-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <reactor-version>3.4.34</reactor-version>

--- a/samples/client/others/java/webclient-useAbstractionForFiles/build.gradle
+++ b/samples/client/others/java/webclient-useAbstractionForFiles/build.gradle
@@ -119,7 +119,7 @@ ext {
     reactor_netty_version = "1.2.8"
     jackson_version = "2.21.5"
     jackson_annotations_version = "2.21"
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.11"
     junit_version = "5.10.2"
 }
 

--- a/samples/client/others/java/webclient-useAbstractionForFiles/pom.xml
+++ b/samples/client/others/java/webclient-useAbstractionForFiles/pom.xml
@@ -131,7 +131,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jackson-version>2.21.5</jackson-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <spring-boot-version>2.7.17</spring-boot-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <reactor-version>3.4.34</reactor-version>

--- a/samples/client/petstore/java-helidon-client/v3/mp/pom.xml
+++ b/samples/client/petstore/java-helidon-client/v3/mp/pom.xml
@@ -17,7 +17,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <version.jackson.databind.nullable>0.2.10</version.jackson.databind.nullable>
+        <version.jackson.databind.nullable>0.2.11</version.jackson.databind.nullable>
     </properties>
 
     <dependencies>

--- a/samples/client/petstore/java-helidon-client/v3/se/pom.xml
+++ b/samples/client/petstore/java-helidon-client/v3/se/pom.xml
@@ -16,7 +16,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <version.jackson.databind.nullable>0.2.10</version.jackson.databind.nullable>
+        <version.jackson.databind.nullable>0.2.11</version.jackson.databind.nullable>
     </properties>
 
     <dependencies>

--- a/samples/client/petstore/java-helidon-client/v4/mp/pom.xml
+++ b/samples/client/petstore/java-helidon-client/v4/mp/pom.xml
@@ -17,7 +17,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <version.jackson.databind.nullable>0.2.10</version.jackson.databind.nullable>
+        <version.jackson.databind.nullable>0.2.11</version.jackson.databind.nullable>
     </properties>
 
     <dependencies>

--- a/samples/client/petstore/java-helidon-client/v4/se/pom.xml
+++ b/samples/client/petstore/java-helidon-client/v4/se/pom.xml
@@ -16,7 +16,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <version.jackson.databind.nullable>0.2.10</version.jackson.databind.nullable>
+        <version.jackson.databind.nullable>0.2.11</version.jackson.databind.nullable>
     </properties>
 
     <dependencies>

--- a/samples/client/petstore/java/apache-httpclient-jackson3/build.gradle
+++ b/samples/client/petstore/java/apache-httpclient-jackson3/build.gradle
@@ -120,7 +120,7 @@ ext {
     swagger_annotations_version = "1.6.6"
     jackson3_version = "3.1.5"
     jackson_annotations_version = "2.21"
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.11"
     jakarta_annotation_version = "1.3.5"
     httpclient_version = "5.1.3"
     jodatime_version = "2.9.9"

--- a/samples/client/petstore/java/apache-httpclient-jackson3/pom.xml
+++ b/samples/client/petstore/java/apache-httpclient-jackson3/pom.xml
@@ -268,7 +268,7 @@
         <httpclient-version>5.2.1</httpclient-version>
         <jackson3-version>3.1.5</jackson3-version>
         <jackson-annotations-version>2.21</jackson-annotations-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <beanvalidation-version>2.0.2</beanvalidation-version>
         <junit-version>5.10.2</junit-version>

--- a/samples/client/petstore/java/apache-httpclient/build.gradle
+++ b/samples/client/petstore/java/apache-httpclient/build.gradle
@@ -121,7 +121,7 @@ ext {
     jackson_version = "2.21.5"
     jackson_annotations_version = "2.21"
     jackson_databind_version = "2.21.5"
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.11"
     jakarta_annotation_version = "1.3.5"
     httpclient_version = "5.1.3"
     jodatime_version = "2.9.9"

--- a/samples/client/petstore/java/apache-httpclient/pom.xml
+++ b/samples/client/petstore/java/apache-httpclient/pom.xml
@@ -273,7 +273,7 @@
         <jackson-version>2.21.5</jackson-version>
         <jackson-annotations-version>2.21</jackson-annotations-version>
         <jackson-databind-version>2.21.5</jackson-databind-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <beanvalidation-version>2.0.2</beanvalidation-version>
         <junit-version>5.10.2</junit-version>

--- a/samples/client/petstore/java/feign-hc5/build.gradle
+++ b/samples/client/petstore/java/feign-hc5/build.gradle
@@ -105,7 +105,7 @@ ext {
     jackson_version = "2.21.5"
     jackson_annotations_version = "2.21"
     jackson_databind_version = "2.21.5"
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.11"
     jakarta_annotation_version = "1.3.5"
     feign_version = "13.5"
     feign_form_version = "3.8.0"

--- a/samples/client/petstore/java/feign-hc5/pom.xml
+++ b/samples/client/petstore/java/feign-hc5/pom.xml
@@ -321,7 +321,7 @@
         <jackson-version>2.21.5</jackson-version>
         <jackson-annotations-version>2.21</jackson-annotations-version>
         <jackson-databind-version>2.21.5</jackson-databind-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <beanvalidation-version>2.0.2</beanvalidation-version>
         <junit-version>5.10.0</junit-version>

--- a/samples/client/petstore/java/feign/build.gradle
+++ b/samples/client/petstore/java/feign/build.gradle
@@ -105,7 +105,7 @@ ext {
     jackson_version = "2.21.5"
     jackson_annotations_version = "2.21"
     jackson_databind_version = "2.21.5"
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.11"
     jakarta_annotation_version = "1.3.5"
     feign_version = "13.5"
     feign_form_version = "3.8.0"

--- a/samples/client/petstore/java/feign/pom.xml
+++ b/samples/client/petstore/java/feign/pom.xml
@@ -321,7 +321,7 @@
         <jackson-version>2.21.5</jackson-version>
         <jackson-annotations-version>2.21</jackson-annotations-version>
         <jackson-databind-version>2.21.5</jackson-databind-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <beanvalidation-version>2.0.2</beanvalidation-version>
         <junit-version>5.10.0</junit-version>

--- a/samples/client/petstore/java/google-api-client/build.gradle
+++ b/samples/client/petstore/java/google-api-client/build.gradle
@@ -101,7 +101,7 @@ ext {
     jackson_version = "2.21.5"
     jackson_annotations_version = "2.21"
     jackson_databind_version = "2.21.5"
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.11"
     jakarta_annotation_version = "1.3.5"
     google_api_client_version = "1.32.2"
     jersey_common_version = "2.25.1"

--- a/samples/client/petstore/java/google-api-client/pom.xml
+++ b/samples/client/petstore/java/google-api-client/pom.xml
@@ -264,7 +264,7 @@
         <jackson-version>2.21.5</jackson-version>
         <jackson-annotations-version>2.21</jackson-annotations-version>
         <jackson-databind-version>2.21.5</jackson-databind-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <maven-plugin-version>1.0.0</maven-plugin-version>
         <junit-version>5.10.2</junit-version>

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/build.gradle
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/build.gradle
@@ -101,7 +101,7 @@ ext {
     jackson_version = "2.21.5"
     jackson_annotations_version = "2.21"
     jackson_databind_version = "2.21.5"
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.11"
     jakarta_annotation_version = "1.3.5"
     jersey_version = "2.35"
     junit_version = "5.8.2"

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/build.sbt
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/build.sbt
@@ -20,7 +20,7 @@ lazy val root = (project in file(".")).
       "com.fasterxml.jackson.core" % "jackson-annotations" % "2.21" % "compile",
       "com.fasterxml.jackson.core" % "jackson-databind" % "2.21.5" % "compile",
       "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % "2.21.5" % "compile",
-      "org.openapitools" % "jackson-databind-nullable" % "0.2.10" % "compile",
+      "org.openapitools" % "jackson-databind-nullable" % "0.2.11" % "compile",
       "com.github.scribejava" % "scribejava-apis" % "8.3.1" % "compile",
       "jakarta.annotation" % "jakarta.annotation-api" % "1.3.5" % "compile",
       "org.junit.jupiter" % "junit-jupiter-api" % "5.8.2" % "test"

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/pom.xml
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/pom.xml
@@ -338,7 +338,7 @@
         <jackson-version>2.21.5</jackson-version>
         <jackson-annotations-version>2.21</jackson-annotations-version>
         <jackson-databind-version>2.21.5</jackson-databind-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <beanvalidation-version>2.0.2</beanvalidation-version>
         <junit-version>5.14.4</junit-version>

--- a/samples/client/petstore/java/jersey2-java8/build.gradle
+++ b/samples/client/petstore/java/jersey2-java8/build.gradle
@@ -101,7 +101,7 @@ ext {
     jackson_version = "2.21.5"
     jackson_annotations_version = "2.21"
     jackson_databind_version = "2.21.5"
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.11"
     jakarta_annotation_version = "1.3.5"
     jersey_version = "2.35"
     junit_version = "5.8.2"

--- a/samples/client/petstore/java/jersey2-java8/build.sbt
+++ b/samples/client/petstore/java/jersey2-java8/build.sbt
@@ -20,7 +20,7 @@ lazy val root = (project in file(".")).
       "com.fasterxml.jackson.core" % "jackson-annotations" % "2.21" % "compile",
       "com.fasterxml.jackson.core" % "jackson-databind" % "2.21.5" % "compile",
       "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % "2.21.5" % "compile",
-      "org.openapitools" % "jackson-databind-nullable" % "0.2.10" % "compile",
+      "org.openapitools" % "jackson-databind-nullable" % "0.2.11" % "compile",
       "com.github.scribejava" % "scribejava-apis" % "8.3.1" % "compile",
       "jakarta.annotation" % "jakarta.annotation-api" % "1.3.5" % "compile",
       "org.junit.jupiter" % "junit-jupiter-api" % "5.8.2" % "test"

--- a/samples/client/petstore/java/jersey2-java8/pom.xml
+++ b/samples/client/petstore/java/jersey2-java8/pom.xml
@@ -338,7 +338,7 @@
         <jackson-version>2.21.5</jackson-version>
         <jackson-annotations-version>2.21</jackson-annotations-version>
         <jackson-databind-version>2.21.5</jackson-databind-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <beanvalidation-version>2.0.2</beanvalidation-version>
         <junit-version>5.14.4</junit-version>

--- a/samples/client/petstore/java/jersey3-jackson3/build.gradle
+++ b/samples/client/petstore/java/jersey3-jackson3/build.gradle
@@ -101,7 +101,7 @@ ext {
     swagger_annotations_version = "1.6.5"
     jackson3_version = "3.1.5"
     jackson_annotations_version = "2.21"
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.11"
     jakarta_annotation_version = "3.0.0"
     bean_validation_version = "3.1.1"
     jersey_version = "3.0.4"

--- a/samples/client/petstore/java/jersey3-jackson3/build.sbt
+++ b/samples/client/petstore/java/jersey3-jackson3/build.sbt
@@ -20,7 +20,7 @@ lazy val root = (project in file(".")).
       "com.fasterxml.jackson.core" % "jackson-annotations" % "2.21" % "compile",
       "com.fasterxml.jackson.core" % "jackson-databind" % "2.21.5" % "compile",
       "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % "2.21.1" % "compile",
-      "org.openapitools" % "jackson-databind-nullable" % "0.2.10" % "compile",
+      "org.openapitools" % "jackson-databind-nullable" % "0.2.11" % "compile",
       "com.github.scribejava" % "scribejava-apis" % "8.3.1" % "compile",
       "org.tomitribe" % "tomitribe-http-signatures" % "1.7" % "compile",
       "jakarta.annotation" % "jakarta.annotation-api" % "2.1.0" % "compile",

--- a/samples/client/petstore/java/jersey3-jackson3/pom.xml
+++ b/samples/client/petstore/java/jersey3-jackson3/pom.xml
@@ -352,7 +352,7 @@
         <jersey-version>3.1.11</jersey-version>
         <jackson3-version>3.1.5</jackson3-version>
         <jackson-annotations-version>2.21</jackson-annotations-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <jakarta-annotation-version>3.0.0</jakarta-annotation-version>
         <beanvalidation-version>3.1.1</beanvalidation-version>
         <junit-version>5.10.0</junit-version>

--- a/samples/client/petstore/java/jersey3-oneOf/build.gradle
+++ b/samples/client/petstore/java/jersey3-oneOf/build.gradle
@@ -102,7 +102,7 @@ ext {
     jackson_version = "2.21.5"
     jackson_annotations_version = "2.21"
     jackson_databind_version = "2.21.5"
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.11"
     jakarta_annotation_version = "3.0.0"
     jersey_version = "3.0.4"
     junit_version = "5.8.2"

--- a/samples/client/petstore/java/jersey3-oneOf/build.sbt
+++ b/samples/client/petstore/java/jersey3-oneOf/build.sbt
@@ -20,7 +20,7 @@ lazy val root = (project in file(".")).
       "com.fasterxml.jackson.core" % "jackson-annotations" % "2.21" % "compile",
       "com.fasterxml.jackson.core" % "jackson-databind" % "2.21.5" % "compile",
       "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % "2.21.1" % "compile",
-      "org.openapitools" % "jackson-databind-nullable" % "0.2.10" % "compile",
+      "org.openapitools" % "jackson-databind-nullable" % "0.2.11" % "compile",
       "jakarta.annotation" % "jakarta.annotation-api" % "2.1.0" % "compile",
       "org.junit.jupiter" % "junit-jupiter-api" % "5.8.2" % "test"
     )

--- a/samples/client/petstore/java/jersey3-oneOf/pom.xml
+++ b/samples/client/petstore/java/jersey3-oneOf/pom.xml
@@ -334,7 +334,7 @@
         <jackson-version>2.21.5</jackson-version>
         <jackson-annotations-version>2.21</jackson-annotations-version>
         <jackson-databind-version>2.21.5</jackson-databind-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <jakarta-annotation-version>3.0.0</jakarta-annotation-version>
         <beanvalidation-version>3.1.1</beanvalidation-version>
         <junit-version>5.10.0</junit-version>

--- a/samples/client/petstore/java/jersey3/build.gradle
+++ b/samples/client/petstore/java/jersey3/build.gradle
@@ -102,7 +102,7 @@ ext {
     jackson_version = "2.21.5"
     jackson_annotations_version = "2.21"
     jackson_databind_version = "2.21.5"
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.11"
     jakarta_annotation_version = "3.0.0"
     bean_validation_version = "3.1.1"
     jersey_version = "3.0.4"

--- a/samples/client/petstore/java/jersey3/build.sbt
+++ b/samples/client/petstore/java/jersey3/build.sbt
@@ -20,7 +20,7 @@ lazy val root = (project in file(".")).
       "com.fasterxml.jackson.core" % "jackson-annotations" % "2.21" % "compile",
       "com.fasterxml.jackson.core" % "jackson-databind" % "2.21.5" % "compile",
       "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % "2.21.1" % "compile",
-      "org.openapitools" % "jackson-databind-nullable" % "0.2.10" % "compile",
+      "org.openapitools" % "jackson-databind-nullable" % "0.2.11" % "compile",
       "com.github.scribejava" % "scribejava-apis" % "8.3.1" % "compile",
       "org.tomitribe" % "tomitribe-http-signatures" % "1.7" % "compile",
       "jakarta.annotation" % "jakarta.annotation-api" % "2.1.0" % "compile",

--- a/samples/client/petstore/java/jersey3/pom.xml
+++ b/samples/client/petstore/java/jersey3/pom.xml
@@ -357,7 +357,7 @@
         <jackson-version>2.21.5</jackson-version>
         <jackson-annotations-version>2.21</jackson-annotations-version>
         <jackson-databind-version>2.21.5</jackson-databind-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <jakarta-annotation-version>3.0.0</jakarta-annotation-version>
         <beanvalidation-version>3.1.1</beanvalidation-version>
         <junit-version>5.10.0</junit-version>

--- a/samples/client/petstore/java/native-async/build.gradle
+++ b/samples/client/petstore/java/native-async/build.gradle
@@ -80,7 +80,7 @@ dependencies {
     implementation "com.fasterxml.jackson.core:jackson-annotations:$jackson_annotations_version"
     implementation "com.fasterxml.jackson.core:jackson-databind:$jackson_version"
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jackson_version"
-    implementation "org.openapitools:jackson-databind-nullable:0.2.10"
+    implementation "org.openapitools:jackson-databind-nullable:0.2.11"
     implementation "jakarta.annotation:jakarta.annotation-api:$jakarta_annotation_version"
     implementation "org.apache.httpcomponents:httpmime:$httpmime_version"
     testImplementation "org.junit.jupiter:junit-jupiter-api:$junit_version"

--- a/samples/client/petstore/java/native-async/pom.xml
+++ b/samples/client/petstore/java/native-async/pom.xml
@@ -255,7 +255,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <jackson-version>2.21.5</jackson-version>
         <jackson-annotations-version>2.21</jackson-annotations-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <beanvalidation-version>2.0.2</beanvalidation-version>
         <httpmime-version>4.5.14</httpmime-version>

--- a/samples/client/petstore/java/native-jackson3-jspecify/pom.xml
+++ b/samples/client/petstore/java/native-jackson3-jspecify/pom.xml
@@ -255,7 +255,7 @@
         <maven.compiler.target>17</maven.compiler.target>
         <jackson3-version>3.1.1</jackson3-version>
         <jackson-annotations-version>2.21</jackson-annotations-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <beanvalidation-version>2.0.2</beanvalidation-version>
         <httpmime-version>4.5.14</httpmime-version>

--- a/samples/client/petstore/java/native-jackson3/pom.xml
+++ b/samples/client/petstore/java/native-jackson3/pom.xml
@@ -257,7 +257,7 @@
         <maven.compiler.target>17</maven.compiler.target>
         <jackson3-version>3.1.1</jackson3-version>
         <jackson-annotations-version>2.21</jackson-annotations-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <beanvalidation-version>2.0.2</beanvalidation-version>
         <httpmime-version>4.5.14</httpmime-version>

--- a/samples/client/petstore/java/native-jakarta/build.gradle
+++ b/samples/client/petstore/java/native-jakarta/build.gradle
@@ -80,7 +80,7 @@ dependencies {
     implementation "com.fasterxml.jackson.core:jackson-annotations:$jackson_annotations_version"
     implementation "com.fasterxml.jackson.core:jackson-databind:$jackson_version"
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jackson_version"
-    implementation "org.openapitools:jackson-databind-nullable:0.2.10"
+    implementation "org.openapitools:jackson-databind-nullable:0.2.11"
     implementation "jakarta.annotation:jakarta.annotation-api:$jakarta_annotation_version"
     implementation "org.apache.httpcomponents:httpmime:$httpmime_version"
     testImplementation "org.junit.jupiter:junit-jupiter-api:$junit_version"

--- a/samples/client/petstore/java/native-jakarta/pom.xml
+++ b/samples/client/petstore/java/native-jakarta/pom.xml
@@ -255,7 +255,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <jackson-version>2.21.5</jackson-version>
         <jackson-annotations-version>2.21</jackson-annotations-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <jakarta-annotation-version>2.1.1</jakarta-annotation-version>
         <beanvalidation-version>3.0.2</beanvalidation-version>
         <httpmime-version>4.5.14</httpmime-version>

--- a/samples/client/petstore/java/native-useGzipFeature/build.gradle
+++ b/samples/client/petstore/java/native-useGzipFeature/build.gradle
@@ -79,7 +79,7 @@ dependencies {
     implementation "com.fasterxml.jackson.core:jackson-annotations:$jackson_annotations_version"
     implementation "com.fasterxml.jackson.core:jackson-databind:$jackson_version"
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jackson_version"
-    implementation "org.openapitools:jackson-databind-nullable:0.2.10"
+    implementation "org.openapitools:jackson-databind-nullable:0.2.11"
     implementation "jakarta.annotation:jakarta.annotation-api:$jakarta_annotation_version"
     testImplementation "org.junit.jupiter:junit-jupiter-api:$junit_version"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit_version"

--- a/samples/client/petstore/java/native-useGzipFeature/pom.xml
+++ b/samples/client/petstore/java/native-useGzipFeature/pom.xml
@@ -250,7 +250,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <jackson-version>2.21.5</jackson-version>
         <jackson-annotations-version>2.21</jackson-annotations-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <jakarta-annotation-version>2.1.1</jakarta-annotation-version>
         <beanvalidation-version>3.0.2</beanvalidation-version>
         <junit-version>5.10.2</junit-version>

--- a/samples/client/petstore/java/native/build.gradle
+++ b/samples/client/petstore/java/native/build.gradle
@@ -81,7 +81,7 @@ dependencies {
     implementation "com.fasterxml.jackson.core:jackson-annotations:$jackson_annotations_version"
     implementation "com.fasterxml.jackson.core:jackson-databind:$jackson_version"
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jackson_version"
-    implementation "org.openapitools:jackson-databind-nullable:0.2.10"
+    implementation "org.openapitools:jackson-databind-nullable:0.2.11"
     implementation "jakarta.annotation:jakarta.annotation-api:$jakarta_annotation_version"
     implementation "org.apache.httpcomponents:httpmime:$httpmime_version"
     implementation "org.apache.commons:commons-lang3:$commons_lang3_version"

--- a/samples/client/petstore/java/native/pom.xml
+++ b/samples/client/petstore/java/native/pom.xml
@@ -261,7 +261,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <jackson-version>2.21.5</jackson-version>
         <jackson-annotations-version>2.21</jackson-annotations-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <beanvalidation-version>2.0.2</beanvalidation-version>
         <httpmime-version>4.5.14</httpmime-version>

--- a/samples/client/petstore/java/okhttp-gson-3.1-duplicated-operationid/build.gradle
+++ b/samples/client/petstore/java/okhttp-gson-3.1-duplicated-operationid/build.gradle
@@ -112,7 +112,7 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.9.1'
     implementation 'io.gsonfire:gson-fire:1.9.0'
     implementation 'jakarta.ws.rs:jakarta.ws.rs-api:2.1.6'
-    implementation 'org.openapitools:jackson-databind-nullable:0.2.10'
+    implementation 'org.openapitools:jackson-databind-nullable:0.2.11'
     implementation group: 'org.apache.oltu.oauth2', name: 'org.apache.oltu.oauth2.client', version: '1.0.2'
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.18.0'
     implementation "jakarta.annotation:jakarta.annotation-api:$jakarta_annotation_version"

--- a/samples/client/petstore/java/okhttp-gson-3.1-duplicated-operationid/build.sbt
+++ b/samples/client/petstore/java/okhttp-gson-3.1-duplicated-operationid/build.sbt
@@ -15,7 +15,7 @@ lazy val root = (project in file(".")).
       "com.google.code.gson" % "gson" % "2.9.1",
       "org.apache.commons" % "commons-lang3" % "3.18.0",
       "jakarta.ws.rs" % "jakarta.ws.rs-api" % "2.1.6",
-      "org.openapitools" % "jackson-databind-nullable" % "0.2.10",
+      "org.openapitools" % "jackson-databind-nullable" % "0.2.11",
       "org.apache.oltu.oauth2" % "org.apache.oltu.oauth2.client" % "1.0.2",
       "io.gsonfire" % "gson-fire" % "1.9.0" % "compile",
       "jakarta.annotation" % "jakarta.annotation-api" % "1.3.5" % "compile",

--- a/samples/client/petstore/java/okhttp-gson-3.1-duplicated-operationid/pom.xml
+++ b/samples/client/petstore/java/okhttp-gson-3.1-duplicated-operationid/pom.xml
@@ -332,7 +332,7 @@
         <okhttp-version>4.12.0</okhttp-version>
         <gson-version>2.10.1</gson-version>
         <commons-lang3-version>3.18.0</commons-lang3-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <beanvalidation-version>2.0.2</beanvalidation-version>
         <junit-version>5.10.3</junit-version>

--- a/samples/client/petstore/java/okhttp-gson-3.1/build.gradle
+++ b/samples/client/petstore/java/okhttp-gson-3.1/build.gradle
@@ -112,7 +112,7 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.9.1'
     implementation 'io.gsonfire:gson-fire:1.9.0'
     implementation 'jakarta.ws.rs:jakarta.ws.rs-api:2.1.6'
-    implementation 'org.openapitools:jackson-databind-nullable:0.2.10'
+    implementation 'org.openapitools:jackson-databind-nullable:0.2.11'
     implementation group: 'org.apache.oltu.oauth2', name: 'org.apache.oltu.oauth2.client', version: '1.0.2'
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.18.0'
     implementation "jakarta.annotation:jakarta.annotation-api:$jakarta_annotation_version"

--- a/samples/client/petstore/java/okhttp-gson-3.1/build.sbt
+++ b/samples/client/petstore/java/okhttp-gson-3.1/build.sbt
@@ -15,7 +15,7 @@ lazy val root = (project in file(".")).
       "com.google.code.gson" % "gson" % "2.9.1",
       "org.apache.commons" % "commons-lang3" % "3.18.0",
       "jakarta.ws.rs" % "jakarta.ws.rs-api" % "2.1.6",
-      "org.openapitools" % "jackson-databind-nullable" % "0.2.10",
+      "org.openapitools" % "jackson-databind-nullable" % "0.2.11",
       "org.apache.oltu.oauth2" % "org.apache.oltu.oauth2.client" % "1.0.2",
       "io.gsonfire" % "gson-fire" % "1.9.0" % "compile",
       "jakarta.annotation" % "jakarta.annotation-api" % "1.3.5" % "compile",

--- a/samples/client/petstore/java/okhttp-gson-3.1/pom.xml
+++ b/samples/client/petstore/java/okhttp-gson-3.1/pom.xml
@@ -332,7 +332,7 @@
         <okhttp-version>4.12.0</okhttp-version>
         <gson-version>2.10.1</gson-version>
         <commons-lang3-version>3.18.0</commons-lang3-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <beanvalidation-version>2.0.2</beanvalidation-version>
         <junit-version>5.10.3</junit-version>

--- a/samples/client/petstore/java/okhttp-gson-awsv4signature/build.gradle
+++ b/samples/client/petstore/java/okhttp-gson-awsv4signature/build.gradle
@@ -112,7 +112,7 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.9.1'
     implementation 'io.gsonfire:gson-fire:1.9.0'
     implementation 'jakarta.ws.rs:jakarta.ws.rs-api:2.1.6'
-    implementation 'org.openapitools:jackson-databind-nullable:0.2.10'
+    implementation 'org.openapitools:jackson-databind-nullable:0.2.11'
     implementation 'software.amazon.awssdk:auth:2.20.157'
     implementation group: 'org.apache.oltu.oauth2', name: 'org.apache.oltu.oauth2.client', version: '1.0.2'
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.18.0'

--- a/samples/client/petstore/java/okhttp-gson-awsv4signature/build.sbt
+++ b/samples/client/petstore/java/okhttp-gson-awsv4signature/build.sbt
@@ -15,7 +15,7 @@ lazy val root = (project in file(".")).
       "com.google.code.gson" % "gson" % "2.9.1",
       "org.apache.commons" % "commons-lang3" % "3.18.0",
       "jakarta.ws.rs" % "jakarta.ws.rs-api" % "2.1.6",
-      "org.openapitools" % "jackson-databind-nullable" % "0.2.10",
+      "org.openapitools" % "jackson-databind-nullable" % "0.2.11",
       "software.amazon.awssdk" % "auth" % "2.20.157",
       "org.apache.oltu.oauth2" % "org.apache.oltu.oauth2.client" % "1.0.2",
       "io.gsonfire" % "gson-fire" % "1.9.0" % "compile",

--- a/samples/client/petstore/java/okhttp-gson-awsv4signature/pom.xml
+++ b/samples/client/petstore/java/okhttp-gson-awsv4signature/pom.xml
@@ -337,7 +337,7 @@
         <okhttp-version>4.12.0</okhttp-version>
         <gson-version>2.10.1</gson-version>
         <commons-lang3-version>3.18.0</commons-lang3-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <beanvalidation-version>2.0.2</beanvalidation-version>
         <junit-version>5.10.3</junit-version>

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/build.gradle
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/build.gradle
@@ -112,7 +112,7 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.9.1'
     implementation 'io.gsonfire:gson-fire:1.9.0'
     implementation 'jakarta.ws.rs:jakarta.ws.rs-api:2.1.6'
-    implementation 'org.openapitools:jackson-databind-nullable:0.2.10'
+    implementation 'org.openapitools:jackson-databind-nullable:0.2.11'
     implementation group: 'org.apache.oltu.oauth2', name: 'org.apache.oltu.oauth2.client', version: '1.0.2'
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.18.0'
     implementation 'io.swagger.parser.v3:swagger-parser-v3:2.0.30'

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/build.sbt
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/build.sbt
@@ -15,7 +15,7 @@ lazy val root = (project in file(".")).
       "com.google.code.gson" % "gson" % "2.9.1",
       "org.apache.commons" % "commons-lang3" % "3.18.0",
       "jakarta.ws.rs" % "jakarta.ws.rs-api" % "2.1.6",
-      "org.openapitools" % "jackson-databind-nullable" % "0.2.10",
+      "org.openapitools" % "jackson-databind-nullable" % "0.2.11",
       "org.apache.oltu.oauth2" % "org.apache.oltu.oauth2.client" % "1.0.2",
       "io.swagger.parser.v3" % "swagger-parser-v3" "2.0.30" % "compile"
       "io.gsonfire" % "gson-fire" % "1.9.0" % "compile",

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/pom.xml
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/pom.xml
@@ -337,7 +337,7 @@
         <okhttp-version>4.12.0</okhttp-version>
         <gson-version>2.10.1</gson-version>
         <commons-lang3-version>3.18.0</commons-lang3-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <beanvalidation-version>2.0.2</beanvalidation-version>
         <junit-version>5.10.3</junit-version>

--- a/samples/client/petstore/java/okhttp-gson-group-parameter/build.gradle
+++ b/samples/client/petstore/java/okhttp-gson-group-parameter/build.gradle
@@ -112,7 +112,7 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.9.1'
     implementation 'io.gsonfire:gson-fire:1.9.0'
     implementation 'jakarta.ws.rs:jakarta.ws.rs-api:2.1.6'
-    implementation 'org.openapitools:jackson-databind-nullable:0.2.10'
+    implementation 'org.openapitools:jackson-databind-nullable:0.2.11'
     implementation group: 'org.apache.oltu.oauth2', name: 'org.apache.oltu.oauth2.client', version: '1.0.2'
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.18.0'
     implementation "jakarta.annotation:jakarta.annotation-api:$jakarta_annotation_version"

--- a/samples/client/petstore/java/okhttp-gson-group-parameter/build.sbt
+++ b/samples/client/petstore/java/okhttp-gson-group-parameter/build.sbt
@@ -15,7 +15,7 @@ lazy val root = (project in file(".")).
       "com.google.code.gson" % "gson" % "2.9.1",
       "org.apache.commons" % "commons-lang3" % "3.18.0",
       "jakarta.ws.rs" % "jakarta.ws.rs-api" % "2.1.6",
-      "org.openapitools" % "jackson-databind-nullable" % "0.2.10",
+      "org.openapitools" % "jackson-databind-nullable" % "0.2.11",
       "org.apache.oltu.oauth2" % "org.apache.oltu.oauth2.client" % "1.0.2",
       "io.gsonfire" % "gson-fire" % "1.9.0" % "compile",
       "jakarta.annotation" % "jakarta.annotation-api" % "1.3.5" % "compile",

--- a/samples/client/petstore/java/okhttp-gson-group-parameter/pom.xml
+++ b/samples/client/petstore/java/okhttp-gson-group-parameter/pom.xml
@@ -332,7 +332,7 @@
         <okhttp-version>4.12.0</okhttp-version>
         <gson-version>2.10.1</gson-version>
         <commons-lang3-version>3.18.0</commons-lang3-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <beanvalidation-version>2.0.2</beanvalidation-version>
         <junit-version>5.10.3</junit-version>

--- a/samples/client/petstore/java/okhttp-gson-nullable-required/build.gradle
+++ b/samples/client/petstore/java/okhttp-gson-nullable-required/build.gradle
@@ -112,7 +112,7 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.9.1'
     implementation 'io.gsonfire:gson-fire:1.9.0'
     implementation 'jakarta.ws.rs:jakarta.ws.rs-api:2.1.6'
-    implementation 'org.openapitools:jackson-databind-nullable:0.2.10'
+    implementation 'org.openapitools:jackson-databind-nullable:0.2.11'
     implementation group: 'org.apache.oltu.oauth2', name: 'org.apache.oltu.oauth2.client', version: '1.0.2'
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.18.0'
     implementation "jakarta.annotation:jakarta.annotation-api:$jakarta_annotation_version"

--- a/samples/client/petstore/java/okhttp-gson-nullable-required/build.sbt
+++ b/samples/client/petstore/java/okhttp-gson-nullable-required/build.sbt
@@ -15,7 +15,7 @@ lazy val root = (project in file(".")).
       "com.google.code.gson" % "gson" % "2.9.1",
       "org.apache.commons" % "commons-lang3" % "3.18.0",
       "jakarta.ws.rs" % "jakarta.ws.rs-api" % "2.1.6",
-      "org.openapitools" % "jackson-databind-nullable" % "0.2.10",
+      "org.openapitools" % "jackson-databind-nullable" % "0.2.11",
       "org.apache.oltu.oauth2" % "org.apache.oltu.oauth2.client" % "1.0.2",
       "io.gsonfire" % "gson-fire" % "1.9.0" % "compile",
       "jakarta.annotation" % "jakarta.annotation-api" % "1.3.5" % "compile",

--- a/samples/client/petstore/java/okhttp-gson-nullable-required/pom.xml
+++ b/samples/client/petstore/java/okhttp-gson-nullable-required/pom.xml
@@ -332,7 +332,7 @@
         <okhttp-version>4.12.0</okhttp-version>
         <gson-version>2.10.1</gson-version>
         <commons-lang3-version>3.18.0</commons-lang3-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <beanvalidation-version>2.0.2</beanvalidation-version>
         <junit-version>5.10.3</junit-version>

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/build.gradle
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/build.gradle
@@ -112,7 +112,7 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.9.1'
     implementation 'io.gsonfire:gson-fire:1.9.0'
     implementation 'jakarta.ws.rs:jakarta.ws.rs-api:2.1.6'
-    implementation 'org.openapitools:jackson-databind-nullable:0.2.10'
+    implementation 'org.openapitools:jackson-databind-nullable:0.2.11'
     implementation group: 'org.apache.oltu.oauth2', name: 'org.apache.oltu.oauth2.client', version: '1.0.2'
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.18.0'
     implementation "jakarta.annotation:jakarta.annotation-api:$jakarta_annotation_version"

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/build.sbt
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/build.sbt
@@ -15,7 +15,7 @@ lazy val root = (project in file(".")).
       "com.google.code.gson" % "gson" % "2.9.1",
       "org.apache.commons" % "commons-lang3" % "3.18.0",
       "jakarta.ws.rs" % "jakarta.ws.rs-api" % "2.1.6",
-      "org.openapitools" % "jackson-databind-nullable" % "0.2.10",
+      "org.openapitools" % "jackson-databind-nullable" % "0.2.11",
       "org.apache.oltu.oauth2" % "org.apache.oltu.oauth2.client" % "1.0.2",
       "io.gsonfire" % "gson-fire" % "1.9.0" % "compile",
       "jakarta.annotation" % "jakarta.annotation-api" % "1.3.5" % "compile",

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/pom.xml
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/pom.xml
@@ -339,7 +339,7 @@
         <okhttp-version>4.12.0</okhttp-version>
         <gson-version>2.10.1</gson-version>
         <commons-lang3-version>3.18.0</commons-lang3-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <beanvalidation-version>2.0.2</beanvalidation-version>
         <junit-version>5.10.3</junit-version>

--- a/samples/client/petstore/java/okhttp-gson-swagger1/build.gradle
+++ b/samples/client/petstore/java/okhttp-gson-swagger1/build.gradle
@@ -114,7 +114,7 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.9.1'
     implementation 'io.gsonfire:gson-fire:1.9.0'
     implementation 'jakarta.ws.rs:jakarta.ws.rs-api:2.1.6'
-    implementation 'org.openapitools:jackson-databind-nullable:0.2.10'
+    implementation 'org.openapitools:jackson-databind-nullable:0.2.11'
     implementation group: 'org.apache.oltu.oauth2', name: 'org.apache.oltu.oauth2.client', version: '1.0.2'
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.18.0'
     implementation "jakarta.annotation:jakarta.annotation-api:$jakarta_annotation_version"

--- a/samples/client/petstore/java/okhttp-gson-swagger1/build.sbt
+++ b/samples/client/petstore/java/okhttp-gson-swagger1/build.sbt
@@ -15,7 +15,7 @@ lazy val root = (project in file(".")).
       "com.google.code.gson" % "gson" % "2.9.1",
       "org.apache.commons" % "commons-lang3" % "3.18.0",
       "jakarta.ws.rs" % "jakarta.ws.rs-api" % "2.1.6",
-      "org.openapitools" % "jackson-databind-nullable" % "0.2.10",
+      "org.openapitools" % "jackson-databind-nullable" % "0.2.11",
       "org.apache.oltu.oauth2" % "org.apache.oltu.oauth2.client" % "1.0.2",
       "io.gsonfire" % "gson-fire" % "1.9.0" % "compile",
       "jakarta.annotation" % "jakarta.annotation-api" % "1.3.5" % "compile",

--- a/samples/client/petstore/java/okhttp-gson-swagger1/pom.xml
+++ b/samples/client/petstore/java/okhttp-gson-swagger1/pom.xml
@@ -338,7 +338,7 @@
         <okhttp-version>4.12.0</okhttp-version>
         <gson-version>2.10.1</gson-version>
         <commons-lang3-version>3.18.0</commons-lang3-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <beanvalidation-version>2.0.2</beanvalidation-version>
         <junit-version>5.10.3</junit-version>

--- a/samples/client/petstore/java/okhttp-gson-swagger2/build.gradle
+++ b/samples/client/petstore/java/okhttp-gson-swagger2/build.gradle
@@ -114,7 +114,7 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.9.1'
     implementation 'io.gsonfire:gson-fire:1.9.0'
     implementation 'jakarta.ws.rs:jakarta.ws.rs-api:2.1.6'
-    implementation 'org.openapitools:jackson-databind-nullable:0.2.10'
+    implementation 'org.openapitools:jackson-databind-nullable:0.2.11'
     implementation group: 'org.apache.oltu.oauth2', name: 'org.apache.oltu.oauth2.client', version: '1.0.2'
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.18.0'
     implementation "jakarta.annotation:jakarta.annotation-api:$jakarta_annotation_version"

--- a/samples/client/petstore/java/okhttp-gson-swagger2/build.sbt
+++ b/samples/client/petstore/java/okhttp-gson-swagger2/build.sbt
@@ -15,7 +15,7 @@ lazy val root = (project in file(".")).
       "com.google.code.gson" % "gson" % "2.9.1",
       "org.apache.commons" % "commons-lang3" % "3.18.0",
       "jakarta.ws.rs" % "jakarta.ws.rs-api" % "2.1.6",
-      "org.openapitools" % "jackson-databind-nullable" % "0.2.10",
+      "org.openapitools" % "jackson-databind-nullable" % "0.2.11",
       "org.apache.oltu.oauth2" % "org.apache.oltu.oauth2.client" % "1.0.2",
       "io.gsonfire" % "gson-fire" % "1.9.0" % "compile",
       "jakarta.annotation" % "jakarta.annotation-api" % "1.3.5" % "compile",

--- a/samples/client/petstore/java/okhttp-gson-swagger2/pom.xml
+++ b/samples/client/petstore/java/okhttp-gson-swagger2/pom.xml
@@ -338,7 +338,7 @@
         <okhttp-version>4.12.0</okhttp-version>
         <gson-version>2.10.1</gson-version>
         <commons-lang3-version>3.18.0</commons-lang3-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <beanvalidation-version>2.0.2</beanvalidation-version>
         <junit-version>5.10.3</junit-version>

--- a/samples/client/petstore/java/okhttp-gson/build.gradle
+++ b/samples/client/petstore/java/okhttp-gson/build.gradle
@@ -112,7 +112,7 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.9.1'
     implementation 'io.gsonfire:gson-fire:1.9.0'
     implementation 'jakarta.ws.rs:jakarta.ws.rs-api:2.1.6'
-    implementation 'org.openapitools:jackson-databind-nullable:0.2.10'
+    implementation 'org.openapitools:jackson-databind-nullable:0.2.11'
     implementation group: 'org.apache.oltu.oauth2', name: 'org.apache.oltu.oauth2.client', version: '1.0.2'
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.18.0'
     implementation "jakarta.annotation:jakarta.annotation-api:$jakarta_annotation_version"

--- a/samples/client/petstore/java/okhttp-gson/build.sbt
+++ b/samples/client/petstore/java/okhttp-gson/build.sbt
@@ -15,7 +15,7 @@ lazy val root = (project in file(".")).
       "com.google.code.gson" % "gson" % "2.9.1",
       "org.apache.commons" % "commons-lang3" % "3.18.0",
       "jakarta.ws.rs" % "jakarta.ws.rs-api" % "2.1.6",
-      "org.openapitools" % "jackson-databind-nullable" % "0.2.10",
+      "org.openapitools" % "jackson-databind-nullable" % "0.2.11",
       "org.apache.oltu.oauth2" % "org.apache.oltu.oauth2.client" % "1.0.2",
       "io.gsonfire" % "gson-fire" % "1.9.0" % "compile",
       "jakarta.annotation" % "jakarta.annotation-api" % "1.3.5" % "compile",

--- a/samples/client/petstore/java/rest-assured-jackson/build.gradle
+++ b/samples/client/petstore/java/rest-assured-jackson/build.gradle
@@ -101,7 +101,7 @@ ext {
     junit_version = "5.10.3"
     jackson_version = "2.21.5"
     jackson_databind_version = "2.21.5"
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.11"
     okio_version = "3.6.0"
     jakarta_annotation_version = "1.3.5"
 }

--- a/samples/client/petstore/java/rest-assured-jackson/build.sbt
+++ b/samples/client/petstore/java/rest-assured-jackson/build.sbt
@@ -16,7 +16,7 @@ lazy val root = (project in file(".")).
       "com.fasterxml.jackson.core" % "jackson-core" % "2.21.5",
       "com.fasterxml.jackson.core" % "jackson-annotations" % "2.21",
       "com.fasterxml.jackson.core" % "jackson-databind" % "2.21.5",
-      "org.openapitools" % "jackson-databind-nullable" % "0.2.10",
+      "org.openapitools" % "jackson-databind-nullable" % "0.2.11",
       "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % "2.13.4.1",
       "com.squareup.okio" % "okio" % "1.17.5" % "compile",
       "jakarta.validation" % "jakarta.validation-api" % "3.0.2" % "compile",

--- a/samples/client/petstore/java/rest-assured-jackson/pom.xml
+++ b/samples/client/petstore/java/rest-assured-jackson/pom.xml
@@ -282,7 +282,7 @@
         <gson-fire-version>1.9.0</gson-fire-version>
         <jackson-version>2.21.5</jackson-version>
         <jackson-databind-version>2.21.5</jackson-databind-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <beanvalidation-version>2.0.2</beanvalidation-version>
         <okio-version>3.6.0</okio-version>

--- a/samples/client/petstore/java/restclient-nullable-arrays/build.gradle
+++ b/samples/client/petstore/java/restclient-nullable-arrays/build.gradle
@@ -99,7 +99,7 @@ if(hasProperty('target') && target == 'android') {
 ext {
     jackson_version = "2.21.5"
     jackson_annotations_version = "2.21"
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.11"
     spring_web_version = "6.2.16"
     jakarta_annotation_version = "2.1.1"
     bean_validation_version = "3.1.1"

--- a/samples/client/petstore/java/restclient-nullable-arrays/pom.xml
+++ b/samples/client/petstore/java/restclient-nullable-arrays/pom.xml
@@ -268,7 +268,7 @@
         <jakarta-annotation-version>2.1.1</jakarta-annotation-version>
 
         <jackson-annotations-version>2.21</jackson-annotations-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <beanvalidation-version>3.1.1</beanvalidation-version>
         <junit-version>5.10.2</junit-version>
     </properties>

--- a/samples/client/petstore/java/restclient-springBoot4-jackson2/build.gradle
+++ b/samples/client/petstore/java/restclient-springBoot4-jackson2/build.gradle
@@ -99,7 +99,7 @@ if(hasProperty('target') && target == 'android') {
 ext {
     jackson_version = "2.21.5"
     jackson_annotations_version = "2.21"
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.11"
     spring_web_version = "7.0.5"
     jakarta_annotation_version = "3.0.0"
     bean_validation_version = "3.1.1"

--- a/samples/client/petstore/java/restclient-springBoot4-jackson2/pom.xml
+++ b/samples/client/petstore/java/restclient-springBoot4-jackson2/pom.xml
@@ -268,7 +268,7 @@
         <jakarta-annotation-version>3.0.0</jakarta-annotation-version>
 
         <jackson-annotations-version>2.21</jackson-annotations-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <beanvalidation-version>3.1.1</beanvalidation-version>
         <junit-version>5.10.2</junit-version>
     </properties>

--- a/samples/client/petstore/java/restclient-swagger2/build.gradle
+++ b/samples/client/petstore/java/restclient-swagger2/build.gradle
@@ -100,7 +100,7 @@ ext {
     swagger_annotations_version = "2.2.43"
     jackson_version = "2.21.5"
     jackson_annotations_version = "2.21"
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.11"
     spring_web_version = "6.2.16"
     jakarta_annotation_version = "2.1.1"
     bean_validation_version = "3.1.1"

--- a/samples/client/petstore/java/restclient-swagger2/pom.xml
+++ b/samples/client/petstore/java/restclient-swagger2/pom.xml
@@ -274,7 +274,7 @@
         <jakarta-annotation-version>2.1.1</jakarta-annotation-version>
 
         <jackson-annotations-version>2.21</jackson-annotations-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <beanvalidation-version>3.1.1</beanvalidation-version>
         <junit-version>5.10.2</junit-version>
     </properties>

--- a/samples/client/petstore/java/restclient-useSingleRequestParameter-static/build.gradle
+++ b/samples/client/petstore/java/restclient-useSingleRequestParameter-static/build.gradle
@@ -99,7 +99,7 @@ if(hasProperty('target') && target == 'android') {
 ext {
     jackson_version = "2.21.5"
     jackson_annotations_version = "2.21"
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.11"
     spring_web_version = "6.2.16"
     jakarta_annotation_version = "2.1.1"
     bean_validation_version = "3.1.1"

--- a/samples/client/petstore/java/restclient-useSingleRequestParameter-static/pom.xml
+++ b/samples/client/petstore/java/restclient-useSingleRequestParameter-static/pom.xml
@@ -268,7 +268,7 @@
         <jakarta-annotation-version>2.1.1</jakarta-annotation-version>
 
         <jackson-annotations-version>2.21</jackson-annotations-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <beanvalidation-version>3.1.1</beanvalidation-version>
         <junit-version>5.10.2</junit-version>
     </properties>

--- a/samples/client/petstore/java/restclient-useSingleRequestParameter/build.gradle
+++ b/samples/client/petstore/java/restclient-useSingleRequestParameter/build.gradle
@@ -99,7 +99,7 @@ if(hasProperty('target') && target == 'android') {
 ext {
     jackson_version = "2.21.5"
     jackson_annotations_version = "2.21"
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.11"
     spring_web_version = "6.2.16"
     jakarta_annotation_version = "2.1.1"
     bean_validation_version = "3.1.1"

--- a/samples/client/petstore/java/restclient-useSingleRequestParameter/pom.xml
+++ b/samples/client/petstore/java/restclient-useSingleRequestParameter/pom.xml
@@ -268,7 +268,7 @@
         <jakarta-annotation-version>2.1.1</jakarta-annotation-version>
 
         <jackson-annotations-version>2.21</jackson-annotations-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <beanvalidation-version>3.1.1</beanvalidation-version>
         <junit-version>5.10.2</junit-version>
     </properties>

--- a/samples/client/petstore/java/restclient/build.gradle
+++ b/samples/client/petstore/java/restclient/build.gradle
@@ -99,7 +99,7 @@ if(hasProperty('target') && target == 'android') {
 ext {
     jackson_version = "2.21.5"
     jackson_annotations_version = "2.21"
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.11"
     spring_web_version = "6.2.16"
     jakarta_annotation_version = "2.1.1"
     bean_validation_version = "3.1.1"

--- a/samples/client/petstore/java/restclient/pom.xml
+++ b/samples/client/petstore/java/restclient/pom.xml
@@ -268,7 +268,7 @@
         <jakarta-annotation-version>2.1.1</jakarta-annotation-version>
 
         <jackson-annotations-version>2.21</jackson-annotations-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <beanvalidation-version>3.1.1</beanvalidation-version>
         <junit-version>5.10.2</junit-version>
     </properties>

--- a/samples/client/petstore/java/resteasy/build.gradle
+++ b/samples/client/petstore/java/resteasy/build.gradle
@@ -100,7 +100,7 @@ ext {
     swagger_annotations_version = "1.6.3"
     jackson_version = "2.21.5"
     jackson_databind_version = "2.21.5"
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.11"
     jakarta_annotation_version = "1.3.5"
     threetenbp_version = "2.9.10"
     resteasy_version = "4.5.11.Final"

--- a/samples/client/petstore/java/resteasy/pom.xml
+++ b/samples/client/petstore/java/resteasy/pom.xml
@@ -257,7 +257,7 @@
         <jackson-version>2.21.5</jackson-version>
         <jackson-annotations-version>2.21</jackson-annotations-version>
         <jackson-databind-version>2.21.5</jackson-databind-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <threetenbp-version>2.9.10</threetenbp-version>
         <maven-plugin-version>1.0.0</maven-plugin-version>

--- a/samples/client/petstore/java/resttemplate-jakarta/build.gradle
+++ b/samples/client/petstore/java/resttemplate-jakarta/build.gradle
@@ -99,7 +99,7 @@ if(hasProperty('target') && target == 'android') {
 ext {
     jackson_version = "2.21.5"
     jackson_annotations_version = "2.21"
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.11"
     spring_web_version = "6.2.8"
     jakarta_annotation_version = "2.1.1"
     bean_validation_version = "3.0.2"

--- a/samples/client/petstore/java/resttemplate-jakarta/pom.xml
+++ b/samples/client/petstore/java/resttemplate-jakarta/pom.xml
@@ -283,7 +283,7 @@
         <jackson-version>2.21.5</jackson-version>
 
         <jackson-annotations-version>2.21</jackson-annotations-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <junit-version>5.10.2</junit-version>
     </properties>
 </project>

--- a/samples/client/petstore/java/resttemplate-springBoot4-jackson2/build.gradle
+++ b/samples/client/petstore/java/resttemplate-springBoot4-jackson2/build.gradle
@@ -99,7 +99,7 @@ if(hasProperty('target') && target == 'android') {
 ext {
     jackson_version = "2.21.5"
     jackson_annotations_version = "2.21"
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.11"
     spring_web_version = "7.0.5"
     jakarta_annotation_version = "3.0.0"
     bean_validation_version = "3.1.1"

--- a/samples/client/petstore/java/resttemplate-springBoot4-jackson2/pom.xml
+++ b/samples/client/petstore/java/resttemplate-springBoot4-jackson2/pom.xml
@@ -284,7 +284,7 @@
         <jakarta-annotation-version>3.0.0</jakarta-annotation-version>
 
         <jackson-annotations-version>2.21</jackson-annotations-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <junit-version>5.10.2</junit-version>
     </properties>
 </project>

--- a/samples/client/petstore/java/resttemplate-swagger1/build.gradle
+++ b/samples/client/petstore/java/resttemplate-swagger1/build.gradle
@@ -100,7 +100,7 @@ ext {
     swagger_annotations_version = "1.6.9"
     jackson_version = "2.21.5"
     jackson_annotations_version = "2.21"
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.11"
     spring_web_version = "5.3.33"
     jakarta_annotation_version = "1.3.5"
     bean_validation_version = "2.0.2"

--- a/samples/client/petstore/java/resttemplate-swagger1/pom.xml
+++ b/samples/client/petstore/java/resttemplate-swagger1/pom.xml
@@ -290,7 +290,7 @@
         <jackson-version>2.21.5</jackson-version>
 
         <jackson-annotations-version>2.21</jackson-annotations-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <junit-version>5.10.2</junit-version>
     </properties>
 </project>

--- a/samples/client/petstore/java/resttemplate-swagger2/build.gradle
+++ b/samples/client/petstore/java/resttemplate-swagger2/build.gradle
@@ -100,7 +100,7 @@ ext {
     swagger_annotations_version = "2.2.9"
     jackson_version = "2.21.5"
     jackson_annotations_version = "2.21"
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.11"
     spring_web_version = "5.3.33"
     jakarta_annotation_version = "1.3.5"
     bean_validation_version = "2.0.2"

--- a/samples/client/petstore/java/resttemplate-swagger2/pom.xml
+++ b/samples/client/petstore/java/resttemplate-swagger2/pom.xml
@@ -290,7 +290,7 @@
         <jackson-version>2.21.5</jackson-version>
 
         <jackson-annotations-version>2.21</jackson-annotations-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <junit-version>5.10.2</junit-version>
     </properties>
 </project>

--- a/samples/client/petstore/java/resttemplate-withXml/build.gradle
+++ b/samples/client/petstore/java/resttemplate-withXml/build.gradle
@@ -99,7 +99,7 @@ if(hasProperty('target') && target == 'android') {
 ext {
     jackson_version = "2.21.5"
     jackson_annotations_version = "2.21"
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.11"
     spring_web_version = "5.3.33"
     jakarta_annotation_version = "1.3.5"
     bean_validation_version = "2.0.2"

--- a/samples/client/petstore/java/resttemplate-withXml/pom.xml
+++ b/samples/client/petstore/java/resttemplate-withXml/pom.xml
@@ -296,7 +296,7 @@
         <jackson-version>2.21.5</jackson-version>
 
         <jackson-annotations-version>2.21</jackson-annotations-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <junit-version>5.10.2</junit-version>
     </properties>
 </project>

--- a/samples/client/petstore/java/resttemplate/build.gradle
+++ b/samples/client/petstore/java/resttemplate/build.gradle
@@ -99,7 +99,7 @@ if(hasProperty('target') && target == 'android') {
 ext {
     jackson_version = "2.21.5"
     jackson_annotations_version = "2.21"
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.11"
     spring_web_version = "5.3.33"
     jakarta_annotation_version = "1.3.5"
     bean_validation_version = "2.0.2"

--- a/samples/client/petstore/java/resttemplate/pom.xml
+++ b/samples/client/petstore/java/resttemplate/pom.xml
@@ -284,7 +284,7 @@
         <jackson-version>2.21.5</jackson-version>
 
         <jackson-annotations-version>2.21</jackson-annotations-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <junit-version>5.10.2</junit-version>
     </properties>
 </project>

--- a/samples/client/petstore/java/retrofit2-play26/build.gradle
+++ b/samples/client/petstore/java/retrofit2-play26/build.gradle
@@ -103,7 +103,7 @@ ext {
     jackson_annotations_version = "2.21"
     jackson_databind_version = "2.21.5"
     javax_ws_rs_api_version = "2.1.1"
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.11"
     play_version = "2.6.7"
     jakarta_annotation_version = "1.3.5"
     swagger_annotations_version = "1.5.22"

--- a/samples/client/petstore/java/retrofit2-play26/pom.xml
+++ b/samples/client/petstore/java/retrofit2-play26/pom.xml
@@ -305,7 +305,7 @@
         <jackson-databind-version>2.21.5</jackson-databind-version>
         <jackson-version>2.21.5</jackson-version>
         <jackson-annotations-version>2.21</jackson-annotations-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <javax.ws.rs-api-version>2.1.1</javax.ws.rs-api-version>
         <play-version>2.6.7</play-version>
         <retrofit-version>2.11.0</retrofit-version>

--- a/samples/client/petstore/java/vertx-no-nullable/pom.xml
+++ b/samples/client/petstore/java/vertx-no-nullable/pom.xml
@@ -268,7 +268,7 @@
         <jackson-version>2.21.5</jackson-version>
         <jackson-annotations-version>2.21</jackson-annotations-version>
         <jackson-databind>2.21.5</jackson-databind>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <junit-version>5.10.3</junit-version>
     </properties>

--- a/samples/client/petstore/java/vertx-supportVertxFuture/build.gradle
+++ b/samples/client/petstore/java/vertx-supportVertxFuture/build.gradle
@@ -34,7 +34,7 @@ ext {
     jackson_databind_version = "2.21.5"
     vertx_version = "4.0.0"
     junit_version = "5.10.3"
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.11"
     jakarta_annotation_version = "1.3.5"
 }
 

--- a/samples/client/petstore/java/vertx-supportVertxFuture/pom.xml
+++ b/samples/client/petstore/java/vertx-supportVertxFuture/pom.xml
@@ -273,7 +273,7 @@
         <jackson-version>2.21.5</jackson-version>
         <jackson-annotations-version>2.21</jackson-annotations-version>
         <jackson-databind>2.21.5</jackson-databind>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <junit-version>5.10.3</junit-version>
     </properties>

--- a/samples/client/petstore/java/vertx/build.gradle
+++ b/samples/client/petstore/java/vertx/build.gradle
@@ -34,7 +34,7 @@ ext {
     jackson_databind_version = "2.21.5"
     vertx_version = "3.5.2"
     junit_version = "5.10.3"
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.11"
     jakarta_annotation_version = "1.3.5"
 }
 

--- a/samples/client/petstore/java/vertx/pom.xml
+++ b/samples/client/petstore/java/vertx/pom.xml
@@ -273,7 +273,7 @@
         <jackson-version>2.21.5</jackson-version>
         <jackson-annotations-version>2.21</jackson-annotations-version>
         <jackson-databind>2.21.5</jackson-databind>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <junit-version>5.10.3</junit-version>
     </properties>

--- a/samples/client/petstore/java/vertx5-supportVertxFuture/build.gradle
+++ b/samples/client/petstore/java/vertx5-supportVertxFuture/build.gradle
@@ -34,7 +34,7 @@ ext {
     jackson_databind_version = "2.21.5"
     vertx_version = "5.0.11"
     junit_version = "5.10.3"
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.11"
     jakarta_annotation_version = "1.3.5"
 }
 

--- a/samples/client/petstore/java/vertx5-supportVertxFuture/pom.xml
+++ b/samples/client/petstore/java/vertx5-supportVertxFuture/pom.xml
@@ -273,7 +273,7 @@
         <jackson-version>2.21.5</jackson-version>
         <jackson-annotations-version>2.21</jackson-annotations-version>
         <jackson-databind>2.21.5</jackson-databind>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <junit-version>5.10.3</junit-version>
     </properties>

--- a/samples/client/petstore/java/vertx5/build.gradle
+++ b/samples/client/petstore/java/vertx5/build.gradle
@@ -34,7 +34,7 @@ ext {
     jackson_databind_version = "2.21.5"
     vertx_version = "5.0.11"
     junit_version = "5.10.3"
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.11"
     jakarta_annotation_version = "1.3.5"
 }
 

--- a/samples/client/petstore/java/vertx5/pom.xml
+++ b/samples/client/petstore/java/vertx5/pom.xml
@@ -273,7 +273,7 @@
         <jackson-version>2.21.5</jackson-version>
         <jackson-annotations-version>2.21</jackson-annotations-version>
         <jackson-databind>2.21.5</jackson-databind>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <junit-version>5.10.3</junit-version>
     </properties>

--- a/samples/client/petstore/java/webclient-jakarta/build.gradle
+++ b/samples/client/petstore/java/webclient-jakarta/build.gradle
@@ -119,7 +119,7 @@ ext {
     reactor_netty_version = "1.2.8"
     jackson_version = "2.21.5"
     jackson_annotations_version = "2.21"
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.11"
     junit_version = "5.10.2"
 }
 

--- a/samples/client/petstore/java/webclient-jakarta/pom.xml
+++ b/samples/client/petstore/java/webclient-jakarta/pom.xml
@@ -131,7 +131,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jackson-version>2.21.5</jackson-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <spring-boot-version>3.5.11</spring-boot-version>
         <jakarta-annotation-version>2.1.1</jakarta-annotation-version>
         <reactor-version>3.5.12</reactor-version>

--- a/samples/client/petstore/java/webclient-nullable-arrays/build.gradle
+++ b/samples/client/petstore/java/webclient-nullable-arrays/build.gradle
@@ -119,7 +119,7 @@ ext {
     reactor_netty_version = "1.2.8"
     jackson_version = "2.21.5"
     jackson_annotations_version = "2.21"
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.11"
     junit_version = "5.10.2"
 }
 

--- a/samples/client/petstore/java/webclient-nullable-arrays/pom.xml
+++ b/samples/client/petstore/java/webclient-nullable-arrays/pom.xml
@@ -131,7 +131,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jackson-version>2.21.5</jackson-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <spring-boot-version>2.7.17</spring-boot-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <reactor-version>3.4.34</reactor-version>

--- a/samples/client/petstore/java/webclient-swagger2/build.gradle
+++ b/samples/client/petstore/java/webclient-swagger2/build.gradle
@@ -120,7 +120,7 @@ ext {
     reactor_netty_version = "1.2.8"
     jackson_version = "2.21.5"
     jackson_annotations_version = "2.21"
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.11"
     junit_version = "5.10.2"
 }
 

--- a/samples/client/petstore/java/webclient-swagger2/pom.xml
+++ b/samples/client/petstore/java/webclient-swagger2/pom.xml
@@ -137,7 +137,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <swagger-annotations-version>2.2.43</swagger-annotations-version>
         <jackson-version>2.21.5</jackson-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <spring-boot-version>2.7.17</spring-boot-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <reactor-version>3.4.34</reactor-version>

--- a/samples/client/petstore/java/webclient-useSingleRequestParameter/build.gradle
+++ b/samples/client/petstore/java/webclient-useSingleRequestParameter/build.gradle
@@ -119,7 +119,7 @@ ext {
     reactor_netty_version = "1.2.8"
     jackson_version = "2.21.5"
     jackson_annotations_version = "2.21"
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.11"
     junit_version = "5.10.2"
 }
 

--- a/samples/client/petstore/java/webclient-useSingleRequestParameter/pom.xml
+++ b/samples/client/petstore/java/webclient-useSingleRequestParameter/pom.xml
@@ -131,7 +131,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jackson-version>2.21.5</jackson-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <spring-boot-version>2.7.17</spring-boot-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <reactor-version>3.4.34</reactor-version>

--- a/samples/client/petstore/java/webclient/build.gradle
+++ b/samples/client/petstore/java/webclient/build.gradle
@@ -119,7 +119,7 @@ ext {
     reactor_netty_version = "1.2.8"
     jackson_version = "2.21.5"
     jackson_annotations_version = "2.21"
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.11"
     junit_version = "5.10.2"
 }
 

--- a/samples/client/petstore/java/webclient/pom.xml
+++ b/samples/client/petstore/java/webclient/pom.xml
@@ -131,7 +131,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jackson-version>2.21.5</jackson-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <spring-boot-version>2.7.17</spring-boot-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <reactor-version>3.4.34</reactor-version>

--- a/samples/client/petstore/spring-cloud-auth/pom.xml
+++ b/samples/client/petstore/spring-cloud-auth/pom.xml
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.10</version>
+            <version>0.2.11</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/samples/client/petstore/spring-cloud-date-time/pom.xml
+++ b/samples/client/petstore/spring-cloud-date-time/pom.xml
@@ -76,7 +76,7 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.10</version>
+            <version>0.2.11</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/samples/client/petstore/spring-cloud-deprecated/pom.xml
+++ b/samples/client/petstore/spring-cloud-deprecated/pom.xml
@@ -76,7 +76,7 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.10</version>
+            <version>0.2.11</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/samples/client/petstore/spring-cloud-feign-without-url/pom.xml
+++ b/samples/client/petstore/spring-cloud-feign-without-url/pom.xml
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.10</version>
+            <version>0.2.11</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/samples/client/petstore/spring-cloud-tags/pom.xml
+++ b/samples/client/petstore/spring-cloud-tags/pom.xml
@@ -76,7 +76,7 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.10</version>
+            <version>0.2.11</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/samples/client/petstore/spring-cloud/pom.xml
+++ b/samples/client/petstore/spring-cloud/pom.xml
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.10</version>
+            <version>0.2.11</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/samples/client/petstore/spring-http-interface-bean-validation/pom.xml
+++ b/samples/client/petstore/spring-http-interface-bean-validation/pom.xml
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.10</version>
+            <version>0.2.11</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/samples/client/petstore/spring-http-interface-noResponseEntity/pom.xml
+++ b/samples/client/petstore/spring-http-interface-noResponseEntity/pom.xml
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.10</version>
+            <version>0.2.11</version>
         </dependency>
         
         <dependency>

--- a/samples/client/petstore/spring-http-interface-reactive-bean-validation/pom.xml
+++ b/samples/client/petstore/spring-http-interface-reactive-bean-validation/pom.xml
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.10</version>
+            <version>0.2.11</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/pom.xml
+++ b/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/pom.xml
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.10</version>
+            <version>0.2.11</version>
         </dependency>
         
         <dependency>

--- a/samples/client/petstore/spring-http-interface-reactive/pom.xml
+++ b/samples/client/petstore/spring-http-interface-reactive/pom.xml
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.10</version>
+            <version>0.2.11</version>
         </dependency>
         
         <dependency>

--- a/samples/client/petstore/spring-http-interface-useHttpServiceProxyFactoryInterfacesConfigurator/pom.xml
+++ b/samples/client/petstore/spring-http-interface-useHttpServiceProxyFactoryInterfacesConfigurator/pom.xml
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.10</version>
+            <version>0.2.11</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/samples/client/petstore/spring-http-interface/pom.xml
+++ b/samples/client/petstore/spring-http-interface/pom.xml
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.10</version>
+            <version>0.2.11</version>
         </dependency>
         
         <dependency>

--- a/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/build.gradle
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/build.gradle
@@ -101,7 +101,7 @@ ext {
     jackson_version = "2.21.5"
     jackson_annotations_version = "2.21"
     jackson_databind_version = "2.21.5"
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.11"
     jakarta_annotation_version = "1.3.5"
     jersey_version = "2.35"
     junit_version = "5.8.2"

--- a/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/build.sbt
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/build.sbt
@@ -20,7 +20,7 @@ lazy val root = (project in file(".")).
       "com.fasterxml.jackson.core" % "jackson-annotations" % "2.21" % "compile",
       "com.fasterxml.jackson.core" % "jackson-databind" % "2.21.5" % "compile",
       "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % "2.21.5" % "compile",
-      "org.openapitools" % "jackson-databind-nullable" % "0.2.10" % "compile",
+      "org.openapitools" % "jackson-databind-nullable" % "0.2.11" % "compile",
       "jakarta.annotation" % "jakarta.annotation-api" % "1.3.5" % "compile",
       "org.junit.jupiter" % "junit-jupiter-api" % "5.8.2" % "test"
     )

--- a/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/pom.xml
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/pom.xml
@@ -333,7 +333,7 @@
         <jackson-version>2.21.5</jackson-version>
         <jackson-annotations-version>2.21</jackson-annotations-version>
         <jackson-databind-version>2.21.5</jackson-databind-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <beanvalidation-version>2.0.2</beanvalidation-version>
         <junit-version>5.14.4</junit-version>

--- a/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/build.gradle
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/build.gradle
@@ -101,7 +101,7 @@ ext {
     jackson_version = "2.21.5"
     jackson_annotations_version = "2.21"
     jackson_databind_version = "2.21.5"
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.11"
     jakarta_annotation_version = "1.3.5"
     jersey_version = "2.35"
     junit_version = "5.8.2"

--- a/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/build.sbt
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/build.sbt
@@ -20,7 +20,7 @@ lazy val root = (project in file(".")).
       "com.fasterxml.jackson.core" % "jackson-annotations" % "2.21" % "compile",
       "com.fasterxml.jackson.core" % "jackson-databind" % "2.21.5" % "compile",
       "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % "2.21.5" % "compile",
-      "org.openapitools" % "jackson-databind-nullable" % "0.2.10" % "compile",
+      "org.openapitools" % "jackson-databind-nullable" % "0.2.11" % "compile",
       "jakarta.annotation" % "jakarta.annotation-api" % "1.3.5" % "compile",
       "org.junit.jupiter" % "junit-jupiter-api" % "5.8.2" % "test"
     )

--- a/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/pom.xml
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/pom.xml
@@ -333,7 +333,7 @@
         <jackson-version>2.21.5</jackson-version>
         <jackson-annotations-version>2.21</jackson-annotations-version>
         <jackson-databind-version>2.21.5</jackson-databind-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <beanvalidation-version>2.0.2</beanvalidation-version>
         <junit-version>5.14.4</junit-version>

--- a/samples/openapi3/client/petstore/java/jersey2-java8-swagger1/build.gradle
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-swagger1/build.gradle
@@ -102,7 +102,7 @@ ext {
     jackson_version = "2.21.5"
     jackson_annotations_version = "2.21"
     jackson_databind_version = "2.21.5"
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.11"
     jakarta_annotation_version = "1.3.5"
     jersey_version = "2.35"
     junit_version = "5.8.2"

--- a/samples/openapi3/client/petstore/java/jersey2-java8-swagger1/build.sbt
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-swagger1/build.sbt
@@ -20,7 +20,7 @@ lazy val root = (project in file(".")).
       "com.fasterxml.jackson.core" % "jackson-annotations" % "2.21" % "compile",
       "com.fasterxml.jackson.core" % "jackson-databind" % "2.21.5" % "compile",
       "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % "2.21.5" % "compile",
-      "org.openapitools" % "jackson-databind-nullable" % "0.2.10" % "compile",
+      "org.openapitools" % "jackson-databind-nullable" % "0.2.11" % "compile",
       "com.github.scribejava" % "scribejava-apis" % "8.3.1" % "compile",
       "jakarta.annotation" % "jakarta.annotation-api" % "1.3.5" % "compile",
       "org.junit.jupiter" % "junit-jupiter-api" % "5.8.2" % "test"

--- a/samples/openapi3/client/petstore/java/jersey2-java8-swagger1/pom.xml
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-swagger1/pom.xml
@@ -344,7 +344,7 @@
         <jackson-version>2.21.5</jackson-version>
         <jackson-annotations-version>2.21</jackson-annotations-version>
         <jackson-databind-version>2.21.5</jackson-databind-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <beanvalidation-version>2.0.2</beanvalidation-version>
         <junit-version>5.14.4</junit-version>

--- a/samples/openapi3/client/petstore/java/jersey2-java8-swagger2/build.gradle
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-swagger2/build.gradle
@@ -102,7 +102,7 @@ ext {
     jackson_version = "2.21.5"
     jackson_annotations_version = "2.21"
     jackson_databind_version = "2.21.5"
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.11"
     jakarta_annotation_version = "1.3.5"
     jersey_version = "2.35"
     junit_version = "5.8.2"

--- a/samples/openapi3/client/petstore/java/jersey2-java8-swagger2/build.sbt
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-swagger2/build.sbt
@@ -20,7 +20,7 @@ lazy val root = (project in file(".")).
       "com.fasterxml.jackson.core" % "jackson-annotations" % "2.21" % "compile",
       "com.fasterxml.jackson.core" % "jackson-databind" % "2.21.5" % "compile",
       "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % "2.21.5" % "compile",
-      "org.openapitools" % "jackson-databind-nullable" % "0.2.10" % "compile",
+      "org.openapitools" % "jackson-databind-nullable" % "0.2.11" % "compile",
       "com.github.scribejava" % "scribejava-apis" % "8.3.1" % "compile",
       "jakarta.annotation" % "jakarta.annotation-api" % "1.3.5" % "compile",
       "org.junit.jupiter" % "junit-jupiter-api" % "5.8.2" % "test"

--- a/samples/openapi3/client/petstore/java/jersey2-java8-swagger2/pom.xml
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-swagger2/pom.xml
@@ -344,7 +344,7 @@
         <jackson-version>2.21.5</jackson-version>
         <jackson-annotations-version>2.21</jackson-annotations-version>
         <jackson-databind-version>2.21.5</jackson-databind-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <beanvalidation-version>2.0.2</beanvalidation-version>
         <junit-version>5.14.4</junit-version>

--- a/samples/openapi3/client/petstore/java/jersey2-java8/build.gradle
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/build.gradle
@@ -101,7 +101,7 @@ ext {
     jackson_version = "2.21.5"
     jackson_annotations_version = "2.21"
     jackson_databind_version = "2.21.5"
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.11"
     jakarta_annotation_version = "1.3.5"
     jersey_version = "2.35"
     junit_version = "5.8.2"

--- a/samples/openapi3/client/petstore/java/jersey2-java8/build.sbt
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/build.sbt
@@ -20,7 +20,7 @@ lazy val root = (project in file(".")).
       "com.fasterxml.jackson.core" % "jackson-annotations" % "2.21" % "compile",
       "com.fasterxml.jackson.core" % "jackson-databind" % "2.21.5" % "compile",
       "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % "2.21.5" % "compile",
-      "org.openapitools" % "jackson-databind-nullable" % "0.2.10" % "compile",
+      "org.openapitools" % "jackson-databind-nullable" % "0.2.11" % "compile",
       "com.github.scribejava" % "scribejava-apis" % "8.3.1" % "compile",
       "org.tomitribe" % "tomitribe-http-signatures" % "1.7" % "compile",
       "jakarta.annotation" % "jakarta.annotation-api" % "1.3.5" % "compile",

--- a/samples/openapi3/client/petstore/java/jersey2-java8/pom.xml
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/pom.xml
@@ -349,7 +349,7 @@
         <jackson-version>2.21.5</jackson-version>
         <jackson-annotations-version>2.21</jackson-annotations-version>
         <jackson-databind-version>2.21.5</jackson-databind-version>
-        <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <beanvalidation-version>2.0.2</beanvalidation-version>
         <junit-version>5.14.4</junit-version>

--- a/samples/openapi3/client/petstore/spring-cloud-3-with-optional/pom.xml
+++ b/samples/openapi3/client/petstore/spring-cloud-3-with-optional/pom.xml
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.10</version>
+            <version>0.2.11</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/samples/openapi3/client/petstore/spring-cloud-3/pom.xml
+++ b/samples/openapi3/client/petstore/spring-cloud-3/pom.xml
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.10</version>
+            <version>0.2.11</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/samples/openapi3/client/petstore/spring-cloud-async/pom.xml
+++ b/samples/openapi3/client/petstore/spring-cloud-async/pom.xml
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.10</version>
+            <version>0.2.11</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/samples/openapi3/client/petstore/spring-cloud-date-time/pom.xml
+++ b/samples/openapi3/client/petstore/spring-cloud-date-time/pom.xml
@@ -76,7 +76,7 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.10</version>
+            <version>0.2.11</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/samples/openapi3/client/petstore/spring-cloud-http-basic/pom.xml
+++ b/samples/openapi3/client/petstore/spring-cloud-http-basic/pom.xml
@@ -76,7 +76,7 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.10</version>
+            <version>0.2.11</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/pom.xml
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/pom.xml
@@ -76,7 +76,7 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.10</version>
+            <version>0.2.11</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/samples/openapi3/client/petstore/spring-cloud-spring-pageable/pom.xml
+++ b/samples/openapi3/client/petstore/spring-cloud-spring-pageable/pom.xml
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.10</version>
+            <version>0.2.11</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/samples/openapi3/client/petstore/spring-cloud/pom.xml
+++ b/samples/openapi3/client/petstore/spring-cloud/pom.xml
@@ -76,7 +76,7 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.10</version>
+            <version>0.2.11</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/samples/openapi3/client/petstore/spring-stubs-skip-default-interface/pom.xml
+++ b/samples/openapi3/client/petstore/spring-stubs-skip-default-interface/pom.xml
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.10</version>
+            <version>0.2.11</version>
         </dependency>
         <!-- Bean Validation API support -->
         <dependency>

--- a/samples/openapi3/client/petstore/spring-stubs/pom.xml
+++ b/samples/openapi3/client/petstore/spring-stubs/pom.xml
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.10</version>
+            <version>0.2.11</version>
         </dependency>
         <!-- Bean Validation API support -->
         <dependency>

--- a/samples/openapi3/server/petstore/spring-boot-oneof-interface/pom.xml
+++ b/samples/openapi3/server/petstore/spring-boot-oneof-interface/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.10</version>
+            <version>0.2.11</version>
         </dependency>
         <!-- Bean Validation API support -->
         <dependency>

--- a/samples/openapi3/server/petstore/spring-boot-oneof-sealed/pom.xml
+++ b/samples/openapi3/server/petstore/spring-boot-oneof-sealed/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.10</version>
+            <version>0.2.11</version>
         </dependency>
         <!-- Bean Validation API support -->
         <dependency>

--- a/samples/openapi3/server/petstore/spring-boot-oneof/pom.xml
+++ b/samples/openapi3/server/petstore/spring-boot-oneof/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.10</version>
+            <version>0.2.11</version>
         </dependency>
         <!-- Bean Validation API support -->
         <dependency>

--- a/samples/openapi3/server/petstore/spring-boot-springdoc/pom.xml
+++ b/samples/openapi3/server/petstore/spring-boot-springdoc/pom.xml
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.10</version>
+            <version>0.2.11</version>
         </dependency>
         <!-- Bean Validation API support -->
         <dependency>

--- a/samples/openapi3/server/petstore/springboot-3-include-http-request-context/pom.xml
+++ b/samples/openapi3/server/petstore/springboot-3-include-http-request-context/pom.xml
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.10</version>
+            <version>0.2.11</version>
         </dependency>
         <!-- Bean Validation API support -->
         <dependency>

--- a/samples/openapi3/server/petstore/springboot-3/pom.xml
+++ b/samples/openapi3/server/petstore/springboot-3/pom.xml
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.10</version>
+            <version>0.2.11</version>
         </dependency>
         <!-- Bean Validation API support -->
         <dependency>

--- a/samples/openapi3/server/petstore/springboot-delegate/pom.xml
+++ b/samples/openapi3/server/petstore/springboot-delegate/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.10</version>
+            <version>0.2.11</version>
         </dependency>
         <!-- Bean Validation API support -->
         <dependency>

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/pom.xml
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.10</version>
+            <version>0.2.11</version>
         </dependency>
         <!-- Bean Validation API support -->
         <dependency>

--- a/samples/openapi3/server/petstore/springboot-source/pom.xml
+++ b/samples/openapi3/server/petstore/springboot-source/pom.xml
@@ -60,7 +60,7 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.10</version>
+            <version>0.2.11</version>
         </dependency>
         <!-- Bean Validation API support -->
         <dependency>

--- a/samples/openapi3/server/petstore/springboot/pom.xml
+++ b/samples/openapi3/server/petstore/springboot/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.10</version>
+            <version>0.2.11</version>
         </dependency>
         <!-- Bean Validation API support -->
         <dependency>

--- a/samples/server/others/java-helidon-server/v3/mp-format-test/pom.xml
+++ b/samples/server/others/java-helidon-server/v3/mp-format-test/pom.xml
@@ -16,7 +16,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <version.jackson.databind.nullable>0.2.10</version.jackson.databind.nullable>
+        <version.jackson.databind.nullable>0.2.11</version.jackson.databind.nullable>
     </properties>
 
     <dependencies>

--- a/samples/server/others/java-helidon-server/v4/mp-format-test/pom.xml
+++ b/samples/server/others/java-helidon-server/v4/mp-format-test/pom.xml
@@ -16,7 +16,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <version.jackson.databind.nullable>0.2.10</version.jackson.databind.nullable>
+        <version.jackson.databind.nullable>0.2.11</version.jackson.databind.nullable>
     </properties>
 
     <dependencies>

--- a/samples/server/petstore/java-camel/pom.xml
+++ b/samples/server/petstore/java-camel/pom.xml
@@ -116,7 +116,7 @@ Do not edit the class manually.
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.10</version>
+            <version>0.2.11</version>
         </dependency>
         <dependency>
             <groupId>io.swagger.core.v3</groupId>

--- a/samples/server/petstore/java-helidon-server/v3/mp/pom.xml
+++ b/samples/server/petstore/java-helidon-server/v3/mp/pom.xml
@@ -16,7 +16,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <version.jackson.databind.nullable>0.2.10</version.jackson.databind.nullable>
+        <version.jackson.databind.nullable>0.2.11</version.jackson.databind.nullable>
     </properties>
 
     <dependencies>

--- a/samples/server/petstore/java-helidon-server/v3/se/pom.xml
+++ b/samples/server/petstore/java-helidon-server/v3/se/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <mainClass>org.openapitools.server.Main</mainClass>
-        <version.jackson.databind.nullable>0.2.10</version.jackson.databind.nullable>
+        <version.jackson.databind.nullable>0.2.11</version.jackson.databind.nullable>
     </properties>
 
     <dependencies>

--- a/samples/server/petstore/java-helidon-server/v4/mp/pom.xml
+++ b/samples/server/petstore/java-helidon-server/v4/mp/pom.xml
@@ -16,7 +16,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <version.jackson.databind.nullable>0.2.10</version.jackson.databind.nullable>
+        <version.jackson.databind.nullable>0.2.11</version.jackson.databind.nullable>
     </properties>
 
     <dependencies>

--- a/samples/server/petstore/java-helidon-server/v4/se-uac-group-by-file-path/pom.xml
+++ b/samples/server/petstore/java-helidon-server/v4/se-uac-group-by-file-path/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <mainClass>org.openapitools.server.Main</mainClass>
-        <version.jackson.databind.nullable>0.2.10</version.jackson.databind.nullable>
+        <version.jackson.databind.nullable>0.2.11</version.jackson.databind.nullable>
     </properties>
 
     <dependencies>

--- a/samples/server/petstore/java-helidon-server/v4/se-uac/pom.xml
+++ b/samples/server/petstore/java-helidon-server/v4/se-uac/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <mainClass>org.openapitools.server.Main</mainClass>
-        <version.jackson.databind.nullable>0.2.10</version.jackson.databind.nullable>
+        <version.jackson.databind.nullable>0.2.11</version.jackson.databind.nullable>
     </properties>
 
     <dependencies>

--- a/samples/server/petstore/java-helidon-server/v4/se/pom.xml
+++ b/samples/server/petstore/java-helidon-server/v4/se/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <mainClass>org.openapitools.server.Main</mainClass>
-        <version.jackson.databind.nullable>0.2.10</version.jackson.databind.nullable>
+        <version.jackson.databind.nullable>0.2.11</version.jackson.databind.nullable>
     </properties>
 
     <dependencies>

--- a/samples/server/petstore/jaxrs-spec-enum/pom.xml
+++ b/samples/server/petstore/jaxrs-spec-enum/pom.xml
@@ -144,6 +144,6 @@
     <javax.annotation-api-version>1.3.2</javax.annotation-api-version>
     <beanvalidation-version>2.0.2</beanvalidation-version>
     <jakarta.ws.rs-version>2.1.6</jakarta.ws.rs-version>
-    <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+    <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
   </properties>
 </project>

--- a/samples/server/petstore/jaxrs-spec-interface-response/pom.xml
+++ b/samples/server/petstore/jaxrs-spec-interface-response/pom.xml
@@ -105,6 +105,6 @@
     <javax.annotation-api-version>1.3.2</javax.annotation-api-version>
     <beanvalidation-version>2.0.2</beanvalidation-version>
     <jakarta.ws.rs-version>2.1.6</jakarta.ws.rs-version>
-    <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+    <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
   </properties>
 </project>

--- a/samples/server/petstore/jaxrs-spec-interface/pom.xml
+++ b/samples/server/petstore/jaxrs-spec-interface/pom.xml
@@ -105,6 +105,6 @@
     <javax.annotation-api-version>1.3.2</javax.annotation-api-version>
     <beanvalidation-version>2.0.2</beanvalidation-version>
     <jakarta.ws.rs-version>2.1.6</jakarta.ws.rs-version>
-    <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+    <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
   </properties>
 </project>

--- a/samples/server/petstore/jaxrs-spec-jakarta/pom.xml
+++ b/samples/server/petstore/jaxrs-spec-jakarta/pom.xml
@@ -144,6 +144,6 @@
     <javax.annotation-api-version>2.1.1</javax.annotation-api-version>
     <beanvalidation-version>3.0.2</beanvalidation-version>
     <jakarta.ws.rs-version>3.1.0</jakarta.ws.rs-version>
-    <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+    <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
   </properties>
 </project>

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/pom.xml
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/pom.xml
@@ -22,7 +22,7 @@
     <surefire-plugin.version>2.22.1</surefire-plugin.version>
     <javax.ws.rs-version>2.1.1</javax.ws.rs-version>
     <javax.annotation-api-version>1.3.2</javax.annotation-api-version>
-    <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+    <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/samples/server/petstore/jaxrs-spec-oneof-interface/pom.xml
+++ b/samples/server/petstore/jaxrs-spec-oneof-interface/pom.xml
@@ -144,6 +144,6 @@
     <javax.annotation-api-version>1.3.2</javax.annotation-api-version>
     <beanvalidation-version>2.0.2</beanvalidation-version>
     <jakarta.ws.rs-version>2.1.6</jakarta.ws.rs-version>
-    <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+    <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
   </properties>
 </project>

--- a/samples/server/petstore/jaxrs-spec-quarkus-mutiny/pom.xml
+++ b/samples/server/petstore/jaxrs-spec-quarkus-mutiny/pom.xml
@@ -23,7 +23,7 @@
     <javax.ws.rs-version>2.1.1</javax.ws.rs-version>
     <javax.annotation-api-version>1.3.2</javax.annotation-api-version>
     <smallrye.rest.client.version>1.2.1</smallrye.rest.client.version>
-    <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+    <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/samples/server/petstore/jaxrs-spec-required-and-readonly-property/pom.xml
+++ b/samples/server/petstore/jaxrs-spec-required-and-readonly-property/pom.xml
@@ -144,6 +144,6 @@
     <javax.annotation-api-version>1.3.2</javax.annotation-api-version>
     <beanvalidation-version>2.0.2</beanvalidation-version>
     <jakarta.ws.rs-version>2.1.6</jakarta.ws.rs-version>
-    <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+    <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
   </properties>
 </project>

--- a/samples/server/petstore/jaxrs-spec-sealed/pom.xml
+++ b/samples/server/petstore/jaxrs-spec-sealed/pom.xml
@@ -144,6 +144,6 @@
     <javax.annotation-api-version>1.3.2</javax.annotation-api-version>
     <beanvalidation-version>2.0.2</beanvalidation-version>
     <jakarta.ws.rs-version>2.1.6</jakarta.ws.rs-version>
-    <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+    <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
   </properties>
 </project>

--- a/samples/server/petstore/jaxrs-spec-swagger-annotations/pom.xml
+++ b/samples/server/petstore/jaxrs-spec-swagger-annotations/pom.xml
@@ -144,6 +144,6 @@
     <javax.annotation-api-version>1.3.2</javax.annotation-api-version>
     <beanvalidation-version>2.0.2</beanvalidation-version>
     <jakarta.ws.rs-version>2.1.6</jakarta.ws.rs-version>
-    <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+    <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
   </properties>
 </project>

--- a/samples/server/petstore/jaxrs-spec-swagger-v3-annotations-jakarta/pom.xml
+++ b/samples/server/petstore/jaxrs-spec-swagger-v3-annotations-jakarta/pom.xml
@@ -144,7 +144,7 @@
     <javax.annotation-api-version>2.1.1</javax.annotation-api-version>
     <beanvalidation-version>3.0.2</beanvalidation-version>
     <jakarta.ws.rs-version>3.1.0</jakarta.ws.rs-version>
-    <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+    <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
     <io.swagger.v3.annotations.version>2.2.21</io.swagger.v3.annotations.version>
   </properties>
 </project>

--- a/samples/server/petstore/jaxrs-spec-swagger-v3-annotations/pom.xml
+++ b/samples/server/petstore/jaxrs-spec-swagger-v3-annotations/pom.xml
@@ -144,7 +144,7 @@
     <javax.annotation-api-version>1.3.2</javax.annotation-api-version>
     <beanvalidation-version>2.0.2</beanvalidation-version>
     <jakarta.ws.rs-version>2.1.6</jakarta.ws.rs-version>
-    <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+    <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
     <io.swagger.v3.annotations.version>2.2.21</io.swagger.v3.annotations.version>
   </properties>
 </project>

--- a/samples/server/petstore/jaxrs-spec-withxml/pom.xml
+++ b/samples/server/petstore/jaxrs-spec-withxml/pom.xml
@@ -144,6 +144,6 @@
     <javax.annotation-api-version>1.3.2</javax.annotation-api-version>
     <beanvalidation-version>2.0.2</beanvalidation-version>
     <jakarta.ws.rs-version>2.1.6</jakarta.ws.rs-version>
-    <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+    <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
   </properties>
 </project>

--- a/samples/server/petstore/jaxrs-spec/pom.xml
+++ b/samples/server/petstore/jaxrs-spec/pom.xml
@@ -144,6 +144,6 @@
     <javax.annotation-api-version>1.3.2</javax.annotation-api-version>
     <beanvalidation-version>2.0.2</beanvalidation-version>
     <jakarta.ws.rs-version>2.1.6</jakarta.ws.rs-version>
-    <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+    <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
   </properties>
 </project>

--- a/samples/server/petstore/jaxrs-spec/quarkus-security/pom.xml
+++ b/samples/server/petstore/jaxrs-spec/quarkus-security/pom.xml
@@ -22,7 +22,7 @@
     <surefire-plugin.version>2.22.1</surefire-plugin.version>
     <jakarta.ws.rs-version>3.1.0</jakarta.ws.rs-version>
     <jakarta.annotation-api-version>2.1.1</jakarta.annotation-api-version>
-    <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+    <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/samples/server/petstore/kotlin-springboot-sort-validation/build.gradle.kts
+++ b/samples/server/petstore/kotlin-springboot-sort-validation/build.gradle.kts
@@ -39,7 +39,7 @@ dependencies {
     implementation("org.springframework.data:spring-data-commons")
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("jakarta.validation:jakarta.validation-api")
-    implementation("org.openapitools:jackson-databind-nullable:0.2.10")
+    implementation("org.openapitools:jackson-databind-nullable:0.2.11")
     implementation("jakarta.annotation:jakarta.annotation-api:2.1.0")
 
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")

--- a/samples/server/petstore/kotlin-springboot-sort-validation/pom.xml
+++ b/samples/server/petstore/kotlin-springboot-sort-validation/pom.xml
@@ -139,7 +139,7 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.10</version>
+            <version>0.2.11</version>
         </dependency>
         <dependency>
             <groupId>jakarta.annotation</groupId>

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/pom.xml
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/pom.xml
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.10</version>
+            <version>0.2.11</version>
         </dependency>
         <!-- Bean Validation API support -->
         <dependency>

--- a/samples/server/petstore/spring-boot-nullable-set/pom.xml
+++ b/samples/server/petstore/spring-boot-nullable-set/pom.xml
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.10</version>
+            <version>0.2.11</version>
         </dependency>
         <!-- Bean Validation API support -->
         <dependency>

--- a/samples/server/petstore/springboot-api-response-examples/pom.xml
+++ b/samples/server/petstore/springboot-api-response-examples/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.10</version>
+            <version>0.2.11</version>
         </dependency>
         <!-- Bean Validation API support -->
         <dependency>

--- a/samples/server/petstore/springboot-beanvalidation/pom.xml
+++ b/samples/server/petstore/springboot-beanvalidation/pom.xml
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.10</version>
+            <version>0.2.11</version>
         </dependency>
         <!-- Bean Validation API support -->
         <dependency>

--- a/samples/server/petstore/springboot-builtin-validation/pom.xml
+++ b/samples/server/petstore/springboot-builtin-validation/pom.xml
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.10</version>
+            <version>0.2.11</version>
         </dependency>
         <!-- Bean Validation API support -->
         <dependency>

--- a/samples/server/petstore/springboot-delegate-j8/pom.xml
+++ b/samples/server/petstore/springboot-delegate-j8/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.10</version>
+            <version>0.2.11</version>
         </dependency>
         <!-- Bean Validation API support -->
         <dependency>

--- a/samples/server/petstore/springboot-delegate-no-response-entity/pom.xml
+++ b/samples/server/petstore/springboot-delegate-no-response-entity/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.10</version>
+            <version>0.2.11</version>
         </dependency>
         <!-- Bean Validation API support -->
         <dependency>

--- a/samples/server/petstore/springboot-delegate/pom.xml
+++ b/samples/server/petstore/springboot-delegate/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.10</version>
+            <version>0.2.11</version>
         </dependency>
         <!-- Bean Validation API support -->
         <dependency>

--- a/samples/server/petstore/springboot-file-delegate-optional/pom.xml
+++ b/samples/server/petstore/springboot-file-delegate-optional/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.10</version>
+            <version>0.2.11</version>
         </dependency>
         <!-- Bean Validation API support -->
         <dependency>

--- a/samples/server/petstore/springboot-include-http-request-context/pom.xml
+++ b/samples/server/petstore/springboot-include-http-request-context/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.10</version>
+            <version>0.2.11</version>
         </dependency>
         <!-- Bean Validation API support -->
         <dependency>

--- a/samples/server/petstore/springboot-lombok-data/pom.xml
+++ b/samples/server/petstore/springboot-lombok-data/pom.xml
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.10</version>
+            <version>0.2.11</version>
         </dependency>
         <!-- Bean Validation API support -->
         <dependency>

--- a/samples/server/petstore/springboot-lombok-tostring/pom.xml
+++ b/samples/server/petstore/springboot-lombok-tostring/pom.xml
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.10</version>
+            <version>0.2.11</version>
         </dependency>
         <!-- Bean Validation API support -->
         <dependency>

--- a/samples/server/petstore/springboot-paged-model/pom.xml
+++ b/samples/server/petstore/springboot-paged-model/pom.xml
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.10</version>
+            <version>0.2.11</version>
         </dependency>
         <!-- Bean Validation API support -->
         <dependency>

--- a/samples/server/petstore/springboot-petstore-with-api-response-examples/pom.xml
+++ b/samples/server/petstore/springboot-petstore-with-api-response-examples/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.10</version>
+            <version>0.2.11</version>
         </dependency>
         <!-- Bean Validation API support -->
         <dependency>

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/pom.xml
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.10</version>
+            <version>0.2.11</version>
         </dependency>
         <!-- Bean Validation API support -->
         <dependency>

--- a/samples/server/petstore/springboot-reactive/pom.xml
+++ b/samples/server/petstore/springboot-reactive/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.10</version>
+            <version>0.2.11</version>
         </dependency>
         <!-- Bean Validation API support -->
         <dependency>

--- a/samples/server/petstore/springboot-sort-validation/pom.xml
+++ b/samples/server/petstore/springboot-sort-validation/pom.xml
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.10</version>
+            <version>0.2.11</version>
         </dependency>
         <!-- Bean Validation API support -->
         <dependency>

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/pom.xml
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.10</version>
+            <version>0.2.11</version>
         </dependency>
         <!-- Bean Validation API support -->
         <dependency>

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern/pom.xml
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.10</version>
+            <version>0.2.11</version>
         </dependency>
         <!-- Bean Validation API support -->
         <dependency>

--- a/samples/server/petstore/springboot-spring-pageable-without-j8/pom.xml
+++ b/samples/server/petstore/springboot-spring-pageable-without-j8/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.10</version>
+            <version>0.2.11</version>
         </dependency>
         <!-- Bean Validation API support -->
         <dependency>

--- a/samples/server/petstore/springboot-spring-pageable/pom.xml
+++ b/samples/server/petstore/springboot-spring-pageable/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.10</version>
+            <version>0.2.11</version>
         </dependency>
         <!-- Bean Validation API support -->
         <dependency>

--- a/samples/server/petstore/springboot-spring-provide-args/pom.xml
+++ b/samples/server/petstore/springboot-spring-provide-args/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.10</version>
+            <version>0.2.11</version>
         </dependency>
         <!-- Bean Validation API support -->
         <dependency>

--- a/samples/server/petstore/springboot-useoptional/pom.xml
+++ b/samples/server/petstore/springboot-useoptional/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.10</version>
+            <version>0.2.11</version>
         </dependency>
         <!-- Bean Validation API support -->
         <dependency>

--- a/samples/server/petstore/springboot-virtualan/pom.xml
+++ b/samples/server/petstore/springboot-virtualan/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.10</version>
+            <version>0.2.11</version>
         </dependency>
         <!-- Bean Validation API support -->
         <dependency>

--- a/samples/server/petstore/springboot-x-implements-skip/pom.xml
+++ b/samples/server/petstore/springboot-x-implements-skip/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.10</version>
+            <version>0.2.11</version>
         </dependency>
         <!-- Bean Validation API support -->
         <dependency>


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `org.openapitools:jackson-databind-nullable` to 0.2.11 across Java/Kotlin generator templates and samples to keep generated projects on the latest nullable support.

- **Dependencies**
  - Set `jackson-databind-nullable` to `0.2.11` in Gradle/Maven/SBT templates for Apache HttpClient, Feign, Google API Client, Jersey 2/3, OkHttp-Gson, Rest Assured, RestClient, Resteasy, RestTemplate, Retrofit2, Vert.x, WebClient, Java JAX-RS (incl. Quarkus), Java Spring (SB3/SB4), Helidon, Kotlin Spring, and related test templates.
  - Updated all affected sample projects to the same version.

<sup>Written for commit 6ed0d3891d3f0b396ab76a99a908b2d9d9a026e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24501?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

