### PR TITLE
fix: kotlin multiplatform inline enum toString uses enum value instead of constant

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/data_class.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/data_class.mustache
@@ -176,6 +176,9 @@ import {{packageName}}.infrastructure.ITransformForStorage
         {{/multiplatform}}
     {{/enumVars}}
     {{/allowableValues}}
+    {{#multiplatform}}
+        override fun toString(): kotlin.String = value{{^isString}}.toString(){{/isString}}
+    {{/multiplatform}}
     }
     {{#kotlinx_serialization}}
     {{#enumUnknownDefaultCase}}

--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/api.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/api.mustache
@@ -46,15 +46,16 @@ import kotlinx.serialization.encoding.*
     {{^enumUnknownDefaultCase}}
         {{#allowableValues}}{{#enumVars}}
         @SerialName(value = {{^isString}}"{{/isString}}{{{value}}}{{^isString}}"{{/isString}})
-        {{&name}}({{{value}}}){{^-last}},{{/-last}}
+        {{&name}}({{{value}}}){{^-last}},{{/-last}}{{#-last}};{{/-last}}
         {{/enumVars}}{{/allowableValues}}
     {{/enumUnknownDefaultCase}}
     {{#enumUnknownDefaultCase}}
         {{#allowableValues}}{{#enumVars}}{{^-last}}
-        @SerialName(value = {{^isString}}"{{/isString}}{{{value}}}{{^isString}}"{{/isString}})
-        {{&name}}({{{value}}}),
+            @SerialName(value = {{^isString}}"{{/isString}}{{{value}}}{{^isString}}"{{/isString}})
+            {{&name}}({{{value}}});
         {{/-last}}{{/enumVars}}{{/allowableValues}}
     {{/enumUnknownDefaultCase}}
+        override fun toString(): kotlin.String = value{{^isString}}.toString(){{/isString}}
     }
 
     {{/isEnum}}

--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/api.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/api.mustache
@@ -47,6 +47,7 @@ import kotlinx.serialization.encoding.*
         @SerialName(value = {{^isString}}"{{/isString}}{{{value}}}{{^isString}}"{{/isString}})
         {{&name}}({{{value}}}){{^-last}},{{/-last}}{{#-last}};{{/-last}}
         {{/enumVars}}{{/allowableValues}}
+        override fun toString(): kotlin.String = value{{^isString}}.toString(){{/isString}}
     }
 
     {{/isEnum}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinClientCodegenModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinClientCodegenModelTest.java
@@ -43,11 +43,12 @@ import java.util.List;
 import java.util.Map;
 
 import static org.openapitools.codegen.CodegenConstants.*;
-import static org.openapitools.codegen.languages.KotlinClientCodegen.COMPANION_OBJECT;
-import static org.openapitools.codegen.languages.KotlinClientCodegen.GENERATE_ONEOF_ANYOF_WRAPPERS;
+import static org.openapitools.codegen.languages.KotlinClientCodegen.*;
 
 @SuppressWarnings("static-method")
 public class KotlinClientCodegenModelTest {
+
+    private static final String KOTLIN_GENERATOR = "kotlin";
 
     private Schema<?> getArrayTestSchema() {
         return new ObjectSchema()
@@ -369,7 +370,7 @@ public class KotlinClientCodegenModelTest {
         output.deleteOnExit();
 
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("kotlin")
+                .setGeneratorName(KOTLIN_GENERATOR)
                 .setLibrary("jvm-retrofit2")
                 .setAdditionalProperties(properties)
                 .setInputSpec("src/test/resources/3_0/issue4808.yaml")
@@ -392,7 +393,7 @@ public class KotlinClientCodegenModelTest {
         output.deleteOnExit();
 
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("kotlin")
+                .setGeneratorName(KOTLIN_GENERATOR)
                 .setInputSpec("src/test/resources/3_0/ping.yaml")
                 .addAdditionalProperty("omitGradleWrapper", true)
                 .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
@@ -495,7 +496,7 @@ public class KotlinClientCodegenModelTest {
         output.deleteOnExit();
 
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("kotlin")
+                .setGeneratorName(KOTLIN_GENERATOR)
                 .setLibrary(clientLibrary.getLibraryName())
                 .setInputSpec("src/test/resources/3_0/issue_19942.json")
                 .addAdditionalProperty("omitGradleWrapper", true)
@@ -519,7 +520,7 @@ public class KotlinClientCodegenModelTest {
         output.deleteOnExit();
 
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("kotlin")
+                .setGeneratorName(KOTLIN_GENERATOR)
                 .setLibrary(clientLibrary.getLibraryName())
                 .setInputSpec("src/test/resources/3_0/issue_19942.json")
                 .addAdditionalProperty("omitGradleWrapper", true)
@@ -582,7 +583,7 @@ public class KotlinClientCodegenModelTest {
 //        File output = Paths.get("/Users/sylvain_maillard/workspaces/openapi-generator/modules/openapi-generator/target/test").toFile();
 
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("kotlin")
+                .setGeneratorName(KOTLIN_GENERATOR)
                 .setInputSpec("src/test/resources/3_1/issue_22216.yaml")
                 .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
 
@@ -607,7 +608,7 @@ public class KotlinClientCodegenModelTest {
         output.deleteOnExit();
 
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("kotlin")
+                .setGeneratorName(KOTLIN_GENERATOR)
                 .setLibrary("jvm-retrofit2")
                 .setAdditionalProperties(new HashMap<>() {{
                     put(CodegenConstants.SERIALIZATION_LIBRARY, "kotlinx_serialization");
@@ -647,7 +648,7 @@ public class KotlinClientCodegenModelTest {
         output.deleteOnExit();
 
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("kotlin")
+                .setGeneratorName(KOTLIN_GENERATOR)
                 .setLibrary("jvm-retrofit2")
                 .setAdditionalProperties(new HashMap<>() {{
                     put(CodegenConstants.SERIALIZATION_LIBRARY, "kotlinx_serialization");
@@ -682,7 +683,7 @@ public class KotlinClientCodegenModelTest {
         output.deleteOnExit();
 
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("kotlin")
+                .setGeneratorName(KOTLIN_GENERATOR)
                 .setLibrary("jvm-retrofit2")
                 .setAdditionalProperties(new HashMap<>() {{
                     put(CodegenConstants.SERIALIZATION_LIBRARY, "kotlinx_serialization");
@@ -748,7 +749,7 @@ public class KotlinClientCodegenModelTest {
         props.putAll(extraProps);
         new DefaultGenerator()
                 .opts(new CodegenConfigurator()
-                        .setGeneratorName("kotlin")
+                        .setGeneratorName(KOTLIN_GENERATOR)
                         .setLibrary("jvm-retrofit2")
                         .setAdditionalProperties(props)
                         .setInputSpec("src/test/resources/3_0/issue_19942.json")
@@ -768,7 +769,7 @@ public class KotlinClientCodegenModelTest {
         output.deleteOnExit();
 
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("kotlin")
+                .setGeneratorName(KOTLIN_GENERATOR)
                 .setLibrary("jvm-okhttp4")
                 .setAdditionalProperties(new HashMap<>() {{
                     put(CodegenConstants.SERIALIZATION_LIBRARY, "jackson");
@@ -824,7 +825,7 @@ public class KotlinClientCodegenModelTest {
       output.deleteOnExit();
 
       final CodegenConfigurator configurator = new CodegenConfigurator()
-              .setGeneratorName("kotlin")
+              .setGeneratorName(KOTLIN_GENERATOR)
               .setLibrary("jvm-ktor")
               .setAdditionalProperties(new HashMap<>() {{
                 put(CodegenConstants.SERIALIZATION_LIBRARY, "jackson");
@@ -850,7 +851,7 @@ public class KotlinClientCodegenModelTest {
       output.deleteOnExit();
 
       final CodegenConfigurator configurator = new CodegenConfigurator()
-              .setGeneratorName("kotlin")
+              .setGeneratorName(KOTLIN_GENERATOR)
               .setLibrary("jvm-ktor")
               .setAdditionalProperties(new HashMap<>() {{
                 put(CodegenConstants.SERIALIZATION_LIBRARY, "jackson");
@@ -880,7 +881,7 @@ public class KotlinClientCodegenModelTest {
       output.deleteOnExit();
 
       final CodegenConfigurator configurator = new CodegenConfigurator()
-              .setGeneratorName("kotlin")
+              .setGeneratorName(KOTLIN_GENERATOR)
               .setLibrary("jvm-retrofit2")
               .setAdditionalProperties(new HashMap<>() {{
                 put(CodegenConstants.SERIALIZATION_LIBRARY, "jackson");
@@ -906,7 +907,7 @@ public class KotlinClientCodegenModelTest {
       output.deleteOnExit();
 
       final CodegenConfigurator configurator = new CodegenConfigurator()
-              .setGeneratorName("kotlin")
+              .setGeneratorName(KOTLIN_GENERATOR)
               .setLibrary("jvm-retrofit2")
               .setAdditionalProperties(new HashMap<>() {{
                 put(CodegenConstants.SERIALIZATION_LIBRARY, "jackson");
@@ -934,7 +935,7 @@ public class KotlinClientCodegenModelTest {
       output.deleteOnExit();
 
       final CodegenConfigurator configurator = new CodegenConfigurator()
-              .setGeneratorName("kotlin")
+              .setGeneratorName(KOTLIN_GENERATOR)
               .setLibrary("jvm-retrofit2")
               .setAdditionalProperties(new HashMap<>() {{
                 put(CodegenConstants.SERIALIZATION_LIBRARY, "jackson");
@@ -960,7 +961,7 @@ public class KotlinClientCodegenModelTest {
       output.deleteOnExit();
 
       final CodegenConfigurator configurator = new CodegenConfigurator()
-              .setGeneratorName("kotlin")
+              .setGeneratorName(KOTLIN_GENERATOR)
               .setLibrary("jvm-retrofit2")
               .setAdditionalProperties(new HashMap<>() {{
                 put(CodegenConstants.SERIALIZATION_LIBRARY, "jackson");
@@ -993,7 +994,7 @@ public class KotlinClientCodegenModelTest {
       output.deleteOnExit();
 
       final CodegenConfigurator configurator = new CodegenConfigurator()
-              .setGeneratorName("kotlin")
+              .setGeneratorName(KOTLIN_GENERATOR)
               .setLibrary("jvm-retrofit2")
               .setAdditionalProperties(new HashMap<>() {{
                 put(CodegenConstants.SERIALIZATION_LIBRARY, "jackson");
@@ -1016,6 +1017,74 @@ public class KotlinClientCodegenModelTest {
       TestUtils.assertFileNotContains(enumKt, "throw IllegalArgumentException(\"Unknown ExampleNumericEnum value");
   }
 
+    @Test
+    public void testMultiplatformEnumWithUnknownDefaultAndCustomVariableNamesOverridesToString() throws IOException {
+        File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName(KOTLIN_GENERATOR)
+                .setLibrary("multiplatform")
+                .setAdditionalProperties(new HashMap<>() {{
+                    put(CodegenConstants.SERIALIZATION_LIBRARY, "jackson");
+                    put(CodegenConstants.MODEL_PACKAGE, "model");
+                    put("dateLibrary", "kotlinx-datetime");
+                    put(ENUM_UNKNOWN_DEFAULT_CASE, "true");
+                }})
+                .setInputSpec("src/test/resources/3_0/kotlin/issue23764-multiplatform-inline-enum-serialization.yaml")
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+        final ClientOptInput clientOptInput = configurator.toClientOptInput();
+        DefaultGenerator generator = new DefaultGenerator();
+
+        generator.opts(clientOptInput).generate();
+
+        final Path definedEnumKt = Paths.get(output + "/src/commonMain/kotlin/model/ApiError.kt");
+        final Path inlineEnumKt = Paths.get(output + "/src/commonMain/kotlin/model/AllowFoo.kt");
+        final Path headerEnumKt = Paths.get(output + "/src/commonMain/kotlin/org/openapitools/client/apis/DefaultApi.kt");
+
+        TestUtils.assertFileContains(definedEnumKt, "override fun toString(): kotlin.String = value.toString()");
+        TestUtils.assertFileContains(definedEnumKt, "@SerialName(value = \"11184809\") unknown_default_open_api(11184809);");
+        TestUtils.assertFileContains(inlineEnumKt, "override fun toString(): kotlin.String = value");
+        TestUtils.assertFileContains(inlineEnumKt, "unknown_default_open_api(\"unknown_default_open_api\");");
+        TestUtils.assertFileContains(headerEnumKt, "override fun toString(): kotlin.String = value");
+        // The enumUnknownDefaultCase should be omitted for query parameters
+        TestUtils.assertFileContains(headerEnumKt, "ALLOW(\"1\");");
+    }
+
+    @Test
+    public void testMultiplatformEnumWithCustomVariableNamesOverridesToString() throws IOException {
+        File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName(KOTLIN_GENERATOR)
+                .setLibrary("multiplatform")
+                .setAdditionalProperties(new HashMap<>() {{
+                    put(CodegenConstants.SERIALIZATION_LIBRARY, "jackson");
+                    put(CodegenConstants.MODEL_PACKAGE, "model");
+                    put("dateLibrary", "kotlinx-datetime");
+                }})
+                .setInputSpec("src/test/resources/3_0/kotlin/issue23764-multiplatform-inline-enum-serialization.yaml")
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+        final ClientOptInput clientOptInput = configurator.toClientOptInput();
+        DefaultGenerator generator = new DefaultGenerator();
+
+        generator.opts(clientOptInput).generate();
+
+        final Path definedEnumKt = Paths.get(output + "/src/commonMain/kotlin/model/ApiError.kt");
+        final Path inlineEnumKt = Paths.get(output + "/src/commonMain/kotlin/model/AllowFoo.kt");
+        final Path headerEnumKt = Paths.get(output + "/src/commonMain/kotlin/org/openapitools/client/apis/DefaultApi.kt");
+
+        TestUtils.assertFileContains(definedEnumKt, "override fun toString(): kotlin.String = value.toString()");
+        TestUtils.assertFileContains(definedEnumKt, "@SerialName(value = \"100\") ERROR(100);");
+        TestUtils.assertFileContains(inlineEnumKt, "override fun toString(): kotlin.String = value");
+        TestUtils.assertFileContains(inlineEnumKt, "ALLOW(\"1\");");
+        TestUtils.assertFileContains(headerEnumKt, "override fun toString(): kotlin.String = value");
+        TestUtils.assertFileContains(headerEnumKt, "ALLOW(\"1\");");
+    }
+
     @Test(description = "convert an empty model to object")
     public void emptyModelKotlinxSerializationTest() throws IOException {
         final Schema<?> schema = new ObjectSchema()
@@ -1030,7 +1099,7 @@ public class KotlinClientCodegenModelTest {
         output.deleteOnExit();
 
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("kotlin")
+                .setGeneratorName(KOTLIN_GENERATOR)
                 .setAdditionalProperties(new HashMap<>() {{
                     put(CodegenConstants.MODEL_PACKAGE, "model");
                     put(GENERATE_ONEOF_ANYOF_WRAPPERS, false);
@@ -1079,7 +1148,7 @@ public class KotlinClientCodegenModelTest {
         output.deleteOnExit();
 
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("kotlin")
+                .setGeneratorName(KOTLIN_GENERATOR)
                 .addAdditionalProperty(COMPANION_OBJECT, true)
                 .setInputSpec("src/test/resources/3_0/petstore.yaml")
                 .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
@@ -1099,7 +1168,7 @@ public class KotlinClientCodegenModelTest {
         output.deleteOnExit();
 
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("kotlin")
+                .setGeneratorName(KOTLIN_GENERATOR)
                 .setInputSpec("src/test/resources/3_0/kotlin/param-json-property.yaml")
                 .setOutputDir(output.getAbsolutePath().replace("\\", "/"))
                 .addAdditionalProperty(CodegenConstants.SERIALIZATION_LIBRARY, "jackson")
@@ -1123,7 +1192,7 @@ public class KotlinClientCodegenModelTest {
         output.deleteOnExit();
 
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("kotlin")
+                .setGeneratorName(KOTLIN_GENERATOR)
                 .setInputSpec("src/test/resources/3_0/kotlin/param-json-property.yaml")
                 .setOutputDir(output.getAbsolutePath().replace("\\", "/"))
                 .addAdditionalProperty(CodegenConstants.SERIALIZATION_LIBRARY, "jackson");

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinClientCodegenModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinClientCodegenModelTest.java
@@ -1064,6 +1064,39 @@ public class KotlinClientCodegenModelTest {
         TestUtils.assertFileContains(apiKt, "ONE(\"1\");");
     }
 
+    @Test
+    public void testMultiplatformEnumWithCustomVariableNamesOverridesToString() throws IOException {
+        File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName(KOTLIN_GENERATOR)
+                .setLibrary("multiplatform")
+                .setAdditionalProperties(new HashMap<>() {{
+                    put(CodegenConstants.SERIALIZATION_LIBRARY, "jackson");
+                    put(CodegenConstants.MODEL_PACKAGE, "model");
+                    put("dateLibrary", "kotlinx-datetime");
+                }})
+                .setInputSpec("src/test/resources/3_0/kotlin/multiplatform-inline-query-enum.yaml")
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+        final ClientOptInput clientOptInput = configurator.toClientOptInput();
+        DefaultGenerator generator = new DefaultGenerator();
+
+        generator.opts(clientOptInput).generate();
+
+        final Path definedEnumKt = Paths.get(output + "/src/commonMain/kotlin/model/ApiError.kt");
+        final Path inlineEnumKt = Paths.get(output + "/src/commonMain/kotlin/model/AllowFoo.kt");
+        final Path headerEnumKt = Paths.get(output + "/src/commonMain/kotlin/org/openapitools/client/apis/DefaultApi.kt");
+
+        TestUtils.assertFileContains(definedEnumKt, "override fun toString(): kotlin.String = value.toString()");
+        TestUtils.assertFileContains(definedEnumKt, "@SerialName(value = \"100\") ERROR(100);");
+        TestUtils.assertFileContains(inlineEnumKt, "override fun toString(): kotlin.String = value");
+        TestUtils.assertFileContains(inlineEnumKt, "ALLOW(\"1\");");
+        TestUtils.assertFileContains(headerEnumKt, "override fun toString(): kotlin.String = value");
+        TestUtils.assertFileContains(headerEnumKt, "ALLOW(\"1\");");
+    }
+
     @Test(description = "convert an empty model to object")
     public void emptyModelKotlinxSerializationTest() throws IOException {
         final Schema<?> schema = new ObjectSchema()

--- a/modules/openapi-generator/src/test/resources/3_0/kotlin/issue23764-multiplatform-inline-enum-serialization.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/kotlin/issue23764-multiplatform-inline-enum-serialization.yaml
@@ -1,0 +1,65 @@
+openapi: 3.0.3
+info:
+  description: >-
+    Example created
+  version: 1.0.0
+  title: OpenAPI Stuff API created to reproduce issue
+  license:
+    name: Apache-2.0
+    url: 'https://www.apache.org/licenses/LICENSE-2.0.html'
+paths:
+  /healthcheck:
+    get:
+      parameters:
+       - name: X-Allow-Foo
+         in: header
+         schema:
+           type: string
+           enum:
+             - '0'
+             - '1'
+           x-enum-varnames:
+            - DISALLOW
+            - ALLOW
+      summary: Health check endpoint.
+      operationId: healthcheck
+      responses:
+        204:
+          description: Successful health check
+        default:
+          description: Unexpected error
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ApiError'
+
+components:
+  schemas:
+    ApiError:
+      required:
+        - errorCode
+      type: object
+      properties:
+        errorCode:
+          type: integer
+          enum:
+            - 0
+            - 100
+          x-enum-varnames:
+            - OK
+            - ERROR
+        reasonCode:
+          $ref: '#/components/schemas/ReasonCode'
+    ReasonCode:
+      type: integer
+      enum:
+        - 10
+        - 20
+    AllowFoo:
+      type: string
+      enum:
+        - '0'
+        - '1'
+      x-enum-varnames:
+        - DISALLOW
+        - ALLOW

--- a/samples/client/petstore/kotlin-multiplatform-kotlinx-datetime/src/commonMain/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-multiplatform-kotlinx-datetime/src/commonMain/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -135,8 +135,9 @@ open class PetApi : ApiClient {
         pending("pending"),
         
         @SerialName(value = "sold")
-        sold("sold")
+        sold("sold");
         
+        override fun toString(): kotlin.String = value.toString()
     }
 
     /**

--- a/samples/client/petstore/kotlin-multiplatform-kotlinx-datetime/src/commonMain/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-multiplatform-kotlinx-datetime/src/commonMain/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -137,6 +137,7 @@ open class PetApi : ApiClient {
         @SerialName(value = "sold")
         sold("sold");
         
+        override fun toString(): kotlin.String = value.toString()
     }
 
     /**

--- a/samples/client/petstore/kotlin-multiplatform-kotlinx-datetime/src/commonMain/kotlin/org/openapitools/client/models/Order.kt
+++ b/samples/client/petstore/kotlin-multiplatform-kotlinx-datetime/src/commonMain/kotlin/org/openapitools/client/models/Order.kt
@@ -67,6 +67,7 @@ data class Order (
         @SerialName(value = "placed") placed("placed"),
         @SerialName(value = "approved") approved("approved"),
         @SerialName(value = "delivered") delivered("delivered");
+        override fun toString(): kotlin.String = value
     }
 
 }

--- a/samples/client/petstore/kotlin-multiplatform-kotlinx-datetime/src/commonMain/kotlin/org/openapitools/client/models/Pet.kt
+++ b/samples/client/petstore/kotlin-multiplatform-kotlinx-datetime/src/commonMain/kotlin/org/openapitools/client/models/Pet.kt
@@ -69,6 +69,7 @@ data class Pet (
         @SerialName(value = "available") available("available"),
         @SerialName(value = "pending") pending("pending"),
         @SerialName(value = "sold") sold("sold");
+        override fun toString(): kotlin.String = value
     }
 
 }

--- a/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -135,8 +135,9 @@ open class PetApi : ApiClient {
         pending("pending"),
         
         @SerialName(value = "sold")
-        sold("sold")
+        sold("sold");
         
+        override fun toString(): kotlin.String = value.toString()
     }
 
     /**

--- a/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -137,6 +137,7 @@ open class PetApi : ApiClient {
         @SerialName(value = "sold")
         sold("sold");
         
+        override fun toString(): kotlin.String = value.toString()
     }
 
     /**

--- a/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/models/Order.kt
+++ b/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/models/Order.kt
@@ -67,6 +67,7 @@ data class Order (
         @SerialName(value = "placed") placed("placed"),
         @SerialName(value = "approved") approved("approved"),
         @SerialName(value = "delivered") delivered("delivered");
+        override fun toString(): kotlin.String = value
     }
 
 }

--- a/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/models/Pet.kt
+++ b/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/models/Pet.kt
@@ -69,6 +69,7 @@ data class Pet (
         @SerialName(value = "available") available("available"),
         @SerialName(value = "pending") pending("pending"),
         @SerialName(value = "sold") sold("sold");
+        override fun toString(): kotlin.String = value
     }
 
 }


### PR DESCRIPTION

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Fixes so that Kotlin `multiplatform` inline enums use the `value` rather than the `constant` for its `.toString()`. This is necessary since the `multiplatform` library uses the string representation rather than the serialized value when for example building a query variable. Since the `constant` is used currently, this will cause issues when `x-enum-varnames` is used, since that will changed the representation on the wire. For example if we were to get:

```kotlin
@Serializable
enum class Status(val value: kotlin.String) {
  @SerialName(value = "available") AVAILABLE("available"),
  @SerialName(value = "pending") PENDING("pending"),
  @SerialName(value = "sold") SOLD("sold");
}
```

The change is scoped to only the `multiplatform` library since I have not investigated how other kotlin libraries handle their serialization for queries and similar.

Fixes #23764

Kotlin committee:
@karismann (2019/03) @Zomzog (2019/04) @andrewemery (2019/10) @4brunu (2019/11) @yutaka0m (2020/03) @stefankoppier (2022/06) @e5l (2024/10)

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Kotlin Multiplatform enums return their serialized value from toString() instead of the constant name, fixing wrong query/header strings when using x-enum-varnames. Fixes #23764.

- **Bug Fixes**
  - Multiplatform enums now override toString() to return value (or value.toString() for non-strings) across model, inline, and operation-parameter enums; respects enumUnknownDefaultCase and skips unknown defaults for parameter enums.
  - Updated templates to add toString() and final semicolons on last enum entries; added tests for custom varnames and numeric enums; regenerated petstore samples.

<sup>Written for commit 894008e16374ea8de9ba6bb4574c2a597a9a74d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24518?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



