### PR TITLE
refactor(kotlin): remove unknown default enum case for inline operation enums in multiplatform library

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -94,7 +94,7 @@ import java.util.stream.Stream;
 import static org.openapitools.codegen.CodegenConstants.*;
 import static org.openapitools.codegen.utils.CamelizeOption.LOWERCASE_FIRST_LETTER;
 import static org.openapitools.codegen.utils.DiscriminatorUtils.*;
-import static org.openapitools.codegen.utils.EnumUtils.getEnumValues;
+import static org.openapitools.codegen.utils.EnumUtils.*;
 import static org.openapitools.codegen.utils.OnceLogger.once;
 import static org.openapitools.codegen.utils.StringUtils.*;
 
@@ -6808,29 +6808,57 @@ public class DefaultCodegen implements CodegenConfig {
         }
 
         if (enumUnknownDefaultCase) {
-            // If the server adds new enum cases, that are unknown by an old spec/client, the client will fail to parse the network response.
-            // With this option enabled, each enum will have a new case, 'unknown_default_open_api', so that when the server sends an enum case that is not known by the client/spec, they can safely fallback to this case.
-            Map<String, Object> enumVar = new HashMap<>();
-            String enumName = enumUnknownDefaultCaseName;
-
-            String enumValue = isDataTypeString(dataType)
-                    ? enumUnknownDefaultCaseName
-                    : // This is a dummy value that attempts to avoid collisions with previously specified cases.
-                    // Int.max / 192
-                    // The number 192 that is used to calculate this random value, is the Swift Evolution proposal for frozen/non-frozen enums.
-                    // [SE-0192](https://github.com/apple/swift-evolution/blob/master/proposals/0192-non-exhaustive-enums.md)
-                    // Since this functionality was born in the Swift 5 generator and latter on broth to all generators
-                    // https://github.com/OpenAPITools/openapi-generator/pull/11013
-                    String.valueOf(11184809);
-
-            enumVar.put(ENUM_NAME, toEnumVarName(enumName, dataType));
-            enumVar.put(ENUM_VALUE, toEnumValue(enumValue, dataType));
-            enumVar.put(ENUM_IS_STRING, isDataTypeString(dataType));
-            // TODO: add isNumeric
-            enumVars.add(enumVar);
+            injectEnumUnknownDefaultCase(enumVars, dataType);
         }
 
         return enumVars;
+    }
+
+    /**
+     * If the server adds new enum cases, that are unknown by an old spec/client, the client will fail to parse the network response.
+     * This adds a default case to the enum, {@link DefaultCodegen#enumUnknownDefaultCaseName}, that can be used as a fallback for unknown values.
+     *
+     * @param enumVars the enumVars
+     * @param dataType the data type of the enum parameter
+     */
+    private void injectEnumUnknownDefaultCase(List<Map<String, Object>> enumVars, String dataType) {
+        Map<String, Object> enumVar = new HashMap<>();
+        String enumName = enumUnknownDefaultCaseName;
+
+        String enumValue = isDataTypeString(dataType)
+                ? enumUnknownDefaultCaseName
+                : // This is a dummy value that attempts to avoid collisions with previously specified cases.
+                // Int.max / 192
+                // The number 192 that is used to calculate this random value, is the Swift Evolution proposal for frozen/non-frozen enums.
+                // [SE-0192](https://github.com/apple/swift-evolution/blob/master/proposals/0192-non-exhaustive-enums.md)
+                // Since this functionality was born in the Swift 5 generator and latter on broth to all generators
+                // https://github.com/OpenAPITools/openapi-generator/pull/11013
+                String.valueOf(11184809);
+
+        enumVar.put(ENUM_NAME, toEnumVarName(enumName, dataType));
+        enumVar.put(ENUM_VALUE, toEnumValue(enumValue, dataType));
+        enumVar.put(ENUM_IS_STRING, isDataTypeString(dataType));
+        // TODO: add isNumeric
+        enumVars.add(enumVar);
+    }
+
+    /**
+     * Removes any injected default enum value that was created with {@link DefaultCodegen#injectEnumUnknownDefaultCase}
+     * from an operation's non-body enum parameters. This can for example be of interest when generating client code
+     * where a fallback is superfluous for a value that is only sent and never received.
+     *
+     * @param operation operation to be processed
+     */
+    protected void removeEnumUnknownDefaultCase(CodegenOperation operation) {
+        for (CodegenParameter param : operation.allParams) {
+            if (!param.isBodyParam && param.isEnum && hasEnumVars(param.allowableValues)) {
+                List<Map<String, Object>> enumVars = getEnumVars(param.allowableValues);
+                if (enumVars != null) {
+                    String unknownName = toEnumVarName(enumUnknownDefaultCaseName, param.dataType);
+                    enumVars.removeIf(ev -> unknownName.equals(ev.get(ENUM_NAME)));
+                }
+            }
+        }
     }
 
     protected void postProcessEnumVars(List<Map<String, Object>> enumVars) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinClientCodegen.java
@@ -39,8 +39,6 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import lombok.Getter;
-import lombok.Setter;
 import org.openapitools.codegen.CliOption;
 import org.openapitools.codegen.CodegenConstants;
 import org.openapitools.codegen.CodegenModel;
@@ -60,6 +58,9 @@ import org.openapitools.codegen.meta.features.WireFormatFeature;
 import org.openapitools.codegen.templating.mustache.ReplaceAllLambda;
 
 import static java.util.Collections.sort;
+import static org.openapitools.codegen.CodegenConstants.ENUM_NAME;
+import static org.openapitools.codegen.utils.EnumUtils.getEnumVars;
+import static org.openapitools.codegen.utils.EnumUtils.hasEnumVars;
 
 /**
  * <p>Mustache templates are located in
@@ -1146,7 +1147,24 @@ public class KotlinClientCodegen extends AbstractKotlinCodegen {
             }
         }
         objs.put("isResponseFile", isResponseFile);
+        removeEnumUnknownDefaultCaseFromOperationParameters(objs);
         return objs;
+    }
+
+    /**
+     * Removes any injected unknown default enum value that stem from {@link DefaultCodegen#enumUnknownDefaultCase}
+     * from an operation's enum parameters.
+     * Applies to the {@value KotlinClientCodegen#MULTIPLATFORM} library since it generates enums locally within the api,
+     * and there we have no need for a defined fallback, since it is values that we only send.
+     * 
+     * @param objs the map containing all the defined operations
+     */
+    private void removeEnumUnknownDefaultCaseFromOperationParameters(OperationsMap objs) {
+        if (enumUnknownDefaultCase && library.equals(MULTIPLATFORM)) {
+            for (CodegenOperation operation : objs.getOperations().getOperation()) {
+                removeEnumUnknownDefaultCase(operation);
+            }
+        }
     }
 
     private static boolean isMultipartType(List<Map<String, String>> consumes) {

--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/api.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/api.mustache
@@ -43,18 +43,10 @@ import kotlinx.serialization.encoding.*
      */
     @Serializable
     {{#nonPublicApi}}internal {{/nonPublicApi}}{{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}enum class {{enumName}}{{operationIdCamelCase}}({{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}val value: {{^isContainer}}{{dataType}}{{/isContainer}}{{#isContainer}}kotlin.String{{/isContainer}}) {
-    {{^enumUnknownDefaultCase}}
         {{#allowableValues}}{{#enumVars}}
         @SerialName(value = {{^isString}}"{{/isString}}{{{value}}}{{^isString}}"{{/isString}})
-        {{&name}}({{{value}}}){{^-last}},{{/-last}}
+        {{&name}}({{{value}}}){{^-last}},{{/-last}}{{#-last}};{{/-last}}
         {{/enumVars}}{{/allowableValues}}
-    {{/enumUnknownDefaultCase}}
-    {{#enumUnknownDefaultCase}}
-        {{#allowableValues}}{{#enumVars}}{{^-last}}
-        @SerialName(value = {{^isString}}"{{/isString}}{{{value}}}{{^isString}}"{{/isString}})
-        {{&name}}({{{value}}}),
-        {{/-last}}{{/enumVars}}{{/allowableValues}}
-    {{/enumUnknownDefaultCase}}
     }
 
     {{/isEnum}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinClientCodegenModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinClientCodegenModelTest.java
@@ -43,11 +43,12 @@ import java.util.List;
 import java.util.Map;
 
 import static org.openapitools.codegen.CodegenConstants.*;
-import static org.openapitools.codegen.languages.KotlinClientCodegen.COMPANION_OBJECT;
-import static org.openapitools.codegen.languages.KotlinClientCodegen.GENERATE_ONEOF_ANYOF_WRAPPERS;
+import static org.openapitools.codegen.languages.KotlinClientCodegen.*;
 
 @SuppressWarnings("static-method")
 public class KotlinClientCodegenModelTest {
+
+    private static final String KOTLIN_GENERATOR = "kotlin";
 
     private Schema<?> getArrayTestSchema() {
         return new ObjectSchema()
@@ -369,7 +370,7 @@ public class KotlinClientCodegenModelTest {
         output.deleteOnExit();
 
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("kotlin")
+                .setGeneratorName(KOTLIN_GENERATOR)
                 .setLibrary("jvm-retrofit2")
                 .setAdditionalProperties(properties)
                 .setInputSpec("src/test/resources/3_0/issue4808.yaml")
@@ -392,7 +393,7 @@ public class KotlinClientCodegenModelTest {
         output.deleteOnExit();
 
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("kotlin")
+                .setGeneratorName(KOTLIN_GENERATOR)
                 .setInputSpec("src/test/resources/3_0/ping.yaml")
                 .addAdditionalProperty("omitGradleWrapper", true)
                 .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
@@ -495,7 +496,7 @@ public class KotlinClientCodegenModelTest {
         output.deleteOnExit();
 
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("kotlin")
+                .setGeneratorName(KOTLIN_GENERATOR)
                 .setLibrary(clientLibrary.getLibraryName())
                 .setInputSpec("src/test/resources/3_0/issue_19942.json")
                 .addAdditionalProperty("omitGradleWrapper", true)
@@ -519,7 +520,7 @@ public class KotlinClientCodegenModelTest {
         output.deleteOnExit();
 
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("kotlin")
+                .setGeneratorName(KOTLIN_GENERATOR)
                 .setLibrary(clientLibrary.getLibraryName())
                 .setInputSpec("src/test/resources/3_0/issue_19942.json")
                 .addAdditionalProperty("omitGradleWrapper", true)
@@ -582,7 +583,7 @@ public class KotlinClientCodegenModelTest {
 //        File output = Paths.get("/Users/sylvain_maillard/workspaces/openapi-generator/modules/openapi-generator/target/test").toFile();
 
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("kotlin")
+                .setGeneratorName(KOTLIN_GENERATOR)
                 .setInputSpec("src/test/resources/3_1/issue_22216.yaml")
                 .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
 
@@ -607,7 +608,7 @@ public class KotlinClientCodegenModelTest {
         output.deleteOnExit();
 
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("kotlin")
+                .setGeneratorName(KOTLIN_GENERATOR)
                 .setLibrary("jvm-retrofit2")
                 .setAdditionalProperties(new HashMap<>() {{
                     put(CodegenConstants.SERIALIZATION_LIBRARY, "kotlinx_serialization");
@@ -647,7 +648,7 @@ public class KotlinClientCodegenModelTest {
         output.deleteOnExit();
 
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("kotlin")
+                .setGeneratorName(KOTLIN_GENERATOR)
                 .setLibrary("jvm-retrofit2")
                 .setAdditionalProperties(new HashMap<>() {{
                     put(CodegenConstants.SERIALIZATION_LIBRARY, "kotlinx_serialization");
@@ -682,7 +683,7 @@ public class KotlinClientCodegenModelTest {
         output.deleteOnExit();
 
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("kotlin")
+                .setGeneratorName(KOTLIN_GENERATOR)
                 .setLibrary("jvm-retrofit2")
                 .setAdditionalProperties(new HashMap<>() {{
                     put(CodegenConstants.SERIALIZATION_LIBRARY, "kotlinx_serialization");
@@ -748,7 +749,7 @@ public class KotlinClientCodegenModelTest {
         props.putAll(extraProps);
         new DefaultGenerator()
                 .opts(new CodegenConfigurator()
-                        .setGeneratorName("kotlin")
+                        .setGeneratorName(KOTLIN_GENERATOR)
                         .setLibrary("jvm-retrofit2")
                         .setAdditionalProperties(props)
                         .setInputSpec("src/test/resources/3_0/issue_19942.json")
@@ -768,7 +769,7 @@ public class KotlinClientCodegenModelTest {
         output.deleteOnExit();
 
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("kotlin")
+                .setGeneratorName(KOTLIN_GENERATOR)
                 .setLibrary("jvm-okhttp4")
                 .setAdditionalProperties(new HashMap<>() {{
                     put(CodegenConstants.SERIALIZATION_LIBRARY, "jackson");
@@ -824,7 +825,7 @@ public class KotlinClientCodegenModelTest {
       output.deleteOnExit();
 
       final CodegenConfigurator configurator = new CodegenConfigurator()
-              .setGeneratorName("kotlin")
+              .setGeneratorName(KOTLIN_GENERATOR)
               .setLibrary("jvm-ktor")
               .setAdditionalProperties(new HashMap<>() {{
                 put(CodegenConstants.SERIALIZATION_LIBRARY, "jackson");
@@ -850,7 +851,7 @@ public class KotlinClientCodegenModelTest {
       output.deleteOnExit();
 
       final CodegenConfigurator configurator = new CodegenConfigurator()
-              .setGeneratorName("kotlin")
+              .setGeneratorName(KOTLIN_GENERATOR)
               .setLibrary("jvm-ktor")
               .setAdditionalProperties(new HashMap<>() {{
                 put(CodegenConstants.SERIALIZATION_LIBRARY, "jackson");
@@ -880,7 +881,7 @@ public class KotlinClientCodegenModelTest {
       output.deleteOnExit();
 
       final CodegenConfigurator configurator = new CodegenConfigurator()
-              .setGeneratorName("kotlin")
+              .setGeneratorName(KOTLIN_GENERATOR)
               .setLibrary("jvm-retrofit2")
               .setAdditionalProperties(new HashMap<>() {{
                 put(CodegenConstants.SERIALIZATION_LIBRARY, "jackson");
@@ -906,7 +907,7 @@ public class KotlinClientCodegenModelTest {
       output.deleteOnExit();
 
       final CodegenConfigurator configurator = new CodegenConfigurator()
-              .setGeneratorName("kotlin")
+              .setGeneratorName(KOTLIN_GENERATOR)
               .setLibrary("jvm-retrofit2")
               .setAdditionalProperties(new HashMap<>() {{
                 put(CodegenConstants.SERIALIZATION_LIBRARY, "jackson");
@@ -934,7 +935,7 @@ public class KotlinClientCodegenModelTest {
       output.deleteOnExit();
 
       final CodegenConfigurator configurator = new CodegenConfigurator()
-              .setGeneratorName("kotlin")
+              .setGeneratorName(KOTLIN_GENERATOR)
               .setLibrary("jvm-retrofit2")
               .setAdditionalProperties(new HashMap<>() {{
                 put(CodegenConstants.SERIALIZATION_LIBRARY, "jackson");
@@ -960,7 +961,7 @@ public class KotlinClientCodegenModelTest {
       output.deleteOnExit();
 
       final CodegenConfigurator configurator = new CodegenConfigurator()
-              .setGeneratorName("kotlin")
+              .setGeneratorName(KOTLIN_GENERATOR)
               .setLibrary("jvm-retrofit2")
               .setAdditionalProperties(new HashMap<>() {{
                 put(CodegenConstants.SERIALIZATION_LIBRARY, "jackson");
@@ -993,7 +994,7 @@ public class KotlinClientCodegenModelTest {
       output.deleteOnExit();
 
       final CodegenConfigurator configurator = new CodegenConfigurator()
-              .setGeneratorName("kotlin")
+              .setGeneratorName(KOTLIN_GENERATOR)
               .setLibrary("jvm-retrofit2")
               .setAdditionalProperties(new HashMap<>() {{
                 put(CodegenConstants.SERIALIZATION_LIBRARY, "jackson");
@@ -1016,6 +1017,53 @@ public class KotlinClientCodegenModelTest {
       TestUtils.assertFileNotContains(enumKt, "throw IllegalArgumentException(\"Unknown ExampleNumericEnum value");
   }
 
+    @Test
+    public void testMultiplatformInlineEnumDropsUnknownDefaultCase() throws IOException {
+        File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName(KOTLIN_GENERATOR)
+                .setLibrary("multiplatform")
+                .setAdditionalProperties(new HashMap<>() {{
+                    put(CodegenConstants.SERIALIZATION_LIBRARY, "jackson");
+                    put(CodegenConstants.MODEL_PACKAGE, "model");
+                    put("dateLibrary", "kotlinx-datetime");
+                    put(ENUM_UNKNOWN_DEFAULT_CASE, "true");
+                }})
+                .setInputSpec("src/test/resources/3_0/kotlin/multiplatform-inline-query-enum.yaml")
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+        final ClientOptInput clientOptInput = configurator.toClientOptInput();
+        DefaultGenerator generator = new DefaultGenerator();
+
+        generator.opts(clientOptInput).generate();
+
+        final Path definedEnumKt = Paths.get(output + "/src/commonMain/kotlin/model/ApiError.kt");
+        final Path definedOperationHeaderEnumKt = Paths.get(output + "/src/commonMain/kotlin/model/AllowFoo.kt");
+        final Path definedOperationQueryEnumKt = Paths.get(output + "/src/commonMain/kotlin/model/AllowFooYn.kt");
+        final Path definedOperationPathEnumKt = Paths.get(output + "/src/commonMain/kotlin/model/AllowFooPath.kt");
+        final Path apiKt = Paths.get(output + "/src/commonMain/kotlin/org/openapitools/client/apis/DefaultApi.kt");
+
+        TestUtils.assertFileContains(definedEnumKt, "@SerialName(value = \"100\") ERROR(100),");
+        TestUtils.assertFileContains(definedEnumKt, "@SerialName(value = \"11184809\") unknown_default_open_api(11184809);");
+        TestUtils.assertFileContains(definedOperationHeaderEnumKt, "ALLOW(\"1\"),");
+        TestUtils.assertFileContains(definedOperationHeaderEnumKt, "unknown_default_open_api(\"unknown_default_open_api\");");
+        TestUtils.assertFileContains(definedOperationQueryEnumKt, "NOPE(\"n\"),");
+        TestUtils.assertFileContains(definedOperationQueryEnumKt, "unknown_default_open_api(\"unknown_default_open_api\");");
+        TestUtils.assertFileContains(definedOperationPathEnumKt, "ONE(\"1\"),");
+        TestUtils.assertFileContains(definedOperationPathEnumKt, "unknown_default_open_api(\"unknown_default_open_api\");");
+        // The enumUnknownDefaultCase should be omitted for inline header parameters
+        TestUtils.assertFileContains(apiKt, "DISALLOW(\"0\"),");
+        TestUtils.assertFileContains(apiKt, "ALLOW(\"1\");");
+        // The enumUnknownDefaultCase should be omitted for inline query parameters
+        TestUtils.assertFileContains(apiKt, "YEP(\"y\"),");
+        TestUtils.assertFileContains(apiKt, "NOPE(\"n\");");
+        // The enumUnknownDefaultCase should be omitted for inline path parameters
+        TestUtils.assertFileContains(apiKt, "ZERO(\"0\"),");
+        TestUtils.assertFileContains(apiKt, "ONE(\"1\");");
+    }
+
     @Test(description = "convert an empty model to object")
     public void emptyModelKotlinxSerializationTest() throws IOException {
         final Schema<?> schema = new ObjectSchema()
@@ -1030,7 +1078,7 @@ public class KotlinClientCodegenModelTest {
         output.deleteOnExit();
 
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("kotlin")
+                .setGeneratorName(KOTLIN_GENERATOR)
                 .setAdditionalProperties(new HashMap<>() {{
                     put(CodegenConstants.MODEL_PACKAGE, "model");
                     put(GENERATE_ONEOF_ANYOF_WRAPPERS, false);
@@ -1079,7 +1127,7 @@ public class KotlinClientCodegenModelTest {
         output.deleteOnExit();
 
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("kotlin")
+                .setGeneratorName(KOTLIN_GENERATOR)
                 .addAdditionalProperty(COMPANION_OBJECT, true)
                 .setInputSpec("src/test/resources/3_0/petstore.yaml")
                 .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
@@ -1099,7 +1147,7 @@ public class KotlinClientCodegenModelTest {
         output.deleteOnExit();
 
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("kotlin")
+                .setGeneratorName(KOTLIN_GENERATOR)
                 .setInputSpec("src/test/resources/3_0/kotlin/param-json-property.yaml")
                 .setOutputDir(output.getAbsolutePath().replace("\\", "/"))
                 .addAdditionalProperty(CodegenConstants.SERIALIZATION_LIBRARY, "jackson")
@@ -1123,7 +1171,7 @@ public class KotlinClientCodegenModelTest {
         output.deleteOnExit();
 
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("kotlin")
+                .setGeneratorName(KOTLIN_GENERATOR)
                 .setInputSpec("src/test/resources/3_0/kotlin/param-json-property.yaml")
                 .setOutputDir(output.getAbsolutePath().replace("\\", "/"))
                 .addAdditionalProperty(CodegenConstants.SERIALIZATION_LIBRARY, "jackson");

--- a/modules/openapi-generator/src/test/resources/3_0/kotlin/multiplatform-inline-query-enum.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/kotlin/multiplatform-inline-query-enum.yaml
@@ -1,0 +1,115 @@
+openapi: 3.0.3
+info:
+  description: >-
+    Example created
+  version: 1.0.0
+  title: OpenAPI Stuff API created to reproduce issue
+  license:
+    name: Apache-2.0
+    url: 'https://www.apache.org/licenses/LICENSE-2.0.html'
+paths:
+  /healthcheck/{X-Allow-Foo-Path}/{X-Allow-Foo-Path-Ref}:
+    get:
+      parameters:
+       - name: X-Allow-Foo-Header
+         in: header
+         schema:
+           type: string
+           enum:
+             - '0'
+             - '1'
+           x-enum-varnames:
+            - DISALLOW
+            - ALLOW
+       - name: X-Allow-Foo-Header-Ref
+         in: header
+         schema:
+           $ref: '#/components/schemas/AllowFoo'
+       - name: X-Allow-Foo-Query
+         in: query
+         schema:
+           type: string
+           enum:
+             - 'y'
+             - 'n'
+           x-enum-varnames:
+             - YEP
+             - NOPE
+       - name: X-Allow-Foo-Query-Ref
+         in: query
+         schema:
+           $ref: '#/components/schemas/AllowFooYn'
+       - name: X-Allow-Foo-Path
+         in: path
+         required: true
+         schema:
+           type: string
+           enum:
+             - '0'
+             - '1'
+           x-enum-varnames:
+             - ZERO
+             - ONE
+       - name: X-Allow-Foo-Path-Ref
+         in: path
+         required: true
+         schema:
+           $ref: '#/components/schemas/AllowFooPath'
+      summary: Health check endpoint.
+      operationId: healthcheck
+      responses:
+        204:
+          description: Successful health check
+        default:
+          description: Unexpected error
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ApiError'
+
+components:
+  schemas:
+    ApiError:
+      required:
+        - errorCode
+      type: object
+      properties:
+        errorCode:
+          type: integer
+          enum:
+            - 0
+            - 100
+          x-enum-varnames:
+            - OK
+            - ERROR
+        reasonCode:
+          $ref: '#/components/schemas/ReasonCode'
+    ReasonCode:
+      type: integer
+      enum:
+        - 10
+        - 20
+    AllowFoo:
+      type: string
+      enum:
+        - '0'
+        - '1'
+      x-enum-varnames:
+        - DISALLOW
+        - ALLOW
+    AllowFooYn:
+      type: string
+      enum:
+        - 'y'
+        - 'n'
+      x-enum-varnames:
+        - YEP
+        - NOPE
+    AllowFooPath:
+      type: string
+      enum:
+        - '0'
+        - '1'
+      x-enum-varnames:
+        - ZERO
+        - ONE

--- a/samples/client/petstore/kotlin-multiplatform-kotlinx-datetime/src/commonMain/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-multiplatform-kotlinx-datetime/src/commonMain/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -135,7 +135,7 @@ open class PetApi : ApiClient {
         pending("pending"),
         
         @SerialName(value = "sold")
-        sold("sold")
+        sold("sold");
         
     }
 

--- a/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -135,7 +135,7 @@ open class PetApi : ApiClient {
         pending("pending"),
         
         @SerialName(value = "sold")
-        sold("sold")
+        sold("sold");
         
     }
 


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

This PR changes how `enumUnknownDefaultCase` is handled with the operations inline enum support that was introduced to the kotlin `multiplatform` library with https://github.com/OpenAPITools/openapi-generator/pull/16327.

The background is that we do not want to have to conduct mustache magic with regards to hiding the unnecessary `enumUnknownDefaultCase` case (hidden since these enums are only used to send values).

It is also tied to being able to place the `;` after the last enum value, this so that the `.toString()` can be overridden in the enum, which would solve [this issue](https://github.com/OpenAPITools/openapi-generator/pull/24518#issuecomment-5116975619).

Thus we move the handling of the ignoring/removal of the `enumUnknownDefaultCase` from the mustache file to the client codegen.

Kotlin committee:
@karismann (2019/03) @Zomzog (2019/04) @andrewemery (2019/10) @4brunu (2019/11) @yutaka0m (2020/03) @stefankoppier (2022/06) @e5l (2024/10)

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the `unknown_default_open_api` enum case from inline operation enums in the Kotlin `multiplatform` client and move default-case handling from the template into codegen. This simplifies generated APIs and allows a trailing semicolon on enum declarations so enum methods (e.g., `toString()`) can be added.

- **Refactors**
  - Add `injectEnumUnknownDefaultCase` and `removeEnumUnknownDefaultCase` in `DefaultCodegen`; remove default enum case for non-body operation params.
  - Apply removal during operation post-processing in `KotlinClientCodegen` for the `multiplatform` library.
  - Simplify `kotlin-client/libraries/multiplatform/api.mustache` by removing `enumUnknownDefaultCase` branching and always adding `;` after the last enum value.
  - Keep the unknown default case for model enums and referenced operation enums to retain fallback behavior when receiving values.

- **Tests**
  - Add `multiplatform-inline-query-enum.yaml` and a test ensuring inline header/query/path enums omit the default case while model/referenced enums keep it.
  - Regenerate Kotlin multiplatform samples to reflect the trailing `;` in generated enums.

<sup>Written for commit 868633d93eecefe8282a2523a05e085c3fa66a6c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24521?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

