### PR TITLE
refactor: replace direct access to allowableValues with utility methods for enum values

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -94,6 +94,7 @@ import java.util.stream.Stream;
 import static org.openapitools.codegen.CodegenConstants.*;
 import static org.openapitools.codegen.utils.CamelizeOption.LOWERCASE_FIRST_LETTER;
 import static org.openapitools.codegen.utils.DiscriminatorUtils.*;
+import static org.openapitools.codegen.utils.EnumUtils.getEnumValues;
 import static org.openapitools.codegen.utils.OnceLogger.once;
 import static org.openapitools.codegen.utils.StringUtils.*;
 
@@ -856,8 +857,7 @@ public class DefaultCodegen implements CodegenConfig {
 
             // for enum model
             if (cm.isEnum && cm.allowableValues != null) {
-                Map<String, Object> allowableValues = cm.allowableValues;
-                List<Object> values = (List<Object>) allowableValues.get(ENUM_VALUES);
+                List<Object> values = getEnumValues(cm.allowableValues);
                 List<Map<String, Object>> enumVars = buildEnumVars(values, cm.dataType);
                 postProcessEnumVars(enumVars);
                 // if "x-enum-varnames" or "x-enum-descriptions" defined, update varnames
@@ -6750,7 +6750,7 @@ public class DefaultCodegen implements CodegenConfig {
             return;
         }
 
-        List<Object> values = (List<Object>) allowableValues.get(ENUM_VALUES);
+        List<Object> values = getEnumValues(allowableValues);
         if (values == null) {
             return;
         }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCSharpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCSharpCodegen.java
@@ -48,6 +48,8 @@ import java.util.stream.Collectors;
 
 import static org.openapitools.codegen.CodegenConstants.*;
 import static org.openapitools.codegen.utils.CamelizeOption.LOWERCASE_FIRST_LETTER;
+import static org.openapitools.codegen.utils.EnumUtils.getEnumValues;
+import static org.openapitools.codegen.utils.EnumUtils.hasEnumValues;
 import static org.openapitools.codegen.utils.ModelUtils.getSchemaItems;
 import static org.openapitools.codegen.utils.StringUtils.camelize;
 import static org.openapitools.codegen.utils.StringUtils.underscore;
@@ -488,8 +490,8 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen {
             if (Boolean.TRUE.equals(this.zeroBasedEnums)) {
                 property.vendorExtensions.put(AbstractCSharpCodegen.zeroBasedEnumVendorExtension, true);
             } else if (!Boolean.FALSE.equals(this.zeroBasedEnums)) {
-                if (property.allowableValues.containsKey(ENUM_VALUES)) {
-                    final List<?> allowableValues = (List<?>) property.allowableValues.get(ENUM_VALUES);
+                if (hasEnumValues(property.allowableValues)) {
+                    final List<?> allowableValues = getEnumValues(property.allowableValues);
                     boolean isZeroBased = String.valueOf(allowableValues.get(0)).toLowerCase(Locale.ROOT).equals("unknown");
                     property.vendorExtensions.put(AbstractCSharpCodegen.zeroBasedEnumVendorExtension, isZeroBased);
                 }
@@ -587,8 +589,8 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen {
                 if (Boolean.TRUE.equals(this.zeroBasedEnums)) {
                     cm.vendorExtensions.put(AbstractCSharpCodegen.zeroBasedEnumVendorExtension, true);
                 } else if (!Boolean.FALSE.equals(this.zeroBasedEnums)) {
-                    if (cm.allowableValues.containsKey(ENUM_VALUES)) {
-                        final List<?> allowableValues = (List<?>) cm.allowableValues.get(ENUM_VALUES);
+                    if (hasEnumValues(cm.allowableValues)) {
+                        final List<?> allowableValues = getEnumValues(cm.allowableValues);
                         boolean isZeroBased = String.valueOf(allowableValues.get(0)).toLowerCase(Locale.ROOT).equals("unknown");
                         cm.vendorExtensions.put(AbstractCSharpCodegen.zeroBasedEnumVendorExtension, isZeroBased);
                     }
@@ -1912,7 +1914,7 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen {
         boolean hasAllowableValues = p.allowableValues != null && !p.allowableValues.isEmpty();
         if (hasAllowableValues) {
             //support examples for inline enums
-            final List<?> values = (List<?>) p.allowableValues.get(ENUM_VALUES);
+            final List<?> values = getEnumValues(p.allowableValues);
             example = String.valueOf(values.get(0));
         } else if (p.defaultValue == null) {
             example = p.example;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractFSharpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractFSharpCodegen.java
@@ -40,6 +40,7 @@ import java.util.*;
 import static org.openapitools.codegen.CodegenConstants.ENUM_VARS;
 import static org.openapitools.codegen.CodegenConstants.X_ENUM_BYTE;
 import static org.openapitools.codegen.utils.CamelizeOption.LOWERCASE_FIRST_LETTER;
+import static org.openapitools.codegen.utils.EnumUtils.getEnumVarsAsString;
 import static org.openapitools.codegen.utils.StringUtils.camelize;
 import static org.openapitools.codegen.utils.StringUtils.underscore;
 
@@ -397,7 +398,6 @@ public abstract class AbstractFSharpCodegen extends DefaultCodegen implements Co
      *
      * @param models processed models to be further processed for enum references
      */
-    @SuppressWarnings("unchecked")
     private void postProcessEnumRefs(final Map<String, ModelsMap> models) {
         Map<String, CodegenModel> enumRefs = new HashMap<>();
         for (String key : models.keySet()) {
@@ -450,7 +450,7 @@ public abstract class AbstractFSharpCodegen extends DefaultCodegen implements Co
 
                     // Since we iterate enumVars for modelInnerEnum and enumClass templates, and CodegenModel is missing some of CodegenProperty's properties,
                     // we can take advantage of Mustache's contextual lookup to add the same "properties" to the model's enumVars scope rather than CodegenProperty's scope.
-                    List<Map<String, String>> enumVars = (ArrayList<Map<String, String>>) model.allowableValues.get(ENUM_VARS);
+                    List<Map<String, String>> enumVars = getEnumVarsAsString(model.allowableValues);
                     List<Map<String, Object>> newEnumVars = new ArrayList<>();
                     for (Map<String, String> enumVar : enumVars) {
                         Map<String, Object> mixedVars = new HashMap<>(enumVar);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -77,6 +77,7 @@ import java.util.stream.StreamSupport;
 
 import static org.openapitools.codegen.CodegenConstants.*;
 import static org.openapitools.codegen.utils.CamelizeOption.*;
+import static org.openapitools.codegen.utils.EnumUtils.getEnumValues;
 import static org.openapitools.codegen.utils.ModelUtils.getSchemaItems;
 import static org.openapitools.codegen.utils.OnceLogger.once;
 import static org.openapitools.codegen.utils.StringUtils.*;
@@ -1787,7 +1788,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
         boolean hasAllowableValues = p.allowableValues != null && !p.allowableValues.isEmpty();
         if (hasAllowableValues) {
             //support examples for inline enums
-            final List<Object> values = (List<Object>) p.allowableValues.get(ENUM_VALUES);
+            final List<Object> values = getEnumValues(p.allowableValues);
             example = String.valueOf(values.get(0));
         } else if (p.defaultValue == null) {
             example = p.example;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
@@ -45,6 +45,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static org.openapitools.codegen.CodegenConstants.*;
+import static org.openapitools.codegen.utils.EnumUtils.getEnumVars;
 import static org.openapitools.codegen.utils.StringUtils.*;
 
 
@@ -1136,7 +1137,7 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
 
             // set enum type in extensions and update `name` in enumVars
             if (model.isEnum) {
-                for (Map<String, Object> enumVars : (List<Map<String, Object>>) model.getAllowableValues().get(ENUM_VARS)) {
+                for (Map<String, Object> enumVars : getEnumVars(model.getAllowableValues())) {
                     if ((Boolean) enumVars.get(ENUM_IS_STRING)) {
                         model.vendorExtensions.putIfAbsent(X_PY_ENUM_TYPE, "str");
                         // Do not overwrite the variable name if already set through x-enum-varnames

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppHttplibServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppHttplibServerCodegen.java
@@ -60,6 +60,8 @@ import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.responses.ApiResponse;
 
 import static org.openapitools.codegen.CodegenConstants.*;
+import static org.openapitools.codegen.utils.EnumUtils.getEnumValues;
+import static org.openapitools.codegen.utils.EnumUtils.hasEnumValues;
 
 /**
  * C++ HTTP Library Server Code Generator.
@@ -1306,9 +1308,8 @@ public class CppHttplibServerCodegen extends AbstractCppCodegen {
                         var.vendorExtensions.put("isOptionalEnum", true);
                     } else {
                         // Required enum: Use first value which is always UNSPECIFIED (added by setEnumVendorExtensions)
-                        if (var.allowableValues != null && var.allowableValues.containsKey(ENUM_VALUES)) {
-                            @SuppressWarnings("unchecked")
-                            List<Object> values = (List<Object>) var.allowableValues.get(ENUM_VALUES);
+                        if (hasEnumValues(var.allowableValues)) {
+                            List<Object> values = getEnumValues(var.allowableValues);
                             if (values != null && !values.isEmpty()) {
                                 // First value is always safe (UNSPECIFIED) after setEnumVendorExtensions
                                 String enumIdentifier = values.get(0).toString();

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CrystalClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CrystalClientCodegen.java
@@ -40,6 +40,8 @@ import java.time.ZoneId;
 import java.util.*;
 
 import static org.openapitools.codegen.CodegenConstants.*;
+import static org.openapitools.codegen.utils.EnumUtils.getEnumValues;
+import static org.openapitools.codegen.utils.EnumUtils.getEnumVarsAsString;
 import static org.openapitools.codegen.utils.StringUtils.camelize;
 import static org.openapitools.codegen.utils.StringUtils.underscore;
 
@@ -928,7 +930,7 @@ public class CrystalClientCodegen extends DefaultCodegen {
         } else if (codegenParameter.isPrimitiveType) { // primitive type
             if (codegenParameter.isEnum) {
                 // When inline enum, set example to first allowable value
-                List<Object> values = (List<Object>) codegenParameter.allowableValues.get(ENUM_VALUES);
+                List<Object> values = getEnumValues(codegenParameter.allowableValues);
                 codegenParameter.example = String.valueOf(values.get(0));
             }
             if (codegenParameter.isString || "String".equalsIgnoreCase(codegenParameter.baseType)) {
@@ -993,7 +995,7 @@ public class CrystalClientCodegen extends DefaultCodegen {
         } else if (codegenProperty.isPrimitiveType) { // primitive type
             if (codegenProperty.isEnum) {
                 // When inline enum, set example to first allowable value
-                List<Object> values = (List<Object>) codegenProperty.allowableValues.get(ENUM_VALUES);
+                List<Object> values = getEnumValues(codegenProperty.allowableValues);
                 codegenProperty.example = String.valueOf(values.get(0));
             }
             if (codegenProperty.isString || "String".equalsIgnoreCase(codegenProperty.baseType)) {
@@ -1062,7 +1064,7 @@ public class CrystalClientCodegen extends DefaultCodegen {
                 throw new RuntimeException("Invalid count when constructing example: " + count);
             }
         } else if (codegenModel.isEnum) {
-            List<Map<String, String>> enumVars = (List<Map<String, String>>) codegenModel.allowableValues.get(ENUM_VARS);
+            List<Map<String, String>> enumVars = getEnumVarsAsString(codegenModel.allowableValues);
             return moduleName + "::" + codegenModel.classname + "::" + enumVars.get(0).get(ENUM_NAME);
         } else if (codegenModel.oneOf != null && !codegenModel.oneOf.isEmpty()) {
             String subModel = (String) codegenModel.oneOf.toArray()[0];

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientCodegen.java
@@ -42,6 +42,8 @@ import java.util.*;
 
 import static org.openapitools.codegen.CodegenConstants.*;
 import static org.openapitools.codegen.utils.CamelizeOption.LOWERCASE_FIRST_LETTER;
+import static org.openapitools.codegen.utils.EnumUtils.getEnumValues;
+import static org.openapitools.codegen.utils.EnumUtils.getEnumVars;
 import static org.openapitools.codegen.utils.StringUtils.camelize;
 
 /**
@@ -800,8 +802,7 @@ public class GoClientCodegen extends AbstractGoCodegen {
                 throw new RuntimeException("Invalid count when constructing example: " + depthList.size());
             }
         } else if (codegenModel.isEnum) {
-            Map<String, Object> allowableValues = codegenModel.allowableValues;
-            List<Object> values = (List<Object>) allowableValues.get(ENUM_VALUES);
+            List<Object> values = getEnumValues(codegenModel.allowableValues);
             String example = String.valueOf(values.get(0));
             if (codegenModel.isString) {
                 example = "\"" + example + "\"";

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/HaskellHttpClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/HaskellHttpClientCodegen.java
@@ -45,6 +45,7 @@ import static org.openapitools.codegen.CodegenConstants.ENUM_NAME;
 import static org.openapitools.codegen.CodegenConstants.ENUM_VARS;
 import static org.openapitools.codegen.utils.CamelizeOption.LOWERCASE_FIRST_LETTER;
 import static org.openapitools.codegen.utils.CamelizeOption.UPPERCASE_FIRST_CHAR;
+import static org.openapitools.codegen.utils.EnumUtils.getEnumVarsAsString;
 import static org.openapitools.codegen.utils.StringUtils.camelize;
 import static org.openapitools.codegen.utils.StringUtils.underscore;
 
@@ -1412,7 +1413,7 @@ public class HaskellHttpClientCodegen extends DefaultCodegen implements CodegenC
         if (allowableValues == null) {
             return;
         }
-        for (Map<String, String> enumVar : (List<Map<String, String>>) allowableValues.get(ENUM_VARS)) {
+        for (Map<String, String> enumVar : getEnumVarsAsString(allowableValues)) {
             enumVar.put(ENUM_NAME, paramNameType + enumVar.get(ENUM_NAME));
         }
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaCXFExtServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaCXFExtServerCodegen.java
@@ -48,6 +48,8 @@ import java.text.SimpleDateFormat;
 import java.util.*;
 
 import static org.openapitools.codegen.CodegenConstants.*;
+import static org.openapitools.codegen.utils.EnumUtils.getEnumValues;
+import static org.openapitools.codegen.utils.EnumUtils.getEnumVars;
 
 /**
  * An Apache CXF-based JAX-RS server with extended capabilities.
@@ -658,14 +660,13 @@ public class JavaCXFExtServerCodegen extends JavaCXFServerCodegen implements CXF
 
     private boolean appendRandomEnum(StringBuilder buffer, CodegenOperation op, CodegenVariable var) {
         if (var != null && var.allowableValues != null) {
-            List<?> values = (List<?>) var.allowableValues.get(ENUM_VALUES);
+            List<?> values = getEnumValues(var.allowableValues);
             int i = (int) (values.size() * Math.random());
             Object randomEnum = values.get(i);
             boolean usingEnumLiteral = false;
             String definingClass = (String) var.varVendorExtensions.get("x-defining-class");
             if (definingClass != null) {
-                @SuppressWarnings("unchecked")
-                List<Map<String, Object>> enumVars = (List<Map<String, Object>>) var.allowableValues.get(ENUM_VARS);
+                List<Map<String, Object>> enumVars = getEnumVars(var.allowableValues);
                 if (enumVars != null) {
                     if (!loadTestDataFromFile) {
                         Map<String, Object> randomEnumVar = enumVars.get(i);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaMicronautAbstractCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaMicronautAbstractCodegen.java
@@ -25,8 +25,9 @@ import java.io.Writer;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import static org.openapitools.codegen.CodegenConstants.ENUM_VALUES;
 import static org.openapitools.codegen.CodegenConstants.INVOKER_PACKAGE;
+import static org.openapitools.codegen.utils.EnumUtils.getEnumValues;
+import static org.openapitools.codegen.utils.EnumUtils.hasEnumValues;
 
 /**
  * @deprecated WARNING! This generator is outdated. Please use the official generator for Micronaut:
@@ -483,8 +484,8 @@ public abstract class JavaMicronautAbstractCodegen extends AbstractJavaCodegen i
                 if (models.containsKey(op.returnType)) {
                     CodegenModel m = models.get(op.returnType);
                     List<Object> allowableValues = null;
-                    if (m.allowableValues != null && m.allowableValues.containsKey(ENUM_VALUES)) {
-                        allowableValues = (List<Object>) m.allowableValues.get(ENUM_VALUES);
+                    if (hasEnumValues(m.allowableValues)) {
+                        allowableValues = getEnumValues(m.allowableValues);
                     }
                     example = getExampleValue(m.defaultValue, null, m.classname, true,
                             allowableValues, null, null, m.requiredVars, false, false);
@@ -566,7 +567,7 @@ public abstract class JavaMicronautAbstractCodegen extends AbstractJavaCodegen i
     }
 
     protected String getParameterExampleValue(CodegenParameter p, boolean groovy) {
-        List<Object> allowableValues = p.allowableValues == null ? null : (List<Object>) p.allowableValues.get(ENUM_VALUES);
+        List<Object> allowableValues = p.allowableValues == null ? null : getEnumValues(p.allowableValues);
 
         return getExampleValue(p.defaultValue, p.example, p.dataType, p.isModel, allowableValues,
                 p.items == null ? null : p.items.dataType,
@@ -575,7 +576,7 @@ public abstract class JavaMicronautAbstractCodegen extends AbstractJavaCodegen i
     }
 
     protected String getPropertyExampleValue(CodegenProperty p, boolean groovy) {
-        List<Object> allowableValues = p.allowableValues == null ? null : (List<Object>) p.allowableValues.get(ENUM_VALUES);
+        List<Object> allowableValues = p.allowableValues == null ? null : getEnumValues(p.allowableValues);
 
         return getExampleValue(p.defaultValue, p.example, p.dataType, p.isModel, allowableValues,
                 p.items == null ? null : p.items.dataType,

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinServerCodegen.java
@@ -55,8 +55,9 @@ import org.openapitools.codegen.templating.mustache.LowercaseLambda;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.openapitools.codegen.CodegenConstants.ENUM_VALUES;
 import static org.openapitools.codegen.languages.KotlinServerCodegen.Constants.USE_TAGS;
+import static org.openapitools.codegen.utils.EnumUtils.getEnumValues;
+import static org.openapitools.codegen.utils.EnumUtils.hasEnumValues;
 
 /**
  * <p>Mustache templates are located in
@@ -480,9 +481,8 @@ public class KotlinServerCodegen extends AbstractKotlinCodegen implements BeanVa
                                         if (prop.getBaseName().equals(discriminatorPropBaseName) && prop.isEnum) {
                                             // If it's an enum with exactly one value, use that as the mapping name
                                             Map<String, Object> allowableValues = prop.getAllowableValues();
-                                            if (allowableValues != null && allowableValues.containsKey(ENUM_VALUES)) {
-                                                @SuppressWarnings("unchecked")
-                                                List<Object> values = (List<Object>) allowableValues.get(ENUM_VALUES);
+                                            if (hasEnumValues(allowableValues)) {
+                                                List<Object> values = getEnumValues(allowableValues);
                                                 if (values != null && values.size() == 1) {
                                                     mappedModel.setMappingName(String.valueOf(values.get(0)));
                                                 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/MysqlSchemaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/MysqlSchemaCodegen.java
@@ -32,6 +32,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static org.openapitools.codegen.CodegenConstants.ENUM_VALUES;
+import static org.openapitools.codegen.utils.EnumUtils.getEnumValues;
 import static org.openapitools.codegen.utils.StringUtils.underscore;
 
 /**
@@ -383,7 +384,7 @@ public class MysqlSchemaCodegen extends DefaultCodegen implements CodegenConfig 
 
         if (Boolean.TRUE.equals(isEnum)) {
             Map<String, Object> allowableValues = property.getAllowableValues();
-            List<Object> enumValues = (List<Object>) allowableValues.get(ENUM_VALUES);
+            List<Object> enumValues = getEnumValues(allowableValues);
             for (int i = 0; i < enumValues.size(); i++) {
                 if (i > ENUM_MAX_ELEMENTS - 1) {
                     LOGGER.warn(
@@ -473,8 +474,7 @@ public class MysqlSchemaCodegen extends DefaultCodegen implements CodegenConfig 
         columnDefinition.put("colName", colName);
 
         if (Boolean.TRUE.equals(isEnum)) {
-            Map<String, Object> allowableValues = property.getAllowableValues();
-            List<Object> enumValues = (List<Object>) allowableValues.get(ENUM_VALUES);
+            List<Object> enumValues = getEnumValues(property.getAllowableValues());
             for (int i = 0; i < enumValues.size(); i++) {
                 if (i > ENUM_MAX_ELEMENTS - 1) {
                     LOGGER.warn(
@@ -615,8 +615,7 @@ public class MysqlSchemaCodegen extends DefaultCodegen implements CodegenConfig 
         columnDefinition.put("colName", colName);
 
         if (Boolean.TRUE.equals(isEnum)) {
-            Map<String, Object> allowableValues = property.getAllowableValues();
-            List<Object> enumValues = (List<Object>) allowableValues.get(ENUM_VALUES);
+            List<Object> enumValues = getEnumValues(property.getAllowableValues());
             columnDefinition.put("colDataType", "ENUM");
             columnDefinition.put("colDataTypeArguments", columnDataTypeArguments);
             for (int i = 0; i < enumValues.size(); i++) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/NimClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/NimClientCodegen.java
@@ -40,6 +40,8 @@ import java.util.regex.Pattern;
 import static org.openapitools.codegen.CodegenConstants.ENUM_VALUE;
 import static org.openapitools.codegen.CodegenConstants.ENUM_VARS;
 import static org.openapitools.codegen.utils.CamelizeOption.LOWERCASE_FIRST_LETTER;
+import static org.openapitools.codegen.utils.EnumUtils.getEnumVars;
+import static org.openapitools.codegen.utils.EnumUtils.hasEnumVars;
 import static org.openapitools.codegen.utils.StringUtils.camelize;
 
 /**
@@ -253,12 +255,11 @@ public class NimClientCodegen extends DefaultCodegen implements CodegenConfig {
      * without quotes so they serialize correctly: %(0) instead of %("0")
      */
     private void stripQuotesFromIntegerEnumValues(Map<String, Object> allowableValues) {
-        if (allowableValues == null || !allowableValues.containsKey(ENUM_VARS)) {
+        if (!hasEnumVars(allowableValues)) {
             return;
         }
 
-        @SuppressWarnings("unchecked")
-        List<Map<String, Object>> enumVars = (List<Map<String, Object>>) allowableValues.get(ENUM_VARS);
+        List<Map<String, Object>> enumVars = getEnumVars(allowableValues);
         for (Map<String, Object> enumVar : enumVars) {
             Object value = enumVar.get(ENUM_VALUE);
             if (value instanceof String) {
@@ -278,7 +279,7 @@ public class NimClientCodegen extends DefaultCodegen implements CodegenConfig {
         for (ModelMap mo : objs.getModels()) {
             CodegenModel cm = mo.getModel();
 
-            if (cm.isEnum && cm.allowableValues != null && cm.allowableValues.containsKey(ENUM_VARS)) {
+            if (cm.isEnum && hasEnumVars(cm.allowableValues)) {
                 cm.vendorExtensions.put("x-is-top-level-enum", true);
 
                 // For integer enums, strip quotes from enum values

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PostgresqlSchemaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PostgresqlSchemaCodegen.java
@@ -34,6 +34,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static org.openapitools.codegen.CodegenConstants.ENUM_VALUES;
+import static org.openapitools.codegen.utils.EnumUtils.getEnumValues;
 import static org.openapitools.codegen.utils.StringUtils.underscore;
 
 /**
@@ -508,8 +509,7 @@ public class PostgresqlSchemaCodegen extends DefaultCodegen {
         }
 
         if (Boolean.TRUE.equals(isEnum)) {
-            Map<String, Object> allowableValues = property.getAllowableValues();
-            List<Object> enumValues = (List<Object>) allowableValues.get(ENUM_VALUES);
+            List<Object> enumValues = getEnumValues(property.getAllowableValues());
             String typeName = this.toTableName(model.getName())
                     + "_" + this.toColumnName(property.getName());
             postgresqlSchema.put("typeDefinition", typeDefinition);
@@ -632,8 +632,7 @@ public class PostgresqlSchemaCodegen extends DefaultCodegen {
         }
 
         if (Boolean.TRUE.equals(isEnum)) {
-            Map<String, Object> allowableValues = property.getAllowableValues();
-            List<Object> enumValues = (List<Object>) allowableValues.get(ENUM_VALUES);
+            List<Object> enumValues = getEnumValues(property.allowableValues);
             String typeName = this.toTableName(model.getName())
                     + "_" + this.toColumnName(property.getName());
             postgresqlSchema.put("typeDefinition", typeDefinition);
@@ -738,8 +737,7 @@ public class PostgresqlSchemaCodegen extends DefaultCodegen {
         }
 
         if (Boolean.TRUE.equals(isEnum)) {
-            Map<String, Object> allowableValues = property.getAllowableValues();
-            List<Object> enumValues = (List<Object>) allowableValues.get(ENUM_VALUES);
+            List<Object> enumValues = getEnumValues(property.allowableValues);
             String typeName = this.toTableName(model.getName())
                     + "_" + this.toColumnName(property.getName());
             postgresqlSchema.put("typeDefinition", typeDefinition);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PowerShellClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PowerShellClientCodegen.java
@@ -39,6 +39,7 @@ import java.util.*;
 
 import static java.util.UUID.randomUUID;
 import static org.openapitools.codegen.CodegenConstants.ENUM_VALUES;
+import static org.openapitools.codegen.utils.EnumUtils.getEnumValues;
 import static org.openapitools.codegen.utils.StringUtils.camelize;
 
 /**
@@ -1369,7 +1370,7 @@ public class PowerShellClientCodegen extends DefaultCodegen implements CodegenCo
 
         example.append("\"");
 
-        List<Object> enumValues = (List<Object>) allowableValues.get(ENUM_VALUES);
+        List<Object> enumValues = getEnumValues(allowableValues);
         example.append(enumValues.get(0));
 
         example.append("\"");

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ProtobufSchemaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ProtobufSchemaCodegen.java
@@ -48,6 +48,7 @@ import java.util.stream.Collectors;
 import com.google.common.base.CaseFormat;
 
 import static org.openapitools.codegen.CodegenConstants.*;
+import static org.openapitools.codegen.utils.EnumUtils.*;
 import static org.openapitools.codegen.utils.StringUtils.*;
 
 /**
@@ -566,8 +567,8 @@ public class ProtobufSchemaCodegen extends DefaultCodegen implements CodegenConf
      * @param prefix          added prefix
      */
     public void addEnumValuesPrefix(Map<String, Object> allowableValues, String prefix) {
-        if (allowableValues.containsKey(ENUM_VARS)) {
-            List<Map<String, Object>> enumVars = (List<Map<String, Object>>) allowableValues.get(ENUM_VARS);
+        if (hasEnumVars(allowableValues)) {
+            List<Map<String, Object>> enumVars = getEnumVars(allowableValues);
             prefix = CaseFormat.LOWER_CAMEL.to(CaseFormat.UPPER_UNDERSCORE, prefix);
             for (Map<String, Object> value : enumVars) {
                 String name = (String) value.get(ENUM_NAME);
@@ -576,8 +577,8 @@ public class ProtobufSchemaCodegen extends DefaultCodegen implements CodegenConf
             }
         }
 
-        if (allowableValues.containsKey(ENUM_VALUES)) {
-            List<Object> values = (List<Object>) allowableValues.get(ENUM_VALUES);
+        if (hasEnumValues(allowableValues)) {
+            List<Object> values = getEnumValues(allowableValues);
             for (Object value : values) {
                 value = useSimplifiedEnumNames ? value : prefix + "_" + value;
             }
@@ -594,8 +595,8 @@ public class ProtobufSchemaCodegen extends DefaultCodegen implements CodegenConf
         final String UNSPECIFIED = "UNSPECIFIED";
 
         if (startEnumsWithUnspecified) {
-            if (allowableValues.containsKey(ENUM_VARS)) {
-                List<Map<String, Object>> enumVars = (List<Map<String, Object>>) allowableValues.get(ENUM_VARS);
+            if (hasEnumVars(allowableValues)) {
+                List<Map<String, Object>> enumVars = getEnumVars(allowableValues);
                 boolean unspecifiedPresent = enumVars.stream()
                         .anyMatch(e -> {
                             return UNSPECIFIED.equals(e.get(ENUM_NAME));
@@ -609,8 +610,8 @@ public class ProtobufSchemaCodegen extends DefaultCodegen implements CodegenConf
                 }
             }
 
-            if (allowableValues.containsKey(ENUM_VALUES)) {
-                List<String> values = (List<String>) allowableValues.get(ENUM_VALUES);
+            if (hasEnumValues(allowableValues)) {
+                List<String> values = getEnumValuesAsString(allowableValues);
                 if (!values.contains(UNSPECIFIED)) {
                     List<String> modifiableValues = new ArrayList<>(values);
                     modifiableValues.add(0, UNSPECIFIED);
@@ -702,8 +703,8 @@ public class ProtobufSchemaCodegen extends DefaultCodegen implements CodegenConf
                 Map<String, Object> allowableValues = cm.getAllowableValues();
                 addUnspecifiedToAllowableValues(allowableValues);
                 addEnumValuesPrefix(allowableValues, cm.getClassname());
-                if (allowableValues.containsKey(ENUM_VARS)) {
-                    List<Map<String, Object>> enumVars = (List<Map<String, Object>>) allowableValues.get(ENUM_VARS);
+                if (hasEnumVars(allowableValues)) {
+                    List<Map<String, Object>> enumVars = getEnumVars(allowableValues);
                     addEnumIndexes(enumVars);
                 }
             }
@@ -758,8 +759,8 @@ public class ProtobufSchemaCodegen extends DefaultCodegen implements CodegenConf
                     addUnspecifiedToAllowableValues(enumProperty.allowableValues);
                     addEnumValuesPrefix(enumProperty.allowableValues, enumProperty.getEnumName());
 
-                    if (enumProperty.allowableValues.containsKey(ENUM_VARS)) {
-                        List<Map<String, Object>> enumVars = (List<Map<String, Object>>) enumProperty.allowableValues.get(ENUM_VARS);
+                    if (hasEnumVars(enumProperty.allowableValues)) {
+                        List<Map<String, Object>> enumVars = getEnumVars(enumProperty.allowableValues);
                         addEnumIndexes(enumVars);
                     }
                     

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RClientCodegen.java
@@ -42,6 +42,7 @@ import java.util.regex.Pattern;
 
 import static org.openapitools.codegen.CodegenConstants.ENUM_VALUES;
 import static org.openapitools.codegen.utils.CamelizeOption.LOWERCASE_FIRST_LETTER;
+import static org.openapitools.codegen.utils.EnumUtils.getEnumValues;
 import static org.openapitools.codegen.utils.StringUtils.camelize;
 import static org.openapitools.codegen.utils.StringUtils.underscore;
 
@@ -968,7 +969,7 @@ public class RClientCodegen extends DefaultCodegen implements CodegenConfig {
                     return "\"" + codegenProperty.example + "\"";
                 } else {
                     if (Boolean.TRUE.equals(codegenProperty.isEnum)) { // enum
-                        return "\"" + ((List<Object>) codegenProperty.allowableValues.get(ENUM_VALUES)).get(0) + "\"";
+                        return "\"" + (getEnumValues(codegenProperty.allowableValues)).get(0) + "\"";
                     } else {
                         return "\"" + codegenProperty.name + "_example\"";
                     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RubyClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RubyClientCodegen.java
@@ -38,6 +38,8 @@ import java.io.Writer;
 import java.util.*;
 
 import static org.openapitools.codegen.CodegenConstants.*;
+import static org.openapitools.codegen.utils.EnumUtils.getEnumValues;
+import static org.openapitools.codegen.utils.EnumUtils.getEnumVarsAsString;
 import static org.openapitools.codegen.utils.StringUtils.camelize;
 import static org.openapitools.codegen.utils.StringUtils.underscore;
 
@@ -645,7 +647,7 @@ public class RubyClientCodegen extends AbstractRubyCodegen {
         } else if (codegenParameter.isPrimitiveType) { // primitive type
             if (codegenParameter.isEnum) {
                 // When inline enum, set example to first allowable value
-                List<Object> values = (List<Object>) codegenParameter.allowableValues.get(ENUM_VALUES);
+                List<Object> values = getEnumValues(codegenParameter.allowableValues);
                 codegenParameter.example = String.valueOf(values.get(0));
             }
             if (codegenParameter.isString || "String".equalsIgnoreCase(codegenParameter.baseType)) {
@@ -715,7 +717,7 @@ public class RubyClientCodegen extends AbstractRubyCodegen {
         } else if (codegenProperty.isPrimitiveType) { // primitive type
             if (codegenProperty.isEnum) {
                 // When inline enum, set example to first allowable value
-                List<Object> values = (List<Object>) codegenProperty.allowableValues.get(ENUM_VALUES);
+                List<Object> values = getEnumValues(codegenProperty.allowableValues);
                 codegenProperty.example = String.valueOf(values.get(0));
             }
             if (codegenProperty.isString || "String".equalsIgnoreCase(codegenProperty.baseType)) {
@@ -782,7 +784,7 @@ public class RubyClientCodegen extends AbstractRubyCodegen {
                 throw new RuntimeException("Invalid count when constructing example: " + count);
             }
         } else if (codegenModel.isEnum) {
-            List<Map<String, String>> enumVars = (List<Map<String, String>>) codegenModel.allowableValues.get(ENUM_VARS);
+            List<Map<String, String>> enumVars = getEnumVarsAsString(codegenModel.allowableValues);
             return moduleName + "::" + codegenModel.classname + "::" + enumVars.get(0).get(ENUM_NAME);
         } else if (codegenModel.oneOf != null && !codegenModel.oneOf.isEmpty()) {
             String subModel = (String) codegenModel.oneOf.toArray()[0];

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
@@ -49,6 +49,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static org.openapitools.codegen.CodegenConstants.*;
+import static org.openapitools.codegen.utils.EnumUtils.*;
 import static org.openapitools.codegen.utils.StringUtils.camelize;
 import static org.openapitools.codegen.utils.StringUtils.underscore;
 
@@ -1651,9 +1652,7 @@ public class RustServerCodegen extends AbstractRustCodegen implements CodegenCon
                 additionalProperties.put("apiUsesIntegerEnums", true);
 
                 // Add numeric discriminant values for enum variants
-                @SuppressWarnings("unchecked")
-                List<Map<String, Object>> enumVars =
-                    (List<Map<String, Object>>) model.allowableValues.get(ENUM_VARS);
+                List<Map<String, Object>> enumVars = getEnumVars(model.allowableValues);
 
                 if (enumVars != null) {
                     for (Map<String, Object> enumVar : enumVars) {
@@ -1768,8 +1767,8 @@ public class RustServerCodegen extends AbstractRustCodegen implements CodegenCon
         } else {
             param.vendorExtensions.put("x-format-string", param.getIsEnumOrRef() ? "{}" : "{:?}");
             // Check if this is a model-type enum (allowableValues with values list)
-            if (param.allowableValues != null && param.allowableValues.containsKey(ENUM_VALUES)) {
-                List<?> values = (List<?>) param.allowableValues.get(ENUM_VALUES);
+            if (hasEnumValues(param.allowableValues)) {
+                List<?> values = getEnumValues(param.allowableValues);
                 if (!values.isEmpty()) {
                     // Use the first enum value as the example.
                     String firstEnumValue = values.get(0).toString();

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegenDeprecated.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegenDeprecated.java
@@ -50,6 +50,8 @@ import java.util.stream.Collectors;
 
 import static org.openapitools.codegen.CodegenConstants.ENUM_VALUES;
 import static org.openapitools.codegen.CodegenConstants.X_ONE_OF_NAME;
+import static org.openapitools.codegen.utils.EnumUtils.getEnumValues;
+import static org.openapitools.codegen.utils.EnumUtils.hasEnumValues;
 import static org.openapitools.codegen.utils.StringUtils.camelize;
 import static org.openapitools.codegen.utils.StringUtils.underscore;
 
@@ -1564,8 +1566,8 @@ public class RustServerCodegenDeprecated extends AbstractRustCodegen implements 
             else {
             param.vendorExtensions.put("x-format-string", "{:?}");
             // Check if this is a model-type enum (allowableValues with values list)
-            if (param.allowableValues != null && param.allowableValues.containsKey(ENUM_VALUES)) {
-                List<?> values = (List<?>) param.allowableValues.get(ENUM_VALUES);
+            if (hasEnumValues(param.allowableValues)) {
+                List<?> values = getEnumValues(param.allowableValues);
                 if (!values.isEmpty()) {
                     // Use the first enum value as the example.
                     String firstEnumValue = values.get(0).toString();

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaLagomServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaLagomServerCodegen.java
@@ -33,6 +33,7 @@ import java.util.*;
 
 import static org.openapitools.codegen.CodegenConstants.ENUM_VALUES;
 import static org.openapitools.codegen.utils.CamelizeOption.LOWERCASE_FIRST_LETTER;
+import static org.openapitools.codegen.utils.EnumUtils.getEnumValues;
 import static org.openapitools.codegen.utils.StringUtils.camelize;
 
 /**
@@ -190,7 +191,7 @@ public class ScalaLagomServerCodegen extends AbstractScalaCodegen implements Cod
 
             for (CodegenProperty var : cm.vars) {
                 if (var.isEnum) {
-                    List<Object> enumValues = (List<Object>) var.allowableValues.get(ENUM_VALUES);
+                    List<Object> enumValues = getEnumValues(var.allowableValues);
 
                     for (final ListIterator<Object> i = enumValues.listIterator(); i.hasNext(); ) {
                         final String element = String.valueOf(i.next());

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
@@ -45,6 +45,7 @@ import static java.util.Objects.nonNull;
 import static org.openapitools.codegen.CodegenConstants.ENUM_NAME;
 import static org.openapitools.codegen.CodegenConstants.ENUM_VARS;
 import static org.openapitools.codegen.utils.CamelizeOption.LOWERCASE_FIRST_LETTER;
+import static org.openapitools.codegen.utils.EnumUtils.getEnumVarsAsString;
 import static org.openapitools.codegen.utils.StringUtils.*;
 
 /**
@@ -591,8 +592,8 @@ public class TypeScriptFetchClientCodegen extends AbstractTypeScriptClientCodege
         } else if (var.dataType.equalsIgnoreCase("boolean")) {
             var.defaultValue = "false";
         } else {
-            if (var.allowableValues != null && var.allowableValues.get(ENUM_VARS) instanceof ArrayList && ((ArrayList) var.allowableValues.get(ENUM_VARS)).get(0) instanceof HashMap) {
-                var.defaultValue = var.dataTypeAlternate + "." + ((HashMap<String, String>) ((ArrayList) var.allowableValues.get(ENUM_VARS)).get(0)).get(ENUM_NAME);
+            if (var.allowableValues != null && var.allowableValues.get(ENUM_VARS) instanceof ArrayList && ((ArrayList<?>) var.allowableValues.get(ENUM_VARS)).get(0) instanceof HashMap) {
+                var.defaultValue = var.dataTypeAlternate + "." + getEnumVarsAsString(var.allowableValues).get(0).get(ENUM_NAME);
             }
         }
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/EnumUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/EnumUtils.java
@@ -2,17 +2,79 @@ package org.openapitools.codegen.utils;
 
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.media.Schema;
+import org.openapitools.codegen.CodegenConstants;
 
 import java.util.*;
 import java.util.stream.Collectors;
 
-import static org.openapitools.codegen.CodegenConstants.X_ENUM_DEPRECATED;
-import static org.openapitools.codegen.CodegenConstants.X_ENUM_DESCRIPTIONS;
+import static org.openapitools.codegen.CodegenConstants.*;
 
 public class EnumUtils {
 
     public static final String ONE_OF = "oneOf";
     public static final String ANY_OF = "anyOf";
+
+    /**
+     *
+     * @param allowableValues The allowableValues map
+     * @return whether the allowableValues map contains {@value CodegenConstants#ENUM_VARS}
+     */
+    public static boolean hasEnumVars(Map<String, Object> allowableValues) {
+        return allowableValues != null && allowableValues.containsKey(ENUM_VARS);
+    }
+
+    /**
+     *
+     * @param allowableValues The allowableValues map
+     * @return whether the allowableValues map contains {@value CodegenConstants#ENUM_VALUES}
+     */
+    public static boolean hasEnumValues(Map<String, Object> allowableValues) {
+        return allowableValues != null && allowableValues.containsKey(ENUM_VALUES);
+    }
+
+    /**
+     * Get the {@value CodegenConstants#ENUM_VARS} from the allowableValues map.
+     * @param allowableValues The allowableValues map
+     * @return the list of enumVars
+     */
+    public static List<Map<String, Object>> getEnumVars(Map<String, Object> allowableValues) {
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> enumVars = (List<Map<String, Object>>) allowableValues.get(ENUM_VARS);
+        return enumVars;
+    }
+
+    /**
+     * Get the {@value CodegenConstants#ENUM_VALUES} from the allowableValues map.
+     * @param allowableValues The allowableValues map
+     * @return the list of enumValues
+     */
+    public static List<Object> getEnumValues(Map<String, Object> allowableValues) {
+        @SuppressWarnings("unchecked")
+        List<Object> enumValues = (List<Object>) allowableValues.get(ENUM_VALUES);
+        return enumValues;
+    }
+
+    /**
+     * Get the {@value CodegenConstants#ENUM_VARS} from the allowableValues map.
+     * @param allowableValues The allowableValues map
+     * @return the list of enumVars
+     */
+    public static List<Map<String, String>> getEnumVarsAsString(Map<String, Object> allowableValues) {
+        @SuppressWarnings("unchecked")
+        List<Map<String, String>> enumVars = (List<Map<String, String>>) allowableValues.get(ENUM_VARS);
+        return enumVars;
+    }
+
+    /**
+     * Get the {@value CodegenConstants#ENUM_VALUES} from the allowableValues map.
+     * @param allowableValues The allowableValues map
+     * @return the list of enumValues
+     */
+    public static List<String> getEnumValuesAsString(Map<String, Object> allowableValues) {
+        @SuppressWarnings("unchecked")
+        List<String> enumValues = (List<String>) allowableValues.get(ENUM_VALUES);
+        return enumValues;
+    }
 
     /**
      * Simplifies a composed schema (oneOf/anyOf) where all sub-schemas are enums


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Centralizes how enums are fetched from a Codegen's `allowableValues`. This abstracts away the field names from the generators, and allows us to work towards harmonizing the enum handling for all generators by delegating the logic to a single shared component. This is part of work towards creating a `CodegenEnum` class that will store and illustrate the shared concepts.

Some checks have been extended from 
```java
if (property.allowableValues.containsKey(ENUM_VALUES)) {
```
to 
```java
if (property.allowableValues != null && property.allowableValues.containsKey(ENUM_VALUES)) {
```
, but I would argue that this is not a behavioral change since there should be no logic that depends on an explicit `NullpointerException`.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes enum handling by switching generators and core to `EnumUtils` helpers, improving null-safety and reducing unchecked casts. Behavior is unchanged and this prepares for a shared `CodegenEnum`.

- **Refactors**
  - Added `EnumUtils` helpers: `hasEnumValues`, `getEnumValues`, `hasEnumVars`, `getEnumVars`, `getEnumVarsAsString`, `getEnumValuesAsString`.
  - Replaced direct `allowableValues` access across core (`DefaultCodegen`) and generators (Java family incl. CXF Ext/Micronaut, C#/F#, Python, Go, Kotlin, TypeScript, Ruby, Crystal, Rust incl. deprecated, Nim, Haskell, Scala, PowerShell, C++, Protobuf, R, MySQL/PostgreSQL).
  - Standardized checks via `hasEnumValues`/`hasEnumVars`, added null guards, and reduced unchecked casts.

<sup>Written for commit 5e0e2e49d8b7b1ac7fbb75d2cf82ce35ce8173f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24504?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

