### PR TITLE
[typescript-fetch] Add required + dataType properties to validation attributes

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/validationAttributes.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/validationAttributes.mustache
@@ -21,7 +21,7 @@ export const {{classname}}PropertyValidationAttributesMap: {
 {{#hasValidation}}
     {{name}}: {
         {{#dataType}}
-        dataType: "{{dataType}}",
+        dataType: "{{{dataType}}}",
         {{/dataType}}
         {{#required}}
         required: {{required}},

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/validationAttributes.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/validationAttributes.mustache
@@ -2,6 +2,8 @@
 
 export const {{classname}}PropertyValidationAttributesMap: {
     [property: string]: {
+        dataType?: string,
+        required?: boolean,
         maxLength?: number,
         minLength?: number,
         pattern?: string,
@@ -18,6 +20,12 @@ export const {{classname}}PropertyValidationAttributesMap: {
 {{#vars}}
 {{#hasValidation}}
     {{name}}: {
+        {{#dataType}}
+        dataType: "{{dataType}}",
+        {{/dataType}}
+        {{#required}}
+        required: {{required}},
+        {{/required}}
         {{#maxLength}}
         maxLength: {{maxLength}},
         {{/maxLength}}

--- a/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/Category.ts
@@ -30,6 +30,8 @@ export interface Category {
 }
 export const CategoryPropertyValidationAttributesMap: {
     [property: string]: {
+        dataType?: string,
+        required?: boolean,
         maxLength?: number,
         minLength?: number,
         pattern?: string,
@@ -44,6 +46,7 @@ export const CategoryPropertyValidationAttributesMap: {
     }
 } = {
     name: {
+        dataType: "string",
         pattern: '/^[a-zA-Z0-9]+[a-zA-Z0-9\\.\\-_]*[a-zA-Z0-9]+$/',
     },
 }

--- a/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/ModelApiResponse.ts
@@ -34,6 +34,8 @@ export interface ModelApiResponse {
 }
 export const ModelApiResponsePropertyValidationAttributesMap: {
     [property: string]: {
+        dataType?: string,
+        required?: boolean,
         maxLength?: number,
         minLength?: number,
         pattern?: string,

--- a/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/Order.ts
@@ -59,6 +59,8 @@ export type OrderStatusEnum = typeof OrderStatusEnum[keyof typeof OrderStatusEnu
 
 export const OrderPropertyValidationAttributesMap: {
     [property: string]: {
+        dataType?: string,
+        required?: boolean,
         maxLength?: number,
         minLength?: number,
         pattern?: string,

--- a/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/Pet.ts
@@ -74,6 +74,8 @@ export type PetStatusEnum = typeof PetStatusEnum[keyof typeof PetStatusEnum];
 
 export const PetPropertyValidationAttributesMap: {
     [property: string]: {
+        dataType?: string,
+        required?: boolean,
         maxLength?: number,
         minLength?: number,
         pattern?: string,
@@ -88,6 +90,8 @@ export const PetPropertyValidationAttributesMap: {
     }
 } = {
     photoUrls: {
+        dataType: "Set&lt;string&gt;",
+        required: true,
         maxItems: 8,
         minItems: 1,
         uniqueItems: true,

--- a/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/Pet.ts
@@ -90,7 +90,7 @@ export const PetPropertyValidationAttributesMap: {
     }
 } = {
     photoUrls: {
-        dataType: "Set&lt;string&gt;",
+        dataType: "Set<string>",
         required: true,
         maxItems: 8,
         minItems: 1,

--- a/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/Tag.ts
@@ -30,6 +30,8 @@ export interface Tag {
 }
 export const TagPropertyValidationAttributesMap: {
     [property: string]: {
+        dataType?: string,
+        required?: boolean,
         maxLength?: number,
         minLength?: number,
         pattern?: string,

--- a/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/User.ts
@@ -58,6 +58,8 @@ export interface User {
 }
 export const UserPropertyValidationAttributesMap: {
     [property: string]: {
+        dataType?: string,
+        required?: boolean,
         maxLength?: number,
         minLength?: number,
         pattern?: string,
@@ -72,13 +74,16 @@ export const UserPropertyValidationAttributesMap: {
     }
 } = {
     password: {
+        dataType: "string",
         maxLength: 256,
         minLength: 8,
     },
     nickname: {
+        dataType: "string",
         pattern: '/^[a-z&]+$/',
     },
     userStatus: {
+        dataType: "number",
         maximum: 100,
         exclusiveMaximum: true,
         minimum: 0,

--- a/samples/server/petstore/kotlin-spring-cloud-4/build.gradle.kts
+++ b/samples/server/petstore/kotlin-spring-cloud-4/build.gradle.kts
@@ -43,7 +43,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-webmvc")
 
     implementation("com.google.code.findbugs:jsr305:3.0.2")
-    val jackson3Version = "3.1.0"
+    val jackson3Version = "3.1.5"
     implementation("tools.jackson.dataformat:jackson-dataformat-yaml:$jackson3Version")
     implementation("tools.jackson.dataformat:jackson-dataformat-xml:$jackson3Version")
     implementation("tools.jackson.module:jackson-module-kotlin:$jackson3Version")

--- a/samples/server/petstore/kotlin-spring-cloud-4/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/server/petstore/kotlin-spring-cloud-4/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/server/petstore/kotlin-spring-cloud-4/pom.xml
+++ b/samples/server/petstore/kotlin-spring-cloud-4/pom.xml
@@ -8,7 +8,7 @@
     <version>1.0.0</version>
     <properties>
         <findbugs-jsr305.version>3.0.2</findbugs-jsr305.version>
-        <jackson3.version>3.1.0</jackson3.version>
+        <jackson3.version>3.1.5</jackson3.version>
         <jakarta-annotation.version>3.0.0</jakarta-annotation.version>
         <kotlin-test-junit5.version>2.2.0</kotlin-test-junit5.version>
 


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

# Changes

- Updated template for validation attributes in `typescript-fetch` generator to include information about whether a field is `required` and which `dataType` it has.


Closes https://github.com/OpenAPITools/openapi-generator/issues/24531

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


@TiFu @taxpon @sebastianhaas @kenisteward @Vrolijkx @macjohnny @topce @akehir @petejohansonxo @amakhrov @davidgamero @mkusaka @joscha @KannaKim



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose `required` and `dataType` in the `typescript-fetch` validation attributes map so clients can read requiredness and types without parsing the schema. Also fixes HTML escaping for `dataType` values.

- **New Features**
  - `validationAttributes.mustache` now emits `dataType` and `required` in `{{classname}}PropertyValidationAttributesMap` when available.
  - Regenerated samples to reflect this; Kotlin Spring Cloud sample bumps Jackson 3 to 3.1.5 and Gradle wrapper to 8.14.5.

- **Bug Fixes**
  - Use unescaped mustache for `dataType` to prevent HTML-escaped output (e.g., Set<string>).

<sup>Written for commit 83fb2960d6fa23d737923c1808dabc5dd22c960c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24533?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





