### PR TITLE
[kotlin-client] Emit enum descriptions

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/data_class.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/data_class.mustache
@@ -152,6 +152,11 @@ import {{packageName}}.infrastructure.ITransformForStorage
     {{#nonPublicApi}}internal {{/nonPublicApi}}{{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}enum class {{{nameInPascalCase}}}({{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}{{#jackson}}@get:JsonValue {{/jackson}}val value: {{^isContainer}}{{dataType}}{{/isContainer}}{{#isContainer}}{{#mostInnerItems}}{{dataType}}{{/mostInnerItems}}{{/isContainer}}) {
     {{#allowableValues}}
     {{#enumVars}}
+        {{#enumDescription}}
+        /**
+        * {{.}}
+        */
+        {{/enumDescription}}
         {{^multiplatform}}
         {{#moshi}}
         @Json(name = {{#lambda.doublequote}}{{{value}}}{{/lambda.doublequote}}) {{&name}}({{{value}}}){{^-last}},{{/-last}}{{#-last}};{{/-last}}

--- a/modules/openapi-generator/src/main/resources/kotlin-client/enum_class.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/enum_class.mustache
@@ -60,6 +60,11 @@ import kotlinx.serialization.encoding.Encoder
 {{/multiplatform}}
 {{#nonPublicApi}}internal {{/nonPublicApi}}{{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}enum class {{classname}}({{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}{{#jackson}}@get:JsonValue {{/jackson}}val value: {{{dataType}}}) {
 {{#allowableValues}}{{#enumVars}}
+    {{#enumDescription}}
+    /**
+     * {{.}}
+     */
+    {{/enumDescription}}
     {{^multiplatform}}
     {{#moshi}}
     @Json(name = {{#lambda.doublequote}}{{{value}}}{{/lambda.doublequote}})

--- a/modules/openapi-generator/src/test/resources/3_0/kotlin/petstore.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/kotlin/petstore.yaml
@@ -682,6 +682,10 @@ components:
             - placed
             - approved
             - delivered
+          x-enum-descriptions:
+            - An order is placed but not yet approved.
+            - An order is approved and delivery is in progress.
+            - An order is delivered and finalized.
         complete:
           type: boolean
           default: false

--- a/samples/client/petstore/kotlin-jvm-ktor-gson/src/main/kotlin/org/openapitools/client/models/Order.kt
+++ b/samples/client/petstore/kotlin-jvm-ktor-gson/src/main/kotlin/org/openapitools/client/models/Order.kt
@@ -67,8 +67,17 @@ data class Order (
      * Values: placed,approved,delivered,unknown_default_open_api
      */
     enum class Status(val value: kotlin.String) {
+        /**
+        * An order is placed but not yet approved.
+        */
         @SerializedName(value = "placed") placed("placed"),
+        /**
+        * An order is approved and delivery is in progress.
+        */
         @SerializedName(value = "approved") approved("approved"),
+        /**
+        * An order is delivered and finalized.
+        */
         @SerializedName(value = "delivered") delivered("delivered"),
         @SerializedName(value = "unknown_default_open_api") unknown_default_open_api("unknown_default_open_api");
     }

--- a/samples/client/petstore/kotlin-model-prefix-type-mappings/src/main/kotlin/org/openapitools/client/models/ApiOrder.kt
+++ b/samples/client/petstore/kotlin-model-prefix-type-mappings/src/main/kotlin/org/openapitools/client/models/ApiOrder.kt
@@ -76,8 +76,17 @@ data class ApiOrder (
      * Values: PLACED,APPROVED,DELIVERED
      */
     enum class Status(val value: kotlin.String) {
+        /**
+        * An order is placed but not yet approved.
+        */
         @SerializedName(value = "placed") PLACED("placed"),
+        /**
+        * An order is approved and delivery is in progress.
+        */
         @SerializedName(value = "approved") APPROVED("approved"),
+        /**
+        * An order is delivered and finalized.
+        */
         @SerializedName(value = "delivered") DELIVERED("delivered");
     }
 

--- a/samples/server/petstore/kotlin-spring-default/src/main/resources/openapi.yaml
+++ b/samples/server/petstore/kotlin-spring-default/src/main/resources/openapi.yaml
@@ -676,6 +676,10 @@ components:
           - approved
           - delivered
           type: string
+          x-enum-descriptions:
+          - An order is placed but not yet approved.
+          - An order is approved and delivery is in progress.
+          - An order is delivered and finalized.
         complete:
           default: false
           type: boolean


### PR DESCRIPTION
This adds a doc comment to all enum classes in `kotlin-client`, and modifies one of the sample specs to make use of the `enum-descriptions` extension.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@karismann (2019/03) @Zomzog (2019/04) @andrewemery (2019/10) @4brunu (2019/11) @yutaka0m (2020/03) @stefankoppier (2022/06) @e5l (2024/10)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Generate KDoc for enum values in `kotlin-client` using the `x-enum-descriptions` extension, improving readability of generated models. Updated petstore specs and samples to show the new docs.

- **New Features**
  - Emit per-value KDoc when `x-enum-descriptions` is provided.
  - Applied in `enum_class.mustache` and `data_class.mustache`.
  - Updated test/spec and samples so `Order.Status` values include their descriptions.

<sup>Written for commit b704abdadaa6971001b26667e8908ea1586eaaf1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24503?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

