### PR TITLE
[typescript-fetch] Document request-parameter interfaces and fix parameter isDeprecated

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
@@ -1206,6 +1206,7 @@ public class TypeScriptFetchClientCodegen extends AbstractTypeScriptClientCodege
         public ExtendedCodegenParameter(CodegenParameter cp) {
             super();
 
+            this.isDeprecated = cp.isDeprecated;
             this.isFormParam = cp.isFormParam;
             this.isQueryParam = cp.isQueryParam;
             this.isPathParam = cp.isPathParam;

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
@@ -25,6 +25,12 @@ import {
 {{#allParams.0}}
 export interface {{#prefixParameterInterfaces}}{{classname}}{{/prefixParameterInterfaces}}{{operationIdCamelCase}}Request {
 {{#allParams}}
+    /**
+     * {{#lambda.indented_star_4}}{{{unescapedDescription}}}{{/lambda.indented_star_4}}
+    {{#isDeprecated}}
+     * @deprecated
+    {{/isDeprecated}}
+     */
     {{paramName}}{{^required}}?{{/required}}: {{#isEnum}}{{{datatypeWithEnum}}}{{/isEnum}}{{^isEnum}}{{#hasReadOnly}}Omit<{{{dataType}}}, {{#readOnlyVars}}'{{name}}'{{^-last}}|{{/-last}}{{/readOnlyVars}}>{{/hasReadOnly}}{{^hasReadOnly}}{{{dataType}}}{{/hasReadOnly}}{{#isNullable}} | null{{/isNullable}}{{/isEnum}};
 {{/allParams}}
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchClientCodegenTest.java
@@ -94,6 +94,35 @@ public class TypeScriptFetchClientCodegenTest {
     }
 
     @Test
+    public void testDeprecatedParameter() throws IOException {
+        File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+
+        Map<String, Object> properties = new HashMap<>();
+        // bundle parameters into a request interface so per-parameter JSDoc is emitted
+        properties.put("useSingleRequestParameter", true);
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("typescript-fetch")
+                .setInputSpec("src/test/resources/3_0/typescript/deprecated-parameter.yaml")
+                .setAdditionalProperties(properties)
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+        Generator generator = new DefaultGenerator();
+        List<File> files = generator.opts(configurator.toClientOptInput()).generate();
+        files.forEach(File::deleteOnExit);
+
+        // the deprecated `name` query parameter must carry an @deprecated JSDoc tag in the
+        // generated request-parameter interface
+        Path file = Paths.get(output + "/apis/DefaultApi.ts");
+        TestUtils.assertFileContains(file, "* @deprecated");
+
+        // only the single deprecated parameter is tagged (the operation is not deprecated)
+        String content = Files.readString(file);
+        Assert.assertEquals(TestUtils.countOccurrences(content, "@deprecated"), 1);
+    }
+
+    @Test
     public void testWithoutSnapshotVersion() {
         OpenAPI api = TestUtils.createOpenAPI();
         TypeScriptFetchClientCodegen codegen = new TypeScriptFetchClientCodegen();

--- a/samples/client/others/typescript-fetch/additional-properties-in-multipart-issue/apis/FileApi.ts
+++ b/samples/client/others/typescript-fetch/additional-properties-in-multipart-issue/apis/FileApi.ts
@@ -20,9 +20,21 @@ import {
 } from '../models/StructuredType';
 
 export interface CreateFileRequest {
+    /**
+     * 
+     */
     documentBytes: Blob;
+    /**
+     * 
+     */
     documentType: string;
+    /**
+     * 
+     */
     properties: { [key: string]: string; };
+    /**
+     * 
+     */
     structured?: StructuredType;
 }
 

--- a/samples/client/others/typescript-fetch/multipart-file-array/apis/DefaultApi.ts
+++ b/samples/client/others/typescript-fetch/multipart-file-array/apis/DefaultApi.ts
@@ -15,7 +15,13 @@
 import * as runtime from '../runtime';
 
 export interface UploadFilesRequest {
+    /**
+     * 
+     */
     files: Array<Blob>;
+    /**
+     * 
+     */
     metadata?: string;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/allOf-nullable/apis/DefaultApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/allOf-nullable/apis/DefaultApi.ts
@@ -20,6 +20,9 @@ import {
 } from '../models/Club';
 
 export interface ListRequest {
+    /**
+     * The id of the person to retrieve
+     */
     personId: string;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/allOf-readonly/apis/DefaultApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/allOf-readonly/apis/DefaultApi.ts
@@ -20,6 +20,9 @@ import {
 } from '../models/Club';
 
 export interface ListRequest {
+    /**
+     * The id of the person to retrieve
+     */
     personId: string;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/AnotherFakeApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/AnotherFakeApi.ts
@@ -20,6 +20,9 @@ import {
 } from '../models/Client';
 
 export interface 123testSpecialTagsRequest {
+    /**
+     * 
+     */
     client: Client;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/FakeApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/FakeApi.ts
@@ -70,118 +70,286 @@ import {
 } from '../models/User';
 
 export interface FakeHttpSignatureTestRequest {
+    /**
+     * 
+     */
     pet: Pet;
+    /**
+     * query parameter
+     */
     query1?: string;
+    /**
+     * header parameter
+     */
     header1?: string;
 }
 
 export interface FakeOuterBooleanSerializeRequest {
+    /**
+     * 
+     */
     body?: boolean;
 }
 
 export interface FakeOuterCompositeSerializeRequest {
+    /**
+     * 
+     */
     outerComposite?: OuterComposite;
 }
 
 export interface FakeOuterNumberSerializeRequest {
+    /**
+     * 
+     */
     body?: number;
 }
 
 export interface FakeOuterStringSerializeRequest {
+    /**
+     * 
+     */
     body?: string;
 }
 
 export interface FakePropertyEnumIntegerSerializeRequest {
+    /**
+     * 
+     */
     outerObjectWithEnumProperty: OuterObjectWithEnumProperty;
 }
 
 export interface TestAdditionalPropertiesReferenceRequest {
+    /**
+     * 
+     */
     requestBody: { [key: string]: any; };
 }
 
 export interface TestBodyWithBinaryRequest {
+    /**
+     * 
+     */
     body: Blob | null;
 }
 
 export interface TestBodyWithFileSchemaRequest {
+    /**
+     * 
+     */
     fileSchemaTestClass: FileSchemaTestClass;
 }
 
 export interface TestBodyWithQueryParamsRequest {
+    /**
+     * 
+     */
     query: string;
+    /**
+     * 
+     */
     user: User;
 }
 
 export interface TestClientModelRequest {
+    /**
+     * 
+     */
     client: Client;
 }
 
 export interface TestEndpointParametersRequest {
+    /**
+     * None
+     */
     number: number;
+    /**
+     * None
+     */
     _double: number;
+    /**
+     * None
+     */
     patternWithoutDelimiter: string;
+    /**
+     * None
+     */
     _byte: string;
+    /**
+     * None
+     */
     integer?: number;
+    /**
+     * None
+     */
     int32?: number;
+    /**
+     * None
+     */
     int64?: number;
+    /**
+     * None
+     */
     _float?: number;
+    /**
+     * None
+     */
     string?: string;
+    /**
+     * None
+     */
     binary?: Blob;
+    /**
+     * None
+     */
     date?: Date;
+    /**
+     * None
+     */
     dateTime?: Date;
+    /**
+     * None
+     */
     password?: string;
+    /**
+     * None
+     */
     callback?: string;
 }
 
 export interface TestEnumParametersRequest {
+    /**
+     * Header parameter enum test (string array)
+     */
     enumHeaderStringArray?: Array<TestEnumParametersEnumHeaderStringArrayEnum>;
+    /**
+     * Header parameter enum test (string)
+     */
     enumHeaderString?: TestEnumParametersEnumHeaderStringEnum;
+    /**
+     * Query parameter enum test (string array)
+     */
     enumQueryStringArray?: Array<TestEnumParametersEnumQueryStringArrayEnum>;
+    /**
+     * Query parameter enum test (string)
+     */
     enumQueryString?: TestEnumParametersEnumQueryStringEnum;
+    /**
+     * Query parameter enum test (double)
+     */
     enumQueryInteger?: TestEnumParametersEnumQueryIntegerEnum;
+    /**
+     * Query parameter enum test (double)
+     */
     enumQueryDouble?: TestEnumParametersEnumQueryDoubleEnum;
+    /**
+     * 
+     */
     enumQueryModelArray?: Array<EnumClass>;
+    /**
+     * Form parameter enum test (string array)
+     */
     enumFormStringArray?: Array<TestEnumParametersEnumFormStringArrayEnum>;
+    /**
+     * Form parameter enum test (string)
+     */
     enumFormString?: TestEnumParametersEnumFormStringEnum;
 }
 
 export interface TestGroupParametersRequest {
+    /**
+     * Required String in group parameters
+     */
     requiredStringGroup: number;
+    /**
+     * Required Boolean in group parameters
+     */
     requiredBooleanGroup: boolean;
+    /**
+     * Required Integer in group parameters
+     */
     requiredInt64Group: number;
+    /**
+     * String in group parameters
+     */
     stringGroup?: number;
+    /**
+     * Boolean in group parameters
+     */
     booleanGroup?: boolean;
+    /**
+     * Integer in group parameters
+     */
     int64Group?: number;
 }
 
 export interface TestInlineAdditionalPropertiesRequest {
+    /**
+     * 
+     */
     requestBody: { [key: string]: string; };
 }
 
 export interface TestInlineFreeformAdditionalPropertiesOperationRequest {
+    /**
+     * 
+     */
     testInlineFreeformAdditionalPropertiesRequest: TestInlineFreeformAdditionalPropertiesRequest;
 }
 
 export interface TestJsonFormDataRequest {
+    /**
+     * field1
+     */
     param: string;
+    /**
+     * field2
+     */
     param2: string;
 }
 
 export interface TestNullableRequest {
+    /**
+     * 
+     */
     childWithNullable: ChildWithNullable;
 }
 
 export interface TestQueryParameterCollectionFormatRequest {
+    /**
+     * 
+     */
     pipe: Array<string>;
+    /**
+     * 
+     */
     ioutil: Array<string>;
+    /**
+     * 
+     */
     http: Array<string>;
+    /**
+     * 
+     */
     url: Array<string>;
+    /**
+     * 
+     */
     context: Array<string>;
+    /**
+     * 
+     */
     allowEmpty: string;
+    /**
+     * 
+     */
     language?: { [key: string]: string; };
 }
 
 export interface TestStringMapReferenceRequest {
+    /**
+     * 
+     */
     requestBody: { [key: string]: string; };
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/FakeClassnameTags123Api.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/FakeClassnameTags123Api.ts
@@ -20,6 +20,9 @@ import {
 } from '../models/Client';
 
 export interface TestClassnameRequest {
+    /**
+     * 
+     */
     client: Client;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/PetApi.ts
@@ -25,45 +25,94 @@ import {
 } from '../models/Pet';
 
 export interface AddPetRequest {
+    /**
+     * 
+     */
     pet: Pet;
 }
 
 export interface DeletePetRequest {
+    /**
+     * Pet id to delete
+     */
     petId: number;
+    /**
+     * 
+     */
     apiKey?: string;
 }
 
 export interface FindPetsByStatusRequest {
+    /**
+     * Status values that need to be considered for filter
+     * @deprecated
+     */
     status: Array<FindPetsByStatusStatusEnum>;
 }
 
 export interface FindPetsByTagsRequest {
+    /**
+     * Tags to filter by
+     */
     tags: Set<string>;
 }
 
 export interface GetPetByIdRequest {
+    /**
+     * ID of pet to return
+     */
     petId: number;
 }
 
 export interface UpdatePetRequest {
+    /**
+     * 
+     */
     pet: Pet;
 }
 
 export interface UpdatePetWithFormRequest {
+    /**
+     * ID of pet that needs to be updated
+     */
     petId: number;
+    /**
+     * Updated name of the pet
+     */
     name?: string;
+    /**
+     * Updated status of the pet
+     */
     status?: string;
 }
 
 export interface UploadFileRequest {
+    /**
+     * ID of pet to update
+     */
     petId: number;
+    /**
+     * Additional data to pass to server
+     */
     additionalMetadata?: string;
+    /**
+     * file to upload
+     */
     file?: Blob;
 }
 
 export interface UploadFileWithRequiredFileRequest {
+    /**
+     * ID of pet to update
+     */
     petId: number;
+    /**
+     * file to upload
+     */
     requiredFile: Blob;
+    /**
+     * Additional data to pass to server
+     */
     additionalMetadata?: string;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/StoreApi.ts
@@ -20,14 +20,23 @@ import {
 } from '../models/Order';
 
 export interface DeleteOrderRequest {
+    /**
+     * ID of the order that needs to be deleted
+     */
     orderId: string;
 }
 
 export interface GetOrderByIdRequest {
+    /**
+     * ID of pet that needs to be fetched
+     */
     orderId: number;
 }
 
 export interface PlaceOrderRequest {
+    /**
+     * 
+     */
     order: Order;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/UserApi.ts
@@ -20,32 +20,59 @@ import {
 } from '../models/User';
 
 export interface CreateUserRequest {
+    /**
+     * 
+     */
     user: User;
 }
 
 export interface CreateUsersWithArrayInputRequest {
+    /**
+     * 
+     */
     user: Array<User>;
 }
 
 export interface CreateUsersWithListInputRequest {
+    /**
+     * 
+     */
     user: Array<User>;
 }
 
 export interface DeleteUserRequest {
+    /**
+     * The name that needs to be deleted
+     */
     username: string;
 }
 
 export interface GetUserByNameRequest {
+    /**
+     * The name that needs to be fetched. Use user1 for testing.
+     */
     username: string;
 }
 
 export interface LoginUserRequest {
+    /**
+     * The user name for login
+     */
     username: string;
+    /**
+     * The password for login in clear text
+     */
     password: string;
 }
 
 export interface UpdateUserRequest {
+    /**
+     * name that need to be deleted
+     */
     username: string;
+    /**
+     * 
+     */
     user: User;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/apis/PetApi.ts
@@ -25,39 +25,78 @@ import {
 } from '../models/Pet';
 
 export interface AddPetRequest {
+    /**
+     * 
+     */
     body: Pet;
 }
 
 export interface DeletePetRequest {
+    /**
+     * Pet id to delete
+     */
     petId: number;
+    /**
+     * 
+     */
     apiKey?: string;
 }
 
 export interface FindPetsByStatusRequest {
+    /**
+     * Status values that need to be considered for filter
+     */
     status: Array<FindPetsByStatusStatusEnum>;
 }
 
 export interface FindPetsByTagsRequest {
+    /**
+     * Tags to filter by
+     */
     tags: Array<string>;
 }
 
 export interface GetPetByIdRequest {
+    /**
+     * ID of pet to return
+     */
     petId: number;
 }
 
 export interface UpdatePetRequest {
+    /**
+     * 
+     */
     body: Pet;
 }
 
 export interface UpdatePetWithFormRequest {
+    /**
+     * ID of pet that needs to be updated
+     */
     petId: number;
+    /**
+     * Updated name of the pet
+     */
     name?: string;
+    /**
+     * Updated status of the pet
+     */
     status?: string;
 }
 
 export interface UploadFileRequest {
+    /**
+     * ID of pet to update
+     */
     petId: number;
+    /**
+     * Additional data to pass to server
+     */
     additionalMetadata?: string;
+    /**
+     * file to upload
+     */
     file?: Blob;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/apis/StoreApi.ts
@@ -20,14 +20,23 @@ import {
 } from '../models/Order';
 
 export interface DeleteOrderRequest {
+    /**
+     * ID of the order that needs to be deleted
+     */
     orderId: string;
 }
 
 export interface GetOrderByIdRequest {
+    /**
+     * ID of pet that needs to be fetched
+     */
     orderId: number;
 }
 
 export interface PlaceOrderRequest {
+    /**
+     * 
+     */
     body: Order;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/apis/UserApi.ts
@@ -20,32 +20,59 @@ import {
 } from '../models/User';
 
 export interface CreateUserRequest {
+    /**
+     * 
+     */
     body: User;
 }
 
 export interface CreateUsersWithArrayInputRequest {
+    /**
+     * 
+     */
     body: Array<User>;
 }
 
 export interface CreateUsersWithListInputRequest {
+    /**
+     * 
+     */
     body: Array<User>;
 }
 
 export interface DeleteUserRequest {
+    /**
+     * The name that needs to be deleted
+     */
     username: string;
 }
 
 export interface GetUserByNameRequest {
+    /**
+     * The name that needs to be fetched. Use user1 for testing.
+     */
     username: string;
 }
 
 export interface LoginUserRequest {
+    /**
+     * The user name for login
+     */
     username: string;
+    /**
+     * The password for login in clear text
+     */
     password: string;
 }
 
 export interface UpdateUserRequest {
+    /**
+     * name that need to be deleted
+     */
     username: string;
+    /**
+     * 
+     */
     body: User;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/enum/apis/DefaultApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/apis/DefaultApi.ts
@@ -35,24 +35,54 @@ import {
 } from '../models/StringEnum';
 
 export interface FakeEnumRequestGetInlineRequest {
+    /**
+     * 
+     */
     stringEnum?: FakeEnumRequestGetInlineStringEnumEnum;
+    /**
+     * 
+     */
     nullableStringEnum?: FakeEnumRequestGetInlineNullableStringEnumEnum;
+    /**
+     * 
+     */
     numberEnum?: FakeEnumRequestGetInlineNumberEnumEnum;
+    /**
+     * 
+     */
     nullableNumberEnum?: FakeEnumRequestGetInlineNullableNumberEnumEnum;
 }
 
 export interface FakeEnumRequestGetRefRequest {
+    /**
+     * 
+     */
     stringEnum?: StringEnum;
+    /**
+     * 
+     */
     nullableStringEnum?: StringEnum | null;
+    /**
+     * 
+     */
     numberEnum?: NumberEnum;
+    /**
+     * 
+     */
     nullableNumberEnum?: NumberEnum | null;
 }
 
 export interface FakeEnumRequestPostInlineRequest {
+    /**
+     * 
+     */
     fakeEnumRequestGetInline200Response?: FakeEnumRequestGetInline200Response;
 }
 
 export interface FakeEnumRequestPostRefRequest {
+    /**
+     * 
+     */
     enumPatternObject?: EnumPatternObject;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/apis/PetApi.ts
@@ -25,39 +25,78 @@ import {
 } from '../models/Pet';
 
 export interface AddPetRequest {
+    /**
+     * 
+     */
     body: Pet;
 }
 
 export interface DeletePetRequest {
+    /**
+     * Pet id to delete
+     */
     petId: number;
+    /**
+     * 
+     */
     apiKey?: string;
 }
 
 export interface FindPetsByStatusRequest {
+    /**
+     * Status values that need to be considered for filter
+     */
     status: Array<FindPetsByStatusStatusEnum>;
 }
 
 export interface FindPetsByTagsRequest {
+    /**
+     * Tags to filter by
+     */
     tags: Array<string>;
 }
 
 export interface GetPetByIdRequest {
+    /**
+     * ID of pet to return
+     */
     petId: number;
 }
 
 export interface UpdatePetRequest {
+    /**
+     * 
+     */
     body: Pet;
 }
 
 export interface UpdatePetWithFormRequest {
+    /**
+     * ID of pet that needs to be updated
+     */
     petId: number;
+    /**
+     * Updated name of the pet
+     */
     name?: string;
+    /**
+     * Updated status of the pet
+     */
     status?: string;
 }
 
 export interface UploadFileRequest {
+    /**
+     * ID of pet to update
+     */
     petId: number;
+    /**
+     * Additional data to pass to server
+     */
     additionalMetadata?: string;
+    /**
+     * file to upload
+     */
     file?: Blob;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/apis/StoreApi.ts
@@ -20,14 +20,23 @@ import {
 } from '../models/Order';
 
 export interface DeleteOrderRequest {
+    /**
+     * ID of the order that needs to be deleted
+     */
     orderId: string;
 }
 
 export interface GetOrderByIdRequest {
+    /**
+     * ID of pet that needs to be fetched
+     */
     orderId: number;
 }
 
 export interface PlaceOrderRequest {
+    /**
+     * 
+     */
     body: Order;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/apis/UserApi.ts
@@ -20,32 +20,59 @@ import {
 } from '../models/User';
 
 export interface CreateUserRequest {
+    /**
+     * 
+     */
     body: User;
 }
 
 export interface CreateUsersWithArrayInputRequest {
+    /**
+     * 
+     */
     body: Array<User>;
 }
 
 export interface CreateUsersWithListInputRequest {
+    /**
+     * 
+     */
     body: Array<User>;
 }
 
 export interface DeleteUserRequest {
+    /**
+     * The name that needs to be deleted
+     */
     username: string;
 }
 
 export interface GetUserByNameRequest {
+    /**
+     * The name that needs to be fetched. Use user1 for testing.
+     */
     username: string;
 }
 
 export interface LoginUserRequest {
+    /**
+     * The user name for login
+     */
     username: string;
+    /**
+     * The password for login in clear text
+     */
     password: string;
 }
 
 export interface UpdateUserRequest {
+    /**
+     * name that need to be deleted
+     */
     username: string;
+    /**
+     * 
+     */
     body: User;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/apis/another-fake-api.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/apis/another-fake-api.ts
@@ -20,6 +20,9 @@ import {
 } from '../models/client';
 
 export interface 123testSpecialTagsRequest {
+    /**
+     * 
+     */
     client: Client;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/apis/fake-api.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/apis/fake-api.ts
@@ -70,118 +70,286 @@ import {
 } from '../models/user';
 
 export interface FakeHttpSignatureTestRequest {
+    /**
+     * 
+     */
     pet: Pet;
+    /**
+     * query parameter
+     */
     query1?: string;
+    /**
+     * header parameter
+     */
     header1?: string;
 }
 
 export interface FakeOuterBooleanSerializeRequest {
+    /**
+     * 
+     */
     body?: boolean;
 }
 
 export interface FakeOuterCompositeSerializeRequest {
+    /**
+     * 
+     */
     outerComposite?: OuterComposite;
 }
 
 export interface FakeOuterNumberSerializeRequest {
+    /**
+     * 
+     */
     body?: number;
 }
 
 export interface FakeOuterStringSerializeRequest {
+    /**
+     * 
+     */
     body?: string;
 }
 
 export interface FakePropertyEnumIntegerSerializeRequest {
+    /**
+     * 
+     */
     outerObjectWithEnumProperty: OuterObjectWithEnumProperty;
 }
 
 export interface TestAdditionalPropertiesReferenceRequest {
+    /**
+     * 
+     */
     requestBody: { [key: string]: any; };
 }
 
 export interface TestBodyWithBinaryRequest {
+    /**
+     * 
+     */
     body: Blob | null;
 }
 
 export interface TestBodyWithFileSchemaRequest {
+    /**
+     * 
+     */
     fileSchemaTestClass: FileSchemaTestClass;
 }
 
 export interface TestBodyWithQueryParamsRequest {
+    /**
+     * 
+     */
     query: string;
+    /**
+     * 
+     */
     user: User;
 }
 
 export interface TestClientModelRequest {
+    /**
+     * 
+     */
     client: Client;
 }
 
 export interface TestEndpointParametersRequest {
+    /**
+     * None
+     */
     number: number;
+    /**
+     * None
+     */
     _double: number;
+    /**
+     * None
+     */
     patternWithoutDelimiter: string;
+    /**
+     * None
+     */
     _byte: string;
+    /**
+     * None
+     */
     integer?: number;
+    /**
+     * None
+     */
     int32?: number;
+    /**
+     * None
+     */
     int64?: number;
+    /**
+     * None
+     */
     _float?: number;
+    /**
+     * None
+     */
     string?: string;
+    /**
+     * None
+     */
     binary?: Blob;
+    /**
+     * None
+     */
     date?: Date;
+    /**
+     * None
+     */
     dateTime?: Date;
+    /**
+     * None
+     */
     password?: string;
+    /**
+     * None
+     */
     callback?: string;
 }
 
 export interface TestEnumParametersRequest {
+    /**
+     * Header parameter enum test (string array)
+     */
     enumHeaderStringArray?: Array<TestEnumParametersEnumHeaderStringArrayEnum>;
+    /**
+     * Header parameter enum test (string)
+     */
     enumHeaderString?: TestEnumParametersEnumHeaderStringEnum;
+    /**
+     * Query parameter enum test (string array)
+     */
     enumQueryStringArray?: Array<TestEnumParametersEnumQueryStringArrayEnum>;
+    /**
+     * Query parameter enum test (string)
+     */
     enumQueryString?: TestEnumParametersEnumQueryStringEnum;
+    /**
+     * Query parameter enum test (double)
+     */
     enumQueryInteger?: TestEnumParametersEnumQueryIntegerEnum;
+    /**
+     * Query parameter enum test (double)
+     */
     enumQueryDouble?: TestEnumParametersEnumQueryDoubleEnum;
+    /**
+     * 
+     */
     enumQueryModelArray?: Array<EnumClass>;
+    /**
+     * Form parameter enum test (string array)
+     */
     enumFormStringArray?: Array<TestEnumParametersEnumFormStringArrayEnum>;
+    /**
+     * Form parameter enum test (string)
+     */
     enumFormString?: TestEnumParametersEnumFormStringEnum;
 }
 
 export interface TestGroupParametersRequest {
+    /**
+     * Required String in group parameters
+     */
     requiredStringGroup: number;
+    /**
+     * Required Boolean in group parameters
+     */
     requiredBooleanGroup: boolean;
+    /**
+     * Required Integer in group parameters
+     */
     requiredInt64Group: number;
+    /**
+     * String in group parameters
+     */
     stringGroup?: number;
+    /**
+     * Boolean in group parameters
+     */
     booleanGroup?: boolean;
+    /**
+     * Integer in group parameters
+     */
     int64Group?: number;
 }
 
 export interface TestInlineAdditionalPropertiesRequest {
+    /**
+     * 
+     */
     requestBody: { [key: string]: string; };
 }
 
 export interface TestInlineFreeformAdditionalPropertiesOperationRequest {
+    /**
+     * 
+     */
     testInlineFreeformAdditionalPropertiesRequest: TestInlineFreeformAdditionalPropertiesRequest;
 }
 
 export interface TestJsonFormDataRequest {
+    /**
+     * field1
+     */
     param: string;
+    /**
+     * field2
+     */
     param2: string;
 }
 
 export interface TestNullableRequest {
+    /**
+     * 
+     */
     childWithNullable: ChildWithNullable;
 }
 
 export interface TestQueryParameterCollectionFormatRequest {
+    /**
+     * 
+     */
     pipe: Array<string>;
+    /**
+     * 
+     */
     ioutil: Array<string>;
+    /**
+     * 
+     */
     http: Array<string>;
+    /**
+     * 
+     */
     url: Array<string>;
+    /**
+     * 
+     */
     context: Array<string>;
+    /**
+     * 
+     */
     allowEmpty: string;
+    /**
+     * 
+     */
     language?: { [key: string]: string; };
 }
 
 export interface TestStringMapReferenceRequest {
+    /**
+     * 
+     */
     requestBody: { [key: string]: string; };
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/apis/fake-classname-tags123-api.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/apis/fake-classname-tags123-api.ts
@@ -20,6 +20,9 @@ import {
 } from '../models/client';
 
 export interface TestClassnameRequest {
+    /**
+     * 
+     */
     client: Client;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/apis/pet-api.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/apis/pet-api.ts
@@ -25,45 +25,94 @@ import {
 } from '../models/pet';
 
 export interface AddPetRequest {
+    /**
+     * 
+     */
     pet: Pet;
 }
 
 export interface DeletePetRequest {
+    /**
+     * Pet id to delete
+     */
     petId: number;
+    /**
+     * 
+     */
     apiKey?: string;
 }
 
 export interface FindPetsByStatusRequest {
+    /**
+     * Status values that need to be considered for filter
+     * @deprecated
+     */
     status: Array<FindPetsByStatusStatusEnum>;
 }
 
 export interface FindPetsByTagsRequest {
+    /**
+     * Tags to filter by
+     */
     tags: Set<string>;
 }
 
 export interface GetPetByIdRequest {
+    /**
+     * ID of pet to return
+     */
     petId: number;
 }
 
 export interface UpdatePetRequest {
+    /**
+     * 
+     */
     pet: Pet;
 }
 
 export interface UpdatePetWithFormRequest {
+    /**
+     * ID of pet that needs to be updated
+     */
     petId: number;
+    /**
+     * Updated name of the pet
+     */
     name?: string;
+    /**
+     * Updated status of the pet
+     */
     status?: string;
 }
 
 export interface UploadFileRequest {
+    /**
+     * ID of pet to update
+     */
     petId: number;
+    /**
+     * Additional data to pass to server
+     */
     additionalMetadata?: string;
+    /**
+     * file to upload
+     */
     file?: Blob;
 }
 
 export interface UploadFileWithRequiredFileRequest {
+    /**
+     * ID of pet to update
+     */
     petId: number;
+    /**
+     * file to upload
+     */
     requiredFile: Blob;
+    /**
+     * Additional data to pass to server
+     */
     additionalMetadata?: string;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/apis/store-api.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/apis/store-api.ts
@@ -20,14 +20,23 @@ import {
 } from '../models/order';
 
 export interface DeleteOrderRequest {
+    /**
+     * ID of the order that needs to be deleted
+     */
     orderId: string;
 }
 
 export interface GetOrderByIdRequest {
+    /**
+     * ID of pet that needs to be fetched
+     */
     orderId: number;
 }
 
 export interface PlaceOrderRequest {
+    /**
+     * 
+     */
     order: Order;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/apis/user-api.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/apis/user-api.ts
@@ -20,32 +20,59 @@ import {
 } from '../models/user';
 
 export interface CreateUserRequest {
+    /**
+     * 
+     */
     user: User;
 }
 
 export interface CreateUsersWithArrayInputRequest {
+    /**
+     * 
+     */
     user: Array<User>;
 }
 
 export interface CreateUsersWithListInputRequest {
+    /**
+     * 
+     */
     user: Array<User>;
 }
 
 export interface DeleteUserRequest {
+    /**
+     * The name that needs to be deleted
+     */
     username: string;
 }
 
 export interface GetUserByNameRequest {
+    /**
+     * The name that needs to be fetched. Use user1 for testing.
+     */
     username: string;
 }
 
 export interface LoginUserRequest {
+    /**
+     * The user name for login
+     */
     username: string;
+    /**
+     * The password for login in clear text
+     */
     password: string;
 }
 
 export interface UpdateUserRequest {
+    /**
+     * name that need to be deleted
+     */
     username: string;
+    /**
+     * 
+     */
     user: User;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/apis/PetApi.ts
@@ -25,39 +25,78 @@ import {
 } from '../models/Pet';
 
 export interface AddPetRequest {
+    /**
+     * 
+     */
     body: Pet;
 }
 
 export interface DeletePetRequest {
+    /**
+     * Pet id to delete
+     */
     petId: number;
+    /**
+     * 
+     */
     apiKey?: string;
 }
 
 export interface FindPetsByStatusRequest {
+    /**
+     * Status values that need to be considered for filter
+     */
     status: Array<FindPetsByStatusStatusEnum>;
 }
 
 export interface FindPetsByTagsRequest {
+    /**
+     * Tags to filter by
+     */
     tags: Array<string>;
 }
 
 export interface GetPetByIdRequest {
+    /**
+     * ID of pet to return
+     */
     petId: number;
 }
 
 export interface UpdatePetRequest {
+    /**
+     * 
+     */
     body: Pet;
 }
 
 export interface UpdatePetWithFormRequest {
+    /**
+     * ID of pet that needs to be updated
+     */
     petId: number;
+    /**
+     * Updated name of the pet
+     */
     name?: string;
+    /**
+     * Updated status of the pet
+     */
     status?: string;
 }
 
 export interface UploadFileRequest {
+    /**
+     * ID of pet to update
+     */
     petId: number;
+    /**
+     * Additional data to pass to server
+     */
     additionalMetadata?: string;
+    /**
+     * file to upload
+     */
     file?: Blob;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/apis/StoreApi.ts
@@ -20,14 +20,23 @@ import {
 } from '../models/Order';
 
 export interface DeleteOrderRequest {
+    /**
+     * ID of the order that needs to be deleted
+     */
     orderId: string;
 }
 
 export interface GetOrderByIdRequest {
+    /**
+     * ID of pet that needs to be fetched
+     */
     orderId: number;
 }
 
 export interface PlaceOrderRequest {
+    /**
+     * 
+     */
     body: Order;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/apis/UserApi.ts
@@ -20,32 +20,59 @@ import {
 } from '../models/User';
 
 export interface CreateUserRequest {
+    /**
+     * 
+     */
     body: User;
 }
 
 export interface CreateUsersWithArrayInputRequest {
+    /**
+     * 
+     */
     body: Array<User>;
 }
 
 export interface CreateUsersWithListInputRequest {
+    /**
+     * 
+     */
     body: Array<User>;
 }
 
 export interface DeleteUserRequest {
+    /**
+     * The name that needs to be deleted
+     */
     username: string;
 }
 
 export interface GetUserByNameRequest {
+    /**
+     * The name that needs to be fetched. Use user1 for testing.
+     */
     username: string;
 }
 
 export interface LoginUserRequest {
+    /**
+     * The user name for login
+     */
     username: string;
+    /**
+     * The password for login in clear text
+     */
     password: string;
 }
 
 export interface UpdateUserRequest {
+    /**
+     * name that need to be deleted
+     */
     username: string;
+    /**
+     * 
+     */
     body: User;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/apis/PetApi.ts
@@ -25,39 +25,78 @@ import {
 } from '../models/Pet';
 
 export interface PetApiAddPetRequest {
+    /**
+     * 
+     */
     body: Pet;
 }
 
 export interface PetApiDeletePetRequest {
+    /**
+     * Pet id to delete
+     */
     petId: number;
+    /**
+     * 
+     */
     apiKey?: string;
 }
 
 export interface PetApiFindPetsByStatusRequest {
+    /**
+     * Status values that need to be considered for filter
+     */
     status: Array<FindPetsByStatusStatusEnum>;
 }
 
 export interface PetApiFindPetsByTagsRequest {
+    /**
+     * Tags to filter by
+     */
     tags: Array<string>;
 }
 
 export interface PetApiGetPetByIdRequest {
+    /**
+     * ID of pet to return
+     */
     petId: number;
 }
 
 export interface PetApiUpdatePetRequest {
+    /**
+     * 
+     */
     body: Pet;
 }
 
 export interface PetApiUpdatePetWithFormRequest {
+    /**
+     * ID of pet that needs to be updated
+     */
     petId: number;
+    /**
+     * Updated name of the pet
+     */
     name?: string;
+    /**
+     * Updated status of the pet
+     */
     status?: string;
 }
 
 export interface PetApiUploadFileRequest {
+    /**
+     * ID of pet to update
+     */
     petId: number;
+    /**
+     * Additional data to pass to server
+     */
     additionalMetadata?: string;
+    /**
+     * file to upload
+     */
     file?: Blob;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/apis/StoreApi.ts
@@ -20,14 +20,23 @@ import {
 } from '../models/Order';
 
 export interface StoreApiDeleteOrderRequest {
+    /**
+     * ID of the order that needs to be deleted
+     */
     orderId: string;
 }
 
 export interface StoreApiGetOrderByIdRequest {
+    /**
+     * ID of pet that needs to be fetched
+     */
     orderId: number;
 }
 
 export interface StoreApiPlaceOrderRequest {
+    /**
+     * 
+     */
     body: Order;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/apis/UserApi.ts
@@ -20,32 +20,59 @@ import {
 } from '../models/User';
 
 export interface UserApiCreateUserRequest {
+    /**
+     * 
+     */
     body: User;
 }
 
 export interface UserApiCreateUsersWithArrayInputRequest {
+    /**
+     * 
+     */
     body: Array<User>;
 }
 
 export interface UserApiCreateUsersWithListInputRequest {
+    /**
+     * 
+     */
     body: Array<User>;
 }
 
 export interface UserApiDeleteUserRequest {
+    /**
+     * The name that needs to be deleted
+     */
     username: string;
 }
 
 export interface UserApiGetUserByNameRequest {
+    /**
+     * The name that needs to be fetched. Use user1 for testing.
+     */
     username: string;
 }
 
 export interface UserApiLoginUserRequest {
+    /**
+     * The user name for login
+     */
     username: string;
+    /**
+     * The password for login in clear text
+     */
     password: string;
 }
 
 export interface UserApiUpdateUserRequest {
+    /**
+     * name that need to be deleted
+     */
     username: string;
+    /**
+     * 
+     */
     body: User;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/BehaviorApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/BehaviorApi.ts
@@ -25,10 +25,16 @@ import {
 } from '../models/GetBehaviorTypeResponse';
 
 export interface GetBehaviorPermissionsRequest {
+    /**
+     * 
+     */
     behaviorId: number;
 }
 
 export interface GetBehaviorTypeRequest {
+    /**
+     * 
+     */
     behaviorId: number;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/PetApi.ts
@@ -45,56 +45,110 @@ import {
 } from '../models/PetRegionsResponse';
 
 export interface AddPetRequest {
+    /**
+     * 
+     */
     dummyCat: Category;
 }
 
 export interface DeletePetRequest {
+    /**
+     * Pet id to delete
+     */
     petId: number;
+    /**
+     * 
+     */
     apiKey?: string;
 }
 
 export interface FindPetsByIdsRequest {
+    /**
+     * Ids to filter by
+     */
     ids: Array<number>;
 }
 
 export interface FindPetsByStatusRequest {
+    /**
+     * Status values that need to be considered for filter
+     */
     status: Array<FindPetsByStatusStatusEnum>;
 }
 
 export interface FindPetsByTagsRequest {
+    /**
+     * Tags to filter by
+     */
     tags: Array<string>;
 }
 
 export interface FindPetsByUserIdsRequest {
+    /**
+     * Ids to filter by
+     */
     ids: Array<number>;
 }
 
 export interface GetPetByIdRequest {
+    /**
+     * ID of pet to return
+     */
     petId: number;
 }
 
 export interface GetPetRegionsRequest {
+    /**
+     * ID of pet
+     */
     petId: number;
 }
 
 export interface UpdatePetRequest {
+    /**
+     * 
+     */
     body: Pet;
 }
 
 export interface UpdatePetRegionsRequest {
+    /**
+     * ID of pet
+     */
     petId: number;
+    /**
+     * 
+     */
     newRegions: Array<Array<number | null>>;
 }
 
 export interface UpdatePetWithFormRequest {
+    /**
+     * ID of pet that needs to be updated
+     */
     petId: number;
+    /**
+     * Updated name of the pet
+     */
     name?: string;
+    /**
+     * Updated status of the pet
+     */
     status?: string;
 }
 
 export interface UploadFileRequest {
+    /**
+     * ID of pet to update
+     */
     petId: number;
+    /**
+     * Additional data to pass to server
+     */
     additionalMetadata?: string;
+    /**
+     * file to upload
+     */
     file?: Blob;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/PetPartApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/PetPartApi.ts
@@ -25,15 +25,36 @@ import {
 } from '../models/GetPetPartTypeResponse';
 
 export interface GetFakePetPartTypeRequest {
+    /**
+     * 
+     */
     fakePetPartId: number;
 }
 
 export interface GetMatchingPartsRequest {
+    /**
+     * 
+     */
     fakePetPartId: number;
+    /**
+     * 
+     */
     _long: boolean;
+    /**
+     * 
+     */
     smooth: boolean;
+    /**
+     * 
+     */
     _short: boolean;
+    /**
+     * 
+     */
     name?: string;
+    /**
+     * 
+     */
     connectedPart?: string;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/StoreApi.ts
@@ -20,14 +20,23 @@ import {
 } from '../models/Order';
 
 export interface DeleteOrderRequest {
+    /**
+     * ID of the order that needs to be deleted
+     */
     orderId: string;
 }
 
 export interface GetOrderByIdRequest {
+    /**
+     * ID of pet that needs to be fetched
+     */
     orderId: number;
 }
 
 export interface PlaceOrderRequest {
+    /**
+     * 
+     */
     body: Order;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/UserApi.ts
@@ -25,32 +25,59 @@ import {
 } from '../models/User';
 
 export interface CreateUserRequest {
+    /**
+     * 
+     */
     body: User;
 }
 
 export interface CreateUsersWithArrayInputRequest {
+    /**
+     * 
+     */
     body: Array<User>;
 }
 
 export interface CreateUsersWithListInputRequest {
+    /**
+     * 
+     */
     body: Array<User>;
 }
 
 export interface DeleteUserRequest {
+    /**
+     * The name that needs to be deleted
+     */
     username: string;
 }
 
 export interface GetUserByNameRequest {
+    /**
+     * The name that needs to be fetched. Use user1 for testing.
+     */
     username: string;
 }
 
 export interface LoginUserRequest {
+    /**
+     * The user name for login
+     */
     username: string;
+    /**
+     * The password for login in clear text
+     */
     password: string;
 }
 
 export interface UpdateUserRequest {
+    /**
+     * name that need to be deleted
+     */
     username: string;
+    /**
+     * 
+     */
     body: User;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/apis/AnotherFakeApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/apis/AnotherFakeApi.ts
@@ -20,6 +20,9 @@ import {
 } from '../models/Client';
 
 export interface 123testSpecialTagsRequest {
+    /**
+     * 
+     */
     client: Client;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/apis/FakeApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/apis/FakeApi.ts
@@ -60,102 +60,258 @@ import {
 } from '../models/User';
 
 export interface FakeHttpSignatureTestRequest {
+    /**
+     * 
+     */
     pet: Pet;
+    /**
+     * query parameter
+     */
     query1?: string;
+    /**
+     * header parameter
+     */
     header1?: string;
 }
 
 export interface FakeOuterBooleanSerializeRequest {
+    /**
+     * 
+     */
     body?: boolean;
 }
 
 export interface FakeOuterCompositeSerializeRequest {
+    /**
+     * 
+     */
     outerComposite?: OuterComposite;
 }
 
 export interface FakeOuterNumberSerializeRequest {
+    /**
+     * 
+     */
     body?: number;
 }
 
 export interface FakeOuterStringSerializeRequest {
+    /**
+     * 
+     */
     body?: string;
 }
 
 export interface FakePropertyEnumIntegerSerializeRequest {
+    /**
+     * 
+     */
     outerObjectWithEnumProperty: OuterObjectWithEnumProperty;
 }
 
 export interface TestBodyWithBinaryRequest {
+    /**
+     * 
+     */
     body: Blob | null;
 }
 
 export interface TestBodyWithFileSchemaRequest {
+    /**
+     * 
+     */
     fileSchemaTestClass: FileSchemaTestClass;
 }
 
 export interface TestBodyWithQueryParamsRequest {
+    /**
+     * 
+     */
     query: string;
+    /**
+     * 
+     */
     user: User;
 }
 
 export interface TestClientModelRequest {
+    /**
+     * 
+     */
     client: Client;
 }
 
 export interface TestEndpointParametersRequest {
+    /**
+     * None
+     */
     number: number;
+    /**
+     * None
+     */
     _double: number;
+    /**
+     * None
+     */
     patternWithoutDelimiter: string;
+    /**
+     * None
+     */
     _byte: string;
+    /**
+     * None
+     */
     integer?: number;
+    /**
+     * None
+     */
     int32?: number;
+    /**
+     * None
+     */
     int64?: number;
+    /**
+     * None
+     */
     _float?: number;
+    /**
+     * None
+     */
     string?: string;
+    /**
+     * None
+     */
     binary?: Blob;
+    /**
+     * None
+     */
     date?: Date;
+    /**
+     * None
+     */
     dateTime?: Date;
+    /**
+     * None
+     */
     password?: string;
+    /**
+     * None
+     */
     callback?: string;
 }
 
 export interface TestEnumParametersRequest {
+    /**
+     * Header parameter enum test (string array)
+     */
     enumHeaderStringArray?: Array<TestEnumParametersEnumHeaderStringArrayEnum>;
+    /**
+     * Header parameter enum test (string)
+     */
     enumHeaderString?: TestEnumParametersEnumHeaderStringEnum;
+    /**
+     * Query parameter enum test (string array)
+     */
     enumQueryStringArray?: Array<TestEnumParametersEnumQueryStringArrayEnum>;
+    /**
+     * Query parameter enum test (string)
+     */
     enumQueryString?: TestEnumParametersEnumQueryStringEnum;
+    /**
+     * Query parameter enum test (double)
+     */
     enumQueryInteger?: TestEnumParametersEnumQueryIntegerEnum;
+    /**
+     * Query parameter enum test (double)
+     */
     enumQueryDouble?: TestEnumParametersEnumQueryDoubleEnum;
+    /**
+     * 
+     */
     enumQueryModelArray?: Array<EnumClass>;
+    /**
+     * Form parameter enum test (string array)
+     */
     enumFormStringArray?: Array<TestEnumParametersEnumFormStringArrayEnum>;
+    /**
+     * Form parameter enum test (string)
+     */
     enumFormString?: TestEnumParametersEnumFormStringEnum;
 }
 
 export interface TestGroupParametersRequest {
+    /**
+     * Required String in group parameters
+     */
     requiredStringGroup: number;
+    /**
+     * Required Boolean in group parameters
+     */
     requiredBooleanGroup: boolean;
+    /**
+     * Required Integer in group parameters
+     */
     requiredInt64Group: number;
+    /**
+     * String in group parameters
+     */
     stringGroup?: number;
+    /**
+     * Boolean in group parameters
+     */
     booleanGroup?: boolean;
+    /**
+     * Integer in group parameters
+     */
     int64Group?: number;
 }
 
 export interface TestInlineAdditionalPropertiesRequest {
+    /**
+     * 
+     */
     requestBody: { [key: string]: string; };
 }
 
 export interface TestJsonFormDataRequest {
+    /**
+     * field1
+     */
     param: string;
+    /**
+     * field2
+     */
     param2: string;
 }
 
 export interface TestQueryParameterCollectionFormatRequest {
+    /**
+     * 
+     */
     pipe: Array<string>;
+    /**
+     * 
+     */
     ioutil: Array<string>;
+    /**
+     * 
+     */
     http: Array<string>;
+    /**
+     * 
+     */
     url: Array<string>;
+    /**
+     * 
+     */
     context: Array<string>;
+    /**
+     * 
+     */
     allowEmpty: string;
+    /**
+     * 
+     */
     language?: { [key: string]: string; };
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/apis/FakeClassnameTags123Api.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/apis/FakeClassnameTags123Api.ts
@@ -20,6 +20,9 @@ import {
 } from '../models/Client';
 
 export interface TestClassnameRequest {
+    /**
+     * 
+     */
     client: Client;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/apis/PetApi.ts
@@ -25,45 +25,94 @@ import {
 } from '../models/Pet';
 
 export interface AddPetRequest {
+    /**
+     * 
+     */
     pet: Pet;
 }
 
 export interface DeletePetRequest {
+    /**
+     * Pet id to delete
+     */
     petId: number;
+    /**
+     * 
+     */
     apiKey?: string;
 }
 
 export interface FindPetsByStatusRequest {
+    /**
+     * Status values that need to be considered for filter
+     * @deprecated
+     */
     status: Array<FindPetsByStatusStatusEnum>;
 }
 
 export interface FindPetsByTagsRequest {
+    /**
+     * Tags to filter by
+     */
     tags: Set<string>;
 }
 
 export interface GetPetByIdRequest {
+    /**
+     * ID of pet to return
+     */
     petId: number;
 }
 
 export interface UpdatePetRequest {
+    /**
+     * 
+     */
     pet: Pet;
 }
 
 export interface UpdatePetWithFormRequest {
+    /**
+     * ID of pet that needs to be updated
+     */
     petId: number;
+    /**
+     * Updated name of the pet
+     */
     name?: string;
+    /**
+     * Updated status of the pet
+     */
     status?: string;
 }
 
 export interface UploadFileRequest {
+    /**
+     * ID of pet to update
+     */
     petId: number;
+    /**
+     * Additional data to pass to server
+     */
     additionalMetadata?: string;
+    /**
+     * file to upload
+     */
     file?: Blob;
 }
 
 export interface UploadFileWithRequiredFileRequest {
+    /**
+     * ID of pet to update
+     */
     petId: number;
+    /**
+     * file to upload
+     */
     requiredFile: Blob;
+    /**
+     * Additional data to pass to server
+     */
     additionalMetadata?: string;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/apis/StoreApi.ts
@@ -20,14 +20,23 @@ import {
 } from '../models/Order';
 
 export interface DeleteOrderRequest {
+    /**
+     * ID of the order that needs to be deleted
+     */
     orderId: string;
 }
 
 export interface GetOrderByIdRequest {
+    /**
+     * ID of pet that needs to be fetched
+     */
     orderId: number;
 }
 
 export interface PlaceOrderRequest {
+    /**
+     * 
+     */
     order: Order;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/apis/UserApi.ts
@@ -20,32 +20,59 @@ import {
 } from '../models/User';
 
 export interface CreateUserRequest {
+    /**
+     * 
+     */
     user: User;
 }
 
 export interface CreateUsersWithArrayInputRequest {
+    /**
+     * 
+     */
     user: Array<User>;
 }
 
 export interface CreateUsersWithListInputRequest {
+    /**
+     * 
+     */
     user: Array<User>;
 }
 
 export interface DeleteUserRequest {
+    /**
+     * The name that needs to be deleted
+     */
     username: string;
 }
 
 export interface GetUserByNameRequest {
+    /**
+     * The name that needs to be fetched. Use user1 for testing.
+     */
     username: string;
 }
 
 export interface LoginUserRequest {
+    /**
+     * The user name for login
+     */
     username: string;
+    /**
+     * The password for login in clear text
+     */
     password: string;
 }
 
 export interface UpdateUserRequest {
+    /**
+     * name that need to be deleted
+     */
     username: string;
+    /**
+     * 
+     */
     user: User;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/validation-attributes/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/validation-attributes/apis/PetApi.ts
@@ -25,39 +25,79 @@ import {
 } from '../models/Pet';
 
 export interface AddPetRequest {
+    /**
+     * 
+     */
     pet: Pet;
 }
 
 export interface DeletePetRequest {
+    /**
+     * Pet id to delete
+     */
     petId: number;
+    /**
+     * 
+     */
     apiKey?: string;
 }
 
 export interface FindPetsByStatusRequest {
+    /**
+     * Status values that need to be considered for filter
+     * @deprecated
+     */
     status: Array<FindPetsByStatusStatusEnum>;
 }
 
 export interface FindPetsByTagsRequest {
+    /**
+     * Tags to filter by
+     */
     tags: Array<string>;
 }
 
 export interface GetPetByIdRequest {
+    /**
+     * ID of pet to return
+     */
     petId: number;
 }
 
 export interface UpdatePetRequest {
+    /**
+     * 
+     */
     pet: Pet;
 }
 
 export interface UpdatePetWithFormRequest {
+    /**
+     * ID of pet that needs to be updated
+     */
     petId: number;
+    /**
+     * Updated name of the pet
+     */
     name?: string;
+    /**
+     * Updated status of the pet
+     */
     status?: string;
 }
 
 export interface UploadFileRequest {
+    /**
+     * ID of pet to update
+     */
     petId: number;
+    /**
+     * Additional data to pass to server
+     */
     additionalMetadata?: string;
+    /**
+     * file to upload
+     */
     file?: Blob;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/validation-attributes/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/validation-attributes/apis/StoreApi.ts
@@ -20,14 +20,23 @@ import {
 } from '../models/Order';
 
 export interface DeleteOrderRequest {
+    /**
+     * ID of the order that needs to be deleted
+     */
     orderId: string;
 }
 
 export interface GetOrderByIdRequest {
+    /**
+     * ID of pet that needs to be fetched
+     */
     orderId: number;
 }
 
 export interface PlaceOrderRequest {
+    /**
+     * 
+     */
     order: Order;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/validation-attributes/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/validation-attributes/apis/UserApi.ts
@@ -20,32 +20,59 @@ import {
 } from '../models/User';
 
 export interface CreateUserRequest {
+    /**
+     * 
+     */
     user: User;
 }
 
 export interface CreateUsersWithArrayInputRequest {
+    /**
+     * 
+     */
     user: Array<User>;
 }
 
 export interface CreateUsersWithListInputRequest {
+    /**
+     * 
+     */
     user: Array<User>;
 }
 
 export interface DeleteUserRequest {
+    /**
+     * The name that needs to be deleted
+     */
     username: string;
 }
 
 export interface GetUserByNameRequest {
+    /**
+     * The name that needs to be fetched. Use user1 for testing.
+     */
     username: string;
 }
 
 export interface LoginUserRequest {
+    /**
+     * The user name for login
+     */
     username: string;
+    /**
+     * The password for login in clear text
+     */
     password: string;
 }
 
 export interface UpdateUserRequest {
+    /**
+     * name that need to be deleted
+     */
     username: string;
+    /**
+     * 
+     */
     user: User;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/apis/PetApi.ts
@@ -25,39 +25,78 @@ import {
 } from '../models/Pet';
 
 export interface AddPetRequest {
+    /**
+     * 
+     */
     body: Pet;
 }
 
 export interface DeletePetRequest {
+    /**
+     * Pet id to delete
+     */
     petId: number;
+    /**
+     * 
+     */
     apiKey?: string;
 }
 
 export interface FindPetsByStatusRequest {
+    /**
+     * Status values that need to be considered for filter
+     */
     status: Array<FindPetsByStatusStatusEnum>;
 }
 
 export interface FindPetsByTagsRequest {
+    /**
+     * Tags to filter by
+     */
     tags: Array<string>;
 }
 
 export interface GetPetByIdRequest {
+    /**
+     * ID of pet to return
+     */
     petId: number;
 }
 
 export interface UpdatePetRequest {
+    /**
+     * 
+     */
     body: Pet;
 }
 
 export interface UpdatePetWithFormRequest {
+    /**
+     * ID of pet that needs to be updated
+     */
     petId: number;
+    /**
+     * Updated name of the pet
+     */
     name?: string;
+    /**
+     * Updated status of the pet
+     */
     status?: string;
 }
 
 export interface UploadFileRequest {
+    /**
+     * ID of pet to update
+     */
     petId: number;
+    /**
+     * Additional data to pass to server
+     */
     additionalMetadata?: string;
+    /**
+     * file to upload
+     */
     file?: Blob;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/apis/StoreApi.ts
@@ -20,14 +20,23 @@ import {
 } from '../models/Order';
 
 export interface DeleteOrderRequest {
+    /**
+     * ID of the order that needs to be deleted
+     */
     orderId: string;
 }
 
 export interface GetOrderByIdRequest {
+    /**
+     * ID of pet that needs to be fetched
+     */
     orderId: number;
 }
 
 export interface PlaceOrderRequest {
+    /**
+     * 
+     */
     body: Order;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/apis/UserApi.ts
@@ -20,32 +20,59 @@ import {
 } from '../models/User';
 
 export interface CreateUserRequest {
+    /**
+     * 
+     */
     body: User;
 }
 
 export interface CreateUsersWithArrayInputRequest {
+    /**
+     * 
+     */
     body: Array<User>;
 }
 
 export interface CreateUsersWithListInputRequest {
+    /**
+     * 
+     */
     body: Array<User>;
 }
 
 export interface DeleteUserRequest {
+    /**
+     * The name that needs to be deleted
+     */
     username: string;
 }
 
 export interface GetUserByNameRequest {
+    /**
+     * The name that needs to be fetched. Use user1 for testing.
+     */
     username: string;
 }
 
 export interface LoginUserRequest {
+    /**
+     * The user name for login
+     */
     username: string;
+    /**
+     * The password for login in clear text
+     */
     password: string;
 }
 
 export interface UpdateUserRequest {
+    /**
+     * name that need to be deleted
+     */
     username: string;
+    /**
+     * 
+     */
     body: User;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/apis/PetApi.ts
@@ -25,39 +25,78 @@ import {
 } from '../models/Pet';
 
 export interface AddPetRequest {
+    /**
+     * 
+     */
     body: Pet;
 }
 
 export interface DeletePetRequest {
+    /**
+     * Pet id to delete
+     */
     petId: number;
+    /**
+     * 
+     */
     apiKey?: string;
 }
 
 export interface FindPetsByStatusRequest {
+    /**
+     * Status values that need to be considered for filter
+     */
     status: Array<FindPetsByStatusStatusEnum>;
 }
 
 export interface FindPetsByTagsRequest {
+    /**
+     * Tags to filter by
+     */
     tags: Array<string>;
 }
 
 export interface GetPetByIdRequest {
+    /**
+     * ID of pet to return
+     */
     petId: number;
 }
 
 export interface UpdatePetRequest {
+    /**
+     * 
+     */
     body: Pet;
 }
 
 export interface UpdatePetWithFormRequest {
+    /**
+     * ID of pet that needs to be updated
+     */
     petId: number;
+    /**
+     * Updated name of the pet
+     */
     name?: string;
+    /**
+     * Updated status of the pet
+     */
     status?: string;
 }
 
 export interface UploadFileRequest {
+    /**
+     * ID of pet to update
+     */
     petId: number;
+    /**
+     * Additional data to pass to server
+     */
     additionalMetadata?: string;
+    /**
+     * file to upload
+     */
     file?: Blob;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/apis/StoreApi.ts
@@ -20,14 +20,23 @@ import {
 } from '../models/Order';
 
 export interface DeleteOrderRequest {
+    /**
+     * ID of the order that needs to be deleted
+     */
     orderId: string;
 }
 
 export interface GetOrderByIdRequest {
+    /**
+     * ID of pet that needs to be fetched
+     */
     orderId: number;
 }
 
 export interface PlaceOrderRequest {
+    /**
+     * 
+     */
     body: Order;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/apis/UserApi.ts
@@ -20,32 +20,59 @@ import {
 } from '../models/User';
 
 export interface CreateUserRequest {
+    /**
+     * 
+     */
     body: User;
 }
 
 export interface CreateUsersWithArrayInputRequest {
+    /**
+     * 
+     */
     body: Array<User>;
 }
 
 export interface CreateUsersWithListInputRequest {
+    /**
+     * 
+     */
     body: Array<User>;
 }
 
 export interface DeleteUserRequest {
+    /**
+     * The name that needs to be deleted
+     */
     username: string;
 }
 
 export interface GetUserByNameRequest {
+    /**
+     * The name that needs to be fetched. Use user1 for testing.
+     */
     username: string;
 }
 
 export interface LoginUserRequest {
+    /**
+     * The user name for login
+     */
     username: string;
+    /**
+     * The password for login in clear text
+     */
     password: string;
 }
 
 export interface UpdateUserRequest {
+    /**
+     * name that need to be deleted
+     */
     username: string;
+    /**
+     * 
+     */
     body: User;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/with-string-enums/apis/DefaultApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-string-enums/apis/DefaultApi.ts
@@ -35,24 +35,54 @@ import {
 } from '../models/StringEnum';
 
 export interface FakeEnumRequestGetInlineRequest {
+    /**
+     * 
+     */
     stringEnum?: FakeEnumRequestGetInlineStringEnumEnum;
+    /**
+     * 
+     */
     nullableStringEnum?: FakeEnumRequestGetInlineNullableStringEnumEnum;
+    /**
+     * 
+     */
     numberEnum?: FakeEnumRequestGetInlineNumberEnumEnum;
+    /**
+     * 
+     */
     nullableNumberEnum?: FakeEnumRequestGetInlineNullableNumberEnumEnum;
 }
 
 export interface FakeEnumRequestGetRefRequest {
+    /**
+     * 
+     */
     stringEnum?: StringEnum;
+    /**
+     * 
+     */
     nullableStringEnum?: StringEnum | null;
+    /**
+     * 
+     */
     numberEnum?: NumberEnum;
+    /**
+     * 
+     */
     nullableNumberEnum?: NumberEnum | null;
 }
 
 export interface FakeEnumRequestPostInlineRequest {
+    /**
+     * 
+     */
     fakeEnumRequestGetInline200Response?: FakeEnumRequestGetInline200Response;
 }
 
 export interface FakeEnumRequestPostRefRequest {
+    /**
+     * 
+     */
     enumPatternObject?: EnumPatternObject;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/apis/PetApi.ts
@@ -19,39 +19,78 @@ import type {
 } from '../models/index';
 
 export interface AddPetRequest {
+    /**
+     * 
+     */
     body: Pet;
 }
 
 export interface DeletePetRequest {
+    /**
+     * Pet id to delete
+     */
     petId: number;
+    /**
+     * 
+     */
     apiKey?: string;
 }
 
 export interface FindPetsByStatusRequest {
+    /**
+     * Status values that need to be considered for filter
+     */
     status: Array<FindPetsByStatusStatusEnum>;
 }
 
 export interface FindPetsByTagsRequest {
+    /**
+     * Tags to filter by
+     */
     tags: Array<string>;
 }
 
 export interface GetPetByIdRequest {
+    /**
+     * ID of pet to return
+     */
     petId: number;
 }
 
 export interface UpdatePetRequest {
+    /**
+     * 
+     */
     body: Pet;
 }
 
 export interface UpdatePetWithFormRequest {
+    /**
+     * ID of pet that needs to be updated
+     */
     petId: number;
+    /**
+     * Updated name of the pet
+     */
     name?: string;
+    /**
+     * Updated status of the pet
+     */
     status?: string;
 }
 
 export interface UploadFileRequest {
+    /**
+     * ID of pet to update
+     */
     petId: number;
+    /**
+     * Additional data to pass to server
+     */
     additionalMetadata?: string;
+    /**
+     * file to upload
+     */
     file?: Blob;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/apis/StoreApi.ts
@@ -18,14 +18,23 @@ import type {
 } from '../models/index';
 
 export interface DeleteOrderRequest {
+    /**
+     * ID of the order that needs to be deleted
+     */
     orderId: string;
 }
 
 export interface GetOrderByIdRequest {
+    /**
+     * ID of pet that needs to be fetched
+     */
     orderId: number;
 }
 
 export interface PlaceOrderRequest {
+    /**
+     * 
+     */
     body: Order;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/apis/UserApi.ts
@@ -18,32 +18,59 @@ import type {
 } from '../models/index';
 
 export interface CreateUserRequest {
+    /**
+     * 
+     */
     body: User;
 }
 
 export interface CreateUsersWithArrayInputRequest {
+    /**
+     * 
+     */
     body: Array<User>;
 }
 
 export interface CreateUsersWithListInputRequest {
+    /**
+     * 
+     */
     body: Array<User>;
 }
 
 export interface DeleteUserRequest {
+    /**
+     * The name that needs to be deleted
+     */
     username: string;
 }
 
 export interface GetUserByNameRequest {
+    /**
+     * The name that needs to be fetched. Use user1 for testing.
+     */
     username: string;
 }
 
 export interface LoginUserRequest {
+    /**
+     * The user name for login
+     */
     username: string;
+    /**
+     * The password for login in clear text
+     */
     password: string;
 }
 
 export interface UpdateUserRequest {
+    /**
+     * name that need to be deleted
+     */
     username: string;
+    /**
+     * 
+     */
     body: User;
 }
 


### PR DESCRIPTION
Fixes #24511

## What is this PR about?

When `useSingleRequestParameter` is enabled, `typescript-fetch` bundles an operation's parameters into a generated `XxxRequest` interface. Those interfaces were emitted with bare properties: no JSDoc descriptions, and no `@deprecated` even when a parameter is marked `deprecated: true` in the spec.

#11522 / #11523 previously added `@deprecated` for operations and model properties, but operation *parameters* were never covered, and a copy-constructor bug made parameter deprecation impossible to detect regardless of template.

This PR does two things:

1. **Fixes `isDeprecated` always being false on parameters.** `DefaultCodegen.fromParameter` correctly sets `CodegenParameter.isDeprecated` from the OpenAPI `deprecated` field, but `TypeScriptFetchClientCodegen.ExtendedCodegenParameter`'s copy constructor wrapped the parameter and copied ~70 fields while omitting `isDeprecated`, silently resetting it to `false`. (The `vendorExtensions` field is copied, which is why only vendor-extension workarounds surfaced deprecation before.) The one-line fix copies `isDeprecated` through, matching what the operation and model wrappers already do.
2. **Documents request-parameter interfaces** in `apis.mustache` with JSDoc (`description` and `@deprecated` when the parameter is deprecated), consistent with the model interface template.

### Example

Given a query parameter marked `deprecated: true`:

```yaml
parameters:
  - name: q
    in: query
    description: Free-text search query.
    schema: { type: string }
  - name: legacyId
    in: query
    deprecated: true
    description: Deprecated. Use id instead.
    schema: { type: string }
```

Before:

```ts
export interface ListItemsRequest {
    q?: string;
    legacyId?: string;
}
```

After:

```ts
export interface ListItemsRequest {
    /**
     * Free-text search query.
     */
    q?: string;
    /**
     * Deprecated. Use id instead.
     * @deprecated
     */
    legacyId?: string;
}
```

## PR checklist

- [x] Read the [contribution guidelines](https://github.com/OpenAPITools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Opened an issue first (#24511) describing the bug with a reproducer.
- [x] Ran `./bin/generate-samples.sh bin/configs/typescript-fetch-*.yaml` to update the samples (additive JSDoc only).
- [x] Added a unit test (`TypeScriptFetchClientCodegenTest#testDeprecatedParameter`).
- [x] Copied the [technical committee](https://github.com/OpenAPITools/openapi-generator/#62---company--project-using-openapi-generator) to review.

cc typescript-fetch technical committee: @macjohnny @topce @amakhrov @davidgamero @joscha


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing deprecation flags and adds JSDoc to request-parameter interfaces in `typescript-fetch` when `useSingleRequestParameter` is enabled. Deprecated parameters now render `@deprecated`, and generated request interfaces include descriptions; samples were regenerated to reflect the changes.

- **Bug Fixes**
  - Copy `isDeprecated` into `ExtendedCodegenParameter` so deprecated params in `XxxRequest` interfaces include `@deprecated`; adds `TypeScriptFetchClientCodegenTest#testDeprecatedParameter`.

- **New Features**
  - Emit JSDoc for properties in `XxxRequest` interfaces via `apis.mustache` (description and `@deprecated` when applicable); regenerates `typescript-fetch` samples.

<sup>Written for commit 69e06309f24945e5d381f3b1de392e3d23250e12. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24510?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->




