### PR TITLE
chore(java): update samples

### DIFF
--- a/samples/client/echo_api/java/restclient/src/main/java/org/openapitools/client/ExceptionProvider.java
+++ b/samples/client/echo_api/java/restclient/src/main/java/org/openapitools/client/ExceptionProvider.java
@@ -31,7 +31,7 @@ import java.text.ParseException;
  * });
  * }</pre>
  */
-@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.23.0-SNAPSHOT")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.25.0-SNAPSHOT")
 public interface ExceptionProvider {
 
     /** Returns an exception indicating that no Bearer authentication is configured. */

--- a/samples/client/others/java/restclient-enum-in-multipart/src/main/java/org/openapitools/client/ExceptionProvider.java
+++ b/samples/client/others/java/restclient-enum-in-multipart/src/main/java/org/openapitools/client/ExceptionProvider.java
@@ -31,7 +31,7 @@ import java.text.ParseException;
  * });
  * }</pre>
  */
-@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.23.0-SNAPSHOT")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.25.0-SNAPSHOT")
 public interface ExceptionProvider {
 
     /** Returns an exception indicating that no Bearer authentication is configured. */

--- a/samples/client/others/java/restclient-sealedInterface/src/main/java/org/openapitools/client/ExceptionProvider.java
+++ b/samples/client/others/java/restclient-sealedInterface/src/main/java/org/openapitools/client/ExceptionProvider.java
@@ -31,7 +31,7 @@ import java.text.ParseException;
  * });
  * }</pre>
  */
-@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.23.0-SNAPSHOT")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.25.0-SNAPSHOT")
 public interface ExceptionProvider {
 
     /** Returns an exception indicating that no Bearer authentication is configured. */

--- a/samples/client/others/java/restclient-useAbstractionForFiles/src/main/java/org/openapitools/client/ExceptionProvider.java
+++ b/samples/client/others/java/restclient-useAbstractionForFiles/src/main/java/org/openapitools/client/ExceptionProvider.java
@@ -31,7 +31,7 @@ import java.text.ParseException;
  * });
  * }</pre>
  */
-@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.23.0-SNAPSHOT")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.25.0-SNAPSHOT")
 public interface ExceptionProvider {
 
     /** Returns an exception indicating that no Bearer authentication is configured. */

--- a/samples/client/others/java/webclient-sealedInterface/src/main/java/org/openapitools/client/ExceptionProvider.java
+++ b/samples/client/others/java/webclient-sealedInterface/src/main/java/org/openapitools/client/ExceptionProvider.java
@@ -31,7 +31,7 @@ import java.text.ParseException;
  * });
  * }</pre>
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.23.0-SNAPSHOT")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.25.0-SNAPSHOT")
 public interface ExceptionProvider {
 
     /** Returns an exception indicating that no Bearer authentication is configured. */

--- a/samples/client/others/java/webclient-sealedInterface_3_1/src/main/java/org/openapitools/client/ExceptionProvider.java
+++ b/samples/client/others/java/webclient-sealedInterface_3_1/src/main/java/org/openapitools/client/ExceptionProvider.java
@@ -31,7 +31,7 @@ import java.text.ParseException;
  * });
  * }</pre>
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.23.0-SNAPSHOT")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.25.0-SNAPSHOT")
 public interface ExceptionProvider {
 
     /** Returns an exception indicating that no Bearer authentication is configured. */

--- a/samples/client/others/java/webclient-useAbstractionForFiles/src/main/java/org/openapitools/client/ExceptionProvider.java
+++ b/samples/client/others/java/webclient-useAbstractionForFiles/src/main/java/org/openapitools/client/ExceptionProvider.java
@@ -31,7 +31,7 @@ import java.text.ParseException;
  * });
  * }</pre>
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.23.0-SNAPSHOT")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.25.0-SNAPSHOT")
 public interface ExceptionProvider {
 
     /** Returns an exception indicating that no Bearer authentication is configured. */

--- a/samples/client/petstore/java/restclient-nullable-arrays/src/main/java/org/openapitools/client/ExceptionProvider.java
+++ b/samples/client/petstore/java/restclient-nullable-arrays/src/main/java/org/openapitools/client/ExceptionProvider.java
@@ -31,7 +31,7 @@ import java.text.ParseException;
  * });
  * }</pre>
  */
-@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.23.0-SNAPSHOT")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.25.0-SNAPSHOT")
 public interface ExceptionProvider {
 
     /** Returns an exception indicating that no Bearer authentication is configured. */

--- a/samples/client/petstore/java/restclient-springBoot4-jackson2/src/main/java/org/openapitools/client/ExceptionProvider.java
+++ b/samples/client/petstore/java/restclient-springBoot4-jackson2/src/main/java/org/openapitools/client/ExceptionProvider.java
@@ -31,7 +31,7 @@ import java.text.ParseException;
  * });
  * }</pre>
  */
-@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.23.0-SNAPSHOT")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.25.0-SNAPSHOT")
 public interface ExceptionProvider {
 
     /** Returns an exception indicating that no Bearer authentication is configured. */

--- a/samples/client/petstore/java/restclient-springBoot4-jackson3-jspecify/src/main/java/org/openapitools/client/ExceptionProvider.java
+++ b/samples/client/petstore/java/restclient-springBoot4-jackson3-jspecify/src/main/java/org/openapitools/client/ExceptionProvider.java
@@ -31,7 +31,7 @@ import java.text.ParseException;
  * });
  * }</pre>
  */
-@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.23.0-SNAPSHOT")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.25.0-SNAPSHOT")
 public interface ExceptionProvider {
 
     /** Returns an exception indicating that no Bearer authentication is configured. */

--- a/samples/client/petstore/java/restclient-springBoot4-jackson3/src/main/java/org/openapitools/client/ExceptionProvider.java
+++ b/samples/client/petstore/java/restclient-springBoot4-jackson3/src/main/java/org/openapitools/client/ExceptionProvider.java
@@ -31,7 +31,7 @@ import java.text.ParseException;
  * });
  * }</pre>
  */
-@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.23.0-SNAPSHOT")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.25.0-SNAPSHOT")
 public interface ExceptionProvider {
 
     /** Returns an exception indicating that no Bearer authentication is configured. */

--- a/samples/client/petstore/java/restclient-swagger2/src/main/java/org/openapitools/client/ExceptionProvider.java
+++ b/samples/client/petstore/java/restclient-swagger2/src/main/java/org/openapitools/client/ExceptionProvider.java
@@ -31,7 +31,7 @@ import java.text.ParseException;
  * });
  * }</pre>
  */
-@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.23.0-SNAPSHOT")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.25.0-SNAPSHOT")
 public interface ExceptionProvider {
 
     /** Returns an exception indicating that no Bearer authentication is configured. */

--- a/samples/client/petstore/java/restclient-useSingleRequestParameter-static/src/main/java/org/openapitools/client/ExceptionProvider.java
+++ b/samples/client/petstore/java/restclient-useSingleRequestParameter-static/src/main/java/org/openapitools/client/ExceptionProvider.java
@@ -31,7 +31,7 @@ import java.text.ParseException;
  * });
  * }</pre>
  */
-@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.23.0-SNAPSHOT")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.25.0-SNAPSHOT")
 public interface ExceptionProvider {
 
     /** Returns an exception indicating that no Bearer authentication is configured. */

--- a/samples/client/petstore/java/restclient-useSingleRequestParameter/src/main/java/org/openapitools/client/ExceptionProvider.java
+++ b/samples/client/petstore/java/restclient-useSingleRequestParameter/src/main/java/org/openapitools/client/ExceptionProvider.java
@@ -31,7 +31,7 @@ import java.text.ParseException;
  * });
  * }</pre>
  */
-@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.23.0-SNAPSHOT")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.25.0-SNAPSHOT")
 public interface ExceptionProvider {
 
     /** Returns an exception indicating that no Bearer authentication is configured. */

--- a/samples/client/petstore/java/restclient/src/main/java/org/openapitools/client/ExceptionProvider.java
+++ b/samples/client/petstore/java/restclient/src/main/java/org/openapitools/client/ExceptionProvider.java
@@ -31,7 +31,7 @@ import java.text.ParseException;
  * });
  * }</pre>
  */
-@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.23.0-SNAPSHOT")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.25.0-SNAPSHOT")
 public interface ExceptionProvider {
 
     /** Returns an exception indicating that no Bearer authentication is configured. */

--- a/samples/client/petstore/java/webclient-jakarta/src/main/java/org/openapitools/client/ExceptionProvider.java
+++ b/samples/client/petstore/java/webclient-jakarta/src/main/java/org/openapitools/client/ExceptionProvider.java
@@ -31,7 +31,7 @@ import java.text.ParseException;
  * });
  * }</pre>
  */
-@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.23.0-SNAPSHOT")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.25.0-SNAPSHOT")
 public interface ExceptionProvider {
 
     /** Returns an exception indicating that no Bearer authentication is configured. */

--- a/samples/client/petstore/java/webclient-nullable-arrays/src/main/java/org/openapitools/client/ExceptionProvider.java
+++ b/samples/client/petstore/java/webclient-nullable-arrays/src/main/java/org/openapitools/client/ExceptionProvider.java
@@ -31,7 +31,7 @@ import java.text.ParseException;
  * });
  * }</pre>
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.23.0-SNAPSHOT")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.25.0-SNAPSHOT")
 public interface ExceptionProvider {
 
     /** Returns an exception indicating that no Bearer authentication is configured. */

--- a/samples/client/petstore/java/webclient-springBoot4-jackson3-jspecify/src/main/java/org/openapitools/client/ExceptionProvider.java
+++ b/samples/client/petstore/java/webclient-springBoot4-jackson3-jspecify/src/main/java/org/openapitools/client/ExceptionProvider.java
@@ -31,7 +31,7 @@ import java.text.ParseException;
  * });
  * }</pre>
  */
-@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.23.0-SNAPSHOT")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.25.0-SNAPSHOT")
 public interface ExceptionProvider {
 
     /** Returns an exception indicating that no Bearer authentication is configured. */

--- a/samples/client/petstore/java/webclient-springBoot4-jackson3/src/main/java/org/openapitools/client/ExceptionProvider.java
+++ b/samples/client/petstore/java/webclient-springBoot4-jackson3/src/main/java/org/openapitools/client/ExceptionProvider.java
@@ -31,7 +31,7 @@ import java.text.ParseException;
  * });
  * }</pre>
  */
-@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.23.0-SNAPSHOT")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.25.0-SNAPSHOT")
 public interface ExceptionProvider {
 
     /** Returns an exception indicating that no Bearer authentication is configured. */

--- a/samples/client/petstore/java/webclient-swagger2/src/main/java/org/openapitools/client/ExceptionProvider.java
+++ b/samples/client/petstore/java/webclient-swagger2/src/main/java/org/openapitools/client/ExceptionProvider.java
@@ -31,7 +31,7 @@ import java.text.ParseException;
  * });
  * }</pre>
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.23.0-SNAPSHOT")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.25.0-SNAPSHOT")
 public interface ExceptionProvider {
 
     /** Returns an exception indicating that no Bearer authentication is configured. */

--- a/samples/client/petstore/java/webclient-useSingleRequestParameter/src/main/java/org/openapitools/client/ExceptionProvider.java
+++ b/samples/client/petstore/java/webclient-useSingleRequestParameter/src/main/java/org/openapitools/client/ExceptionProvider.java
@@ -31,7 +31,7 @@ import java.text.ParseException;
  * });
  * }</pre>
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.23.0-SNAPSHOT")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.25.0-SNAPSHOT")
 public interface ExceptionProvider {
 
     /** Returns an exception indicating that no Bearer authentication is configured. */

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/ExceptionProvider.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/ExceptionProvider.java
@@ -31,7 +31,7 @@ import java.text.ParseException;
  * });
  * }</pre>
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.23.0-SNAPSHOT")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.25.0-SNAPSHOT")
 public interface ExceptionProvider {
 
     /** Returns an exception indicating that no Bearer authentication is configured. */


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Updates samples after the merge of https://github.com/OpenAPITools/openapi-generator/pull/23878. Should we remove the generator annotation from these samples to avoid this issue in the future?

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Regenerated Java client samples to sync with generator 7.25.0-SNAPSHOT after OpenAPITools/openapi-generator#23878. Only the `@jakarta.annotation.Generated`/`@javax.annotation.Generated` annotation comment in ExceptionProvider was updated; no behavior changes.

<sup>Written for commit 1617cc584f720514c78f9af84f44ccf5dac50e23. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24507?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

