### PR TITLE
Update go-server deps

### DIFF
--- a/.github/workflows/samples-go.yaml
+++ b/.github/workflows/samples-go.yaml
@@ -47,7 +47,7 @@ jobs:
         sample:
           - samples/server/petstore/go-api-server/
         go-version:
-          - "1.23"
+          - "1.25"
     steps:
       - uses: actions/checkout@v7
       - name: Set up Go

--- a/.github/workflows/samples-go.yaml
+++ b/.github/workflows/samples-go.yaml
@@ -47,7 +47,7 @@ jobs:
         sample:
           - samples/server/petstore/go-api-server/
         go-version:
-          - "1.18"
+          - "1.23"
     steps:
       - uses: actions/checkout@v7
       - name: Set up Go

--- a/modules/openapi-generator/src/main/resources/go-server/go.mod.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/go.mod.mustache
@@ -1,6 +1,6 @@
 module {{gitHost}}/{{gitUserId}}/{{gitRepoId}}
 
-go 1.18
+go 1.25
 
 {{#hasPathParams}}
 {{#routers}}
@@ -11,7 +11,7 @@ require github.com/gorilla/handlers v1.5.1
 		{{/featureCORS}}
 	{{/mux}}
 	{{#chi}}
-require github.com/go-chi/chi/v5 v5.2.2
+require github.com/go-chi/chi/v5 v5.2.4
 		{{#featureCORS}}
 require github.com/go-chi/cors v1.2.1
 		{{/featureCORS}}

--- a/samples/openapi3/server/petstore/go/go-petstore/go.mod
+++ b/samples/openapi3/server/petstore/go/go-petstore/go.mod
@@ -1,5 +1,5 @@
 module github.com/GIT_USER_ID/GIT_REPO_ID
 
-go 1.18
+go 1.25
 
-require github.com/go-chi/chi/v5 v5.2.2
+require github.com/go-chi/chi/v5 v5.2.4

--- a/samples/server/others/go-server/no-body-path-params/go.mod
+++ b/samples/server/others/go-server/no-body-path-params/go.mod
@@ -1,5 +1,5 @@
 module github.com/GIT_USER_ID/GIT_REPO_ID
 
-go 1.18
+go 1.25
 
 require github.com/gorilla/mux v1.8.0

--- a/samples/server/others/go-server/optional-body/go.mod
+++ b/samples/server/others/go-server/optional-body/go.mod
@@ -1,4 +1,4 @@
 module github.com/GIT_USER_ID/GIT_REPO_ID
 
-go 1.18
+go 1.25
 

--- a/samples/server/others/go-server/required-zero-value/go.mod
+++ b/samples/server/others/go-server/required-zero-value/go.mod
@@ -1,4 +1,4 @@
 module github.com/GIT_USER_ID/GIT_REPO_ID
 
-go 1.18
+go 1.25
 

--- a/samples/server/petstore/go-api-server/go.mod
+++ b/samples/server/petstore/go-api-server/go.mod
@@ -1,5 +1,5 @@
 module github.com/GIT_USER_ID/GIT_REPO_ID
 
-go 1.18
+go 1.25
 
 require github.com/gorilla/mux v1.8.0

--- a/samples/server/petstore/go-api-server/samples_tests/go_mod_test.go
+++ b/samples/server/petstore/go-api-server/samples_tests/go_mod_test.go
@@ -25,7 +25,7 @@ func Test_Go_Mod(t *testing.T) {
 		filepath := "../go.mod"
 
 		lines := utils.ReadLines(filepath)
-		expected := "go 1.18"
+		expected := "go 1.25"
 		
 		if lines[2] != expected {
 			t.Errorf("Expected '%s', but got '%s'", expected, lines[2])

--- a/samples/server/petstore/go-chi-server/go.mod
+++ b/samples/server/petstore/go-chi-server/go.mod
@@ -1,5 +1,5 @@
 module github.com/GIT_USER_ID/GIT_REPO_ID
 
-go 1.18
+go 1.25
 
-require github.com/go-chi/chi/v5 v5.2.2
+require github.com/go-chi/chi/v5 v5.2.4


### PR DESCRIPTION
to close https://github.com/OpenAPITools/openapi-generator/pull/24058/
<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raise Go server template, samples, CI, and tests to Go 1.25 and `github.com/go-chi/chi/v5` v5.2.4. Previously these used Go 1.18 and chi v5.2.2; generated servers now target Go 1.25 and chi v5.2.4.

- **Changes**
  - Template `go.mod.mustache`: `go` 1.18 → 1.25; `github.com/go-chi/chi/v5` v5.2.2 → v5.2.4.
  - Sample `go.mod`: set `go` 1.25; chi-based samples pin `github.com/go-chi/chi/v5` v5.2.4.
  - CI samples workflow uses Go 1.25.
  - Sample test updated to expect `go 1.25`.

- **Migration**
  - Build and test with Go 1.25+.
  - Regenerate Go servers and run `go mod tidy`.

<sup>Written for commit 4a8e50013ccb0fbd1f9e2ff3fabf6c6899c3eb4a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24527?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



cc @antihax (2017/11) @grokify (2018/07) @kemokemo (2018/09) @jirikuncar (2021/01) @ph4r5h4d (2021/04) @lwj5 (2023/04)
