### PR TITLE
[typescript-fetch] remove @type and @memberof from model docs

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelGenericInterfaces.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelGenericInterfaces.mustache
@@ -16,8 +16,6 @@ export type {{classname}} = {{{parent}}} & {
 {{#vars}}
     /**
      * {{#lambda.indented_star_4}}{{{unescapedDescription}}}{{/lambda.indented_star_4}}
-     * @type {{=<% %>=}}{<%&datatypeWithEnum%>}<%={{ }}=%>
-     * @memberof {{classname}}
     {{#deprecated}}
      * @deprecated
     {{/deprecated}}

--- a/samples/client/others/typescript-fetch/additional-properties-in-multipart-issue/models/StructuredType.ts
+++ b/samples/client/others/typescript-fetch/additional-properties-in-multipart-issue/models/StructuredType.ts
@@ -21,8 +21,6 @@ import { mapValues } from '../runtime';
 export interface StructuredType {
     /**
      * 
-     * @type {string}
-     * @memberof StructuredType
      */
     someString?: string;
 }

--- a/samples/client/others/typescript-fetch/infinite-recursion-issue/models/ExtendDto.ts
+++ b/samples/client/others/typescript-fetch/infinite-recursion-issue/models/ExtendDto.ts
@@ -36,8 +36,6 @@ import {
 export interface ExtendDto extends TestBaseDto {
     /**
      * 
-     * @type {Array<TestBaseDto>}
-     * @memberof ExtendDto
      */
     someItems?: Array<TestBaseDto>;
 }

--- a/samples/client/others/typescript-fetch/infinite-recursion-issue/models/TestBaseDto.ts
+++ b/samples/client/others/typescript-fetch/infinite-recursion-issue/models/TestBaseDto.ts
@@ -30,14 +30,10 @@ import { type ExtendDto, ExtendDtoFromJSONTyped, ExtendDtoToJSON, ExtendDtoToJSO
 export interface TestBaseDto {
     /**
      * 
-     * @type {string}
-     * @memberof TestBaseDto
      */
     something?: string;
     /**
      * 
-     * @type {TestObjectType}
-     * @memberof TestBaseDto
      */
     testObjectType?: TestObjectType;
 }

--- a/samples/client/others/typescript-fetch/self-import-issue/models/AbstractUserDto.ts
+++ b/samples/client/others/typescript-fetch/self-import-issue/models/AbstractUserDto.ts
@@ -31,20 +31,14 @@ import { type RemoteAuthenticatedUserDto, RemoteAuthenticatedUserDtoFromJSONType
 export interface AbstractUserDto {
     /**
      * 
-     * @type {string}
-     * @memberof AbstractUserDto
      */
     username?: string;
     /**
      * 
-     * @type {BranchDto}
-     * @memberof AbstractUserDto
      */
     branch?: BranchDto;
     /**
      * 
-     * @type {string}
-     * @memberof AbstractUserDto
      */
     type?: string;
 }

--- a/samples/client/others/typescript-fetch/self-import-issue/models/BranchDto.ts
+++ b/samples/client/others/typescript-fetch/self-import-issue/models/BranchDto.ts
@@ -21,8 +21,6 @@ import { mapValues } from '../runtime';
 export interface BranchDto {
     /**
      * 
-     * @type {string}
-     * @memberof BranchDto
      */
     name?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/allOf-nullable/models/Club.ts
+++ b/samples/client/petstore/typescript-fetch/builds/allOf-nullable/models/Club.ts
@@ -29,8 +29,6 @@ import {
 export interface Club {
     /**
      * 
-     * @type {Owner}
-     * @memberof Club
      */
     owner?: Owner | null;
 }

--- a/samples/client/petstore/typescript-fetch/builds/allOf-nullable/models/Owner.ts
+++ b/samples/client/petstore/typescript-fetch/builds/allOf-nullable/models/Owner.ts
@@ -21,8 +21,6 @@ import { mapValues } from '../runtime';
 export interface Owner {
     /**
      * 
-     * @type {string}
-     * @memberof Owner
      */
     name?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/allOf-readonly/models/Club.ts
+++ b/samples/client/petstore/typescript-fetch/builds/allOf-readonly/models/Club.ts
@@ -29,8 +29,6 @@ import {
 export interface Club {
     /**
      * 
-     * @type {Owner}
-     * @memberof Club
      */
     readonly owner?: Owner;
 }

--- a/samples/client/petstore/typescript-fetch/builds/allOf-readonly/models/Owner.ts
+++ b/samples/client/petstore/typescript-fetch/builds/allOf-readonly/models/Owner.ts
@@ -21,8 +21,6 @@ import { mapValues } from '../runtime';
 export interface Owner {
     /**
      * 
-     * @type {string}
-     * @memberof Owner
      */
     name?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/AdditionalPropertiesClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/AdditionalPropertiesClass.ts
@@ -21,14 +21,10 @@ import { mapValues } from '../runtime';
 export interface AdditionalPropertiesClass {
     /**
      * 
-     * @type {{ [key: string]: string; }}
-     * @memberof AdditionalPropertiesClass
      */
     mapProperty?: { [key: string]: string; };
     /**
      * 
-     * @type {{ [key: string]: { [key: string]: string; }; }}
-     * @memberof AdditionalPropertiesClass
      */
     mapOfMapProperty?: { [key: string]: { [key: string]: string; }; };
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/AllOfWithSingleRef.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/AllOfWithSingleRef.ts
@@ -29,14 +29,10 @@ import {
 export interface AllOfWithSingleRef {
     /**
      * 
-     * @type {string}
-     * @memberof AllOfWithSingleRef
      */
     username?: string;
     /**
      * 
-     * @type {SingleRefType}
-     * @memberof AllOfWithSingleRef
      */
     singleRefType?: SingleRefType;
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Animal.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Animal.ts
@@ -23,14 +23,10 @@ import { type Dog, DogFromJSONTyped, DogToJSON, DogToJSONTyped } from './Dog';
 export interface Animal {
     /**
      * 
-     * @type {string}
-     * @memberof Animal
      */
     className: string;
     /**
      * 
-     * @type {string}
-     * @memberof Animal
      */
     color?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ArrayOfArrayOfNumberOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ArrayOfArrayOfNumberOnly.ts
@@ -21,8 +21,6 @@ import { mapValues } from '../runtime';
 export interface ArrayOfArrayOfNumberOnly {
     /**
      * 
-     * @type {Array<Array<number>>}
-     * @memberof ArrayOfArrayOfNumberOnly
      */
     arrayArrayNumber?: Array<Array<number>>;
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ArrayOfNumberOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ArrayOfNumberOnly.ts
@@ -21,8 +21,6 @@ import { mapValues } from '../runtime';
 export interface ArrayOfNumberOnly {
     /**
      * 
-     * @type {Array<number>}
-     * @memberof ArrayOfNumberOnly
      */
     arrayNumber?: Array<number>;
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ArrayTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ArrayTest.ts
@@ -29,20 +29,14 @@ import {
 export interface ArrayTest {
     /**
      * 
-     * @type {Array<string>}
-     * @memberof ArrayTest
      */
     arrayOfString?: Array<string>;
     /**
      * 
-     * @type {Array<Array<number>>}
-     * @memberof ArrayTest
      */
     arrayArrayOfInteger?: Array<Array<number>>;
     /**
      * 
-     * @type {Array<Array<ReadOnlyFirst>>}
-     * @memberof ArrayTest
      */
     arrayArrayOfModel?: Array<Array<ReadOnlyFirst>>;
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Capitalization.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Capitalization.ts
@@ -21,39 +21,27 @@ import { mapValues } from '../runtime';
 export interface Capitalization {
     /**
      * 
-     * @type {string}
-     * @memberof Capitalization
      */
     smallCamel?: string;
     /**
      * 
-     * @type {string}
-     * @memberof Capitalization
      */
     capitalCamel?: string;
     /**
      * 
-     * @type {string}
-     * @memberof Capitalization
      */
     smallSnake?: string;
     /**
      * 
-     * @type {string}
-     * @memberof Capitalization
      */
     capitalSnake?: string;
     /**
      * 
-     * @type {string}
-     * @memberof Capitalization
      */
     sCAETHFlowPoints?: string;
     /**
      * Name of the pet
      * 
-     * @type {string}
-     * @memberof Capitalization
      */
     aTTNAME?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Cat.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Cat.ts
@@ -29,8 +29,6 @@ import {
 export interface Cat extends Animal {
     /**
      * 
-     * @type {boolean}
-     * @memberof Cat
      */
     declawed?: boolean;
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Category.ts
@@ -21,14 +21,10 @@ import { mapValues } from '../runtime';
 export interface Category {
     /**
      * 
-     * @type {number}
-     * @memberof Category
      */
     id?: number;
     /**
      * 
-     * @type {string}
-     * @memberof Category
      */
     name: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ChildWithNullable.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ChildWithNullable.ts
@@ -29,8 +29,6 @@ import {
 export interface ChildWithNullable extends ParentWithNullable {
     /**
      * 
-     * @type {string}
-     * @memberof ChildWithNullable
      */
     otherProperty?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ClassModel.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ClassModel.ts
@@ -21,8 +21,6 @@ import { mapValues } from '../runtime';
 export interface ClassModel {
     /**
      * 
-     * @type {string}
-     * @memberof ClassModel
      */
     _class?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Client.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Client.ts
@@ -21,8 +21,6 @@ import { mapValues } from '../runtime';
 export interface Client {
     /**
      * 
-     * @type {string}
-     * @memberof Client
      */
     client?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/DeprecatedObject.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/DeprecatedObject.ts
@@ -21,8 +21,6 @@ import { mapValues } from '../runtime';
 export interface DeprecatedObject {
     /**
      * 
-     * @type {string}
-     * @memberof DeprecatedObject
      */
     name?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Dog.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Dog.ts
@@ -29,8 +29,6 @@ import {
 export interface Dog extends Animal {
     /**
      * 
-     * @type {string}
-     * @memberof Dog
      */
     breed?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumArrays.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumArrays.ts
@@ -21,14 +21,10 @@ import { mapValues } from '../runtime';
 export interface EnumArrays {
     /**
      * 
-     * @type {EnumArraysJustSymbolEnum}
-     * @memberof EnumArrays
      */
     justSymbol?: EnumArraysJustSymbolEnum;
     /**
      * 
-     * @type {Array<EnumArraysArrayEnumEnum>}
-     * @memberof EnumArrays
      */
     arrayEnum?: Array<EnumArraysArrayEnumEnum>;
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumTest.ts
@@ -50,50 +50,34 @@ import {
 export interface EnumTest {
     /**
      * 
-     * @type {EnumTestEnumStringEnum}
-     * @memberof EnumTest
      */
     enumString?: EnumTestEnumStringEnum;
     /**
      * 
-     * @type {EnumTestEnumStringRequiredEnum}
-     * @memberof EnumTest
      */
     enumStringRequired: EnumTestEnumStringRequiredEnum;
     /**
      * 
-     * @type {EnumTestEnumIntegerEnum}
-     * @memberof EnumTest
      */
     enumInteger?: EnumTestEnumIntegerEnum;
     /**
      * 
-     * @type {EnumTestEnumNumberEnum}
-     * @memberof EnumTest
      */
     enumNumber?: EnumTestEnumNumberEnum;
     /**
      * 
-     * @type {OuterEnum}
-     * @memberof EnumTest
      */
     outerEnum?: OuterEnum | null;
     /**
      * 
-     * @type {OuterEnumInteger}
-     * @memberof EnumTest
      */
     outerEnumInteger?: OuterEnumInteger;
     /**
      * 
-     * @type {OuterEnumDefaultValue}
-     * @memberof EnumTest
      */
     outerEnumDefaultValue?: OuterEnumDefaultValue;
     /**
      * 
-     * @type {OuterEnumIntegerDefaultValue}
-     * @memberof EnumTest
      */
     outerEnumIntegerDefaultValue?: OuterEnumIntegerDefaultValue;
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FakeBigDecimalMap200Response.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FakeBigDecimalMap200Response.ts
@@ -21,14 +21,10 @@ import { mapValues } from '../runtime';
 export interface FakeBigDecimalMap200Response {
     /**
      * 
-     * @type {number}
-     * @memberof FakeBigDecimalMap200Response
      */
     someId?: number;
     /**
      * 
-     * @type {{ [key: string]: number; }}
-     * @memberof FakeBigDecimalMap200Response
      */
     someMap?: { [key: string]: number; };
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FileSchemaTestClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FileSchemaTestClass.ts
@@ -21,14 +21,10 @@ import { mapValues } from '../runtime';
 export interface FileSchemaTestClass {
     /**
      * 
-     * @type {any}
-     * @memberof FileSchemaTestClass
      */
     file?: any;
     /**
      * 
-     * @type {Array<any>}
-     * @memberof FileSchemaTestClass
      */
     files?: Array<any>;
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Foo.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Foo.ts
@@ -21,8 +21,6 @@ import { mapValues } from '../runtime';
 export interface Foo {
     /**
      * 
-     * @type {string}
-     * @memberof Foo
      */
     bar?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FooGetDefaultResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FooGetDefaultResponse.ts
@@ -29,8 +29,6 @@ import {
 export interface FooGetDefaultResponse {
     /**
      * 
-     * @type {Foo}
-     * @memberof FooGetDefaultResponse
      */
     string?: Foo;
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FormatTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FormatTest.ts
@@ -21,98 +21,66 @@ import { mapValues } from '../runtime';
 export interface FormatTest {
     /**
      * 
-     * @type {number}
-     * @memberof FormatTest
      */
     integer?: number;
     /**
      * 
-     * @type {number}
-     * @memberof FormatTest
      */
     int32?: number;
     /**
      * 
-     * @type {number}
-     * @memberof FormatTest
      */
     int64?: number;
     /**
      * 
-     * @type {number}
-     * @memberof FormatTest
      */
     number: number;
     /**
      * 
-     * @type {number}
-     * @memberof FormatTest
      */
     _float?: number;
     /**
      * 
-     * @type {number}
-     * @memberof FormatTest
      */
     _double?: number;
     /**
      * 
-     * @type {string}
-     * @memberof FormatTest
      */
     decimal?: string;
     /**
      * 
-     * @type {string}
-     * @memberof FormatTest
      */
     string?: string;
     /**
      * 
-     * @type {string}
-     * @memberof FormatTest
      */
     _byte: string;
     /**
      * 
-     * @type {Blob}
-     * @memberof FormatTest
      */
     binary?: Blob;
     /**
      * 
-     * @type {Date}
-     * @memberof FormatTest
      */
     date: Date;
     /**
      * 
-     * @type {Date}
-     * @memberof FormatTest
      */
     dateTime?: Date;
     /**
      * 
-     * @type {string}
-     * @memberof FormatTest
      */
     uuid?: string;
     /**
      * 
-     * @type {string}
-     * @memberof FormatTest
      */
     password: string;
     /**
      * A string that is a 10 digit number. Can have leading zeros.
-     * @type {string}
-     * @memberof FormatTest
      */
     patternWithDigits?: string;
     /**
      * A string starting with 'image_' (case insensitive) and one to three digits following i.e. Image_01.
-     * @type {string}
-     * @memberof FormatTest
      */
     patternWithDigitsAndDelimiter?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/HasOnlyReadOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/HasOnlyReadOnly.ts
@@ -21,14 +21,10 @@ import { mapValues } from '../runtime';
 export interface HasOnlyReadOnly {
     /**
      * 
-     * @type {string}
-     * @memberof HasOnlyReadOnly
      */
     readonly bar?: string;
     /**
      * 
-     * @type {string}
-     * @memberof HasOnlyReadOnly
      */
     readonly foo?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/HealthCheckResult.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/HealthCheckResult.ts
@@ -21,8 +21,6 @@ import { mapValues } from '../runtime';
 export interface HealthCheckResult {
     /**
      * 
-     * @type {string}
-     * @memberof HealthCheckResult
      */
     nullableMessage?: string | null;
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/List.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/List.ts
@@ -21,8 +21,6 @@ import { mapValues } from '../runtime';
 export interface List {
     /**
      * 
-     * @type {string}
-     * @memberof List
      */
     _123list?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/MapTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/MapTest.ts
@@ -21,26 +21,18 @@ import { mapValues } from '../runtime';
 export interface MapTest {
     /**
      * 
-     * @type {{ [key: string]: { [key: string]: string; }; }}
-     * @memberof MapTest
      */
     mapMapOfString?: { [key: string]: { [key: string]: string; }; };
     /**
      * 
-     * @type {{ [key: string]: MapTestMapOfEnumStringEnum; }}
-     * @memberof MapTest
      */
     mapOfEnumString?: { [key: string]: MapTestMapOfEnumStringEnum; };
     /**
      * 
-     * @type {{ [key: string]: boolean; }}
-     * @memberof MapTest
      */
     directMap?: { [key: string]: boolean; };
     /**
      * 
-     * @type {{ [key: string]: boolean; }}
-     * @memberof MapTest
      */
     indirectMap?: { [key: string]: boolean; };
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/MixedPropertiesAndAdditionalPropertiesClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/MixedPropertiesAndAdditionalPropertiesClass.ts
@@ -29,20 +29,14 @@ import {
 export interface MixedPropertiesAndAdditionalPropertiesClass {
     /**
      * 
-     * @type {string}
-     * @memberof MixedPropertiesAndAdditionalPropertiesClass
      */
     uuid?: string;
     /**
      * 
-     * @type {Date}
-     * @memberof MixedPropertiesAndAdditionalPropertiesClass
      */
     dateTime?: Date;
     /**
      * 
-     * @type {{ [key: string]: Animal; }}
-     * @memberof MixedPropertiesAndAdditionalPropertiesClass
      */
     map?: { [key: string]: Animal; };
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Model200Response.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Model200Response.ts
@@ -21,14 +21,10 @@ import { mapValues } from '../runtime';
 export interface Model200Response {
     /**
      * 
-     * @type {number}
-     * @memberof Model200Response
      */
     name?: number;
     /**
      * 
-     * @type {string}
-     * @memberof Model200Response
      */
     _class?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ModelApiResponse.ts
@@ -21,20 +21,14 @@ import { mapValues } from '../runtime';
 export interface ModelApiResponse {
     /**
      * 
-     * @type {number}
-     * @memberof ModelApiResponse
      */
     code?: number;
     /**
      * 
-     * @type {string}
-     * @memberof ModelApiResponse
      */
     type?: string;
     /**
      * 
-     * @type {string}
-     * @memberof ModelApiResponse
      */
     message?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ModelFile.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ModelFile.ts
@@ -21,8 +21,6 @@ import { mapValues } from '../runtime';
 export interface ModelFile {
     /**
      * Test capitalization
-     * @type {string}
-     * @memberof ModelFile
      */
     sourceURI?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Name.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Name.ts
@@ -21,26 +21,18 @@ import { mapValues } from '../runtime';
 export interface Name {
     /**
      * 
-     * @type {number}
-     * @memberof Name
      */
     name: number;
     /**
      * 
-     * @type {number}
-     * @memberof Name
      */
     readonly snakeCase?: number;
     /**
      * 
-     * @type {string}
-     * @memberof Name
      */
     property?: string;
     /**
      * 
-     * @type {number}
-     * @memberof Name
      */
     readonly _123number?: number;
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/NullableClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/NullableClass.ts
@@ -22,74 +22,50 @@ export interface NullableClass {
     [key: string]: object | any;
     /**
      * 
-     * @type {number}
-     * @memberof NullableClass
      */
     integerProp?: number | null;
     /**
      * 
-     * @type {number}
-     * @memberof NullableClass
      */
     numberProp?: number | null;
     /**
      * 
-     * @type {boolean}
-     * @memberof NullableClass
      */
     booleanProp?: boolean | null;
     /**
      * 
-     * @type {string}
-     * @memberof NullableClass
      */
     stringProp?: string | null;
     /**
      * 
-     * @type {Date}
-     * @memberof NullableClass
      */
     dateProp?: Date | null;
     /**
      * 
-     * @type {Date}
-     * @memberof NullableClass
      */
     datetimeProp?: Date | null;
     /**
      * 
-     * @type {Array<object>}
-     * @memberof NullableClass
      */
     arrayNullableProp?: Array<object> | null;
     /**
      * 
-     * @type {Array<object | null>}
-     * @memberof NullableClass
      */
     arrayAndItemsNullableProp?: Array<object | null> | null;
     /**
      * 
-     * @type {Array<object | null>}
-     * @memberof NullableClass
      */
     arrayItemsNullable?: Array<object | null>;
     /**
      * 
-     * @type {{ [key: string]: object; }}
-     * @memberof NullableClass
      */
     objectNullableProp?: { [key: string]: object; } | null;
     /**
      * 
-     * @type {{ [key: string]: object | null; }}
-     * @memberof NullableClass
      */
     objectAndItemsNullableProp?: { [key: string]: object | null; } | null;
     /**
      * 
-     * @type {{ [key: string]: object | null; }}
-     * @memberof NullableClass
      */
     objectItemsNullable?: { [key: string]: object | null; };
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/NumberOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/NumberOnly.ts
@@ -21,8 +21,6 @@ import { mapValues } from '../runtime';
 export interface NumberOnly {
     /**
      * 
-     * @type {number}
-     * @memberof NumberOnly
      */
     justNumber?: number;
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ObjectWithDeprecatedFields.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ObjectWithDeprecatedFields.ts
@@ -29,28 +29,20 @@ import {
 export interface ObjectWithDeprecatedFields {
     /**
      * 
-     * @type {string}
-     * @memberof ObjectWithDeprecatedFields
      */
     uuid?: string;
     /**
      * 
-     * @type {number}
-     * @memberof ObjectWithDeprecatedFields
      * @deprecated
      */
     id?: number;
     /**
      * 
-     * @type {DeprecatedObject}
-     * @memberof ObjectWithDeprecatedFields
      * @deprecated
      */
     deprecatedRef?: DeprecatedObject;
     /**
      * 
-     * @type {Array<string>}
-     * @memberof ObjectWithDeprecatedFields
      * @deprecated
      */
     bars?: Array<string>;

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Order.ts
@@ -21,38 +21,26 @@ import { mapValues } from '../runtime';
 export interface Order {
     /**
      * 
-     * @type {number}
-     * @memberof Order
      */
     id?: number;
     /**
      * 
-     * @type {number}
-     * @memberof Order
      */
     petId?: number;
     /**
      * 
-     * @type {number}
-     * @memberof Order
      */
     quantity?: number;
     /**
      * 
-     * @type {Date}
-     * @memberof Order
      */
     shipDate?: Date;
     /**
      * Order Status
-     * @type {OrderStatusEnum}
-     * @memberof Order
      */
     status?: OrderStatusEnum;
     /**
      * 
-     * @type {boolean}
-     * @memberof Order
      */
     complete?: boolean;
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterComposite.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterComposite.ts
@@ -21,20 +21,14 @@ import { mapValues } from '../runtime';
 export interface OuterComposite {
     /**
      * 
-     * @type {number}
-     * @memberof OuterComposite
      */
     myNumber?: number;
     /**
      * 
-     * @type {string}
-     * @memberof OuterComposite
      */
     myString?: string;
     /**
      * 
-     * @type {boolean}
-     * @memberof OuterComposite
      */
     myBoolean?: boolean;
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterObjectWithEnumProperty.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterObjectWithEnumProperty.ts
@@ -29,8 +29,6 @@ import {
 export interface OuterObjectWithEnumProperty {
     /**
      * 
-     * @type {OuterEnumInteger}
-     * @memberof OuterObjectWithEnumProperty
      */
     value: OuterEnumInteger;
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ParentWithNullable.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ParentWithNullable.ts
@@ -22,14 +22,10 @@ import { type ChildWithNullable, ChildWithNullableFromJSONTyped, ChildWithNullab
 export interface ParentWithNullable {
     /**
      * 
-     * @type {ParentWithNullableTypeEnum}
-     * @memberof ParentWithNullable
      */
     type?: ParentWithNullableTypeEnum;
     /**
      * 
-     * @type {string}
-     * @memberof ParentWithNullable
      */
     nullableProperty?: string | null;
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Pet.ts
@@ -36,38 +36,26 @@ import {
 export interface Pet {
     /**
      * 
-     * @type {number}
-     * @memberof Pet
      */
     id?: number;
     /**
      * 
-     * @type {Category}
-     * @memberof Pet
      */
     category?: Category;
     /**
      * 
-     * @type {string}
-     * @memberof Pet
      */
     name: string;
     /**
      * 
-     * @type {Set<string>}
-     * @memberof Pet
      */
     photoUrls: Set<string>;
     /**
      * 
-     * @type {Array<Tag>}
-     * @memberof Pet
      */
     tags?: Array<Tag>;
     /**
      * pet status in the store
-     * @type {PetStatusEnum}
-     * @memberof Pet
      */
     status?: PetStatusEnum;
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ReadOnlyFirst.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ReadOnlyFirst.ts
@@ -21,14 +21,10 @@ import { mapValues } from '../runtime';
 export interface ReadOnlyFirst {
     /**
      * 
-     * @type {string}
-     * @memberof ReadOnlyFirst
      */
     readonly bar?: string;
     /**
      * 
-     * @type {string}
-     * @memberof ReadOnlyFirst
      */
     baz?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Return.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Return.ts
@@ -21,8 +21,6 @@ import { mapValues } from '../runtime';
 export interface Return {
     /**
      * 
-     * @type {number}
-     * @memberof Return
      */
     _return?: number;
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/SpecialModelName.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/SpecialModelName.ts
@@ -21,8 +21,6 @@ import { mapValues } from '../runtime';
 export interface SpecialModelName {
     /**
      * 
-     * @type {number}
-     * @memberof SpecialModelName
      */
     $specialPropertyName?: number;
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Tag.ts
@@ -21,14 +21,10 @@ import { mapValues } from '../runtime';
 export interface Tag {
     /**
      * 
-     * @type {number}
-     * @memberof Tag
      */
     id?: number;
     /**
      * 
-     * @type {string}
-     * @memberof Tag
      */
     name?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/TestInlineFreeformAdditionalPropertiesRequest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/TestInlineFreeformAdditionalPropertiesRequest.ts
@@ -22,8 +22,6 @@ export interface TestInlineFreeformAdditionalPropertiesRequest {
     [key: string]: any | any;
     /**
      * 
-     * @type {string}
-     * @memberof TestInlineFreeformAdditionalPropertiesRequest
      */
     someProperty?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/User.ts
@@ -21,50 +21,34 @@ import { mapValues } from '../runtime';
 export interface User {
     /**
      * 
-     * @type {number}
-     * @memberof User
      */
     id?: number;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     username?: string;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     firstName?: string;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     lastName?: string;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     email?: string;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     password?: string;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     phone?: string;
     /**
      * User Status
-     * @type {number}
-     * @memberof User
      */
     userStatus?: number;
 }

--- a/samples/client/petstore/typescript-fetch/builds/default/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/models/Category.ts
@@ -21,14 +21,10 @@ import { mapValues } from '../runtime';
 export interface Category {
     /**
      * 
-     * @type {number}
-     * @memberof Category
      */
     id?: number;
     /**
      * 
-     * @type {string}
-     * @memberof Category
      */
     name?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/default/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/models/ModelApiResponse.ts
@@ -21,20 +21,14 @@ import { mapValues } from '../runtime';
 export interface ModelApiResponse {
     /**
      * 
-     * @type {number}
-     * @memberof ModelApiResponse
      */
     code?: number;
     /**
      * 
-     * @type {string}
-     * @memberof ModelApiResponse
      */
     type?: string;
     /**
      * 
-     * @type {string}
-     * @memberof ModelApiResponse
      */
     message?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/default/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/models/Order.ts
@@ -21,38 +21,26 @@ import { mapValues } from '../runtime';
 export interface Order {
     /**
      * 
-     * @type {number}
-     * @memberof Order
      */
     id?: number;
     /**
      * 
-     * @type {number}
-     * @memberof Order
      */
     petId?: number;
     /**
      * 
-     * @type {number}
-     * @memberof Order
      */
     quantity?: number;
     /**
      * 
-     * @type {Date}
-     * @memberof Order
      */
     shipDate?: Date;
     /**
      * Order Status
-     * @type {OrderStatusEnum}
-     * @memberof Order
      */
     status?: OrderStatusEnum;
     /**
      * 
-     * @type {boolean}
-     * @memberof Order
      */
     complete?: boolean;
 }

--- a/samples/client/petstore/typescript-fetch/builds/default/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/models/Pet.ts
@@ -36,38 +36,26 @@ import {
 export interface Pet {
     /**
      * 
-     * @type {number}
-     * @memberof Pet
      */
     id?: number;
     /**
      * 
-     * @type {Category}
-     * @memberof Pet
      */
     category?: Category;
     /**
      * 
-     * @type {string}
-     * @memberof Pet
      */
     name: string;
     /**
      * 
-     * @type {Array<string>}
-     * @memberof Pet
      */
     photoUrls: Array<string>;
     /**
      * 
-     * @type {Array<Tag>}
-     * @memberof Pet
      */
     tags?: Array<Tag>;
     /**
      * pet status in the store
-     * @type {PetStatusEnum}
-     * @memberof Pet
      */
     status?: PetStatusEnum;
 }

--- a/samples/client/petstore/typescript-fetch/builds/default/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/models/Tag.ts
@@ -21,14 +21,10 @@ import { mapValues } from '../runtime';
 export interface Tag {
     /**
      * 
-     * @type {number}
-     * @memberof Tag
      */
     id?: number;
     /**
      * 
-     * @type {string}
-     * @memberof Tag
      */
     name?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/default/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/models/User.ts
@@ -21,50 +21,34 @@ import { mapValues } from '../runtime';
 export interface User {
     /**
      * 
-     * @type {number}
-     * @memberof User
      */
     id?: number;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     username?: string;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     firstName?: string;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     lastName?: string;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     email?: string;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     password?: string;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     phone?: string;
     /**
      * User Status
-     * @type {number}
-     * @memberof User
      */
     userStatus?: number;
 }

--- a/samples/client/petstore/typescript-fetch/builds/enum/models/EnumPatternObject.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/models/EnumPatternObject.ts
@@ -36,26 +36,18 @@ import {
 export interface EnumPatternObject {
     /**
      * 
-     * @type {StringEnum}
-     * @memberof EnumPatternObject
      */
     stringEnum?: StringEnum;
     /**
      * 
-     * @type {StringEnum}
-     * @memberof EnumPatternObject
      */
     nullableStringEnum?: StringEnum | null;
     /**
      * 
-     * @type {NumberEnum}
-     * @memberof EnumPatternObject
      */
     numberEnum?: NumberEnum;
     /**
      * 
-     * @type {NumberEnum}
-     * @memberof EnumPatternObject
      */
     nullableNumberEnum?: NumberEnum | null;
 }

--- a/samples/client/petstore/typescript-fetch/builds/enum/models/FakeEnumRequestGetInline200Response.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/models/FakeEnumRequestGetInline200Response.ts
@@ -21,26 +21,18 @@ import { mapValues } from '../runtime';
 export interface FakeEnumRequestGetInline200Response {
     /**
      * 
-     * @type {FakeEnumRequestGetInline200ResponseStringEnumEnum}
-     * @memberof FakeEnumRequestGetInline200Response
      */
     stringEnum?: FakeEnumRequestGetInline200ResponseStringEnumEnum;
     /**
      * 
-     * @type {FakeEnumRequestGetInline200ResponseNullableStringEnumEnum}
-     * @memberof FakeEnumRequestGetInline200Response
      */
     nullableStringEnum?: FakeEnumRequestGetInline200ResponseNullableStringEnumEnum;
     /**
      * 
-     * @type {FakeEnumRequestGetInline200ResponseNumberEnumEnum}
-     * @memberof FakeEnumRequestGetInline200Response
      */
     numberEnum?: FakeEnumRequestGetInline200ResponseNumberEnumEnum;
     /**
      * 
-     * @type {FakeEnumRequestGetInline200ResponseNullableNumberEnumEnum}
-     * @memberof FakeEnumRequestGetInline200Response
      */
     nullableNumberEnum?: FakeEnumRequestGetInline200ResponseNullableNumberEnumEnum;
 }

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Category.ts
@@ -21,14 +21,10 @@ import { mapValues } from '../runtime';
 export interface Category {
     /**
      * 
-     * @type {number}
-     * @memberof Category
      */
     id?: number;
     /**
      * 
-     * @type {string}
-     * @memberof Category
      */
     name?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/ModelApiResponse.ts
@@ -21,20 +21,14 @@ import { mapValues } from '../runtime';
 export interface ModelApiResponse {
     /**
      * 
-     * @type {number}
-     * @memberof ModelApiResponse
      */
     code?: number;
     /**
      * 
-     * @type {string}
-     * @memberof ModelApiResponse
      */
     type?: string;
     /**
      * 
-     * @type {string}
-     * @memberof ModelApiResponse
      */
     message?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Order.ts
@@ -21,38 +21,26 @@ import { mapValues } from '../runtime';
 export interface Order {
     /**
      * 
-     * @type {number}
-     * @memberof Order
      */
     id?: number;
     /**
      * 
-     * @type {number}
-     * @memberof Order
      */
     petId?: number;
     /**
      * 
-     * @type {number}
-     * @memberof Order
      */
     quantity?: number;
     /**
      * 
-     * @type {Date}
-     * @memberof Order
      */
     shipDate?: Date;
     /**
      * Order Status
-     * @type {OrderStatusEnum}
-     * @memberof Order
      */
     status?: OrderStatusEnum;
     /**
      * 
-     * @type {boolean}
-     * @memberof Order
      */
     complete?: boolean;
 }

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Pet.ts
@@ -36,38 +36,26 @@ import {
 export interface Pet {
     /**
      * 
-     * @type {number}
-     * @memberof Pet
      */
     id?: number;
     /**
      * 
-     * @type {Category}
-     * @memberof Pet
      */
     category?: Category;
     /**
      * 
-     * @type {string}
-     * @memberof Pet
      */
     name: string;
     /**
      * 
-     * @type {Array<string>}
-     * @memberof Pet
      */
     photoUrls: Array<string>;
     /**
      * 
-     * @type {Array<Tag>}
-     * @memberof Pet
      */
     tags?: Array<Tag>;
     /**
      * pet status in the store
-     * @type {PetStatusEnum}
-     * @memberof Pet
      */
     status?: PetStatusEnum;
 }

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Tag.ts
@@ -21,14 +21,10 @@ import { mapValues } from '../runtime';
 export interface Tag {
     /**
      * 
-     * @type {number}
-     * @memberof Tag
      */
     id?: number;
     /**
      * 
-     * @type {string}
-     * @memberof Tag
      */
     name?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/User.ts
@@ -21,50 +21,34 @@ import { mapValues } from '../runtime';
 export interface User {
     /**
      * 
-     * @type {number}
-     * @memberof User
      */
     id?: number;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     username?: string;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     firstName?: string;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     lastName?: string;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     email?: string;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     password?: string;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     phone?: string;
     /**
      * User Status
-     * @type {number}
-     * @memberof User
      */
     userStatus?: number;
 }

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/additional-properties-class.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/additional-properties-class.ts
@@ -21,14 +21,10 @@ import { mapValues } from '../runtime';
 export interface AdditionalPropertiesClass {
     /**
      * 
-     * @type {{ [key: string]: string; }}
-     * @memberof AdditionalPropertiesClass
      */
     mapProperty?: { [key: string]: string; };
     /**
      * 
-     * @type {{ [key: string]: { [key: string]: string; }; }}
-     * @memberof AdditionalPropertiesClass
      */
     mapOfMapProperty?: { [key: string]: { [key: string]: string; }; };
 }

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/all-of-with-single-ref.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/all-of-with-single-ref.ts
@@ -29,14 +29,10 @@ import {
 export interface AllOfWithSingleRef {
     /**
      * 
-     * @type {string}
-     * @memberof AllOfWithSingleRef
      */
     username?: string;
     /**
      * 
-     * @type {SingleRefType}
-     * @memberof AllOfWithSingleRef
      */
     singleRefType?: SingleRefType;
 }

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/animal.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/animal.ts
@@ -23,14 +23,10 @@ import { type Dog, DogFromJSONTyped, DogToJSON, DogToJSONTyped } from './Dog';
 export interface Animal {
     /**
      * 
-     * @type {string}
-     * @memberof Animal
      */
     className: string;
     /**
      * 
-     * @type {string}
-     * @memberof Animal
      */
     color?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/array-of-array-of-number-only.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/array-of-array-of-number-only.ts
@@ -21,8 +21,6 @@ import { mapValues } from '../runtime';
 export interface ArrayOfArrayOfNumberOnly {
     /**
      * 
-     * @type {Array<Array<number>>}
-     * @memberof ArrayOfArrayOfNumberOnly
      */
     arrayArrayNumber?: Array<Array<number>>;
 }

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/array-of-number-only.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/array-of-number-only.ts
@@ -21,8 +21,6 @@ import { mapValues } from '../runtime';
 export interface ArrayOfNumberOnly {
     /**
      * 
-     * @type {Array<number>}
-     * @memberof ArrayOfNumberOnly
      */
     arrayNumber?: Array<number>;
 }

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/array-test.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/array-test.ts
@@ -29,20 +29,14 @@ import {
 export interface ArrayTest {
     /**
      * 
-     * @type {Array<string>}
-     * @memberof ArrayTest
      */
     arrayOfString?: Array<string>;
     /**
      * 
-     * @type {Array<Array<number>>}
-     * @memberof ArrayTest
      */
     arrayArrayOfInteger?: Array<Array<number>>;
     /**
      * 
-     * @type {Array<Array<ReadOnlyFirst>>}
-     * @memberof ArrayTest
      */
     arrayArrayOfModel?: Array<Array<ReadOnlyFirst>>;
 }

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/capitalization.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/capitalization.ts
@@ -21,39 +21,27 @@ import { mapValues } from '../runtime';
 export interface Capitalization {
     /**
      * 
-     * @type {string}
-     * @memberof Capitalization
      */
     smallCamel?: string;
     /**
      * 
-     * @type {string}
-     * @memberof Capitalization
      */
     capitalCamel?: string;
     /**
      * 
-     * @type {string}
-     * @memberof Capitalization
      */
     smallSnake?: string;
     /**
      * 
-     * @type {string}
-     * @memberof Capitalization
      */
     capitalSnake?: string;
     /**
      * 
-     * @type {string}
-     * @memberof Capitalization
      */
     sCAETHFlowPoints?: string;
     /**
      * Name of the pet
      * 
-     * @type {string}
-     * @memberof Capitalization
      */
     aTTNAME?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/cat.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/cat.ts
@@ -29,8 +29,6 @@ import {
 export interface Cat extends Animal {
     /**
      * 
-     * @type {boolean}
-     * @memberof Cat
      */
     declawed?: boolean;
 }

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/category.ts
@@ -21,14 +21,10 @@ import { mapValues } from '../runtime';
 export interface Category {
     /**
      * 
-     * @type {number}
-     * @memberof Category
      */
     id?: number;
     /**
      * 
-     * @type {string}
-     * @memberof Category
      */
     name: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/child-with-nullable.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/child-with-nullable.ts
@@ -29,8 +29,6 @@ import {
 export interface ChildWithNullable extends ParentWithNullable {
     /**
      * 
-     * @type {string}
-     * @memberof ChildWithNullable
      */
     otherProperty?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/class-model.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/class-model.ts
@@ -21,8 +21,6 @@ import { mapValues } from '../runtime';
 export interface ClassModel {
     /**
      * 
-     * @type {string}
-     * @memberof ClassModel
      */
     _class?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/client.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/client.ts
@@ -21,8 +21,6 @@ import { mapValues } from '../runtime';
 export interface Client {
     /**
      * 
-     * @type {string}
-     * @memberof Client
      */
     client?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/deprecated-object.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/deprecated-object.ts
@@ -21,8 +21,6 @@ import { mapValues } from '../runtime';
 export interface DeprecatedObject {
     /**
      * 
-     * @type {string}
-     * @memberof DeprecatedObject
      */
     name?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/dog.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/dog.ts
@@ -29,8 +29,6 @@ import {
 export interface Dog extends Animal {
     /**
      * 
-     * @type {string}
-     * @memberof Dog
      */
     breed?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/enum-arrays.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/enum-arrays.ts
@@ -21,14 +21,10 @@ import { mapValues } from '../runtime';
 export interface EnumArrays {
     /**
      * 
-     * @type {EnumArraysJustSymbolEnum}
-     * @memberof EnumArrays
      */
     justSymbol?: EnumArraysJustSymbolEnum;
     /**
      * 
-     * @type {Array<EnumArraysArrayEnumEnum>}
-     * @memberof EnumArrays
      */
     arrayEnum?: Array<EnumArraysArrayEnumEnum>;
 }

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/enum-test.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/enum-test.ts
@@ -50,50 +50,34 @@ import {
 export interface EnumTest {
     /**
      * 
-     * @type {EnumTestEnumStringEnum}
-     * @memberof EnumTest
      */
     enumString?: EnumTestEnumStringEnum;
     /**
      * 
-     * @type {EnumTestEnumStringRequiredEnum}
-     * @memberof EnumTest
      */
     enumStringRequired: EnumTestEnumStringRequiredEnum;
     /**
      * 
-     * @type {EnumTestEnumIntegerEnum}
-     * @memberof EnumTest
      */
     enumInteger?: EnumTestEnumIntegerEnum;
     /**
      * 
-     * @type {EnumTestEnumNumberEnum}
-     * @memberof EnumTest
      */
     enumNumber?: EnumTestEnumNumberEnum;
     /**
      * 
-     * @type {OuterEnum}
-     * @memberof EnumTest
      */
     outerEnum?: OuterEnum | null;
     /**
      * 
-     * @type {OuterEnumInteger}
-     * @memberof EnumTest
      */
     outerEnumInteger?: OuterEnumInteger;
     /**
      * 
-     * @type {OuterEnumDefaultValue}
-     * @memberof EnumTest
      */
     outerEnumDefaultValue?: OuterEnumDefaultValue;
     /**
      * 
-     * @type {OuterEnumIntegerDefaultValue}
-     * @memberof EnumTest
      */
     outerEnumIntegerDefaultValue?: OuterEnumIntegerDefaultValue;
 }

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/fake-big-decimal-map200-response.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/fake-big-decimal-map200-response.ts
@@ -21,14 +21,10 @@ import { mapValues } from '../runtime';
 export interface FakeBigDecimalMap200Response {
     /**
      * 
-     * @type {number}
-     * @memberof FakeBigDecimalMap200Response
      */
     someId?: number;
     /**
      * 
-     * @type {{ [key: string]: number; }}
-     * @memberof FakeBigDecimalMap200Response
      */
     someMap?: { [key: string]: number; };
 }

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/file-schema-test-class.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/file-schema-test-class.ts
@@ -21,14 +21,10 @@ import { mapValues } from '../runtime';
 export interface FileSchemaTestClass {
     /**
      * 
-     * @type {any}
-     * @memberof FileSchemaTestClass
      */
     file?: any;
     /**
      * 
-     * @type {Array<any>}
-     * @memberof FileSchemaTestClass
      */
     files?: Array<any>;
 }

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/foo-get-default-response.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/foo-get-default-response.ts
@@ -29,8 +29,6 @@ import {
 export interface FooGetDefaultResponse {
     /**
      * 
-     * @type {Foo}
-     * @memberof FooGetDefaultResponse
      */
     string?: Foo;
 }

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/foo.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/foo.ts
@@ -21,8 +21,6 @@ import { mapValues } from '../runtime';
 export interface Foo {
     /**
      * 
-     * @type {string}
-     * @memberof Foo
      */
     bar?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/format-test.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/format-test.ts
@@ -21,98 +21,66 @@ import { mapValues } from '../runtime';
 export interface FormatTest {
     /**
      * 
-     * @type {number}
-     * @memberof FormatTest
      */
     integer?: number;
     /**
      * 
-     * @type {number}
-     * @memberof FormatTest
      */
     int32?: number;
     /**
      * 
-     * @type {number}
-     * @memberof FormatTest
      */
     int64?: number;
     /**
      * 
-     * @type {number}
-     * @memberof FormatTest
      */
     number: number;
     /**
      * 
-     * @type {number}
-     * @memberof FormatTest
      */
     _float?: number;
     /**
      * 
-     * @type {number}
-     * @memberof FormatTest
      */
     _double?: number;
     /**
      * 
-     * @type {string}
-     * @memberof FormatTest
      */
     decimal?: string;
     /**
      * 
-     * @type {string}
-     * @memberof FormatTest
      */
     string?: string;
     /**
      * 
-     * @type {string}
-     * @memberof FormatTest
      */
     _byte: string;
     /**
      * 
-     * @type {Blob}
-     * @memberof FormatTest
      */
     binary?: Blob;
     /**
      * 
-     * @type {Date}
-     * @memberof FormatTest
      */
     date: Date;
     /**
      * 
-     * @type {Date}
-     * @memberof FormatTest
      */
     dateTime?: Date;
     /**
      * 
-     * @type {string}
-     * @memberof FormatTest
      */
     uuid?: string;
     /**
      * 
-     * @type {string}
-     * @memberof FormatTest
      */
     password: string;
     /**
      * A string that is a 10 digit number. Can have leading zeros.
-     * @type {string}
-     * @memberof FormatTest
      */
     patternWithDigits?: string;
     /**
      * A string starting with 'image_' (case insensitive) and one to three digits following i.e. Image_01.
-     * @type {string}
-     * @memberof FormatTest
      */
     patternWithDigitsAndDelimiter?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/has-only-read-only.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/has-only-read-only.ts
@@ -21,14 +21,10 @@ import { mapValues } from '../runtime';
 export interface HasOnlyReadOnly {
     /**
      * 
-     * @type {string}
-     * @memberof HasOnlyReadOnly
      */
     readonly bar?: string;
     /**
      * 
-     * @type {string}
-     * @memberof HasOnlyReadOnly
      */
     readonly foo?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/health-check-result.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/health-check-result.ts
@@ -21,8 +21,6 @@ import { mapValues } from '../runtime';
 export interface HealthCheckResult {
     /**
      * 
-     * @type {string}
-     * @memberof HealthCheckResult
      */
     nullableMessage?: string | null;
 }

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/list.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/list.ts
@@ -21,8 +21,6 @@ import { mapValues } from '../runtime';
 export interface List {
     /**
      * 
-     * @type {string}
-     * @memberof List
      */
     _123list?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/map-test.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/map-test.ts
@@ -21,26 +21,18 @@ import { mapValues } from '../runtime';
 export interface MapTest {
     /**
      * 
-     * @type {{ [key: string]: { [key: string]: string; }; }}
-     * @memberof MapTest
      */
     mapMapOfString?: { [key: string]: { [key: string]: string; }; };
     /**
      * 
-     * @type {{ [key: string]: MapTestMapOfEnumStringEnum; }}
-     * @memberof MapTest
      */
     mapOfEnumString?: { [key: string]: MapTestMapOfEnumStringEnum; };
     /**
      * 
-     * @type {{ [key: string]: boolean; }}
-     * @memberof MapTest
      */
     directMap?: { [key: string]: boolean; };
     /**
      * 
-     * @type {{ [key: string]: boolean; }}
-     * @memberof MapTest
      */
     indirectMap?: { [key: string]: boolean; };
 }

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/mixed-properties-and-additional-properties-class.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/mixed-properties-and-additional-properties-class.ts
@@ -29,20 +29,14 @@ import {
 export interface MixedPropertiesAndAdditionalPropertiesClass {
     /**
      * 
-     * @type {string}
-     * @memberof MixedPropertiesAndAdditionalPropertiesClass
      */
     uuid?: string;
     /**
      * 
-     * @type {Date}
-     * @memberof MixedPropertiesAndAdditionalPropertiesClass
      */
     dateTime?: Date;
     /**
      * 
-     * @type {{ [key: string]: Animal; }}
-     * @memberof MixedPropertiesAndAdditionalPropertiesClass
      */
     map?: { [key: string]: Animal; };
 }

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/model-api-response.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/model-api-response.ts
@@ -21,20 +21,14 @@ import { mapValues } from '../runtime';
 export interface ModelApiResponse {
     /**
      * 
-     * @type {number}
-     * @memberof ModelApiResponse
      */
     code?: number;
     /**
      * 
-     * @type {string}
-     * @memberof ModelApiResponse
      */
     type?: string;
     /**
      * 
-     * @type {string}
-     * @memberof ModelApiResponse
      */
     message?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/model-file.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/model-file.ts
@@ -21,8 +21,6 @@ import { mapValues } from '../runtime';
 export interface ModelFile {
     /**
      * Test capitalization
-     * @type {string}
-     * @memberof ModelFile
      */
     sourceURI?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/model200-response.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/model200-response.ts
@@ -21,14 +21,10 @@ import { mapValues } from '../runtime';
 export interface Model200Response {
     /**
      * 
-     * @type {number}
-     * @memberof Model200Response
      */
     name?: number;
     /**
      * 
-     * @type {string}
-     * @memberof Model200Response
      */
     _class?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/name.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/name.ts
@@ -21,26 +21,18 @@ import { mapValues } from '../runtime';
 export interface Name {
     /**
      * 
-     * @type {number}
-     * @memberof Name
      */
     name: number;
     /**
      * 
-     * @type {number}
-     * @memberof Name
      */
     readonly snakeCase?: number;
     /**
      * 
-     * @type {string}
-     * @memberof Name
      */
     property?: string;
     /**
      * 
-     * @type {number}
-     * @memberof Name
      */
     readonly _123number?: number;
 }

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/nullable-class.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/nullable-class.ts
@@ -22,74 +22,50 @@ export interface NullableClass {
     [key: string]: object | any;
     /**
      * 
-     * @type {number}
-     * @memberof NullableClass
      */
     integerProp?: number | null;
     /**
      * 
-     * @type {number}
-     * @memberof NullableClass
      */
     numberProp?: number | null;
     /**
      * 
-     * @type {boolean}
-     * @memberof NullableClass
      */
     booleanProp?: boolean | null;
     /**
      * 
-     * @type {string}
-     * @memberof NullableClass
      */
     stringProp?: string | null;
     /**
      * 
-     * @type {Date}
-     * @memberof NullableClass
      */
     dateProp?: Date | null;
     /**
      * 
-     * @type {Date}
-     * @memberof NullableClass
      */
     datetimeProp?: Date | null;
     /**
      * 
-     * @type {Array<object>}
-     * @memberof NullableClass
      */
     arrayNullableProp?: Array<object> | null;
     /**
      * 
-     * @type {Array<object | null>}
-     * @memberof NullableClass
      */
     arrayAndItemsNullableProp?: Array<object | null> | null;
     /**
      * 
-     * @type {Array<object | null>}
-     * @memberof NullableClass
      */
     arrayItemsNullable?: Array<object | null>;
     /**
      * 
-     * @type {{ [key: string]: object; }}
-     * @memberof NullableClass
      */
     objectNullableProp?: { [key: string]: object; } | null;
     /**
      * 
-     * @type {{ [key: string]: object | null; }}
-     * @memberof NullableClass
      */
     objectAndItemsNullableProp?: { [key: string]: object | null; } | null;
     /**
      * 
-     * @type {{ [key: string]: object | null; }}
-     * @memberof NullableClass
      */
     objectItemsNullable?: { [key: string]: object | null; };
 }

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/number-only.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/number-only.ts
@@ -21,8 +21,6 @@ import { mapValues } from '../runtime';
 export interface NumberOnly {
     /**
      * 
-     * @type {number}
-     * @memberof NumberOnly
      */
     justNumber?: number;
 }

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/object-with-deprecated-fields.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/object-with-deprecated-fields.ts
@@ -29,28 +29,20 @@ import {
 export interface ObjectWithDeprecatedFields {
     /**
      * 
-     * @type {string}
-     * @memberof ObjectWithDeprecatedFields
      */
     uuid?: string;
     /**
      * 
-     * @type {number}
-     * @memberof ObjectWithDeprecatedFields
      * @deprecated
      */
     id?: number;
     /**
      * 
-     * @type {DeprecatedObject}
-     * @memberof ObjectWithDeprecatedFields
      * @deprecated
      */
     deprecatedRef?: DeprecatedObject;
     /**
      * 
-     * @type {Array<string>}
-     * @memberof ObjectWithDeprecatedFields
      * @deprecated
      */
     bars?: Array<string>;

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/order.ts
@@ -21,38 +21,26 @@ import { mapValues } from '../runtime';
 export interface Order {
     /**
      * 
-     * @type {number}
-     * @memberof Order
      */
     id?: number;
     /**
      * 
-     * @type {number}
-     * @memberof Order
      */
     petId?: number;
     /**
      * 
-     * @type {number}
-     * @memberof Order
      */
     quantity?: number;
     /**
      * 
-     * @type {Date}
-     * @memberof Order
      */
     shipDate?: Date;
     /**
      * Order Status
-     * @type {OrderStatusEnum}
-     * @memberof Order
      */
     status?: OrderStatusEnum;
     /**
      * 
-     * @type {boolean}
-     * @memberof Order
      */
     complete?: boolean;
 }

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/outer-composite.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/outer-composite.ts
@@ -21,20 +21,14 @@ import { mapValues } from '../runtime';
 export interface OuterComposite {
     /**
      * 
-     * @type {number}
-     * @memberof OuterComposite
      */
     myNumber?: number;
     /**
      * 
-     * @type {string}
-     * @memberof OuterComposite
      */
     myString?: string;
     /**
      * 
-     * @type {boolean}
-     * @memberof OuterComposite
      */
     myBoolean?: boolean;
 }

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/outer-object-with-enum-property.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/outer-object-with-enum-property.ts
@@ -29,8 +29,6 @@ import {
 export interface OuterObjectWithEnumProperty {
     /**
      * 
-     * @type {OuterEnumInteger}
-     * @memberof OuterObjectWithEnumProperty
      */
     value: OuterEnumInteger;
 }

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/parent-with-nullable.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/parent-with-nullable.ts
@@ -22,14 +22,10 @@ import { type ChildWithNullable, ChildWithNullableFromJSONTyped, ChildWithNullab
 export interface ParentWithNullable {
     /**
      * 
-     * @type {ParentWithNullableTypeEnum}
-     * @memberof ParentWithNullable
      */
     type?: ParentWithNullableTypeEnum;
     /**
      * 
-     * @type {string}
-     * @memberof ParentWithNullable
      */
     nullableProperty?: string | null;
 }

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/pet.ts
@@ -36,38 +36,26 @@ import {
 export interface Pet {
     /**
      * 
-     * @type {number}
-     * @memberof Pet
      */
     id?: number;
     /**
      * 
-     * @type {Category}
-     * @memberof Pet
      */
     category?: Category;
     /**
      * 
-     * @type {string}
-     * @memberof Pet
      */
     name: string;
     /**
      * 
-     * @type {Set<string>}
-     * @memberof Pet
      */
     photoUrls: Set<string>;
     /**
      * 
-     * @type {Array<Tag>}
-     * @memberof Pet
      */
     tags?: Array<Tag>;
     /**
      * pet status in the store
-     * @type {PetStatusEnum}
-     * @memberof Pet
      */
     status?: PetStatusEnum;
 }

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/read-only-first.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/read-only-first.ts
@@ -21,14 +21,10 @@ import { mapValues } from '../runtime';
 export interface ReadOnlyFirst {
     /**
      * 
-     * @type {string}
-     * @memberof ReadOnlyFirst
      */
     readonly bar?: string;
     /**
      * 
-     * @type {string}
-     * @memberof ReadOnlyFirst
      */
     baz?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/return.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/return.ts
@@ -21,8 +21,6 @@ import { mapValues } from '../runtime';
 export interface Return {
     /**
      * 
-     * @type {number}
-     * @memberof Return
      */
     _return?: number;
 }

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/special-model-name.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/special-model-name.ts
@@ -21,8 +21,6 @@ import { mapValues } from '../runtime';
 export interface SpecialModelName {
     /**
      * 
-     * @type {number}
-     * @memberof SpecialModelName
      */
     $specialPropertyName?: number;
 }

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/tag.ts
@@ -21,14 +21,10 @@ import { mapValues } from '../runtime';
 export interface Tag {
     /**
      * 
-     * @type {number}
-     * @memberof Tag
      */
     id?: number;
     /**
      * 
-     * @type {string}
-     * @memberof Tag
      */
     name?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/test-inline-freeform-additional-properties-request.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/test-inline-freeform-additional-properties-request.ts
@@ -22,8 +22,6 @@ export interface TestInlineFreeformAdditionalPropertiesRequest {
     [key: string]: any | any;
     /**
      * 
-     * @type {string}
-     * @memberof TestInlineFreeformAdditionalPropertiesRequest
      */
     someProperty?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/user.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/user.ts
@@ -21,50 +21,34 @@ import { mapValues } from '../runtime';
 export interface User {
     /**
      * 
-     * @type {number}
-     * @memberof User
      */
     id?: number;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     username?: string;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     firstName?: string;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     lastName?: string;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     email?: string;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     password?: string;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     phone?: string;
     /**
      * User Status
-     * @type {number}
-     * @memberof User
      */
     userStatus?: number;
 }

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Category.ts
@@ -21,14 +21,10 @@ import { mapValues } from '../runtime';
 export interface Category {
     /**
      * 
-     * @type {number}
-     * @memberof Category
      */
     id?: number;
     /**
      * 
-     * @type {string}
-     * @memberof Category
      */
     name?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/ModelApiResponse.ts
@@ -21,20 +21,14 @@ import { mapValues } from '../runtime';
 export interface ModelApiResponse {
     /**
      * 
-     * @type {number}
-     * @memberof ModelApiResponse
      */
     code?: number;
     /**
      * 
-     * @type {string}
-     * @memberof ModelApiResponse
      */
     type?: string;
     /**
      * 
-     * @type {string}
-     * @memberof ModelApiResponse
      */
     message?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Order.ts
@@ -21,38 +21,26 @@ import { mapValues } from '../runtime';
 export interface Order {
     /**
      * 
-     * @type {number}
-     * @memberof Order
      */
     id?: number;
     /**
      * 
-     * @type {number}
-     * @memberof Order
      */
     petId?: number;
     /**
      * 
-     * @type {number}
-     * @memberof Order
      */
     quantity?: number;
     /**
      * 
-     * @type {Date}
-     * @memberof Order
      */
     shipDate?: Date;
     /**
      * Order Status
-     * @type {OrderStatusEnum}
-     * @memberof Order
      */
     status?: OrderStatusEnum;
     /**
      * 
-     * @type {boolean}
-     * @memberof Order
      */
     complete?: boolean;
 }

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Pet.ts
@@ -36,38 +36,26 @@ import {
 export interface Pet {
     /**
      * 
-     * @type {number}
-     * @memberof Pet
      */
     id?: number;
     /**
      * 
-     * @type {Category}
-     * @memberof Pet
      */
     category?: Category;
     /**
      * 
-     * @type {string}
-     * @memberof Pet
      */
     name: string;
     /**
      * 
-     * @type {Array<string>}
-     * @memberof Pet
      */
     photoUrls: Array<string>;
     /**
      * 
-     * @type {Array<Tag>}
-     * @memberof Pet
      */
     tags?: Array<Tag>;
     /**
      * pet status in the store
-     * @type {PetStatusEnum}
-     * @memberof Pet
      */
     status?: PetStatusEnum;
 }

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Tag.ts
@@ -21,14 +21,10 @@ import { mapValues } from '../runtime';
 export interface Tag {
     /**
      * 
-     * @type {number}
-     * @memberof Tag
      */
     id?: number;
     /**
      * 
-     * @type {string}
-     * @memberof Tag
      */
     name?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/User.ts
@@ -21,50 +21,34 @@ import { mapValues } from '../runtime';
 export interface User {
     /**
      * 
-     * @type {number}
-     * @memberof User
      */
     id?: number;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     username?: string;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     firstName?: string;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     lastName?: string;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     email?: string;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     password?: string;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     phone?: string;
     /**
      * User Status
-     * @type {number}
-     * @memberof User
      */
     userStatus?: number;
 }

--- a/samples/client/petstore/typescript-fetch/builds/oneOf/models/DashedOptionOne.ts
+++ b/samples/client/petstore/typescript-fetch/builds/oneOf/models/DashedOptionOne.ts
@@ -21,14 +21,10 @@ import { mapValues } from '../runtime';
 export interface DashedOptionOne {
     /**
      * 
-     * @type {DashedOptionOneDiscriminatorFieldEnum}
-     * @memberof DashedOptionOne
      */
     discriminatorField: DashedOptionOneDiscriminatorFieldEnum;
     /**
      * 
-     * @type {string}
-     * @memberof DashedOptionOne
      */
     someProperty: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/oneOf/models/DashedOptionTwo.ts
+++ b/samples/client/petstore/typescript-fetch/builds/oneOf/models/DashedOptionTwo.ts
@@ -21,14 +21,10 @@ import { mapValues } from '../runtime';
 export interface DashedOptionTwo {
     /**
      * 
-     * @type {DashedOptionTwoDiscriminatorFieldEnum}
-     * @memberof DashedOptionTwo
      */
     discriminatorField: DashedOptionTwoDiscriminatorFieldEnum;
     /**
      * 
-     * @type {string}
-     * @memberof DashedOptionTwo
      */
     someProperty: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/oneOf/models/NumericSingletonEnumModel.ts
+++ b/samples/client/petstore/typescript-fetch/builds/oneOf/models/NumericSingletonEnumModel.ts
@@ -21,8 +21,6 @@ import { mapValues } from '../runtime';
 export interface NumericSingletonEnumModel {
     /**
      * 
-     * @type {NumericSingletonEnumModelKindEnum}
-     * @memberof NumericSingletonEnumModel
      */
     kind: NumericSingletonEnumModelKindEnum;
 }

--- a/samples/client/petstore/typescript-fetch/builds/oneOf/models/OptionOne.ts
+++ b/samples/client/petstore/typescript-fetch/builds/oneOf/models/OptionOne.ts
@@ -21,8 +21,6 @@ import { mapValues } from '../runtime';
 export interface OptionOne {
     /**
      * 
-     * @type {OptionOneDiscriminatorFieldEnum}
-     * @memberof OptionOne
      */
     discriminatorField: OptionOneDiscriminatorFieldEnum;
 }

--- a/samples/client/petstore/typescript-fetch/builds/oneOf/models/OptionTwo.ts
+++ b/samples/client/petstore/typescript-fetch/builds/oneOf/models/OptionTwo.ts
@@ -21,8 +21,6 @@ import { mapValues } from '../runtime';
 export interface OptionTwo {
     /**
      * 
-     * @type {OptionTwoDiscriminatorFieldEnum}
-     * @memberof OptionTwo
      */
     discriminatorField: OptionTwoDiscriminatorFieldEnum;
 }

--- a/samples/client/petstore/typescript-fetch/builds/oneOf/models/SnakeOptionOne.ts
+++ b/samples/client/petstore/typescript-fetch/builds/oneOf/models/SnakeOptionOne.ts
@@ -21,14 +21,10 @@ import { mapValues } from '../runtime';
 export interface SnakeOptionOne {
     /**
      * 
-     * @type {SnakeOptionOneDiscriminatorFieldEnum}
-     * @memberof SnakeOptionOne
      */
     discriminatorField: SnakeOptionOneDiscriminatorFieldEnum;
     /**
      * 
-     * @type {string}
-     * @memberof SnakeOptionOne
      */
     someProperty: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/oneOf/models/SnakeOptionTwo.ts
+++ b/samples/client/petstore/typescript-fetch/builds/oneOf/models/SnakeOptionTwo.ts
@@ -21,14 +21,10 @@ import { mapValues } from '../runtime';
 export interface SnakeOptionTwo {
     /**
      * 
-     * @type {SnakeOptionTwoDiscriminatorFieldEnum}
-     * @memberof SnakeOptionTwo
      */
     discriminatorField: SnakeOptionTwoDiscriminatorFieldEnum;
     /**
      * 
-     * @type {string}
-     * @memberof SnakeOptionTwo
      */
     someProperty: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/oneOf/models/TestA.ts
+++ b/samples/client/petstore/typescript-fetch/builds/oneOf/models/TestA.ts
@@ -21,8 +21,6 @@ import { mapValues } from '../runtime';
 export interface TestA {
     /**
      * 
-     * @type {string}
-     * @memberof TestA
      */
     foo: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/oneOf/models/TestB.ts
+++ b/samples/client/petstore/typescript-fetch/builds/oneOf/models/TestB.ts
@@ -21,8 +21,6 @@ import { mapValues } from '../runtime';
 export interface TestB {
     /**
      * 
-     * @type {string}
-     * @memberof TestB
      */
     bar: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Category.ts
@@ -21,14 +21,10 @@ import { mapValues } from '../runtime';
 export interface Category {
     /**
      * 
-     * @type {number}
-     * @memberof Category
      */
     id?: number;
     /**
      * 
-     * @type {string}
-     * @memberof Category
      */
     name?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/ModelApiResponse.ts
@@ -21,20 +21,14 @@ import { mapValues } from '../runtime';
 export interface ModelApiResponse {
     /**
      * 
-     * @type {number}
-     * @memberof ModelApiResponse
      */
     code?: number;
     /**
      * 
-     * @type {string}
-     * @memberof ModelApiResponse
      */
     type?: string;
     /**
      * 
-     * @type {string}
-     * @memberof ModelApiResponse
      */
     message?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Order.ts
@@ -21,38 +21,26 @@ import { mapValues } from '../runtime';
 export interface Order {
     /**
      * 
-     * @type {number}
-     * @memberof Order
      */
     id?: number;
     /**
      * 
-     * @type {number}
-     * @memberof Order
      */
     petId?: number;
     /**
      * 
-     * @type {number}
-     * @memberof Order
      */
     quantity?: number;
     /**
      * 
-     * @type {Date}
-     * @memberof Order
      */
     shipDate?: Date;
     /**
      * Order Status
-     * @type {OrderStatusEnum}
-     * @memberof Order
      */
     status?: OrderStatusEnum;
     /**
      * 
-     * @type {boolean}
-     * @memberof Order
      */
     complete?: boolean;
 }

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Pet.ts
@@ -36,38 +36,26 @@ import {
 export interface Pet {
     /**
      * 
-     * @type {number}
-     * @memberof Pet
      */
     id?: number;
     /**
      * 
-     * @type {Category}
-     * @memberof Pet
      */
     category?: Category;
     /**
      * 
-     * @type {string}
-     * @memberof Pet
      */
     name: string;
     /**
      * 
-     * @type {Array<string>}
-     * @memberof Pet
      */
     photoUrls: Array<string>;
     /**
      * 
-     * @type {Array<Tag>}
-     * @memberof Pet
      */
     tags?: Array<Tag>;
     /**
      * pet status in the store
-     * @type {PetStatusEnum}
-     * @memberof Pet
      */
     status?: PetStatusEnum;
 }

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Tag.ts
@@ -21,14 +21,10 @@ import { mapValues } from '../runtime';
 export interface Tag {
     /**
      * 
-     * @type {number}
-     * @memberof Tag
      */
     id?: number;
     /**
      * 
-     * @type {string}
-     * @memberof Tag
      */
     name?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/User.ts
@@ -21,50 +21,34 @@ import { mapValues } from '../runtime';
 export interface User {
     /**
      * 
-     * @type {number}
-     * @memberof User
      */
     id?: number;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     username?: string;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     firstName?: string;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     lastName?: string;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     email?: string;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     password?: string;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     phone?: string;
     /**
      * User Status
-     * @type {number}
-     * @memberof User
      */
     userStatus?: number;
 }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Category.ts
@@ -21,14 +21,10 @@ import { mapValues } from '../runtime';
 export interface Category {
     /**
      * 
-     * @type {number}
-     * @memberof Category
      */
     id?: number;
     /**
      * 
-     * @type {string}
-     * @memberof Category
      */
     name?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/DefaultMetaOnlyResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/DefaultMetaOnlyResponse.ts
@@ -29,8 +29,6 @@ import {
 export interface DefaultMetaOnlyResponse {
     /**
      * 
-     * @type {ResponseMeta}
-     * @memberof DefaultMetaOnlyResponse
      */
     meta: ResponseMeta;
 }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/FindPetsByStatusResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/FindPetsByStatusResponse.ts
@@ -36,14 +36,10 @@ import {
 export interface FindPetsByStatusResponse {
     /**
      * 
-     * @type {ResponseMeta}
-     * @memberof FindPetsByStatusResponse
      */
     meta: ResponseMeta;
     /**
      * 
-     * @type {Array<Pet>}
-     * @memberof FindPetsByStatusResponse
      */
     data?: Array<Pet>;
 }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/FindPetsByUserResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/FindPetsByUserResponse.ts
@@ -36,14 +36,10 @@ import {
 export interface FindPetsByUserResponse {
     /**
      * 
-     * @type {ResponseMeta}
-     * @memberof FindPetsByUserResponse
      */
     meta: ResponseMeta;
     /**
      * 
-     * @type {Array<User>}
-     * @memberof FindPetsByUserResponse
      */
     data?: Array<User>;
 }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetBehaviorPermissionsResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetBehaviorPermissionsResponse.ts
@@ -29,14 +29,10 @@ import {
 export interface GetBehaviorPermissionsResponse {
     /**
      * 
-     * @type {ResponseMeta}
-     * @memberof GetBehaviorPermissionsResponse
      */
     meta: ResponseMeta;
     /**
      * 
-     * @type {{ [key: string]: boolean; }}
-     * @memberof GetBehaviorPermissionsResponse
      */
     data?: { [key: string]: boolean; };
 }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetBehaviorTypeResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetBehaviorTypeResponse.ts
@@ -36,14 +36,10 @@ import {
 export interface GetBehaviorTypeResponse {
     /**
      * 
-     * @type {ResponseMeta}
-     * @memberof GetBehaviorTypeResponse
      */
     meta: ResponseMeta;
     /**
      * 
-     * @type {BehaviorType}
-     * @memberof GetBehaviorTypeResponse
      */
     data?: BehaviorType;
 }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetMatchingPartsResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetMatchingPartsResponse.ts
@@ -36,14 +36,10 @@ import {
 export interface GetMatchingPartsResponse {
     /**
      * 
-     * @type {ResponseMeta}
-     * @memberof GetMatchingPartsResponse
      */
     meta: ResponseMeta;
     /**
      * 
-     * @type {MatchingParts}
-     * @memberof GetMatchingPartsResponse
      */
     data?: MatchingParts;
 }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetPetPartTypeResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetPetPartTypeResponse.ts
@@ -36,14 +36,10 @@ import {
 export interface GetPetPartTypeResponse {
     /**
      * 
-     * @type {ResponseMeta}
-     * @memberof GetPetPartTypeResponse
      */
     meta: ResponseMeta;
     /**
      * 
-     * @type {PetPartType}
-     * @memberof GetPetPartTypeResponse
      */
     data?: PetPartType;
 }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ItemId.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ItemId.ts
@@ -21,14 +21,10 @@ import { mapValues } from '../runtime';
 export interface ItemId {
     /**
      * Unique identifier of the item
-     * @type {string}
-     * @memberof ItemId
      */
     id: string;
     /**
      * playlist
-     * @type {string}
-     * @memberof ItemId
      */
     type: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/MatchingParts.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/MatchingParts.ts
@@ -29,14 +29,10 @@ import {
 export interface MatchingParts {
     /**
      * List of all the connected parts
-     * @type {Array<Part>}
-     * @memberof MatchingParts
      */
     connected: Array<Part>;
     /**
      * List of all the related parts
-     * @type {Array<Part>}
-     * @memberof MatchingParts
      */
     related: Array<Part>;
 }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ModelApiResponse.ts
@@ -21,20 +21,14 @@ import { mapValues } from '../runtime';
 export interface ModelApiResponse {
     /**
      * 
-     * @type {number}
-     * @memberof ModelApiResponse
      */
     code?: number;
     /**
      * 
-     * @type {string}
-     * @memberof ModelApiResponse
      */
     type?: string;
     /**
      * 
-     * @type {string}
-     * @memberof ModelApiResponse
      */
     message?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ModelError.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ModelError.ts
@@ -29,26 +29,18 @@ import {
 export interface ModelError {
     /**
      * Usually contains the simple name of the exception
-     * @type {string}
-     * @memberof ModelError
      */
     type: string;
     /**
      * 
-     * @type {ItemId}
-     * @memberof ModelError
      */
     itemInfo?: ItemId;
     /**
      * Simple explanation of the error
-     * @type {string}
-     * @memberof ModelError
      */
     details?: string;
     /**
      * Message of the exception that will help developer to debug this problem if needed
-     * @type {string}
-     * @memberof ModelError
      */
     exception?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Order.ts
@@ -21,38 +21,26 @@ import { mapValues } from '../runtime';
 export interface Order {
     /**
      * 
-     * @type {number}
-     * @memberof Order
      */
     id?: number;
     /**
      * 
-     * @type {number}
-     * @memberof Order
      */
     petId?: number;
     /**
      * 
-     * @type {number}
-     * @memberof Order
      */
     quantity?: number;
     /**
      * 
-     * @type {Date}
-     * @memberof Order
      */
     shipDate?: Date;
     /**
      * Order Status
-     * @type {OrderStatusEnum}
-     * @memberof Order
      */
     status?: OrderStatusEnum;
     /**
      * 
-     * @type {boolean}
-     * @memberof Order
      */
     complete?: boolean;
 }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Part.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Part.ts
@@ -21,14 +21,10 @@ import { mapValues } from '../runtime';
 export interface Part {
     /**
      * Unique identifier from the database
-     * @type {number}
-     * @memberof Part
      */
     id: number;
     /**
      * Name of the part
-     * @type {string}
-     * @memberof Part
      */
     name: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Pet.ts
@@ -50,128 +50,86 @@ import {
 export interface Pet {
     /**
      * 
-     * @type {number}
-     * @memberof Pet
      */
     id: number;
     /**
      * 
-     * @type {number}
-     * @memberof Pet
      */
     friendId?: number;
     /**
      * 
-     * @type {Array<number>}
-     * @memberof Pet
      */
     otherFriendIds: Array<number>;
     /**
      * 
-     * @type {number}
-     * @memberof Pet
      */
     friendAge: number;
     /**
      * 
-     * @type {number}
-     * @memberof Pet
      */
     age: number;
     /**
      * 
-     * @type {boolean}
-     * @memberof Pet
      */
     isHappy: boolean;
     /**
      * 
-     * @type {boolean}
-     * @memberof Pet
      */
     isTall: boolean;
     /**
      * 
-     * @type {Category}
-     * @memberof Pet
      */
     category: Category;
     /**
      * 
-     * @type {Category}
-     * @memberof Pet
      */
     optionalCategory?: Category;
     /**
      * 
-     * @type {string}
-     * @memberof Pet
      */
     name: string;
     /**
      * 
-     * @type {Array<Category>}
-     * @memberof Pet
      */
     _entries?: Array<Category>;
     /**
      * 
-     * @type {string}
-     * @memberof Pet
      */
     surname?: string;
     /**
      * 
-     * @type {Array<string>}
-     * @memberof Pet
      */
     photoUrls: Array<string>;
     /**
      * 
-     * @type {WarningCode}
-     * @memberof Pet
      */
     warningStatus: WarningCode;
     /**
      * 
-     * @type {DeploymentRequestStatus}
-     * @memberof Pet
      */
     depStatus?: DeploymentRequestStatus;
     /**
      * 
-     * @type {DeploymentRequestStatus}
-     * @memberof Pet
      */
     alternateStatus: DeploymentRequestStatus;
     /**
      * 
-     * @type {Array<DeploymentRequestStatus>}
-     * @memberof Pet
      */
     otherDepStatuses: Array<DeploymentRequestStatus>;
     /**
      * 
-     * @type {Array<Tag>}
-     * @memberof Pet
      */
     tags: Array<Tag>;
     /**
      * 
-     * @type {Array<Tag>}
-     * @memberof Pet
      */
     optionalTags?: Array<Tag>;
     /**
      * pet status in the store
-     * @type {PetStatusEnum}
-     * @memberof Pet
      */
     status: PetStatusEnum;
     /**
      * An array of all 15-minute time slots in 24 hours.
-     * @type {Array<Array<number | null>>}
-     * @memberof Pet
      */
     regions?: Array<Array<number | null>>;
 }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/PetRegionsResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/PetRegionsResponse.ts
@@ -29,14 +29,10 @@ import {
 export interface PetRegionsResponse {
     /**
      * 
-     * @type {ResponseMeta}
-     * @memberof PetRegionsResponse
      */
     meta: ResponseMeta;
     /**
      * An array of all 15-minute time slots in 24 hours.
-     * @type {Array<Array<number | null>>}
-     * @memberof PetRegionsResponse
      */
     data?: Array<Array<number | null>>;
 }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ResponseMeta.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ResponseMeta.ts
@@ -29,38 +29,26 @@ import {
 export interface ResponseMeta {
     /**
      * Code returned by the function
-     * @type {ResponseMetaCodeEnum}
-     * @memberof ResponseMeta
      */
     code: ResponseMetaCodeEnum;
     /**
      * Explanation of what went wrong
-     * @type {string}
-     * @memberof ResponseMeta
      */
     detail?: string;
     /**
      * Message of the exception that will help developer to debug this problem if needed
-     * @type {string}
-     * @memberof ResponseMeta
      */
     exception?: string;
     /**
      * Type of error
-     * @type {string}
-     * @memberof ResponseMeta
      */
     type?: string;
     /**
      * 
-     * @type {ErrorCode}
-     * @memberof ResponseMeta
      */
     errorCode?: ErrorCode;
     /**
      * An array of all the specific error encountered during the request
-     * @type {Array<Error>}
-     * @memberof ResponseMeta
      */
     errors?: Array<Error>;
 }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Tag.ts
@@ -21,14 +21,10 @@ import { mapValues } from '../runtime';
 export interface Tag {
     /**
      * 
-     * @type {number}
-     * @memberof Tag
      */
     id?: number;
     /**
      * 
-     * @type {string}
-     * @memberof Tag
      */
     name?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/User.ts
@@ -21,62 +21,42 @@ import { mapValues } from '../runtime';
 export interface User {
     /**
      * 
-     * @type {number}
-     * @memberof User
      */
     id: number;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     username?: string;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     firstName?: string;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     lastName?: string;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     email?: string;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     password?: string;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     phone?: string;
     /**
      * User Status
-     * @type {number}
-     * @memberof User
      */
     userStatus?: number;
     /**
      * 
-     * @type {User}
-     * @memberof User
      */
     subUser?: User;
     /**
      * 
-     * @type {User}
-     * @memberof User
      */
     subUser2: User;
 }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/AdditionalPropertiesClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/AdditionalPropertiesClass.ts
@@ -21,14 +21,10 @@ import { mapValues } from '../runtime';
 export interface AdditionalPropertiesClass {
     /**
      * 
-     * @type {{ [key: string]: string; }}
-     * @memberof AdditionalPropertiesClass
      */
     mapProperty?: { [key: string]: string; };
     /**
      * 
-     * @type {{ [key: string]: { [key: string]: string; }; }}
-     * @memberof AdditionalPropertiesClass
      */
     mapOfMapProperty?: { [key: string]: { [key: string]: string; }; };
 }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/AllOfWithSingleRef.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/AllOfWithSingleRef.ts
@@ -29,14 +29,10 @@ import {
 export interface AllOfWithSingleRef {
     /**
      * 
-     * @type {string}
-     * @memberof AllOfWithSingleRef
      */
     username?: string;
     /**
      * 
-     * @type {SingleRefType}
-     * @memberof AllOfWithSingleRef
      */
     singleRefType?: SingleRefType;
 }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Animal.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Animal.ts
@@ -23,14 +23,10 @@ import { type Dog, DogFromJSONTyped, DogToJSON, DogToJSONTyped } from './Dog';
 export interface Animal {
     /**
      * 
-     * @type {string}
-     * @memberof Animal
      */
     className: string;
     /**
      * 
-     * @type {string}
-     * @memberof Animal
      */
     color?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ArrayOfArrayOfNumberOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ArrayOfArrayOfNumberOnly.ts
@@ -21,8 +21,6 @@ import { mapValues } from '../runtime';
 export interface ArrayOfArrayOfNumberOnly {
     /**
      * 
-     * @type {Array<Array<number>>}
-     * @memberof ArrayOfArrayOfNumberOnly
      */
     arrayArrayNumber?: Array<Array<number>>;
 }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ArrayOfNumberOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ArrayOfNumberOnly.ts
@@ -21,8 +21,6 @@ import { mapValues } from '../runtime';
 export interface ArrayOfNumberOnly {
     /**
      * 
-     * @type {Array<number>}
-     * @memberof ArrayOfNumberOnly
      */
     arrayNumber?: Array<number>;
 }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ArrayTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ArrayTest.ts
@@ -29,20 +29,14 @@ import {
 export interface ArrayTest {
     /**
      * 
-     * @type {Array<string>}
-     * @memberof ArrayTest
      */
     arrayOfString?: Array<string>;
     /**
      * 
-     * @type {Array<Array<number>>}
-     * @memberof ArrayTest
      */
     arrayArrayOfInteger?: Array<Array<number>>;
     /**
      * 
-     * @type {Array<Array<ReadOnlyFirst>>}
-     * @memberof ArrayTest
      */
     arrayArrayOfModel?: Array<Array<ReadOnlyFirst>>;
 }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Capitalization.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Capitalization.ts
@@ -21,39 +21,27 @@ import { mapValues } from '../runtime';
 export interface Capitalization {
     /**
      * 
-     * @type {string}
-     * @memberof Capitalization
      */
     smallCamel?: string;
     /**
      * 
-     * @type {string}
-     * @memberof Capitalization
      */
     capitalCamel?: string;
     /**
      * 
-     * @type {string}
-     * @memberof Capitalization
      */
     smallSnake?: string;
     /**
      * 
-     * @type {string}
-     * @memberof Capitalization
      */
     capitalSnake?: string;
     /**
      * 
-     * @type {string}
-     * @memberof Capitalization
      */
     sCAETHFlowPoints?: string;
     /**
      * Name of the pet
      * 
-     * @type {string}
-     * @memberof Capitalization
      */
     aTTNAME?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Cat.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Cat.ts
@@ -29,8 +29,6 @@ import {
 export interface Cat extends Animal {
     /**
      * 
-     * @type {boolean}
-     * @memberof Cat
      */
     declawed?: boolean;
 }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Category.ts
@@ -21,14 +21,10 @@ import { mapValues } from '../runtime';
 export interface Category {
     /**
      * 
-     * @type {number}
-     * @memberof Category
      */
     id?: number;
     /**
      * 
-     * @type {string}
-     * @memberof Category
      */
     name: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ClassModel.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ClassModel.ts
@@ -21,8 +21,6 @@ import { mapValues } from '../runtime';
 export interface ClassModel {
     /**
      * 
-     * @type {string}
-     * @memberof ClassModel
      */
     _class?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Client.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Client.ts
@@ -21,8 +21,6 @@ import { mapValues } from '../runtime';
 export interface Client {
     /**
      * 
-     * @type {string}
-     * @memberof Client
      */
     client?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/DeprecatedObject.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/DeprecatedObject.ts
@@ -21,8 +21,6 @@ import { mapValues } from '../runtime';
 export interface DeprecatedObject {
     /**
      * 
-     * @type {string}
-     * @memberof DeprecatedObject
      */
     name?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Dog.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Dog.ts
@@ -29,8 +29,6 @@ import {
 export interface Dog extends Animal {
     /**
      * 
-     * @type {string}
-     * @memberof Dog
      */
     breed?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/EnumArrays.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/EnumArrays.ts
@@ -21,14 +21,10 @@ import { mapValues } from '../runtime';
 export interface EnumArrays {
     /**
      * 
-     * @type {EnumArraysJustSymbolEnum}
-     * @memberof EnumArrays
      */
     justSymbol?: EnumArraysJustSymbolEnum;
     /**
      * 
-     * @type {Array<EnumArraysArrayEnumEnum>}
-     * @memberof EnumArrays
      */
     arrayEnum?: Array<EnumArraysArrayEnumEnum>;
 }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/EnumTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/EnumTest.ts
@@ -50,50 +50,34 @@ import {
 export interface EnumTest {
     /**
      * 
-     * @type {EnumTestEnumStringEnum}
-     * @memberof EnumTest
      */
     enumString?: EnumTestEnumStringEnum;
     /**
      * 
-     * @type {EnumTestEnumStringRequiredEnum}
-     * @memberof EnumTest
      */
     enumStringRequired: EnumTestEnumStringRequiredEnum;
     /**
      * 
-     * @type {EnumTestEnumIntegerEnum}
-     * @memberof EnumTest
      */
     enumInteger?: EnumTestEnumIntegerEnum;
     /**
      * 
-     * @type {EnumTestEnumNumberEnum}
-     * @memberof EnumTest
      */
     enumNumber?: EnumTestEnumNumberEnum;
     /**
      * 
-     * @type {OuterEnum}
-     * @memberof EnumTest
      */
     outerEnum?: OuterEnum | null;
     /**
      * 
-     * @type {OuterEnumInteger}
-     * @memberof EnumTest
      */
     outerEnumInteger?: OuterEnumInteger;
     /**
      * 
-     * @type {OuterEnumDefaultValue}
-     * @memberof EnumTest
      */
     outerEnumDefaultValue?: OuterEnumDefaultValue;
     /**
      * 
-     * @type {OuterEnumIntegerDefaultValue}
-     * @memberof EnumTest
      */
     outerEnumIntegerDefaultValue?: OuterEnumIntegerDefaultValue;
 }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/FakeBigDecimalMap200Response.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/FakeBigDecimalMap200Response.ts
@@ -21,14 +21,10 @@ import { mapValues } from '../runtime';
 export interface FakeBigDecimalMap200Response {
     /**
      * 
-     * @type {number}
-     * @memberof FakeBigDecimalMap200Response
      */
     someId?: number;
     /**
      * 
-     * @type {{ [key: string]: number; }}
-     * @memberof FakeBigDecimalMap200Response
      */
     someMap?: { [key: string]: number; };
 }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/FileSchemaTestClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/FileSchemaTestClass.ts
@@ -21,14 +21,10 @@ import { mapValues } from '../runtime';
 export interface FileSchemaTestClass {
     /**
      * 
-     * @type {any}
-     * @memberof FileSchemaTestClass
      */
     file?: any;
     /**
      * 
-     * @type {Array<any>}
-     * @memberof FileSchemaTestClass
      */
     files?: Array<any>;
 }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Foo.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Foo.ts
@@ -21,8 +21,6 @@ import { mapValues } from '../runtime';
 export interface Foo {
     /**
      * 
-     * @type {string}
-     * @memberof Foo
      */
     bar?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/FooGetDefaultResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/FooGetDefaultResponse.ts
@@ -29,8 +29,6 @@ import {
 export interface FooGetDefaultResponse {
     /**
      * 
-     * @type {Foo}
-     * @memberof FooGetDefaultResponse
      */
     string?: Foo;
 }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/FormatTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/FormatTest.ts
@@ -21,98 +21,66 @@ import { mapValues } from '../runtime';
 export interface FormatTest {
     /**
      * 
-     * @type {number}
-     * @memberof FormatTest
      */
     integer?: number;
     /**
      * 
-     * @type {number}
-     * @memberof FormatTest
      */
     int32?: number;
     /**
      * 
-     * @type {number}
-     * @memberof FormatTest
      */
     int64?: number;
     /**
      * 
-     * @type {number}
-     * @memberof FormatTest
      */
     number: number;
     /**
      * 
-     * @type {number}
-     * @memberof FormatTest
      */
     _float?: number;
     /**
      * 
-     * @type {number}
-     * @memberof FormatTest
      */
     _double?: number;
     /**
      * 
-     * @type {string}
-     * @memberof FormatTest
      */
     decimal?: string;
     /**
      * 
-     * @type {string}
-     * @memberof FormatTest
      */
     string?: string;
     /**
      * 
-     * @type {string}
-     * @memberof FormatTest
      */
     _byte: string;
     /**
      * 
-     * @type {Blob}
-     * @memberof FormatTest
      */
     binary?: Blob;
     /**
      * 
-     * @type {Date}
-     * @memberof FormatTest
      */
     date: Date;
     /**
      * 
-     * @type {Date}
-     * @memberof FormatTest
      */
     dateTime?: Date;
     /**
      * 
-     * @type {string}
-     * @memberof FormatTest
      */
     uuid?: string;
     /**
      * 
-     * @type {string}
-     * @memberof FormatTest
      */
     password: string;
     /**
      * A string that is a 10 digit number. Can have leading zeros.
-     * @type {string}
-     * @memberof FormatTest
      */
     patternWithDigits?: string;
     /**
      * A string starting with 'image_' (case insensitive) and one to three digits following i.e. Image_01.
-     * @type {string}
-     * @memberof FormatTest
      */
     patternWithDigitsAndDelimiter?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/HasOnlyReadOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/HasOnlyReadOnly.ts
@@ -21,14 +21,10 @@ import { mapValues } from '../runtime';
 export interface HasOnlyReadOnly {
     /**
      * 
-     * @type {string}
-     * @memberof HasOnlyReadOnly
      */
     readonly bar?: string;
     /**
      * 
-     * @type {string}
-     * @memberof HasOnlyReadOnly
      */
     readonly foo?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/HealthCheckResult.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/HealthCheckResult.ts
@@ -21,8 +21,6 @@ import { mapValues } from '../runtime';
 export interface HealthCheckResult {
     /**
      * 
-     * @type {string}
-     * @memberof HealthCheckResult
      */
     nullableMessage?: string | null;
 }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/List.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/List.ts
@@ -21,8 +21,6 @@ import { mapValues } from '../runtime';
 export interface List {
     /**
      * 
-     * @type {string}
-     * @memberof List
      */
     _123list?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/MapTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/MapTest.ts
@@ -21,26 +21,18 @@ import { mapValues } from '../runtime';
 export interface MapTest {
     /**
      * 
-     * @type {{ [key: string]: { [key: string]: string; }; }}
-     * @memberof MapTest
      */
     mapMapOfString?: { [key: string]: { [key: string]: string; }; };
     /**
      * 
-     * @type {{ [key: string]: MapTestMapOfEnumStringEnum; }}
-     * @memberof MapTest
      */
     mapOfEnumString?: { [key: string]: MapTestMapOfEnumStringEnum; };
     /**
      * 
-     * @type {{ [key: string]: boolean; }}
-     * @memberof MapTest
      */
     directMap?: { [key: string]: boolean; };
     /**
      * 
-     * @type {{ [key: string]: boolean; }}
-     * @memberof MapTest
      */
     indirectMap?: { [key: string]: boolean; };
 }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/MixedPropertiesAndAdditionalPropertiesClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/MixedPropertiesAndAdditionalPropertiesClass.ts
@@ -29,20 +29,14 @@ import {
 export interface MixedPropertiesAndAdditionalPropertiesClass {
     /**
      * 
-     * @type {string}
-     * @memberof MixedPropertiesAndAdditionalPropertiesClass
      */
     uuid?: string;
     /**
      * 
-     * @type {Date}
-     * @memberof MixedPropertiesAndAdditionalPropertiesClass
      */
     dateTime?: Date;
     /**
      * 
-     * @type {{ [key: string]: Animal; }}
-     * @memberof MixedPropertiesAndAdditionalPropertiesClass
      */
     map?: { [key: string]: Animal; };
 }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Model200Response.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Model200Response.ts
@@ -21,14 +21,10 @@ import { mapValues } from '../runtime';
 export interface Model200Response {
     /**
      * 
-     * @type {number}
-     * @memberof Model200Response
      */
     name?: number;
     /**
      * 
-     * @type {string}
-     * @memberof Model200Response
      */
     _class?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ModelApiResponse.ts
@@ -21,20 +21,14 @@ import { mapValues } from '../runtime';
 export interface ModelApiResponse {
     /**
      * 
-     * @type {number}
-     * @memberof ModelApiResponse
      */
     code?: number;
     /**
      * 
-     * @type {string}
-     * @memberof ModelApiResponse
      */
     type?: string;
     /**
      * 
-     * @type {string}
-     * @memberof ModelApiResponse
      */
     message?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ModelFile.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ModelFile.ts
@@ -21,8 +21,6 @@ import { mapValues } from '../runtime';
 export interface ModelFile {
     /**
      * Test capitalization
-     * @type {string}
-     * @memberof ModelFile
      */
     sourceURI?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Name.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Name.ts
@@ -21,26 +21,18 @@ import { mapValues } from '../runtime';
 export interface Name {
     /**
      * 
-     * @type {number}
-     * @memberof Name
      */
     name: number;
     /**
      * 
-     * @type {number}
-     * @memberof Name
      */
     readonly snakeCase?: number;
     /**
      * 
-     * @type {string}
-     * @memberof Name
      */
     property?: string;
     /**
      * 
-     * @type {number}
-     * @memberof Name
      */
     readonly _123number?: number;
 }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/NullableClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/NullableClass.ts
@@ -22,74 +22,50 @@ export interface NullableClass {
     [key: string]: object | any;
     /**
      * 
-     * @type {number}
-     * @memberof NullableClass
      */
     integerProp?: number | null;
     /**
      * 
-     * @type {number}
-     * @memberof NullableClass
      */
     numberProp?: number | null;
     /**
      * 
-     * @type {boolean}
-     * @memberof NullableClass
      */
     booleanProp?: boolean | null;
     /**
      * 
-     * @type {string}
-     * @memberof NullableClass
      */
     stringProp?: string | null;
     /**
      * 
-     * @type {Date}
-     * @memberof NullableClass
      */
     dateProp?: Date | null;
     /**
      * 
-     * @type {Date}
-     * @memberof NullableClass
      */
     datetimeProp?: Date | null;
     /**
      * 
-     * @type {Array<object>}
-     * @memberof NullableClass
      */
     arrayNullableProp?: Array<object> | null;
     /**
      * 
-     * @type {Array<object | null>}
-     * @memberof NullableClass
      */
     arrayAndItemsNullableProp?: Array<object | null> | null;
     /**
      * 
-     * @type {Array<object | null>}
-     * @memberof NullableClass
      */
     arrayItemsNullable?: Array<object | null>;
     /**
      * 
-     * @type {{ [key: string]: object; }}
-     * @memberof NullableClass
      */
     objectNullableProp?: { [key: string]: object; } | null;
     /**
      * 
-     * @type {{ [key: string]: object | null; }}
-     * @memberof NullableClass
      */
     objectAndItemsNullableProp?: { [key: string]: object | null; } | null;
     /**
      * 
-     * @type {{ [key: string]: object | null; }}
-     * @memberof NullableClass
      */
     objectItemsNullable?: { [key: string]: object | null; };
 }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/NumberOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/NumberOnly.ts
@@ -21,8 +21,6 @@ import { mapValues } from '../runtime';
 export interface NumberOnly {
     /**
      * 
-     * @type {number}
-     * @memberof NumberOnly
      */
     justNumber?: number;
 }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ObjectWithDeprecatedFields.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ObjectWithDeprecatedFields.ts
@@ -29,28 +29,20 @@ import {
 export interface ObjectWithDeprecatedFields {
     /**
      * 
-     * @type {string}
-     * @memberof ObjectWithDeprecatedFields
      */
     uuid?: string;
     /**
      * 
-     * @type {number}
-     * @memberof ObjectWithDeprecatedFields
      * @deprecated
      */
     id?: number;
     /**
      * 
-     * @type {DeprecatedObject}
-     * @memberof ObjectWithDeprecatedFields
      * @deprecated
      */
     deprecatedRef?: DeprecatedObject;
     /**
      * 
-     * @type {Array<string>}
-     * @memberof ObjectWithDeprecatedFields
      * @deprecated
      */
     bars?: Array<string>;

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Order.ts
@@ -21,38 +21,26 @@ import { mapValues } from '../runtime';
 export interface Order {
     /**
      * 
-     * @type {number}
-     * @memberof Order
      */
     id?: number;
     /**
      * 
-     * @type {number}
-     * @memberof Order
      */
     petId?: number;
     /**
      * 
-     * @type {number}
-     * @memberof Order
      */
     quantity?: number;
     /**
      * 
-     * @type {Date}
-     * @memberof Order
      */
     shipDate?: Date;
     /**
      * Order Status
-     * @type {OrderStatusEnum}
-     * @memberof Order
      */
     status?: OrderStatusEnum;
     /**
      * 
-     * @type {boolean}
-     * @memberof Order
      */
     complete?: boolean;
 }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterComposite.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterComposite.ts
@@ -21,20 +21,14 @@ import { mapValues } from '../runtime';
 export interface OuterComposite {
     /**
      * 
-     * @type {number}
-     * @memberof OuterComposite
      */
     myNumber?: number;
     /**
      * 
-     * @type {string}
-     * @memberof OuterComposite
      */
     myString?: string;
     /**
      * 
-     * @type {boolean}
-     * @memberof OuterComposite
      */
     myBoolean?: boolean;
 }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterObjectWithEnumProperty.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterObjectWithEnumProperty.ts
@@ -29,8 +29,6 @@ import {
 export interface OuterObjectWithEnumProperty {
     /**
      * 
-     * @type {OuterEnumInteger}
-     * @memberof OuterObjectWithEnumProperty
      */
     value: OuterEnumInteger;
 }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Pet.ts
@@ -36,38 +36,26 @@ import {
 export interface Pet {
     /**
      * 
-     * @type {number}
-     * @memberof Pet
      */
     id?: number;
     /**
      * 
-     * @type {Category}
-     * @memberof Pet
      */
     category?: Category;
     /**
      * 
-     * @type {string}
-     * @memberof Pet
      */
     name: string;
     /**
      * 
-     * @type {Set<string>}
-     * @memberof Pet
      */
     photoUrls: Set<string>;
     /**
      * 
-     * @type {Array<Tag>}
-     * @memberof Pet
      */
     tags?: Array<Tag>;
     /**
      * pet status in the store
-     * @type {PetStatusEnum}
-     * @memberof Pet
      */
     status?: PetStatusEnum;
 }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ReadOnlyFirst.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ReadOnlyFirst.ts
@@ -21,14 +21,10 @@ import { mapValues } from '../runtime';
 export interface ReadOnlyFirst {
     /**
      * 
-     * @type {string}
-     * @memberof ReadOnlyFirst
      */
     readonly bar?: string;
     /**
      * 
-     * @type {string}
-     * @memberof ReadOnlyFirst
      */
     baz?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Return.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Return.ts
@@ -21,8 +21,6 @@ import { mapValues } from '../runtime';
 export interface Return {
     /**
      * 
-     * @type {number}
-     * @memberof Return
      */
     _return?: number;
 }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/SpecialModelName.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/SpecialModelName.ts
@@ -21,8 +21,6 @@ import { mapValues } from '../runtime';
 export interface SpecialModelName {
     /**
      * 
-     * @type {number}
-     * @memberof SpecialModelName
      */
     $specialPropertyName?: number;
 }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Tag.ts
@@ -21,14 +21,10 @@ import { mapValues } from '../runtime';
 export interface Tag {
     /**
      * 
-     * @type {number}
-     * @memberof Tag
      */
     id?: number;
     /**
      * 
-     * @type {string}
-     * @memberof Tag
      */
     name?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/User.ts
@@ -21,50 +21,34 @@ import { mapValues } from '../runtime';
 export interface User {
     /**
      * 
-     * @type {number}
-     * @memberof User
      */
     id?: number;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     username?: string;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     firstName?: string;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     lastName?: string;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     email?: string;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     password?: string;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     phone?: string;
     /**
      * User Status
-     * @type {number}
-     * @memberof User
      */
     userStatus?: number;
 }

--- a/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/Category.ts
@@ -21,14 +21,10 @@ import { mapValues } from '../runtime';
 export interface Category {
     /**
      * 
-     * @type {number}
-     * @memberof Category
      */
     id?: number;
     /**
      * 
-     * @type {string}
-     * @memberof Category
      */
     name?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/ModelApiResponse.ts
@@ -21,20 +21,14 @@ import { mapValues } from '../runtime';
 export interface ModelApiResponse {
     /**
      * 
-     * @type {number}
-     * @memberof ModelApiResponse
      */
     code?: number;
     /**
      * 
-     * @type {string}
-     * @memberof ModelApiResponse
      */
     type?: string;
     /**
      * 
-     * @type {string}
-     * @memberof ModelApiResponse
      */
     message?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/Order.ts
@@ -22,38 +22,26 @@ export interface Order {
     [key: string]: string | any;
     /**
      * 
-     * @type {number}
-     * @memberof Order
      */
     id?: number;
     /**
      * 
-     * @type {number}
-     * @memberof Order
      */
     petId?: number;
     /**
      * 
-     * @type {number}
-     * @memberof Order
      */
     quantity?: number;
     /**
      * 
-     * @type {Date}
-     * @memberof Order
      */
     shipDate?: Date;
     /**
      * Order Status
-     * @type {OrderStatusEnum}
-     * @memberof Order
      */
     status?: OrderStatusEnum;
     /**
      * 
-     * @type {boolean}
-     * @memberof Order
      */
     complete?: boolean;
 }

--- a/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/Pet.ts
@@ -36,38 +36,26 @@ import {
 export interface Pet {
     /**
      * 
-     * @type {number}
-     * @memberof Pet
      */
     id?: number;
     /**
      * 
-     * @type {Category}
-     * @memberof Pet
      */
     category?: Category;
     /**
      * 
-     * @type {string}
-     * @memberof Pet
      */
     name: string;
     /**
      * 
-     * @type {Set<string>}
-     * @memberof Pet
      */
     photoUrls: Set<string>;
     /**
      * 
-     * @type {Array<Tag>}
-     * @memberof Pet
      */
     tags?: Array<Tag>;
     /**
      * pet status in the store
-     * @type {PetStatusEnum}
-     * @memberof Pet
      * @deprecated
      */
     status?: PetStatusEnum;

--- a/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/Tag.ts
@@ -21,14 +21,10 @@ import { mapValues } from '../runtime';
 export interface Tag {
     /**
      * 
-     * @type {number}
-     * @memberof Tag
      */
     id?: number;
     /**
      * 
-     * @type {string}
-     * @memberof Tag
      */
     name?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/User.ts
@@ -21,56 +21,38 @@ import { mapValues } from '../runtime';
 export interface User {
     /**
      * 
-     * @type {number}
-     * @memberof User
      */
     id?: number;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     username?: string;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     firstName?: string;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     lastName?: string;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     email?: string;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     password?: string;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     phone?: string;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     nickname?: string;
     /**
      * User Status
-     * @type {number}
-     * @memberof User
      */
     userStatus?: number;
 }

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Category.ts
@@ -21,14 +21,10 @@ import { mapValues } from '../runtime';
 export interface Category {
     /**
      * 
-     * @type {number}
-     * @memberof Category
      */
     id?: number;
     /**
      * 
-     * @type {string}
-     * @memberof Category
      */
     name?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/ModelApiResponse.ts
@@ -21,20 +21,14 @@ import { mapValues } from '../runtime';
 export interface ModelApiResponse {
     /**
      * 
-     * @type {number}
-     * @memberof ModelApiResponse
      */
     code?: number;
     /**
      * 
-     * @type {string}
-     * @memberof ModelApiResponse
      */
     type?: string;
     /**
      * 
-     * @type {string}
-     * @memberof ModelApiResponse
      */
     message?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Order.ts
@@ -21,38 +21,26 @@ import { mapValues } from '../runtime';
 export interface Order {
     /**
      * 
-     * @type {number}
-     * @memberof Order
      */
     id?: number;
     /**
      * 
-     * @type {number}
-     * @memberof Order
      */
     petId?: number;
     /**
      * 
-     * @type {number}
-     * @memberof Order
      */
     quantity?: number;
     /**
      * 
-     * @type {Date}
-     * @memberof Order
      */
     shipDate?: Date;
     /**
      * Order Status
-     * @type {OrderStatusEnum}
-     * @memberof Order
      */
     status?: OrderStatusEnum;
     /**
      * 
-     * @type {boolean}
-     * @memberof Order
      */
     complete?: boolean;
 }

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Pet.ts
@@ -36,38 +36,26 @@ import {
 export interface Pet {
     /**
      * 
-     * @type {number}
-     * @memberof Pet
      */
     id?: number;
     /**
      * 
-     * @type {Category}
-     * @memberof Pet
      */
     category?: Category;
     /**
      * 
-     * @type {string}
-     * @memberof Pet
      */
     name: string;
     /**
      * 
-     * @type {Array<string>}
-     * @memberof Pet
      */
     photoUrls: Array<string>;
     /**
      * 
-     * @type {Array<Tag>}
-     * @memberof Pet
      */
     tags?: Array<Tag>;
     /**
      * pet status in the store
-     * @type {PetStatusEnum}
-     * @memberof Pet
      */
     status?: PetStatusEnum;
 }

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Tag.ts
@@ -21,14 +21,10 @@ import { mapValues } from '../runtime';
 export interface Tag {
     /**
      * 
-     * @type {number}
-     * @memberof Tag
      */
     id?: number;
     /**
      * 
-     * @type {string}
-     * @memberof Tag
      */
     name?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/User.ts
@@ -21,50 +21,34 @@ import { mapValues } from '../runtime';
 export interface User {
     /**
      * 
-     * @type {number}
-     * @memberof User
      */
     id?: number;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     username?: string;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     firstName?: string;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     lastName?: string;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     email?: string;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     password?: string;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     phone?: string;
     /**
      * User Status
-     * @type {number}
-     * @memberof User
      */
     userStatus?: number;
 }

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Category.ts
@@ -21,14 +21,10 @@ import { mapValues } from '../runtime';
 export interface Category {
     /**
      * 
-     * @type {number}
-     * @memberof Category
      */
     id?: number;
     /**
      * 
-     * @type {string}
-     * @memberof Category
      */
     name?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/ModelApiResponse.ts
@@ -21,20 +21,14 @@ import { mapValues } from '../runtime';
 export interface ModelApiResponse {
     /**
      * 
-     * @type {number}
-     * @memberof ModelApiResponse
      */
     code?: number;
     /**
      * 
-     * @type {string}
-     * @memberof ModelApiResponse
      */
     type?: string;
     /**
      * 
-     * @type {string}
-     * @memberof ModelApiResponse
      */
     message?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Order.ts
@@ -21,38 +21,26 @@ import { mapValues } from '../runtime';
 export interface Order {
     /**
      * 
-     * @type {number}
-     * @memberof Order
      */
     id?: number;
     /**
      * 
-     * @type {number}
-     * @memberof Order
      */
     petId?: number;
     /**
      * 
-     * @type {number}
-     * @memberof Order
      */
     quantity?: number;
     /**
      * 
-     * @type {Date}
-     * @memberof Order
      */
     shipDate?: Date;
     /**
      * Order Status
-     * @type {OrderStatusEnum}
-     * @memberof Order
      */
     status?: OrderStatusEnum;
     /**
      * 
-     * @type {boolean}
-     * @memberof Order
      */
     complete?: boolean;
 }

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Pet.ts
@@ -36,38 +36,26 @@ import {
 export interface Pet {
     /**
      * 
-     * @type {number}
-     * @memberof Pet
      */
     id?: number;
     /**
      * 
-     * @type {Category}
-     * @memberof Pet
      */
     category?: Category;
     /**
      * 
-     * @type {string}
-     * @memberof Pet
      */
     name: string;
     /**
      * 
-     * @type {Array<string>}
-     * @memberof Pet
      */
     photoUrls: Array<string>;
     /**
      * 
-     * @type {Array<Tag>}
-     * @memberof Pet
      */
     tags?: Array<Tag>;
     /**
      * pet status in the store
-     * @type {PetStatusEnum}
-     * @memberof Pet
      */
     status?: PetStatusEnum;
 }

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Tag.ts
@@ -21,14 +21,10 @@ import { mapValues } from '../runtime';
 export interface Tag {
     /**
      * 
-     * @type {number}
-     * @memberof Tag
      */
     id?: number;
     /**
      * 
-     * @type {string}
-     * @memberof Tag
      */
     name?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/User.ts
@@ -21,50 +21,34 @@ import { mapValues } from '../runtime';
 export interface User {
     /**
      * 
-     * @type {number}
-     * @memberof User
      */
     id?: number;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     username?: string;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     firstName?: string;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     lastName?: string;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     email?: string;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     password?: string;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     phone?: string;
     /**
      * User Status
-     * @type {number}
-     * @memberof User
      */
     userStatus?: number;
 }

--- a/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/EnumPatternObject.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/EnumPatternObject.ts
@@ -36,26 +36,18 @@ import {
 export interface EnumPatternObject {
     /**
      * 
-     * @type {StringEnum}
-     * @memberof EnumPatternObject
      */
     stringEnum?: StringEnum;
     /**
      * 
-     * @type {StringEnum}
-     * @memberof EnumPatternObject
      */
     nullableStringEnum?: StringEnum | null;
     /**
      * 
-     * @type {NumberEnum}
-     * @memberof EnumPatternObject
      */
     numberEnum?: NumberEnum;
     /**
      * 
-     * @type {NumberEnum}
-     * @memberof EnumPatternObject
      */
     nullableNumberEnum?: NumberEnum | null;
 }

--- a/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/FakeEnumRequestGetInline200Response.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/FakeEnumRequestGetInline200Response.ts
@@ -21,26 +21,18 @@ import { mapValues } from '../runtime';
 export interface FakeEnumRequestGetInline200Response {
     /**
      * 
-     * @type {FakeEnumRequestGetInline200ResponseStringEnumEnum}
-     * @memberof FakeEnumRequestGetInline200Response
      */
     stringEnum?: FakeEnumRequestGetInline200ResponseStringEnumEnum;
     /**
      * 
-     * @type {FakeEnumRequestGetInline200ResponseNullableStringEnumEnum}
-     * @memberof FakeEnumRequestGetInline200Response
      */
     nullableStringEnum?: FakeEnumRequestGetInline200ResponseNullableStringEnumEnum;
     /**
      * 
-     * @type {FakeEnumRequestGetInline200ResponseNumberEnumEnum}
-     * @memberof FakeEnumRequestGetInline200Response
      */
     numberEnum?: FakeEnumRequestGetInline200ResponseNumberEnumEnum;
     /**
      * 
-     * @type {FakeEnumRequestGetInline200ResponseNullableNumberEnumEnum}
-     * @memberof FakeEnumRequestGetInline200Response
      */
     nullableNumberEnum?: FakeEnumRequestGetInline200ResponseNullableNumberEnumEnum;
 }

--- a/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/models/index.ts
+++ b/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/models/index.ts
@@ -8,14 +8,10 @@
 export interface Category {
     /**
      * 
-     * @type {number}
-     * @memberof Category
      */
     id?: number;
     /**
      * 
-     * @type {string}
-     * @memberof Category
      */
     name?: string;
 }
@@ -27,20 +23,14 @@ export interface Category {
 export interface ModelApiResponse {
     /**
      * 
-     * @type {number}
-     * @memberof ModelApiResponse
      */
     code?: number;
     /**
      * 
-     * @type {string}
-     * @memberof ModelApiResponse
      */
     type?: string;
     /**
      * 
-     * @type {string}
-     * @memberof ModelApiResponse
      */
     message?: string;
 }
@@ -52,38 +42,26 @@ export interface ModelApiResponse {
 export interface Order {
     /**
      * 
-     * @type {number}
-     * @memberof Order
      */
     id?: number;
     /**
      * 
-     * @type {number}
-     * @memberof Order
      */
     petId?: number;
     /**
      * 
-     * @type {number}
-     * @memberof Order
      */
     quantity?: number;
     /**
      * 
-     * @type {string}
-     * @memberof Order
      */
     shipDate?: string;
     /**
      * Order Status
-     * @type {OrderStatusEnum}
-     * @memberof Order
      */
     status?: OrderStatusEnum;
     /**
      * 
-     * @type {boolean}
-     * @memberof Order
      */
     complete?: boolean;
 }
@@ -107,38 +85,26 @@ export type OrderStatusEnum = typeof OrderStatusEnum[keyof typeof OrderStatusEnu
 export interface Pet {
     /**
      * 
-     * @type {number}
-     * @memberof Pet
      */
     id?: number;
     /**
      * 
-     * @type {Category}
-     * @memberof Pet
      */
     category?: Category;
     /**
      * 
-     * @type {string}
-     * @memberof Pet
      */
     name: string;
     /**
      * 
-     * @type {Array<string>}
-     * @memberof Pet
      */
     photoUrls: Array<string>;
     /**
      * 
-     * @type {Array<Tag>}
-     * @memberof Pet
      */
     tags?: Array<Tag>;
     /**
      * pet status in the store
-     * @type {PetStatusEnum}
-     * @memberof Pet
      */
     status?: PetStatusEnum;
 }
@@ -162,14 +128,10 @@ export type PetStatusEnum = typeof PetStatusEnum[keyof typeof PetStatusEnum];
 export interface Tag {
     /**
      * 
-     * @type {number}
-     * @memberof Tag
      */
     id?: number;
     /**
      * 
-     * @type {string}
-     * @memberof Tag
      */
     name?: string;
 }
@@ -181,50 +143,34 @@ export interface Tag {
 export interface User {
     /**
      * 
-     * @type {number}
-     * @memberof User
      */
     id?: number;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     username?: string;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     firstName?: string;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     lastName?: string;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     email?: string;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     password?: string;
     /**
      * 
-     * @type {string}
-     * @memberof User
      */
     phone?: string;
     /**
      * User Status
-     * @type {number}
-     * @memberof User
      */
     userStatus?: number;
 }


### PR DESCRIPTION
Drop the `@type` and `@memberof` JSDoc annotations from the generated model interfaces and regenerate the samples.

This is a follow-up of this comment:
https://github.com/OpenAPITools/openapi-generator/pull/24510#discussion_r3671783048

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc @macjohnny 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove `@type` and `@memberof` JSDoc tags from generated `typescript-fetch` model interfaces to simplify field docs and rely on TypeScript types for accuracy.

- **Refactors**
  - Updated `modelGenericInterfaces.mustache` to stop emitting `@type` and `@memberof` on model fields.
  - Regenerated `typescript-fetch` samples to reflect the new doc comments.

<sup>Written for commit 66b27f207d2544e6cd21c40b564c4b12d55303c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24514?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

