### PR TITLE
refactor(dart): align enum description field name with the DefaultCodegen

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractDartCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractDartCodegen.java
@@ -30,6 +30,8 @@ import java.util.stream.Stream;
 
 import static org.openapitools.codegen.CodegenConstants.*;
 import static org.openapitools.codegen.utils.CamelizeOption.LOWERCASE_FIRST_LETTER;
+import static org.openapitools.codegen.utils.EnumUtils.BUNGIE_X_ENUM_VALUES;
+import static org.openapitools.codegen.utils.EnumUtils.getBungieEnumValues;
 import static org.openapitools.codegen.utils.StringUtils.*;
 
 public abstract class AbstractDartCodegen extends DefaultCodegen {
@@ -852,21 +854,19 @@ public abstract class AbstractDartCodegen extends DefaultCodegen {
 
     @Override
     protected void updateEnumVarsWithExtensions(List<Map<String, Object>> enumVars, Map<String, Object> vendorExtensions, String dataType) {
-        if (vendorExtensions != null && useEnumExtension && vendorExtensions.containsKey("x-enum-values")) {
+        if (vendorExtensions != null && useEnumExtension && vendorExtensions.containsKey(BUNGIE_X_ENUM_VALUES)) {
             // Use the x-enum-values extension for this enum
             // Existing enumVars added by the default handling need to be removed first
             enumVars.clear();
 
-            Object extension = vendorExtensions.get("x-enum-values");
-            List<Map<String, Object>> values = (List<Map<String, Object>>) extension;
-            for (Map<String, Object> value : values) {
-                Map<String, Object> enumVar = new HashMap<>();
-                enumVar.put(ENUM_NAME, toEnumVarName((String) value.get("identifier"), dataType));
-                enumVar.put(ENUM_VALUE, toEnumValue(value.get("numericValue").toString(), dataType));
-                enumVar.put(ENUM_IS_STRING, isDataTypeString(dataType));
-                if (value.containsKey("description")) {
-                    enumVar.put("description", value.get("description").toString());
-                }
+            List<Map<String, String>> bungieEnumValues = getBungieEnumValues((List<Map<String, Object>>) vendorExtensions.get(BUNGIE_X_ENUM_VALUES));
+
+            boolean isString = isDataTypeString(dataType);
+            for (Map<String, String> value : bungieEnumValues) {
+                Map<String, Object> enumVar = new HashMap<>(value);
+                enumVar.put(ENUM_NAME, toEnumVarName(value.get(ENUM_NAME), dataType));
+                enumVar.put(ENUM_VALUE, toEnumValue(value.get(ENUM_VALUE), dataType));
+                enumVar.put(ENUM_IS_STRING, isString);
                 enumVars.add(enumVar);
             }
         } else {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/EnumUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/EnumUtils.java
@@ -11,6 +11,11 @@ import static org.openapitools.codegen.CodegenConstants.*;
 
 public class EnumUtils {
 
+    public static final String BUNGIE_X_ENUM_VALUES = "x-enum-values";
+    private static final String BUNGIE_ENUM_DESCRIPTION = "description";
+    private static final String BUNGIE_ENUM_IDENTIFIER = "identifier";
+    private static final String BUNGIE_ENUM_NUMERIC_VALUE = "numericValue";
+
     public static final String ONE_OF = "oneOf";
     public static final String ANY_OF = "anyOf";
 
@@ -74,6 +79,30 @@ public class EnumUtils {
         @SuppressWarnings("unchecked")
         List<String> enumValues = (List<String>) allowableValues.get(ENUM_VALUES);
         return enumValues;
+    }
+
+    /**
+     * Bungie has defined their own enum extension to describe enum values.
+     * See <a href="https://github.com/Bungie-net/api?tab=readme-ov-file">documentation</a> and the section with
+     * {@code x-enum-values} for more information.
+     *
+     * @param xEnumValues The {@code x-enum-values} Bungie extension map
+     * @return A list of {@code enumVars} extracted from the {@code x-enum-values} extension
+     */
+    public static List<Map<String, String>> getBungieEnumValues(List<Map<String, Object>> xEnumValues) {
+        List<Map<String, String>> enumVars = new ArrayList<>();
+        for (Map<String, Object> enumValue : xEnumValues) {
+            Map<String, String> enumVar = new HashMap<>();
+            enumVar.put(ENUM_NAME, (String) enumValue.get(BUNGIE_ENUM_IDENTIFIER));
+            if (enumValue.containsKey(BUNGIE_ENUM_NUMERIC_VALUE) && enumValue.get(BUNGIE_ENUM_NUMERIC_VALUE) != null) {
+                enumVar.put(ENUM_VALUE, enumValue.get(BUNGIE_ENUM_NUMERIC_VALUE).toString());
+            }
+            if (enumValue.containsKey(BUNGIE_ENUM_DESCRIPTION) && enumValue.get(BUNGIE_ENUM_DESCRIPTION) != null) {
+                enumVar.put(ENUM_DESCRIPTION, enumValue.get(BUNGIE_ENUM_DESCRIPTION).toString());
+            }
+            enumVars.add(enumVar);
+        }
+        return enumVars;
     }
 
     /**

--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/built_value/enum.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/built_value/enum.mustache
@@ -4,6 +4,9 @@ import 'package:built_value/serializer.dart';
 
 part '{{classFilename}}.g.dart';
 
+{{#description}}
+/// {{{description}}}
+{{/description}}
 {{#isDeprecated}}
 @Deprecated('{{{classname}}} has been deprecated')
 {{/isDeprecated}}
@@ -11,9 +14,9 @@ class {{classname}} extends EnumClass {
 
   {{#allowableValues}}
     {{#enumVars}}
-      {{#description}}
+      {{#enumDescription}}
   /// {{{.}}}
-      {{/description}}
+      {{/enumDescription}}
   @BuiltValueEnumConst({{#isInteger}}wireNumber: {{{value}}}{{/isInteger}}{{#isLong}}wireNumber: {{{value}}}{{/isLong}}{{^isInteger}}{{^isLong}}wireName: r{{{value}}}{{/isLong}}{{/isInteger}}{{#enumUnknownDefaultCase}}{{#-last}}, fallback: true{{/-last}}{{/enumUnknownDefaultCase}})
   static const {{classname}} {{name}} = _${{name}};
     {{/enumVars}}

--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/built_value/enum_inline.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/built_value/enum_inline.mustache
@@ -1,3 +1,6 @@
+{{#description}}
+/// {{{description}}}
+{{/description}}
 {{#isDeprecated}}
 @Deprecated('{{{enumName}}} has been deprecated')
 {{/isDeprecated}}
@@ -5,9 +8,9 @@ class {{{enumName}}} extends EnumClass {
 
   {{#allowableValues}}
     {{#enumVars}}
-      {{#description}}
+      {{#enumDescription}}
   /// {{{.}}}
-      {{/description}}
+      {{/enumDescription}}
   @BuiltValueEnumConst({{#isInteger}}wireNumber: {{{value}}}{{/isInteger}}{{#isLong}}wireNumber: {{{value}}}{{/isLong}}{{^isInteger}}{{^isLong}}wireName: r{{{value}}}{{/isLong}}{{/isInteger}}{{#enumUnknownDefaultCase}}{{#-last}}, fallback: true{{/-last}}{{/enumUnknownDefaultCase}})
   static const {{{enumName}}} {{name}} = _${{#lambda.camelcase}}{{{enumName}}}{{/lambda.camelcase}}_{{name}};
     {{/enumVars}}

--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/json_serializable/enum.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/json_serializable/enum.mustache
@@ -1,6 +1,8 @@
 import 'package:json_annotation/json_annotation.dart';
 
-{{#description}}/// {{{description}}}{{/description}}
+{{#description}}
+/// {{{description}}}
+{{/description}}
 {{#isDeprecated}}
 @Deprecated('{{{classname}}} has been deprecated')
 {{/isDeprecated}}
@@ -8,9 +10,9 @@ enum {{{classname}}} {
 {{#allowableValues}}
 {{#enumVars}}
   {{^isNull}}
-      {{#description}}
+      {{#enumDescription}}
           /// {{{.}}}
-      {{/description}}
+      {{/enumDescription}}
       @JsonValue({{#isString}}r{{/isString}}{{{value}}})
       {{{name}}}({{^isString}}'{{/isString}}{{#isString}}r{{/isString}}{{{value}}}{{^isString}}'{{/isString}}){{^-last}},{{/-last}}{{#-last}};{{/-last}}
   {{/isNull}}

--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/json_serializable/enum_inline.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/json_serializable/enum_inline.mustache
@@ -1,5 +1,7 @@
 {{#enumName}}
-{{#description}}/// {{{description}}}{{/description}}
+{{#description}}
+/// {{{description}}}
+{{/description}}
 {{#isDeprecated}}
 @Deprecated('{{{enumName}}} has been deprecated')
 {{/isDeprecated}}
@@ -7,9 +9,9 @@ enum {{{ enumName }}} {
 {{#allowableValues}}
 {{#enumVars}}
 {{^isNull}}
-{{#description}}
+{{#enumDescription}}
     /// {{{.}}}
-{{/description}}
+{{/enumDescription}}
 @JsonValue({{#isString}}r{{/isString}}{{{value}}})
 {{{name}}}({{^isString}}'{{/isString}}{{#isString}}r{{/isString}}{{{value}}}{{^isString}}'{{/isString}}){{^-last}},{{/-last}}{{#-last}};{{/-last}}
 {{/isNull}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/dart/DartModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/dart/DartModelTest.java
@@ -550,12 +550,12 @@ public class DartModelTest {
         Assert.assertEquals(enumVars.get(0).get("name"), "foo");
         Assert.assertEquals(enumVars.get(0).get("value"), "1");
         Assert.assertEquals(enumVars.get(0).get("isString"), false);
-        Assert.assertEquals(enumVars.get(0).get("description"), "the foo");
+        Assert.assertEquals(enumVars.get(0).get("enumDescription"), "the foo");
 
         Assert.assertEquals(enumVars.get(1).get("name"), "bar");
         Assert.assertEquals(enumVars.get(1).get("value"), "2");
         Assert.assertEquals(enumVars.get(1).get("isString"), false);
-        Assert.assertEquals(enumVars.get(1).get("description"), "the bar");
+        Assert.assertEquals(enumVars.get(1).get("enumDescription"), "the bar");
     }
 
     // datetime (or primitive type) not yet supported in HTTP request body

--- a/samples/openapi3/client/petstore/dart-dio/petstore-timemachine/lib/src/model/order.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore-timemachine/lib/src/model/order.dart
@@ -207,18 +207,15 @@ class _$OrderSerializer implements PrimitiveSerializer<Order> {
   }
 }
 
+/// Order Status
 class OrderStatusEnum extends EnumClass {
 
-  /// Order Status
   @BuiltValueEnumConst(wireName: r'placed')
   static const OrderStatusEnum placed = _$orderStatusEnum_placed;
-  /// Order Status
   @BuiltValueEnumConst(wireName: r'approved')
   static const OrderStatusEnum approved = _$orderStatusEnum_approved;
-  /// Order Status
   @BuiltValueEnumConst(wireName: r'delivered')
   static const OrderStatusEnum delivered = _$orderStatusEnum_delivered;
-  /// Order Status
   @BuiltValueEnumConst(wireName: r'unknown_default_open_api', fallback: true)
   static const OrderStatusEnum unknownDefaultOpenApi = _$orderStatusEnum_unknownDefaultOpenApi;
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore-timemachine/lib/src/model/pet.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore-timemachine/lib/src/model/pet.dart
@@ -202,18 +202,15 @@ class _$PetSerializer implements PrimitiveSerializer<Pet> {
   }
 }
 
+/// pet status in the store
 class PetStatusEnum extends EnumClass {
 
-  /// pet status in the store
   @BuiltValueEnumConst(wireName: r'available')
   static const PetStatusEnum available = _$petStatusEnum_available;
-  /// pet status in the store
   @BuiltValueEnumConst(wireName: r'pending')
   static const PetStatusEnum pending = _$petStatusEnum_pending;
-  /// pet status in the store
   @BuiltValueEnumConst(wireName: r'sold')
   static const PetStatusEnum sold = _$petStatusEnum_sold;
-  /// pet status in the store
   @BuiltValueEnumConst(wireName: r'unknown_default_open_api', fallback: true)
   static const PetStatusEnum unknownDefaultOpenApi = _$petStatusEnum_unknownDefaultOpenApi;
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/model/enum_arrays.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/model/enum_arrays.dart
@@ -74,7 +74,6 @@ class EnumArrays {
 
 }
 
-
 enum EnumArraysJustSymbolEnum {
 @JsonValue(r'>=')
 greaterThanEqual(r'>='),
@@ -90,7 +89,6 @@ final String value;
 @override
 String toString() => value;
 }
-
 
 
 enum EnumArraysArrayEnumEnum {

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/model/enum_test.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/model/enum_test.dart
@@ -180,7 +180,6 @@ class EnumTest {
 
 }
 
-
 enum EnumTestEnumStringEnum {
 @JsonValue(r'UPPER')
 UPPER(r'UPPER'),
@@ -198,7 +197,6 @@ final String value;
 @override
 String toString() => value;
 }
-
 
 
 enum EnumTestEnumStringRequiredEnum {
@@ -220,7 +218,6 @@ String toString() => value;
 }
 
 
-
 enum EnumTestEnumIntegerEnum {
 @JsonValue(1)
 number1('1'),
@@ -236,7 +233,6 @@ final String value;
 @override
 String toString() => value;
 }
-
 
 
 enum EnumTestEnumNumberEnum {

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/model/map_test.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/model/map_test.dart
@@ -105,7 +105,6 @@ class MapTest {
 
 }
 
-
 enum MapTestMapOfEnumStringEnum {
 @JsonValue(r'UPPER')
 UPPER(r'UPPER'),

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/model/model_enum_class.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/model/model_enum_class.dart
@@ -5,7 +5,6 @@
 // ignore_for_file: unused_element
 import 'package:json_annotation/json_annotation.dart';
 
-
 enum ModelEnumClass {
       @JsonValue(r'_abc')
       abc(r'_abc'),

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/model/object_with_duplicate_inline_enum.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/model/object_with_duplicate_inline_enum.dart
@@ -58,7 +58,6 @@ class ObjectWithDuplicateInlineEnum {
 
 }
 
-
 enum ObjectWithDuplicateInlineEnumAttributeEnum {
 @JsonValue(r'value_one')
 valueOne(r'value_one'),

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/model/object_with_inline_enum.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/model/object_with_inline_enum.dart
@@ -58,7 +58,6 @@ class ObjectWithInlineEnum {
 
 }
 
-
 enum ObjectWithInlineEnumAttributeEnum {
 @JsonValue(r'value_one')
 valueOne(r'value_one'),

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/model/object_with_inline_enum_default_value.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/model/object_with_inline_enum_default_value.dart
@@ -60,13 +60,10 @@ class ObjectWithInlineEnumDefaultValue {
 
 /// Object one attribute enum with default value
 enum ObjectWithInlineEnumDefaultValueAttributeEnum {
-    /// Object one attribute enum with default value
 @JsonValue(r'value_one')
 valueOne(r'value_one'),
-    /// Object one attribute enum with default value
 @JsonValue(r'value_two')
 valueTwo(r'value_two'),
-    /// Object one attribute enum with default value
 @JsonValue(r'unknown_default_open_api')
 unknownDefaultOpenApi(r'unknown_default_open_api');
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/model/order.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/model/order.dart
@@ -140,16 +140,12 @@ class Order {
 
 /// Order Status
 enum OrderStatusEnum {
-    /// Order Status
 @JsonValue(r'placed')
 placed(r'placed'),
-    /// Order Status
 @JsonValue(r'approved')
 approved(r'approved'),
-    /// Order Status
 @JsonValue(r'delivered')
 delivered(r'delivered'),
-    /// Order Status
 @JsonValue(r'unknown_default_open_api')
 unknownDefaultOpenApi(r'unknown_default_open_api');
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/model/outer_enum.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/model/outer_enum.dart
@@ -5,7 +5,6 @@
 // ignore_for_file: unused_element
 import 'package:json_annotation/json_annotation.dart';
 
-
 enum OuterEnum {
       @JsonValue(r'placed')
       placed(r'placed'),

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/model/outer_enum_default_value.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/model/outer_enum_default_value.dart
@@ -5,7 +5,6 @@
 // ignore_for_file: unused_element
 import 'package:json_annotation/json_annotation.dart';
 
-
 enum OuterEnumDefaultValue {
       @JsonValue(r'placed')
       placed(r'placed'),

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/model/outer_enum_integer.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/model/outer_enum_integer.dart
@@ -5,7 +5,6 @@
 // ignore_for_file: unused_element
 import 'package:json_annotation/json_annotation.dart';
 
-
 enum OuterEnumInteger {
       @JsonValue(0)
       number0('0'),

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/model/outer_enum_integer_default_value.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/model/outer_enum_integer_default_value.dart
@@ -5,7 +5,6 @@
 // ignore_for_file: unused_element
 import 'package:json_annotation/json_annotation.dart';
 
-
 enum OuterEnumIntegerDefaultValue {
       @JsonValue(0)
       number0('0'),

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/model/pet.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/model/pet.dart
@@ -142,16 +142,12 @@ class Pet {
 
 /// pet status in the store
 enum PetStatusEnum {
-    /// pet status in the store
 @JsonValue(r'available')
 available(r'available'),
-    /// pet status in the store
 @JsonValue(r'pending')
 pending(r'pending'),
-    /// pet status in the store
 @JsonValue(r'sold')
 sold(r'sold'),
-    /// pet status in the store
 @JsonValue(r'unknown_default_open_api')
 unknownDefaultOpenApi(r'unknown_default_open_api');
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/model/single_ref_type.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/model/single_ref_type.dart
@@ -5,7 +5,6 @@
 // ignore_for_file: unused_element
 import 'package:json_annotation/json_annotation.dart';
 
-
 enum SingleRefType {
       @JsonValue(r'admin')
       admin(r'admin'),

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/model/test_enum.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/model/test_enum.dart
@@ -5,7 +5,6 @@
 // ignore_for_file: unused_element
 import 'package:json_annotation/json_annotation.dart';
 
-
 enum TestEnum {
       @JsonValue(r'')
       empty(r''),

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/object_with_inline_enum_default_value.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/object_with_inline_enum_default_value.dart
@@ -111,15 +111,13 @@ class _$ObjectWithInlineEnumDefaultValueSerializer implements PrimitiveSerialize
   }
 }
 
+/// Object one attribute enum with default value
 class ObjectWithInlineEnumDefaultValueAttributeEnum extends EnumClass {
 
-  /// Object one attribute enum with default value
   @BuiltValueEnumConst(wireName: r'value_one')
   static const ObjectWithInlineEnumDefaultValueAttributeEnum valueOne = _$objectWithInlineEnumDefaultValueAttributeEnum_valueOne;
-  /// Object one attribute enum with default value
   @BuiltValueEnumConst(wireName: r'value_two')
   static const ObjectWithInlineEnumDefaultValueAttributeEnum valueTwo = _$objectWithInlineEnumDefaultValueAttributeEnum_valueTwo;
-  /// Object one attribute enum with default value
   @BuiltValueEnumConst(wireName: r'unknown_default_open_api', fallback: true)
   static const ObjectWithInlineEnumDefaultValueAttributeEnum unknownDefaultOpenApi = _$objectWithInlineEnumDefaultValueAttributeEnum_unknownDefaultOpenApi;
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/order.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/order.dart
@@ -206,18 +206,15 @@ class _$OrderSerializer implements PrimitiveSerializer<Order> {
   }
 }
 
+/// Order Status
 class OrderStatusEnum extends EnumClass {
 
-  /// Order Status
   @BuiltValueEnumConst(wireName: r'placed')
   static const OrderStatusEnum placed = _$orderStatusEnum_placed;
-  /// Order Status
   @BuiltValueEnumConst(wireName: r'approved')
   static const OrderStatusEnum approved = _$orderStatusEnum_approved;
-  /// Order Status
   @BuiltValueEnumConst(wireName: r'delivered')
   static const OrderStatusEnum delivered = _$orderStatusEnum_delivered;
-  /// Order Status
   @BuiltValueEnumConst(wireName: r'unknown_default_open_api', fallback: true)
   static const OrderStatusEnum unknownDefaultOpenApi = _$orderStatusEnum_unknownDefaultOpenApi;
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/pet.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/pet.dart
@@ -201,18 +201,15 @@ class _$PetSerializer implements PrimitiveSerializer<Pet> {
   }
 }
 
+/// pet status in the store
 class PetStatusEnum extends EnumClass {
 
-  /// pet status in the store
   @BuiltValueEnumConst(wireName: r'available')
   static const PetStatusEnum available = _$petStatusEnum_available;
-  /// pet status in the store
   @BuiltValueEnumConst(wireName: r'pending')
   static const PetStatusEnum pending = _$petStatusEnum_pending;
-  /// pet status in the store
   @BuiltValueEnumConst(wireName: r'sold')
   static const PetStatusEnum sold = _$petStatusEnum_sold;
-  /// pet status in the store
   @BuiltValueEnumConst(wireName: r'unknown_default_open_api', fallback: true)
   static const PetStatusEnum unknownDefaultOpenApi = _$petStatusEnum_unknownDefaultOpenApi;
 


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

This changes how enum descriptions are handled in Dart, and aligns the behavior with the `DefaultCodegen`. 

The **behavioral change** is that we look for `enumDescription` rather than `description` in `allowableValues` -> `enumVars`. This can unexpectedly affect a consumer that redefines the template, since now the codegen will expose `enumDescription` rather than `description`. The **fallback** is the update the local template to also use `enumDescription`.

The change from description to enumDescription also ensures that the enum's own description is not leaked to each enum item. This occurs now when the enum items do not have a description themselves, which in turn makes the mustache parses look further up the tree for a value (and thus find the CodegenModel's `description`). An enum like the one below is an example that would leak the description.
```yaml
components:
  schemas:
    Order:
      status:
        type: string
        description: Order Status
        enum:
          - placed
          - approved
          - delivered
```
I have instead aligned all Dart enum classes so that they place the schema description once on the class itself instead. This behavior already exists on some enums.

The interpretation of the vendor extension `x-enum-values` have also been extracted to the EnumUtils since it is a format that comes from Bungie, and it might be of interest to use in other `Codegens` too. See for example https://github.com/OpenAPITools/openapi-generator/pull/1486.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

Dart commitee:
@jaumard (2018/09) @amondnet (2019/12) @sbu-WBT (2020/12) @kuhnroyal (2020/12) @agilob (2020/12) @ahmednfwela (2021/08)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns Dart enum descriptions with `DefaultCodegen`: enum items now expose `enumDescription`, and the schema `description` is emitted once on the enum type. Standardizes Bungie `x-enum-values` handling and updates templates, tests, and samples.

- **Refactors**
  - Update built_value and json_serializable templates (inline and non-inline) to read `enumDescription` for item docs and render the enum’s `description` once at the type.
  - Centralize `x-enum-values` parsing in `EnumUtils` (`BUNGIE_X_ENUM_VALUES`, `getBungieEnumValues`) and use it in `AbstractDartCodegen`; tests and samples updated to expect `enumDescription`.

- **Migration**
  - If you customized Dart enum templates, replace enum item `description` with `enumDescription`.

<sup>Written for commit 38796f6a3f6aeaf4f4f085c8a59a745f0aa52e77. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24506?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

