### PR TITLE
fix(kotlin-restclient): only emit first consumes type as Content-Type

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-spring-restclient/api.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-spring-restclient/api.mustache
@@ -121,8 +121,8 @@ import {{packageName}}.infrastructure.*
         {{#headerParams}}
         {{{paramName}}}{{^required}}?{{/required}}.apply { localVariableHeaders["{{baseName}}"] = {{#isContainer}}this.joinToString(separator = collectionDelimiter("{{collectionFormat}}")){{/isContainer}}{{^isContainer}}this.toString(){{/isContainer}} }
         {{/headerParams}}
-        {{^hasFormParams}}{{#hasConsumes}}{{#consumes}}localVariableHeaders["Content-Type"] = "{{{mediaType}}}"
-        {{/consumes}}{{/hasConsumes}}{{/hasFormParams}}{{#hasProduces}}localVariableHeaders["Accept"] = "{{#produces}}{{{mediaType}}}{{^-last}}, {{/-last}}{{/produces}}"
+        {{^hasFormParams}}{{#hasConsumes}}{{#consumes.0}}localVariableHeaders["Content-Type"] = "{{{mediaType}}}"
+        {{/consumes.0}}{{/hasConsumes}}{{/hasFormParams}}{{#hasProduces}}localVariableHeaders["Accept"] = "{{#produces}}{{{mediaType}}}{{^-last}}, {{/-last}}{{/produces}}"
 {{/hasProduces}}
 
         val params = mutableMapOf<String, Any>(

--- a/samples/client/petstore/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -65,7 +65,6 @@ open class PetApi(client: RestClient) : ApiClient(client) {
         val localVariableQuery = mutableMapOf<kotlin.String, kotlin.collections.List<kotlin.String>>()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Content-Type"] = "application/json"
-        localVariableHeaders["Content-Type"] = "application/xml"
         localVariableHeaders["Accept"] = "application/xml, application/json"
 
         val params = mutableMapOf<String, Any>(
@@ -261,7 +260,6 @@ open class PetApi(client: RestClient) : ApiClient(client) {
         val localVariableQuery = mutableMapOf<kotlin.String, kotlin.collections.List<kotlin.String>>()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Content-Type"] = "application/json"
-        localVariableHeaders["Content-Type"] = "application/xml"
         localVariableHeaders["Accept"] = "application/xml, application/json"
 
         val params = mutableMapOf<String, Any>(


### PR DESCRIPTION
Fixes #24500.

For operations with no  formData  parameters but multiple declared  consumes  media types (e.g. an endpoint that accepts both a JSON body and a separate multipart/form-data variant), the  jvm-spring-restclient   api.mustache  template emitted one  localVariableHeaders["Content-Type"] = ...  assignment per  consumes  entry. Since every assignment targets the same map key, the last declared media type always won at runtime — regardless of which one actually matched the body being serialized.

This mirrors the sibling  hasFormParams  branch a few lines above in the same template, which already guards against this by using  consumes.0  instead of iterating over all  consumes  entries. This PR applies the same fix to the  hasFormParams=false  branch.

Verified with a minimal reproduction spec (attached to #24500) and by regenerating all  jvm-spring-restclient  Petstore samples: only  samples/client/petstore/kotlin-jvm-spring-3-restclient/.../PetApi.kt  changes, removing the previously-bogus second  Content-Type  assignment on  addPet / updatePet  (which declare  consumes: [application/json, application/xml] ) — confirming the same latent bug was already present in the committed sample and is fixed by this change.

Note: this fix makes content-type selection deterministic by always using the first  consumes  entry (matching the  native  Java library's convention), but is still order-dependent, unlike Java's  restclient / resttemplate / webclient  libraries which use a runtime  selectHeaderContentType  helper that prefers JSON regardless of position. See comment on #24500 for a possible follow-up.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set Content-Type to the first declared consumes media type in the Kotlin `jvm-spring-restclient` generator when no form params are present. This prevents duplicate header assignments where the last consumes value wins (fixes #24500).

- **Bug Fixes**
  - In `api.mustache`, use `consumes.0` for `Content-Type` when `hasFormParams=false` instead of iterating all `consumes`.
  - Aligns with the `hasFormParams` branch and makes selection deterministic.
  - Updated Petstore sample to remove the extra `Content-Type` assignment.

<sup>Written for commit 763dafb66bb13cadbadcac2fa17e02b2a512aa3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24502?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

