### PR TITLE
[BUG] Normalize OAS 3.1 nullable map type array under NORMALIZE_31SPEC

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
@@ -986,18 +986,13 @@ public class OpenAPINormalizer {
         } else if (ModelUtils.hasProperties(schema)) {
             // OAS 3.1: if the type array includes "null", extract it and set nullable:true
             // on the parent schema before normalizing its child properties.
-            // We intentionally do NOT call the full processNormalize31Spec here because
-            // that method can replace a JsonSchema with properties (but no explicit type)
-            // with an empty schema, discarding all properties.
-            if (getRule(NORMALIZE_31SPEC) && schema.getTypes() != null && schema.getTypes().contains("null")) {
-                schema.setNullable(true);
-                schema.getTypes().remove("null");
-                if (schema.getTypes().size() == 1) {
-                    schema.setType(String.valueOf(schema.getTypes().iterator().next()));
-                }
-            }
+            normalizeNullTypeArray31(schema);
             normalizeProperties(schema, visitedSchemas);
         } else if (schema.getAdditionalProperties() instanceof Schema) { // map
+            // OAS 3.1: same as the schema-with-properties branch above, a map schema can
+            // declare its own nullability with a type array (e.g.
+            // `type: [object, "null"]` alongside `additionalProperties`).
+            normalizeNullTypeArray31(schema);
             normalizeMapSchema(schema);
             Schema additionalProperties = (Schema) schema.getAdditionalProperties();
             if (getRule(NORMALIZE_31SPEC) && ModelUtils.isNullTypeSchema(openAPI, additionalProperties)) {
@@ -1106,6 +1101,30 @@ public class OpenAPINormalizer {
 
     protected Schema normalizeMapSchema(Schema schema) {
         return processSetMapToNullable(schema);
+    }
+
+    /**
+     * OAS 3.1 allows a schema to express nullability with a type array, e.g.
+     * `type: [object, "null"]`. Move the `null` entry onto `nullable: true` and, once a single
+     * type is left, set it as the OAS 3.0 style `type` so that the rest of the codegen sees a
+     * plain (nullable) object or map instead of a multi-type schema.
+     * <p>
+     * This is deliberately narrower than {@link #processNormalize31Spec(Schema, Set)}: that method
+     * replaces a JsonSchema carrying no explicit type with an empty schema, which would discard the
+     * `properties` / `additionalProperties` of the schemas handled here.
+     *
+     * @param schema Schema
+     */
+    protected void normalizeNullTypeArray31(Schema schema) {
+        if (!getRule(NORMALIZE_31SPEC) || schema.getTypes() == null || !schema.getTypes().contains("null")) {
+            return;
+        }
+
+        schema.setNullable(true);
+        schema.getTypes().remove("null");
+        if (schema.getTypes().size() == 1) {
+            schema.setType(String.valueOf(schema.getTypes().iterator().next()));
+        }
     }
 
     protected Schema normalizeSimpleSchema(Schema schema, Set<Schema> visitedSchemas) {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/OpenAPINormalizerTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/OpenAPINormalizerTest.java
@@ -1983,6 +1983,43 @@ public class OpenAPINormalizerTest {
         assertEquals(errorsValue.getType(), "array");
         assertTrue(errorsValue.getNullable());
         assertNotNull(errorsValue.getItems());
+
+        // the maps themselves are declared `type: [object, "null"]`, so they must end up as
+        // nullable object schemas rather than keeping the OAS 3.1 type array.
+        for (String mapProperty : List.of("stringMap", "errorsByKey")) {
+            Schema map = (Schema) schema.getProperties().get(mapProperty);
+            assertEquals(map.getType(), "object", mapProperty + " should be normalized to type object");
+            assertTrue(map.getNullable(), mapProperty + " should be nullable");
+        }
+    }
+
+    /**
+     * A map declared with an OAS 3.1 type array (`type: ["null", object]`) whose value schema is a
+     * `$ref` must be normalized to a nullable object schema, keeping the `$ref` value schema intact.
+     * Without it the `null` entry stays in the type array and generators resolve the property to a
+     * fictional `Null` model, dropping both the nullability and the import of the referenced model.
+     * Regression test for <a href="https://github.com/OpenAPITools/openapi-generator/issues/24517">#24517</a>.
+     */
+    @Test
+    public void testIssue24517NullableMapWithRefValueUsingTypeArray() {
+        OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_1/issue_24517.yaml");
+        Map<String, String> inputRules = Map.of("NORMALIZE_31SPEC", "true");
+        new OpenAPINormalizer(openAPI, inputRules).normalize();
+
+        Schema map = (Schema) openAPI.getComponents().getSchemas().get("ParentNullableMap")
+                .getProperties().get("map");
+        assertEquals(map.getType(), "object");
+        assertFalse(map.getTypes().contains("null"), "the `null` entry must be removed from the type array");
+        assertTrue(map.getNullable());
+        assertEquals(ModelUtils.getAdditionalProperties(map).get$ref(), "#/components/schemas/Child",
+                "the $ref value schema of the map must be preserved");
+
+        // control: the equivalent nullable array was already normalized correctly
+        Schema list = (Schema) openAPI.getComponents().getSchemas().get("ParentNullableArray")
+                .getProperties().get("list");
+        assertEquals(list.getType(), "array");
+        assertTrue(list.getNullable());
+        assertEquals(list.getItems().get$ref(), "#/components/schemas/Child");
     }
 
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/axios/TypeScriptAxiosClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/axios/TypeScriptAxiosClientCodegenTest.java
@@ -258,4 +258,37 @@ public class TypeScriptAxiosClientCodegenTest {
                         "    Xyz: '(xyz)',\n" +
                         "} as const;");
     }
+
+    @Test(description = "A nullable map (OAS 3.1 type array) with a $ref value imports the referenced model")
+    public void testNullableMapWithRefValueImportsReferencedModel() throws Exception {
+        final File output = Files.createTempDirectory("typescript_axios_nullable_map_ref_").toFile();
+        output.deleteOnExit();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("typescript-axios")
+                .setInputSpec("src/test/resources/3_1/issue_24517.yaml")
+                .setModelPackage("models")
+                .setApiPackage("api")
+                .addAdditionalProperty(TypeScriptAxiosClientCodegen.SEPARATE_MODELS_AND_API, true)
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+        final List<File> files = new DefaultGenerator().opts(configurator.toClientOptInput()).generate();
+        files.forEach(File::deleteOnExit);
+
+        // `map` is `type: ["null", object]` with `additionalProperties: {$ref: Child}`: the value model
+        // has to be imported and the property has to stay nullable. Before the fix the generator
+        // emitted an import of a `Null` model that it never writes and left `Child` unimported,
+        // so the output did not compile.
+        Path nullableMap = Paths.get(output + "/models/parent-nullable-map.ts");
+        TestUtils.assertFileContains(nullableMap,
+                "import type { Child } from './child';",
+                "'map'?: { [key: string]: Child; } | null;");
+        TestUtils.assertFileNotContains(nullableMap, "from './null'");
+
+        // control: the equivalent nullable array of the same $ref was already generated correctly
+        Path nullableArray = Paths.get(output + "/models/parent-nullable-array.ts");
+        TestUtils.assertFileContains(nullableArray,
+                "import type { Child } from './child';",
+                "'list'?: Array<Child> | null;");
+    }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/axios/TypeScriptAxiosClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/axios/TypeScriptAxiosClientCodegenTest.java
@@ -291,4 +291,30 @@ public class TypeScriptAxiosClientCodegenTest {
                 "import type { Child } from './child';",
                 "'list'?: Array<Child> | null;");
     }
+
+    @Test(description = "A nullable map (OAS 3.1 type array) with a primitive value keeps its nullability")
+    public void testNullableMapWithPrimitiveValueKeepsNullability() throws Exception {
+        final File output = Files.createTempDirectory("typescript_axios_nullable_map_primitive_").toFile();
+        output.deleteOnExit();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("typescript-axios")
+                .setInputSpec("src/test/resources/3_1/issue_24517.yaml")
+                .setModelPackage("models")
+                .setApiPackage("api")
+                .addAdditionalProperty(TypeScriptAxiosClientCodegen.SEPARATE_MODELS_AND_API, true)
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+        final List<File> files = new DefaultGenerator().opts(configurator.toClientOptInput()).generate();
+        files.forEach(File::deleteOnExit);
+
+        // Same `type: ["null", object]` map shape, but with a primitive value schema. This form never
+        // failed to compile - the dangling `Null` import is suppressed by the generated `@ts-ignore`
+        // and the type declaration was already a map - so the only visible symptom was the missing
+        // `| null`. It needs its own guard: a future regression could keep imports working while
+        // dropping nullability again, and that would leave the assertions above green.
+        Path primitiveMap = Paths.get(output + "/models/parent-nullable-primitive-map.ts");
+        TestUtils.assertFileContains(primitiveMap, "'counts'?: { [key: string]: number; } | null;");
+        TestUtils.assertFileNotContains(primitiveMap, "from './null'");
+    }
 }

--- a/modules/openapi-generator/src/test/resources/3_1/issue_24517.yaml
+++ b/modules/openapi-generator/src/test/resources/3_1/issue_24517.yaml
@@ -1,0 +1,27 @@
+openapi: 3.1.0
+info:
+  title: Repro
+  version: 1.0.0
+components:
+  schemas:
+    Child:
+      type: object
+      properties:
+        name:
+          type: string
+    ParentNullableMap:
+      type: object
+      properties:
+        # a nullable map whose value schema is a $ref
+        map:
+          type: ["null", object]
+          additionalProperties:
+            $ref: "#/components/schemas/Child"
+    ParentNullableArray:
+      type: object
+      properties:
+        # control: a nullable array of the same $ref, which is already normalized correctly
+        list:
+          type: ["null", array]
+          items:
+            $ref: "#/components/schemas/Child"

--- a/modules/openapi-generator/src/test/resources/3_1/issue_24517.yaml
+++ b/modules/openapi-generator/src/test/resources/3_1/issue_24517.yaml
@@ -17,6 +17,15 @@ components:
           type: ["null", object]
           additionalProperties:
             $ref: "#/components/schemas/Child"
+    ParentNullablePrimitiveMap:
+      type: object
+      properties:
+        # the same nullable map shape with a primitive value schema. This one always compiled,
+        # it just dropped its nullability silently, so it needs its own regression guard.
+        counts:
+          type: ["null", object]
+          additionalProperties:
+            type: integer
     ParentNullableArray:
       type: object
       properties:


### PR DESCRIPTION
Fixes #24517

### Status against current master (updated 2026-08-01)

`master` moved under this PR since it was opened, and it took over one of the two halves described below. Re-measured against `501e5c6265f`:

| build | `tsc --strict --noEmit` on the generated models | files importing `./null` (never generated) |
| --- | --- | --- |
| `master` `501e5c6265f` | 1 error, `TS2304: Cannot find name 'Child'` | 2 |
| this PR, rebased onto it | 0 errors | 0 |

What changed upstream: #23778 (merged 2026-07-31) makes `ModelUtils.isNullable()` return `true` for an OAS 3.1 type array containing `"null"` and propagates that into `CodegenProperty`. That fixes the **nullability** half on its own, so the `| null` before/after this description originally claimed for the primitive-valued map is no longer this PR's delta — master already emits it. The description below has been corrected accordingly rather than left as it was.

What it does not fix is the **import set**, which is the half that breaks compilation. On today's master the declared type and the `| null` are both already correct, and the property still imports a `Null` model the generator never writes while never importing `Child`:

```ts
// master 501e5c6265f, models/parent-nullable-map.ts
// @ts-ignore
import type { Null } from './null';        // ./null is never generated
export interface ParentNullableMap {
    'map'?: { [key: string]: Child; } | null;   // Child is referenced but never imported
}
```

Rebased locally onto `501e5c6265f`: applies with no conflicts, the diff is unchanged (161 insertions), and `./mvnw -pl modules/openapi-generator test` passes (4637 tests, 0 failures, 7 skipped, JDK 21). I have left the branch as it is rather than force-pushing, since the PR still reports `MERGEABLE` / `CLEAN` and its checks are currently green; happy to push the rebase if you would rather review it on top of master.

For the avoidance of doubt about #23961, which was noted as also covering this issue: applying it to `501e5c6265f` leaves the `typescript-axios` output for this spec byte-identical to master (`tsc` still reports the same single `TS2304`), and it does not produce the `Map<String, Child>` that the `java` case below needs. It changes `AbstractJavaCodegen` only, whereas the cause here is in the shared normalizer, so the two do not overlap on this issue.

### Root cause

`OpenAPINormalizer.normalizeSchema` strips the OAS 3.1 `"null"` entry out of a type array for arrays (`normalizeArraySchema` -> `processNormalize31Spec`) and, since #24139, for schemas with `properties`. The `additionalProperties` (map) branch has no equivalent, so a map that declares its own nullability with a type array keeps both entries:

```yaml
map:
  type: ["null", object]
  additionalProperties:
    $ref: "#/components/schemas/Child"
```

`nullable` is therefore never set on the map schema, and `ModelUtils.getType()` returns the first entry of the type array, which is `"null"`. That had two separate consequences:

1. **The property loses its nullability** — on every nullable map, whatever the value schema is. This one is now handled on master by #23778, which sets `isNullable` from the type array further downstream.
2. **If the value schema is a `$ref`**, the property loses that import and picks up an import of a `Null` model the generator never writes. That is what makes the output fail to compile, and it is still present on master, because #23778 does not touch import resolution.

The first revision of this description mentioned only the second one ("generators resolve the property to a model that is never written and lose the import of the value schema"). That was the incomplete half. @rony-remedio measured the ratio on a production 3.1.1 spec (486 generated models): of its six nullable maps, one was the `$ref` form and five were primitive-valued — silently non-nullable, compiling cleanly, no symptom at all. That measurement is what motivated the primitive-valued fixture and test below; as of #23778 the visible part of that quiet half is fixed on master, and what this PR still removes for those five is the dangling `./null` import.

This is also not specific to `typescript-axios` — the cause is in the shared normalizer, so other generators produce uncompilable output from the same spec (`java` shown below).

It is not a recent regression either. The fixture below generates identical `models/` and `docs/` on every release from 7.16.0 to 7.24.0 (`typescript-axios`, one jar per release). #24520 reaches the same never-generated `Null` model through the bare `type: "null"` path and does bisect to 7.17.0; this one does not, so the map branch has simply never had the handling.

### Scope: not opt-in

`NORMALIZE_31SPEC` is not a rule consumers have to enable. `DefaultGenerator` sets it for every spec at 3.1.0 or above (`DefaultGenerator.java:261-265`), `DefaultCodegen.getUseOpenapiNormalizer()` returns `true`, and no generator overrides it. Measured rather than read off the source: generating the fixture below with 7.24.0 with and without `--openapi-normalizer NORMALIZE_31SPEC=true` gives byte-identical trees.

So this change reaches every 3.1 spec by default, and cannot affect a 3.0 one.

### Fix

Extracted the existing null-in-type-array handling from the `hasProperties` branch into `normalizeNullTypeArray31(Schema)` and called it from the map branch as well.

It deliberately stays narrower than `processNormalize31Spec`: that method replaces a `JsonSchema` carrying no explicit type with an empty schema, which would discard `properties` / `additionalProperties`. That is the reason the `hasProperties` branch never called it either, and the rationale now lives on the extracted method.

### Before / after

`typescript-axios`, `withSeparateModelsAndApi=true`, no normalizer flags (see above — the rule is on by default here). "Before" is `master` at `501e5c6265f`, i.e. with #23778 already in.

`models/parent-nullable-map.ts`, the `$ref` form, which does not compile before:

```ts
// before
// @ts-ignore
import type { Null } from './null';        // ./null is never generated
export interface ParentNullableMap {
    'map'?: { [key: string]: Child; } | null;   // Child is never imported
}

// after
// @ts-ignore
import type { Child } from './child';
export interface ParentNullableMap {
    'map'?: { [key: string]: Child; } | null;
}
```

`models/parent-nullable-primitive-map.ts`, the quiet form, which compiles before and after. Since #23778 the only remaining difference is the dangling import:

```ts
// before
// @ts-ignore
import type { Null } from './null';        // dangling, but suppressed by the @ts-ignore above it
export interface ParentNullablePrimitiveMap {
    'counts'?: { [key: string]: number; } | null;
}

// after
export interface ParentNullablePrimitiveMap {
    'counts'?: { [key: string]: number; } | null;
}
```

Type-checking the generated models (`tsc --noEmit --strict --skipLibCheck models/*.ts`): before, `error TS2304: Cannot find name 'Child'`; after, clean.

`java` (`library=native`), `ParentNullableMap.java`, from the same spec:

```java
// before
import org.openapitools.client.model.ModelNull;               // never generated either
private JsonNullable<ModelNull<String, Child>> map = JsonNullable.<ModelNull<String, Child>>undefined();

// after
import org.openapitools.client.model.Child;
private JsonNullable<Map<String, Child>> map = JsonNullable.<Map<String, Child>>undefined();
```

The generated docs improve on the same specs as a side effect: `docs/ParentNullableMap.md` linked the property to `(.md)` (an empty target) and now links to `(Child.md)`, and the primitive-valued one drops the empty link entirely.

### Tests

New fixture `modules/openapi-generator/src/test/resources/3_1/issue_24517.yaml`: the minimal spec from the issue, its nullable-array control, and a primitive-valued nullable map for the quiet form.

- `OpenAPINormalizerTest.testIssue24517NullableMapWithRefValueUsingTypeArray` — the map normalizes to a nullable `object` and keeps its `$ref` value schema; the nullable array is asserted alongside as the control that already worked.
- `TypeScriptAxiosClientCodegenTest.testNullableMapWithRefValueImportsReferencedModel` — end to end: the generated model imports `Child`, the property is `| null`, and there is no import from `./null`.
- `TypeScriptAxiosClientCodegenTest.testNullableMapWithPrimitiveValueKeepsNullability` — end to end for the quiet form: `'counts'?: { [key: string]: number; } | null;` and no dangling `./null` import.
- `OpenAPINormalizerTest.testOpenAPINormalizer31SpecNullMapAdditionalProperties` — extended. `3_1/issue_23945.yaml` already declared its maps as `type: [object, "null"]`, but only the value schemas were asserted, so the map-level half of the same bug was uncovered.

All four still fail on `master` at `501e5c6265f` and pass with this change — re-checked after #23778 landed, by restoring `OpenAPINormalizer.java` to master and keeping the tests (4 run, 4 failures). #23778 did not make any of them redundant; the primitive-valued one now fails on its dangling-import assertion rather than on `| null`.

The last two are not redundant with each other. Replacing the fix with a `$ref`-only variant — `if (((Schema) schema.getAdditionalProperties()).get$ref() != null)` around the new call, which is what a fix aimed only at the missing import would look like — leaves `testNullableMapWithRefValueImportsReferencedModel` green and fails `testNullableMapWithPrimitiveValueKeepsNullability` and `testOpenAPINormalizer31SpecNullMapAdditionalProperties`. So at the codegen level the primitive-valued test is the only guard on the quiet half.

### Samples

No sample changed. Of the 246 distinct `inputSpec` files referenced from `bin/configs/**`, none declares a schema carrying both a `null`-containing type array and an `additionalProperties` schema, so the change cannot alter existing output. Verified rather than assumed: regenerating the 21 configs that use a 3.1 spec plus the 15 `typescript-axios` configs (36 generators) leaves `samples/` clean.

`./mvnw -pl modules/openapi-generator test` passes locally on JDK 21, both on the branch as pushed and rebased onto `501e5c6265f` (4637 tests, 0 failures, 7 skipped).

cc @nicokoenig (TypeScript / Axios)

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Built the project and checked the samples (see above — no sample output changes).
- [x] Filed the PR against the correct branch: `master`.
- [x] Copied the technical committee to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix normalization for OAS 3.1 nullable map schemas (`type: ["null", object]`) under `NORMALIZE_31SPEC`. Maps are now correctly marked nullable and keep their value schema, so generated code compiles.

- **Bug Fixes**
  - Added `normalizeNullTypeArray31` and applied it to map schemas to move `"null"` from the type array to `nullable: true`, and set `type: "object"` when appropriate.
  - Keeps `additionalProperties` intact (including `$ref` value schemas).
  - Prevents generators like `typescript-axios` and `java` from resolving to fake `Null`/`ModelNull` models and dropping imports.
  - Tests: normalizer regression, end-to-end for `$ref` maps, plus a new `typescript-axios` test guarding primitive map values to keep `| null`. Minimal 3.1 fixture added; no sample changes.

<sup>Written for commit b1f4c290959f6e544c2e89e089bd075912a2ebc2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24519?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



