### PR TITLE
fix: generate automatic headers before custom headers. Fixes #24529

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-okhttp/api.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-okhttp/api.mustache
@@ -255,12 +255,12 @@ import {{packageName}}.infrastructure.Serializer
             }
             {{/hasQueryParams}}
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf({{#hasFormParams}}"Content-Type" to {{^consumes}}"multipart/form-data"{{/consumes}}{{#consumes.0}}"{{{mediaType}}}"{{/consumes.0}}{{/hasFormParams}})
-        {{#headerParams}}
-        {{{paramName}}}{{^required}}?{{/required}}.apply { localVariableHeaders["{{#lambda.escapeDollar}}{{baseName}}{{/lambda.escapeDollar}}"] = {{#isContainer}}this.joinToString(separator = collectionDelimiter("{{collectionFormat}}")){{/isContainer}}{{^isContainer}}this.toString(){{/isContainer}} }
-        {{/headerParams}}
         {{^hasFormParams}}{{#hasConsumes}}{{#consumes}}localVariableHeaders["Content-Type"] = "{{{mediaType}}}"
         {{/consumes}}{{/hasConsumes}}{{/hasFormParams}}{{#hasProduces}}localVariableHeaders["Accept"] = "{{#produces}}{{{mediaType}}}{{^-last}}, {{/-last}}{{/produces}}"
-{{/hasProduces}}
+        {{/hasProduces}}
+        {{#headerParams}}
+        {{{paramName}}}{{^required}}?{{/required}}.apply { localVariableHeaders["{{#lambda.escapeDollar}}{{baseName}}{{/lambda.escapeDollar}}"] = {{#isContainer}}this.joinToString(separator = collectionDelimiter("{{collectionFormat}}")){{/isContainer}}{{^isContainer}}this.toString(){{/isContainer}} }
+{{/headerParams}}
 
         return RequestConfig(
             method = RequestMethod.{{httpMethod}},

--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-okhttp/api.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-okhttp/api.mustache
@@ -256,9 +256,8 @@ import {{packageName}}.infrastructure.Serializer
             {{/hasQueryParams}}
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf({{#hasFormParams}}"Content-Type" to {{^consumes}}"multipart/form-data"{{/consumes}}{{#consumes.0}}"{{{mediaType}}}"{{/consumes.0}}{{/hasFormParams}})
         {{^hasFormParams}}{{#hasConsumes}}{{#consumes}}localVariableHeaders["Content-Type"] = "{{{mediaType}}}"
-        {{/consumes}}{{/hasConsumes}}{{/hasFormParams}}{{#hasProduces}}localVariableHeaders["Accept"] = "{{#produces}}{{{mediaType}}}{{^-last}}, {{/-last}}{{/produces}}"
-        {{/hasProduces}}
-        {{#headerParams}}
+        {{/consumes}}{{/hasConsumes}}{{/hasFormParams}}{{#hasProduces}}localVariableHeaders["Accept"] = "{{#produces}}{{{mediaType}}}{{^-last}}, {{/-last}}{{/produces}}"{{/hasProduces}}
+{{#headerParams}}
         {{{paramName}}}{{^required}}?{{/required}}.apply { localVariableHeaders["{{#lambda.escapeDollar}}{{baseName}}{{/lambda.escapeDollar}}"] = {{#isContainer}}this.joinToString(separator = collectionDelimiter("{{collectionFormat}}")){{/isContainer}}{{^isContainer}}this.toString(){{/isContainer}} }
 {{/headerParams}}
 

--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-spring-restclient/api.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-spring-restclient/api.mustache
@@ -118,12 +118,12 @@ import {{packageName}}.infrastructure.*
             }
             {{/hasQueryParams}}
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf({{#hasFormParams}}"Content-Type" to {{^consumes}}"multipart/form-data"{{/consumes}}{{#consumes.0}}"{{{mediaType}}}"{{/consumes.0}}{{/hasFormParams}})
-        {{#headerParams}}
-        {{{paramName}}}{{^required}}?{{/required}}.apply { localVariableHeaders["{{baseName}}"] = {{#isContainer}}this.joinToString(separator = collectionDelimiter("{{collectionFormat}}")){{/isContainer}}{{^isContainer}}this.toString(){{/isContainer}} }
-        {{/headerParams}}
         {{^hasFormParams}}{{#hasConsumes}}{{#consumes}}localVariableHeaders["Content-Type"] = "{{{mediaType}}}"
         {{/consumes}}{{/hasConsumes}}{{/hasFormParams}}{{#hasProduces}}localVariableHeaders["Accept"] = "{{#produces}}{{{mediaType}}}{{^-last}}, {{/-last}}{{/produces}}"
-{{/hasProduces}}
+        {{/hasProduces}}
+        {{#headerParams}}
+        {{{paramName}}}{{^required}}?{{/required}}.apply { localVariableHeaders["{{baseName}}"] = {{#isContainer}}this.joinToString(separator = collectionDelimiter("{{collectionFormat}}")){{/isContainer}}{{^isContainer}}this.toString(){{/isContainer}} }
+{{/headerParams}}
 
         val params = mutableMapOf<String, Any>(
         {{#pathParams}}

--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-spring-restclient/api.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-spring-restclient/api.mustache
@@ -119,9 +119,8 @@ import {{packageName}}.infrastructure.*
             {{/hasQueryParams}}
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf({{#hasFormParams}}"Content-Type" to {{^consumes}}"multipart/form-data"{{/consumes}}{{#consumes.0}}"{{{mediaType}}}"{{/consumes.0}}{{/hasFormParams}})
         {{^hasFormParams}}{{#hasConsumes}}{{#consumes}}localVariableHeaders["Content-Type"] = "{{{mediaType}}}"
-        {{/consumes}}{{/hasConsumes}}{{/hasFormParams}}{{#hasProduces}}localVariableHeaders["Accept"] = "{{#produces}}{{{mediaType}}}{{^-last}}, {{/-last}}{{/produces}}"
-        {{/hasProduces}}
-        {{#headerParams}}
+        {{/consumes}}{{/hasConsumes}}{{/hasFormParams}}{{#hasProduces}}localVariableHeaders["Accept"] = "{{#produces}}{{{mediaType}}}{{^-last}}, {{/-last}}{{/produces}}"{{/hasProduces}}
+{{#headerParams}}
         {{{paramName}}}{{^required}}?{{/required}}.apply { localVariableHeaders["{{baseName}}"] = {{#isContainer}}this.joinToString(separator = collectionDelimiter("{{collectionFormat}}")){{/isContainer}}{{^isContainer}}this.toString(){{/isContainer}} }
 {{/headerParams}}
 

--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-spring-webclient/api.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-spring-webclient/api.mustache
@@ -120,12 +120,12 @@ import {{packageName}}.infrastructure.*
             }
             {{/hasQueryParams}}
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf({{#hasFormParams}}"Content-Type" to {{^consumes}}"multipart/form-data"{{/consumes}}{{#consumes.0}}"{{{mediaType}}}"{{/consumes.0}}{{/hasFormParams}})
-        {{#headerParams}}
-        {{{paramName}}}{{^required}}?{{/required}}.apply { localVariableHeaders["{{baseName}}"] = {{#isContainer}}this.joinToString(separator = collectionDelimiter("{{collectionFormat}}")){{/isContainer}}{{^isContainer}}this.toString(){{/isContainer}} }
-        {{/headerParams}}
         {{^hasFormParams}}{{#hasConsumes}}{{#consumes}}localVariableHeaders["Content-Type"] = "{{{mediaType}}}"
         {{/consumes}}{{/hasConsumes}}{{/hasFormParams}}{{#hasProduces}}localVariableHeaders["Accept"] = "{{#produces}}{{{mediaType}}}{{^-last}}, {{/-last}}{{/produces}}"
-{{/hasProduces}}
+        {{/hasProduces}}
+        {{#headerParams}}
+        {{{paramName}}}{{^required}}?{{/required}}.apply { localVariableHeaders["{{baseName}}"] = {{#isContainer}}this.joinToString(separator = collectionDelimiter("{{collectionFormat}}")){{/isContainer}}{{^isContainer}}this.toString(){{/isContainer}} }
+{{/headerParams}}
 
         val params = mutableMapOf<String, Any>(
         {{#pathParams}}

--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-spring-webclient/api.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-spring-webclient/api.mustache
@@ -121,9 +121,8 @@ import {{packageName}}.infrastructure.*
             {{/hasQueryParams}}
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf({{#hasFormParams}}"Content-Type" to {{^consumes}}"multipart/form-data"{{/consumes}}{{#consumes.0}}"{{{mediaType}}}"{{/consumes.0}}{{/hasFormParams}})
         {{^hasFormParams}}{{#hasConsumes}}{{#consumes}}localVariableHeaders["Content-Type"] = "{{{mediaType}}}"
-        {{/consumes}}{{/hasConsumes}}{{/hasFormParams}}{{#hasProduces}}localVariableHeaders["Accept"] = "{{#produces}}{{{mediaType}}}{{^-last}}, {{/-last}}{{/produces}}"
-        {{/hasProduces}}
-        {{#headerParams}}
+        {{/consumes}}{{/hasConsumes}}{{/hasFormParams}}{{#hasProduces}}localVariableHeaders["Accept"] = "{{#produces}}{{{mediaType}}}{{^-last}}, {{/-last}}{{/produces}}"{{/hasProduces}}
+{{#headerParams}}
         {{{paramName}}}{{^required}}?{{/required}}.apply { localVariableHeaders["{{baseName}}"] = {{#isContainer}}this.joinToString(separator = collectionDelimiter("{{collectionFormat}}")){{/isContainer}}{{^isContainer}}this.toString(){{/isContainer}} }
 {{/headerParams}}
 

--- a/samples/client/echo_api/kotlin-jvm-okhttp/src/main/kotlin/org/openapitools/client/apis/BodyApi.kt
+++ b/samples/client/echo_api/kotlin-jvm-okhttp/src/main/kotlin/org/openapitools/client/apis/BodyApi.kt
@@ -113,6 +113,7 @@ open class BodyApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/binary/gif",

--- a/samples/client/echo_api/kotlin-jvm-okhttp/src/main/kotlin/org/openapitools/client/apis/HeaderApi.kt
+++ b/samples/client/echo_api/kotlin-jvm-okhttp/src/main/kotlin/org/openapitools/client/apis/HeaderApi.kt
@@ -144,12 +144,12 @@ open class HeaderApi(basePath: kotlin.String = defaultBasePath, client: Call.Fac
         val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
+        localVariableHeaders["Accept"] = "text/plain"
         integerHeader?.apply { localVariableHeaders["integer_header"] = this.toString() }
         booleanHeader?.apply { localVariableHeaders["boolean_header"] = this.toString() }
         stringHeader?.apply { localVariableHeaders["string_header"] = this.toString() }
         enumNonrefStringHeader?.apply { localVariableHeaders["enum_nonref_string_header"] = this.toString() }
         enumRefStringHeader?.apply { localVariableHeaders["enum_ref_string_header"] = this.toString() }
-        localVariableHeaders["Accept"] = "text/plain"
 
         return RequestConfig(
             method = RequestMethod.GET,

--- a/samples/client/echo_api/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/apis/HeaderApi.kt
+++ b/samples/client/echo_api/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/apis/HeaderApi.kt
@@ -72,12 +72,12 @@ open class HeaderApi(client: RestClient) : ApiClient(client) {
         val localVariableBody = null
         val localVariableQuery = mutableMapOf<kotlin.String, kotlin.collections.List<kotlin.String>>()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
+        localVariableHeaders["Accept"] = "text/plain"
         integerHeader?.apply { localVariableHeaders["integer_header"] = this.toString() }
         booleanHeader?.apply { localVariableHeaders["boolean_header"] = this.toString() }
         stringHeader?.apply { localVariableHeaders["string_header"] = this.toString() }
         enumNonrefStringHeader?.apply { localVariableHeaders["enum_nonref_string_header"] = this.toString() }
         enumRefStringHeader?.apply { localVariableHeaders["enum_ref_string_header"] = this.toString() }
-        localVariableHeaders["Accept"] = "text/plain"
 
         val params = mutableMapOf<String, Any>(
         )

--- a/samples/client/echo_api/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/apis/HeaderApi.kt
+++ b/samples/client/echo_api/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/apis/HeaderApi.kt
@@ -76,12 +76,12 @@ open class HeaderApi(client: WebClient) : ApiClient(client) {
         val localVariableBody = null
         val localVariableQuery = mutableMapOf<kotlin.String, kotlin.collections.List<kotlin.String>>()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
+        localVariableHeaders["Accept"] = "text/plain"
         integerHeader?.apply { localVariableHeaders["integer_header"] = this.toString() }
         booleanHeader?.apply { localVariableHeaders["boolean_header"] = this.toString() }
         stringHeader?.apply { localVariableHeaders["string_header"] = this.toString() }
         enumNonrefStringHeader?.apply { localVariableHeaders["enum_nonref_string_header"] = this.toString() }
         enumRefStringHeader?.apply { localVariableHeaders["enum_ref_string_header"] = this.toString() }
-        localVariableHeaders["Accept"] = "text/plain"
 
         val params = mutableMapOf<String, Any>(
         )

--- a/samples/client/others/kotlin-jvm-okhttp-non-ascii-headers/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/others/kotlin-jvm-okhttp-non-ascii-headers/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -190,7 +190,8 @@ open class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factor
         val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-                apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
+        
+        apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
 
         return RequestConfig(
             method = RequestMethod.DELETE,
@@ -592,6 +593,7 @@ open class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factor
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "application/x-www-form-urlencoded")
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/pet/{petId}".replace("{"+"petId"+"}", encodeURIComponent(petId.toString())),

--- a/samples/client/others/kotlin-jvm-okhttp-non-ascii-headers/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/others/kotlin-jvm-okhttp-non-ascii-headers/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -190,8 +190,8 @@ open class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factor
         val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
-        
+                apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
+
         return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/pet/{petId}".replace("{"+"petId"+"}", encodeURIComponent(petId.toString())),

--- a/samples/client/others/kotlin-jvm-okhttp-non-ascii-headers/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/others/kotlin-jvm-okhttp-non-ascii-headers/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -113,6 +113,7 @@ open class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Fact
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/store/order/{orderId}".replace("{"+"orderId"+"}", encodeURIComponent(orderId.toString())),

--- a/samples/client/others/kotlin-jvm-okhttp-non-ascii-headers/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/others/kotlin-jvm-okhttp-non-ascii-headers/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -114,6 +114,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Content-Type"] = "application/json"
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/user",
@@ -185,6 +186,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Content-Type"] = "application/json"
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/user/createWithArray",
@@ -256,6 +258,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Content-Type"] = "application/json"
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/user/createWithList",
@@ -326,6 +329,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/user/{username}".replace("{"+"username"+"}", encodeURIComponent(username.toString())),
@@ -546,6 +550,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.GET,
             path = "/user/logout",
@@ -620,6 +625,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Content-Type"] = "application/json"
         
+
         return RequestConfig(
             method = RequestMethod.PUT,
             path = "/user/{username}".replace("{"+"username"+"}", encodeURIComponent(username.toString())),

--- a/samples/client/others/kotlin-jvm-okhttp-parameter-tests/src/main/kotlin/org/openapitools/client/apis/DefaultApi.kt
+++ b/samples/client/others/kotlin-jvm-okhttp-parameter-tests/src/main/kotlin/org/openapitools/client/apis/DefaultApi.kt
@@ -224,7 +224,8 @@ open class DefaultApi(basePath: kotlin.String = defaultBasePath, client: Call.Fa
                 }
             }
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-                headerDefault?.apply { localVariableHeaders["header_default"] = this.toString() }
+        
+        headerDefault?.apply { localVariableHeaders["header_default"] = this.toString() }
         headerDefaultEnum?.apply { localVariableHeaders["header_default_enum"] = this.toString() }
         headerDefaultInt?.apply { localVariableHeaders["header_default_int"] = this.toString() }
         headerNullable?.apply { localVariableHeaders["header_nullable"] = this.toString() }

--- a/samples/client/others/kotlin-jvm-okhttp-parameter-tests/src/main/kotlin/org/openapitools/client/apis/DefaultApi.kt
+++ b/samples/client/others/kotlin-jvm-okhttp-parameter-tests/src/main/kotlin/org/openapitools/client/apis/DefaultApi.kt
@@ -224,11 +224,11 @@ open class DefaultApi(basePath: kotlin.String = defaultBasePath, client: Call.Fa
                 }
             }
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        headerDefault?.apply { localVariableHeaders["header_default"] = this.toString() }
+                headerDefault?.apply { localVariableHeaders["header_default"] = this.toString() }
         headerDefaultEnum?.apply { localVariableHeaders["header_default_enum"] = this.toString() }
         headerDefaultInt?.apply { localVariableHeaders["header_default_int"] = this.toString() }
         headerNullable?.apply { localVariableHeaders["header_nullable"] = this.toString() }
-        
+
         return RequestConfig(
             method = RequestMethod.GET,
             path = "/test/parameters/{path_default}/{path_nullable}".replace("{"+"path_default"+"}", encodeURIComponent(pathDefault.toString())).replace("{"+"path_nullable"+"}", encodeURIComponent(pathNullable.toString())),

--- a/samples/client/others/kotlin-jvm-spring-3-restclient-nullable-return/src/main/kotlin/org/openapitools/client/apis/DefaultApi.kt
+++ b/samples/client/others/kotlin-jvm-spring-3-restclient-nullable-return/src/main/kotlin/org/openapitools/client/apis/DefaultApi.kt
@@ -63,6 +63,7 @@ open class DefaultApi(client: RestClient) : ApiClient(client) {
         val localVariableQuery = mutableMapOf<kotlin.String, kotlin.collections.List<kotlin.String>>()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         val params = mutableMapOf<String, Any>(
         )
 

--- a/samples/client/petstore/kotlin-array-simple-string-jvm-okhttp4/src/main/kotlin/org/openapitools/client/apis/DefaultApi.kt
+++ b/samples/client/petstore/kotlin-array-simple-string-jvm-okhttp4/src/main/kotlin/org/openapitools/client/apis/DefaultApi.kt
@@ -112,6 +112,7 @@ open class DefaultApi(basePath: kotlin.String = defaultBasePath, client: Call.Fa
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.GET,
             path = "/{ids}".replace("{"+"ids"+"}", encodeURIComponent(ids.joinToString(","))),

--- a/samples/client/petstore/kotlin-bigdecimal-default-okhttp4/src/main/kotlin/org/openapitools/client/apis/DefaultApi.kt
+++ b/samples/client/petstore/kotlin-bigdecimal-default-okhttp4/src/main/kotlin/org/openapitools/client/apis/DefaultApi.kt
@@ -114,6 +114,7 @@ open class DefaultApi(basePath: kotlin.String = defaultBasePath, client: Call.Fa
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Content-Type"] = "application/json"
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/test",

--- a/samples/client/petstore/kotlin-default-values-jvm-okhttp4/src/main/kotlin/org/openapitools/client/apis/DefaultApi.kt
+++ b/samples/client/petstore/kotlin-default-values-jvm-okhttp4/src/main/kotlin/org/openapitools/client/apis/DefaultApi.kt
@@ -222,7 +222,8 @@ open class DefaultApi(basePath: kotlin.String = defaultBasePath, client: Call.Fa
                 put("qn3", listOf(qn3.toString()))
             }
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "multipart/form-data")
-                hi0?.apply { localVariableHeaders["hi0"] = this.toString() }
+        
+        hi0?.apply { localVariableHeaders["hi0"] = this.toString() }
         hi1.apply { localVariableHeaders["hi1"] = this.toString() }
         hi2?.apply { localVariableHeaders["hi2"] = this.toString() }
         hi3.apply { localVariableHeaders["hi3"] = this.toString() }

--- a/samples/client/petstore/kotlin-default-values-jvm-okhttp4/src/main/kotlin/org/openapitools/client/apis/DefaultApi.kt
+++ b/samples/client/petstore/kotlin-default-values-jvm-okhttp4/src/main/kotlin/org/openapitools/client/apis/DefaultApi.kt
@@ -222,7 +222,7 @@ open class DefaultApi(basePath: kotlin.String = defaultBasePath, client: Call.Fa
                 put("qn3", listOf(qn3.toString()))
             }
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "multipart/form-data")
-        hi0?.apply { localVariableHeaders["hi0"] = this.toString() }
+                hi0?.apply { localVariableHeaders["hi0"] = this.toString() }
         hi1.apply { localVariableHeaders["hi1"] = this.toString() }
         hi2?.apply { localVariableHeaders["hi2"] = this.toString() }
         hi3.apply { localVariableHeaders["hi3"] = this.toString() }
@@ -230,7 +230,7 @@ open class DefaultApi(basePath: kotlin.String = defaultBasePath, client: Call.Fa
         hn1.apply { localVariableHeaders["hn1"] = this.toString() }
         hn2?.apply { localVariableHeaders["hn2"] = this.toString() }
         hn3.apply { localVariableHeaders["hn3"] = this.toString() }
-        
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/test".replace("{"+"pi0"+"}", encodeURIComponent(pi0.toString())).replace("{"+"pi1"+"}", encodeURIComponent(pi1.toString())).replace("{"+"pn0"+"}", encodeURIComponent(pn0.toString())).replace("{"+"pn1"+"}", encodeURIComponent(pn1.toString())),

--- a/samples/client/petstore/kotlin-explicit/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-explicit/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -115,6 +115,7 @@ public open class PetApi(basePath: kotlin.String = defaultBasePath, client: Call
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Content-Type"] = "application/json"
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/pet",
@@ -187,7 +188,8 @@ public open class PetApi(basePath: kotlin.String = defaultBasePath, client: Call
         val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-                apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
+        
+        apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
 
         return RequestConfig(
             method = RequestMethod.DELETE,
@@ -508,6 +510,7 @@ public open class PetApi(basePath: kotlin.String = defaultBasePath, client: Call
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Content-Type"] = "application/json"
         
+
         return RequestConfig(
             method = RequestMethod.PUT,
             path = "/pet",
@@ -586,6 +589,7 @@ public open class PetApi(basePath: kotlin.String = defaultBasePath, client: Call
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "application/x-www-form-urlencoded")
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/pet/{petId}".replace("{"+"petId"+"}", encodeURIComponent(petId.toString())),

--- a/samples/client/petstore/kotlin-explicit/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-explicit/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -187,8 +187,8 @@ public open class PetApi(basePath: kotlin.String = defaultBasePath, client: Call
         val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
-        
+                apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
+
         return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/pet/{petId}".replace("{"+"petId"+"}", encodeURIComponent(petId.toString())),

--- a/samples/client/petstore/kotlin-explicit/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-explicit/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -113,6 +113,7 @@ public open class StoreApi(basePath: kotlin.String = defaultBasePath, client: Ca
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/store/order/{orderId}".replace("{"+"orderId"+"}", encodeURIComponent(orderId.toString())),

--- a/samples/client/petstore/kotlin-explicit/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-explicit/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -113,6 +113,7 @@ public open class UserApi(basePath: kotlin.String = defaultBasePath, client: Cal
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/user",
@@ -183,6 +184,7 @@ public open class UserApi(basePath: kotlin.String = defaultBasePath, client: Cal
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/user/createWithArray",
@@ -253,6 +255,7 @@ public open class UserApi(basePath: kotlin.String = defaultBasePath, client: Cal
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/user/createWithList",
@@ -323,6 +326,7 @@ public open class UserApi(basePath: kotlin.String = defaultBasePath, client: Cal
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/user/{username}".replace("{"+"username"+"}", encodeURIComponent(username.toString())),
@@ -543,6 +547,7 @@ public open class UserApi(basePath: kotlin.String = defaultBasePath, client: Cal
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.GET,
             path = "/user/logout",
@@ -616,6 +621,7 @@ public open class UserApi(basePath: kotlin.String = defaultBasePath, client: Cal
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.PUT,
             path = "/user/{username}".replace("{"+"username"+"}", encodeURIComponent(username.toString())),

--- a/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -190,7 +190,8 @@ open class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factor
         val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-                apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
+        
+        apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
 
         return RequestConfig(
             method = RequestMethod.DELETE,
@@ -592,6 +593,7 @@ open class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factor
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "application/x-www-form-urlencoded")
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/pet/{petId}".replace("{"+"petId"+"}", encodeURIComponent(petId.toString())),

--- a/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -190,8 +190,8 @@ open class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factor
         val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
-        
+                apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
+
         return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/pet/{petId}".replace("{"+"petId"+"}", encodeURIComponent(petId.toString())),

--- a/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -113,6 +113,7 @@ open class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Fact
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/store/order/{orderId}".replace("{"+"orderId"+"}", encodeURIComponent(orderId.toString())),

--- a/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -114,6 +114,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Content-Type"] = "application/json"
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/user",
@@ -185,6 +186,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Content-Type"] = "application/json"
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/user/createWithArray",
@@ -256,6 +258,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Content-Type"] = "application/json"
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/user/createWithList",
@@ -326,6 +329,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/user/{username}".replace("{"+"username"+"}", encodeURIComponent(username.toString())),
@@ -546,6 +550,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.GET,
             path = "/user/logout",
@@ -620,6 +625,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Content-Type"] = "application/json"
         
+
         return RequestConfig(
             method = RequestMethod.PUT,
             path = "/user/{username}".replace("{"+"username"+"}", encodeURIComponent(username.toString())),

--- a/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -187,8 +187,8 @@ open class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factor
         val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
-        
+                apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
+
         return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/pet/{petId}".replace("{"+"petId"+"}", encodeURIComponent(petId.toString())),

--- a/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -115,6 +115,7 @@ open class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factor
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Content-Type"] = "application/json"
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/pet",
@@ -187,7 +188,8 @@ open class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factor
         val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-                apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
+        
+        apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
 
         return RequestConfig(
             method = RequestMethod.DELETE,
@@ -509,6 +511,7 @@ open class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factor
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Content-Type"] = "application/json"
         
+
         return RequestConfig(
             method = RequestMethod.PUT,
             path = "/pet",
@@ -587,6 +590,7 @@ open class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factor
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "application/x-www-form-urlencoded")
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/pet/{petId}".replace("{"+"petId"+"}", encodeURIComponent(petId.toString())),

--- a/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -113,6 +113,7 @@ open class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Fact
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/store/order/{orderId}".replace("{"+"orderId"+"}", encodeURIComponent(orderId.toString())),

--- a/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -113,6 +113,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/user",
@@ -183,6 +184,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/user/createWithArray",
@@ -253,6 +255,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/user/createWithList",
@@ -323,6 +326,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/user/{username}".replace("{"+"username"+"}", encodeURIComponent(username.toString())),
@@ -543,6 +547,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.GET,
             path = "/user/logout",
@@ -616,6 +621,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.PUT,
             path = "/user/{username}".replace("{"+"username"+"}", encodeURIComponent(username.toString())),

--- a/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -189,8 +189,8 @@ open class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factor
         val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
-        
+                apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
+
         return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/pet/{petId}".replace("{"+"petId"+"}", encodeURIComponent(petId.toString())),

--- a/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -117,6 +117,7 @@ open class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factor
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Content-Type"] = "application/json"
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/pet",
@@ -189,7 +190,8 @@ open class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factor
         val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-                apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
+        
+        apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
 
         return RequestConfig(
             method = RequestMethod.DELETE,
@@ -494,6 +496,7 @@ open class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factor
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Content-Type"] = "application/json"
         
+
         return RequestConfig(
             method = RequestMethod.PUT,
             path = "/pet",
@@ -572,6 +575,7 @@ open class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factor
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "application/x-www-form-urlencoded")
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/pet/{petId}".replace("{"+"petId"+"}", encodeURIComponent(petId.toString())),

--- a/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -115,6 +115,7 @@ open class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Fact
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/store/order/{orderId}".replace("{"+"orderId"+"}", encodeURIComponent(orderId.toString())),

--- a/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -115,6 +115,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/user",
@@ -185,6 +186,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/user/createWithArray",
@@ -255,6 +257,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/user/createWithList",
@@ -325,6 +328,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/user/{username}".replace("{"+"username"+"}", encodeURIComponent(username.toString())),
@@ -545,6 +549,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.GET,
             path = "/user/logout",
@@ -618,6 +623,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.PUT,
             path = "/user/{username}".replace("{"+"username"+"}", encodeURIComponent(username.toString())),

--- a/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -189,8 +189,8 @@ open class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factor
         val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
-        
+                apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
+
         return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/pet/{petId}".replace("{"+"petId"+"}", encodeURIComponent(petId.toString())),

--- a/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -117,6 +117,7 @@ open class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factor
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Content-Type"] = "application/json"
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/pet",
@@ -189,7 +190,8 @@ open class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factor
         val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-                apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
+        
+        apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
 
         return RequestConfig(
             method = RequestMethod.DELETE,
@@ -510,6 +512,7 @@ open class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factor
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Content-Type"] = "application/json"
         
+
         return RequestConfig(
             method = RequestMethod.PUT,
             path = "/pet",
@@ -588,6 +591,7 @@ open class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factor
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "application/x-www-form-urlencoded")
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/pet/{petId}".replace("{"+"petId"+"}", encodeURIComponent(petId.toString())),

--- a/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -115,6 +115,7 @@ open class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Fact
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/store/order/{orderId}".replace("{"+"orderId"+"}", encodeURIComponent(orderId.toString())),

--- a/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -115,6 +115,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/user",
@@ -185,6 +186,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/user/createWithArray",
@@ -255,6 +257,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/user/createWithList",
@@ -325,6 +328,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/user/{username}".replace("{"+"username"+"}", encodeURIComponent(username.toString())),
@@ -545,6 +549,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.GET,
             path = "/user/logout",
@@ -618,6 +623,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.PUT,
             path = "/user/{username}".replace("{"+"username"+"}", encodeURIComponent(username.toString())),

--- a/samples/client/petstore/kotlin-jvm-spring-2-webclient/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-2-webclient/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -105,8 +105,8 @@ open class PetApi(client: WebClient) : ApiClient(client) {
         val localVariableBody = null
         val localVariableQuery = mutableMapOf<kotlin.String, kotlin.collections.List<kotlin.String>>()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
-        
+                apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
+
         val params = mutableMapOf<String, Any>(
             "petId" to petId,
         )

--- a/samples/client/petstore/kotlin-jvm-spring-2-webclient/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-2-webclient/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -105,7 +105,8 @@ open class PetApi(client: WebClient) : ApiClient(client) {
         val localVariableBody = null
         val localVariableQuery = mutableMapOf<kotlin.String, kotlin.collections.List<kotlin.String>>()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-                apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
+        
+        apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
 
         val params = mutableMapOf<String, Any>(
             "petId" to petId,
@@ -305,6 +306,7 @@ open class PetApi(client: WebClient) : ApiClient(client) {
         val localVariableQuery = mutableMapOf<kotlin.String, kotlin.collections.List<kotlin.String>>()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "application/x-www-form-urlencoded")
         
+
         val params = mutableMapOf<String, Any>(
             "petId" to petId,
         )

--- a/samples/client/petstore/kotlin-jvm-spring-2-webclient/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-2-webclient/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -68,6 +68,7 @@ open class StoreApi(client: WebClient) : ApiClient(client) {
         val localVariableQuery = mutableMapOf<kotlin.String, kotlin.collections.List<kotlin.String>>()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         val params = mutableMapOf<String, Any>(
             "orderId" to orderId,
         )

--- a/samples/client/petstore/kotlin-jvm-spring-2-webclient/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-2-webclient/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -69,6 +69,7 @@ open class UserApi(client: WebClient) : ApiClient(client) {
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Content-Type"] = "application/json"
         
+
         val params = mutableMapOf<String, Any>(
         )
 
@@ -104,6 +105,7 @@ open class UserApi(client: WebClient) : ApiClient(client) {
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Content-Type"] = "application/json"
         
+
         val params = mutableMapOf<String, Any>(
         )
 
@@ -139,6 +141,7 @@ open class UserApi(client: WebClient) : ApiClient(client) {
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Content-Type"] = "application/json"
         
+
         val params = mutableMapOf<String, Any>(
         )
 
@@ -173,6 +176,7 @@ open class UserApi(client: WebClient) : ApiClient(client) {
         val localVariableQuery = mutableMapOf<kotlin.String, kotlin.collections.List<kotlin.String>>()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         val params = mutableMapOf<String, Any>(
             "username" to username,
         )
@@ -283,6 +287,7 @@ open class UserApi(client: WebClient) : ApiClient(client) {
         val localVariableQuery = mutableMapOf<kotlin.String, kotlin.collections.List<kotlin.String>>()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         val params = mutableMapOf<String, Any>(
         )
 
@@ -318,6 +323,7 @@ open class UserApi(client: WebClient) : ApiClient(client) {
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Content-Type"] = "application/json"
         
+
         val params = mutableMapOf<String, Any>(
             "username" to username,
         )

--- a/samples/client/petstore/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -100,7 +100,8 @@ open class PetApi(client: RestClient) : ApiClient(client) {
         val localVariableBody = null
         val localVariableQuery = mutableMapOf<kotlin.String, kotlin.collections.List<kotlin.String>>()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-                apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
+        
+        apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
 
         val params = mutableMapOf<String, Any>(
             "petId" to petId,
@@ -299,6 +300,7 @@ open class PetApi(client: RestClient) : ApiClient(client) {
         val localVariableQuery = mutableMapOf<kotlin.String, kotlin.collections.List<kotlin.String>>()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "application/x-www-form-urlencoded")
         
+
         val params = mutableMapOf<String, Any>(
             "petId" to petId,
         )

--- a/samples/client/petstore/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -100,8 +100,8 @@ open class PetApi(client: RestClient) : ApiClient(client) {
         val localVariableBody = null
         val localVariableQuery = mutableMapOf<kotlin.String, kotlin.collections.List<kotlin.String>>()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
-        
+                apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
+
         val params = mutableMapOf<String, Any>(
             "petId" to petId,
         )

--- a/samples/client/petstore/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -63,6 +63,7 @@ open class StoreApi(client: RestClient) : ApiClient(client) {
         val localVariableQuery = mutableMapOf<kotlin.String, kotlin.collections.List<kotlin.String>>()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         val params = mutableMapOf<String, Any>(
             "orderId" to orderId,
         )

--- a/samples/client/petstore/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -64,6 +64,7 @@ open class UserApi(client: RestClient) : ApiClient(client) {
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Content-Type"] = "application/json"
         
+
         val params = mutableMapOf<String, Any>(
         )
 
@@ -98,6 +99,7 @@ open class UserApi(client: RestClient) : ApiClient(client) {
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Content-Type"] = "application/json"
         
+
         val params = mutableMapOf<String, Any>(
         )
 
@@ -132,6 +134,7 @@ open class UserApi(client: RestClient) : ApiClient(client) {
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Content-Type"] = "application/json"
         
+
         val params = mutableMapOf<String, Any>(
         )
 
@@ -165,6 +168,7 @@ open class UserApi(client: RestClient) : ApiClient(client) {
         val localVariableQuery = mutableMapOf<kotlin.String, kotlin.collections.List<kotlin.String>>()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         val params = mutableMapOf<String, Any>(
             "username" to username,
         )
@@ -274,6 +278,7 @@ open class UserApi(client: RestClient) : ApiClient(client) {
         val localVariableQuery = mutableMapOf<kotlin.String, kotlin.collections.List<kotlin.String>>()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         val params = mutableMapOf<String, Any>(
         )
 
@@ -308,6 +313,7 @@ open class UserApi(client: RestClient) : ApiClient(client) {
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Content-Type"] = "application/json"
         
+
         val params = mutableMapOf<String, Any>(
             "username" to username,
         )

--- a/samples/client/petstore/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -105,8 +105,8 @@ open class PetApi(client: WebClient) : ApiClient(client) {
         val localVariableBody = null
         val localVariableQuery = mutableMapOf<kotlin.String, kotlin.collections.List<kotlin.String>>()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
-        
+                apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
+
         val params = mutableMapOf<String, Any>(
             "petId" to petId,
         )

--- a/samples/client/petstore/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -105,7 +105,8 @@ open class PetApi(client: WebClient) : ApiClient(client) {
         val localVariableBody = null
         val localVariableQuery = mutableMapOf<kotlin.String, kotlin.collections.List<kotlin.String>>()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-                apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
+        
+        apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
 
         val params = mutableMapOf<String, Any>(
             "petId" to petId,
@@ -305,6 +306,7 @@ open class PetApi(client: WebClient) : ApiClient(client) {
         val localVariableQuery = mutableMapOf<kotlin.String, kotlin.collections.List<kotlin.String>>()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "application/x-www-form-urlencoded")
         
+
         val params = mutableMapOf<String, Any>(
             "petId" to petId,
         )

--- a/samples/client/petstore/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -68,6 +68,7 @@ open class StoreApi(client: WebClient) : ApiClient(client) {
         val localVariableQuery = mutableMapOf<kotlin.String, kotlin.collections.List<kotlin.String>>()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         val params = mutableMapOf<String, Any>(
             "orderId" to orderId,
         )

--- a/samples/client/petstore/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -69,6 +69,7 @@ open class UserApi(client: WebClient) : ApiClient(client) {
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Content-Type"] = "application/json"
         
+
         val params = mutableMapOf<String, Any>(
         )
 
@@ -104,6 +105,7 @@ open class UserApi(client: WebClient) : ApiClient(client) {
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Content-Type"] = "application/json"
         
+
         val params = mutableMapOf<String, Any>(
         )
 
@@ -139,6 +141,7 @@ open class UserApi(client: WebClient) : ApiClient(client) {
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Content-Type"] = "application/json"
         
+
         val params = mutableMapOf<String, Any>(
         )
 
@@ -173,6 +176,7 @@ open class UserApi(client: WebClient) : ApiClient(client) {
         val localVariableQuery = mutableMapOf<kotlin.String, kotlin.collections.List<kotlin.String>>()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         val params = mutableMapOf<String, Any>(
             "username" to username,
         )
@@ -283,6 +287,7 @@ open class UserApi(client: WebClient) : ApiClient(client) {
         val localVariableQuery = mutableMapOf<kotlin.String, kotlin.collections.List<kotlin.String>>()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         val params = mutableMapOf<String, Any>(
         )
 
@@ -318,6 +323,7 @@ open class UserApi(client: WebClient) : ApiClient(client) {
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Content-Type"] = "application/json"
         
+
         val params = mutableMapOf<String, Any>(
             "username" to username,
         )

--- a/samples/client/petstore/kotlin-kotlinx-datetime/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-kotlinx-datetime/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -187,8 +187,8 @@ open class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factor
         val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
-        
+                apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
+
         return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/pet/{petId}".replace("{"+"petId"+"}", encodeURIComponent(petId.toString())),

--- a/samples/client/petstore/kotlin-kotlinx-datetime/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-kotlinx-datetime/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -115,6 +115,7 @@ open class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factor
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Content-Type"] = "application/json"
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/pet",
@@ -187,7 +188,8 @@ open class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factor
         val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-                apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
+        
+        apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
 
         return RequestConfig(
             method = RequestMethod.DELETE,
@@ -508,6 +510,7 @@ open class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factor
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Content-Type"] = "application/json"
         
+
         return RequestConfig(
             method = RequestMethod.PUT,
             path = "/pet",
@@ -586,6 +589,7 @@ open class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factor
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "application/x-www-form-urlencoded")
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/pet/{petId}".replace("{"+"petId"+"}", encodeURIComponent(petId.toString())),

--- a/samples/client/petstore/kotlin-kotlinx-datetime/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-kotlinx-datetime/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -113,6 +113,7 @@ open class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Fact
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/store/order/{orderId}".replace("{"+"orderId"+"}", encodeURIComponent(orderId.toString())),

--- a/samples/client/petstore/kotlin-kotlinx-datetime/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-kotlinx-datetime/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -113,6 +113,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/user",
@@ -183,6 +184,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/user/createWithArray",
@@ -253,6 +255,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/user/createWithList",
@@ -323,6 +326,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/user/{username}".replace("{"+"username"+"}", encodeURIComponent(username.toString())),
@@ -543,6 +547,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.GET,
             path = "/user/logout",
@@ -616,6 +621,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.PUT,
             path = "/user/{username}".replace("{"+"username"+"}", encodeURIComponent(username.toString())),

--- a/samples/client/petstore/kotlin-modelMutable/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-modelMutable/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -187,8 +187,8 @@ open class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factor
         val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
-        
+                apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
+
         return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/pet/{petId}".replace("{"+"petId"+"}", encodeURIComponent(petId.toString())),

--- a/samples/client/petstore/kotlin-modelMutable/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-modelMutable/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -115,6 +115,7 @@ open class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factor
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Content-Type"] = "application/json"
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/pet",
@@ -187,7 +188,8 @@ open class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factor
         val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-                apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
+        
+        apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
 
         return RequestConfig(
             method = RequestMethod.DELETE,
@@ -508,6 +510,7 @@ open class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factor
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Content-Type"] = "application/json"
         
+
         return RequestConfig(
             method = RequestMethod.PUT,
             path = "/pet",
@@ -586,6 +589,7 @@ open class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factor
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "application/x-www-form-urlencoded")
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/pet/{petId}".replace("{"+"petId"+"}", encodeURIComponent(petId.toString())),

--- a/samples/client/petstore/kotlin-modelMutable/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-modelMutable/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -113,6 +113,7 @@ open class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Fact
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/store/order/{orderId}".replace("{"+"orderId"+"}", encodeURIComponent(orderId.toString())),

--- a/samples/client/petstore/kotlin-modelMutable/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-modelMutable/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -113,6 +113,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/user",
@@ -183,6 +184,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/user/createWithArray",
@@ -253,6 +255,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/user/createWithList",
@@ -323,6 +326,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/user/{username}".replace("{"+"username"+"}", encodeURIComponent(username.toString())),
@@ -543,6 +547,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.GET,
             path = "/user/logout",
@@ -616,6 +621,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.PUT,
             path = "/user/{username}".replace("{"+"username"+"}", encodeURIComponent(username.toString())),

--- a/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -187,8 +187,8 @@ open class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factor
         val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
-        
+                apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
+
         return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/pet/{petId}".replace("{"+"petId"+"}", encodeURIComponent(petId.toString())),

--- a/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -115,6 +115,7 @@ open class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factor
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Content-Type"] = "application/json"
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/pet",
@@ -187,7 +188,8 @@ open class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factor
         val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-                apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
+        
+        apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
 
         return RequestConfig(
             method = RequestMethod.DELETE,
@@ -508,6 +510,7 @@ open class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factor
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Content-Type"] = "application/json"
         
+
         return RequestConfig(
             method = RequestMethod.PUT,
             path = "/pet",
@@ -586,6 +589,7 @@ open class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factor
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "application/x-www-form-urlencoded")
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/pet/{petId}".replace("{"+"petId"+"}", encodeURIComponent(petId.toString())),

--- a/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -113,6 +113,7 @@ open class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Fact
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/store/order/{orderId}".replace("{"+"orderId"+"}", encodeURIComponent(orderId.toString())),

--- a/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -113,6 +113,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/user",
@@ -183,6 +184,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/user/createWithArray",
@@ -253,6 +255,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/user/createWithList",
@@ -323,6 +326,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/user/{username}".replace("{"+"username"+"}", encodeURIComponent(username.toString())),
@@ -543,6 +547,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.GET,
             path = "/user/logout",
@@ -616,6 +621,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.PUT,
             path = "/user/{username}".replace("{"+"username"+"}", encodeURIComponent(username.toString())),

--- a/samples/client/petstore/kotlin-name-parameter-mappings/src/main/kotlin/org/openapitools/client/apis/FakeApi.kt
+++ b/samples/client/petstore/kotlin-name-parameter-mappings/src/main/kotlin/org/openapitools/client/apis/FakeApi.kt
@@ -127,9 +127,9 @@ open class FakeApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
                 put("http_debug_option", listOf(httpDebugOption.toString()))
             }
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
+        localVariableHeaders["Accept"] = "application/json"
         underscoreType.apply { localVariableHeaders["_type"] = this.toString() }
         typeWithUnderscore.apply { localVariableHeaders["type_"] = this.toString() }
-        localVariableHeaders["Accept"] = "application/json"
 
         return RequestConfig(
             method = RequestMethod.GET,

--- a/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -187,8 +187,8 @@ internal class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Fa
         val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
-        
+                apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
+
         return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/pet/{petId}".replace("{"+"petId"+"}", encodeURIComponent(petId.toString())),

--- a/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -115,6 +115,7 @@ internal class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Fa
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Content-Type"] = "application/json"
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/pet",
@@ -187,7 +188,8 @@ internal class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Fa
         val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-                apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
+        
+        apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
 
         return RequestConfig(
             method = RequestMethod.DELETE,
@@ -508,6 +510,7 @@ internal class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Fa
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Content-Type"] = "application/json"
         
+
         return RequestConfig(
             method = RequestMethod.PUT,
             path = "/pet",
@@ -586,6 +589,7 @@ internal class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Fa
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "application/x-www-form-urlencoded")
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/pet/{petId}".replace("{"+"petId"+"}", encodeURIComponent(petId.toString())),

--- a/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -113,6 +113,7 @@ internal class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/store/order/{orderId}".replace("{"+"orderId"+"}", encodeURIComponent(orderId.toString())),

--- a/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -113,6 +113,7 @@ internal class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.F
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/user",
@@ -183,6 +184,7 @@ internal class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.F
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/user/createWithArray",
@@ -253,6 +255,7 @@ internal class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.F
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/user/createWithList",
@@ -323,6 +326,7 @@ internal class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.F
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/user/{username}".replace("{"+"username"+"}", encodeURIComponent(username.toString())),
@@ -543,6 +547,7 @@ internal class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.F
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.GET,
             path = "/user/logout",
@@ -616,6 +621,7 @@ internal class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.F
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.PUT,
             path = "/user/{username}".replace("{"+"username"+"}", encodeURIComponent(username.toString())),

--- a/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -187,8 +187,8 @@ open class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factor
         val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
-        
+                apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
+
         return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/pet/{petId}".replace("{"+"petId"+"}", encodeURIComponent(petId.toString())),

--- a/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -115,6 +115,7 @@ open class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factor
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Content-Type"] = "application/json"
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/pet",
@@ -187,7 +188,8 @@ open class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factor
         val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-                apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
+        
+        apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
 
         return RequestConfig(
             method = RequestMethod.DELETE,
@@ -508,6 +510,7 @@ open class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factor
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Content-Type"] = "application/json"
         
+
         return RequestConfig(
             method = RequestMethod.PUT,
             path = "/pet",
@@ -586,6 +589,7 @@ open class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factor
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "application/x-www-form-urlencoded")
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/pet/{petId}".replace("{"+"petId"+"}", encodeURIComponent(petId.toString())),

--- a/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -113,6 +113,7 @@ open class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Fact
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/store/order/{orderId}".replace("{"+"orderId"+"}", encodeURIComponent(orderId.toString())),

--- a/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -113,6 +113,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/user",
@@ -183,6 +184,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/user/createWithArray",
@@ -253,6 +255,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/user/createWithList",
@@ -323,6 +326,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/user/{username}".replace("{"+"username"+"}", encodeURIComponent(username.toString())),
@@ -543,6 +547,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.GET,
             path = "/user/logout",
@@ -616,6 +621,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.PUT,
             path = "/user/{username}".replace("{"+"username"+"}", encodeURIComponent(username.toString())),

--- a/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -187,8 +187,8 @@ open class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factor
         val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
-        
+                apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
+
         return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/pet/{petId}".replace("{"+"petId"+"}", encodeURIComponent(petId.toString())),

--- a/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -115,6 +115,7 @@ open class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factor
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Content-Type"] = "application/json"
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/pet",
@@ -187,7 +188,8 @@ open class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factor
         val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-                apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
+        
+        apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
 
         return RequestConfig(
             method = RequestMethod.DELETE,
@@ -508,6 +510,7 @@ open class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factor
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Content-Type"] = "application/json"
         
+
         return RequestConfig(
             method = RequestMethod.PUT,
             path = "/pet",
@@ -586,6 +589,7 @@ open class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factor
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "application/x-www-form-urlencoded")
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/pet/{petId}".replace("{"+"petId"+"}", encodeURIComponent(petId.toString())),

--- a/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -113,6 +113,7 @@ open class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Fact
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/store/order/{orderId}".replace("{"+"orderId"+"}", encodeURIComponent(orderId.toString())),

--- a/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -113,6 +113,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/user",
@@ -183,6 +184,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/user/createWithArray",
@@ -253,6 +255,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/user/createWithList",
@@ -323,6 +326,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/user/{username}".replace("{"+"username"+"}", encodeURIComponent(username.toString())),
@@ -543,6 +547,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.GET,
             path = "/user/logout",
@@ -616,6 +621,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.PUT,
             path = "/user/{username}".replace("{"+"username"+"}", encodeURIComponent(username.toString())),

--- a/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -187,8 +187,8 @@ open class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factor
         val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
-        
+                apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
+
         return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/pet/{petId}".replace("{"+"petId"+"}", encodeURIComponent(petId.toString())),

--- a/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -115,6 +115,7 @@ open class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factor
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Content-Type"] = "application/json"
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/pet",
@@ -187,7 +188,8 @@ open class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factor
         val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-                apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
+        
+        apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
 
         return RequestConfig(
             method = RequestMethod.DELETE,
@@ -508,6 +510,7 @@ open class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factor
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Content-Type"] = "application/json"
         
+
         return RequestConfig(
             method = RequestMethod.PUT,
             path = "/pet",
@@ -586,6 +589,7 @@ open class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factor
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "application/x-www-form-urlencoded")
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/pet/{petId}".replace("{"+"petId"+"}", encodeURIComponent(petId.toString())),

--- a/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -113,6 +113,7 @@ open class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Fact
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/store/order/{orderId}".replace("{"+"orderId"+"}", encodeURIComponent(orderId.toString())),

--- a/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -113,6 +113,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/user",
@@ -183,6 +184,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/user/createWithArray",
@@ -253,6 +255,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/user/createWithList",
@@ -323,6 +326,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/user/{username}".replace("{"+"username"+"}", encodeURIComponent(username.toString())),
@@ -543,6 +547,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.GET,
             path = "/user/logout",
@@ -616,6 +621,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.PUT,
             path = "/user/{username}".replace("{"+"username"+"}", encodeURIComponent(username.toString())),

--- a/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -187,8 +187,8 @@ open class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factor
         val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
-        
+                apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
+
         return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/pet/{petId}".replace("{"+"petId"+"}", encodeURIComponent(petId.toString())),

--- a/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -115,6 +115,7 @@ open class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factor
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Content-Type"] = "application/json"
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/pet",
@@ -187,7 +188,8 @@ open class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factor
         val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-                apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
+        
+        apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
 
         return RequestConfig(
             method = RequestMethod.DELETE,
@@ -508,6 +510,7 @@ open class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factor
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Content-Type"] = "application/json"
         
+
         return RequestConfig(
             method = RequestMethod.PUT,
             path = "/pet",
@@ -586,6 +589,7 @@ open class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factor
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "application/x-www-form-urlencoded")
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/pet/{petId}".replace("{"+"petId"+"}", encodeURIComponent(petId.toString())),

--- a/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -113,6 +113,7 @@ open class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Fact
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/store/order/{orderId}".replace("{"+"orderId"+"}", encodeURIComponent(orderId.toString())),

--- a/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -113,6 +113,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/user",
@@ -183,6 +184,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/user/createWithArray",
@@ -253,6 +255,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/user/createWithList",
@@ -323,6 +326,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/user/{username}".replace("{"+"username"+"}", encodeURIComponent(username.toString())),
@@ -543,6 +547,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.GET,
             path = "/user/logout",
@@ -616,6 +621,7 @@ open class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Facto
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+
         return RequestConfig(
             method = RequestMethod.PUT,
             path = "/user/{username}".replace("{"+"username"+"}", encodeURIComponent(username.toString())),


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Generate automatic headers (Content-Type, Accept) before custom header params in Kotlin JVM clients so user-defined values override defaults. Applies to `jvm-okhttp`, `jvm-spring-restclient`, and `jvm-spring-webclient`; improved header formatting and regenerated Kotlin samples. Fixes #24529.

<sup>Written for commit 44e068777d482a6111da7ccf5e2773d3dddcf1a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24530?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

