### PR TITLE
[ruby-nextgen] Let Configuration carry Faraday SSL options

### DIFF
--- a/modules/openapi-generator/src/main/resources/ruby-nextgen/README.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-nextgen/README.mustache
@@ -49,6 +49,9 @@ coexist in the same process — there is no global state.
 ```ruby
 client = {{moduleName}}::Client.new(base_url: "{{{basePath}}}") do |config|
   config.timeout = 10
+  # Handed to Faraday verbatim. Needed when the server presents a certificate issued by a
+  # private CA, which the default trust store does not know:
+  #   config.ssl = { ca_file: "/path/to/root.crt" }
 {{#authMethods}}
 {{#isApiKey}}
   config.api_key = "YOUR_API_KEY"

--- a/modules/openapi-generator/src/main/resources/ruby-nextgen/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-nextgen/configuration.mustache
@@ -2,13 +2,18 @@
 
 module {{moduleName}}
   class Configuration
-    attr_accessor :base_url, :timeout, :logger, :debugging, :query_array_encoding{{#authMethods}}{{#isApiKey}}, :api_key{{/isApiKey}}{{#isBasicBearer}}, :access_token{{/isBasicBearer}}{{#isBasicBasic}}, :username, :password{{/isBasicBasic}}{{/authMethods}}
+    # `ssl` is handed to Faraday verbatim, e.g. `{ ca_file: "/path/to/root.crt" }` for a server
+    # whose certificate is issued by a private CA. Such a server is otherwise unreachable — the
+    # default trust store holds public authorities only — and no middleware can make up for it:
+    # TLS is settled when the connection is built, before any middleware runs.
+    attr_accessor :base_url, :timeout, :logger, :debugging, :query_array_encoding, :ssl{{#authMethods}}{{#isApiKey}}, :api_key{{/isApiKey}}{{#isBasicBearer}}, :access_token{{/isBasicBearer}}{{#isBasicBasic}}, :username, :password{{/isBasicBasic}}{{/authMethods}}
 
     def initialize(base_url: nil, **options)
       @base_url = base_url || '{{{basePath}}}'
       @timeout = 60
       @query_array_encoding = :repeat
       @debugging = false
+      @ssl = {}
       @middlewares = []
       options.each do |k, v|
         raise ArgumentError, "unknown configuration option: #{k}" unless respond_to?("#{k}=")

--- a/modules/openapi-generator/src/main/resources/ruby-nextgen/connection.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-nextgen/connection.mustache
@@ -10,7 +10,9 @@ module {{moduleName}}
       # relative (their leading slash is stripped in #call) and resolved against it.
       base = configuration.base_url
       base += '/' unless base.end_with?('/')
-      @faraday = Faraday.new(url: base) do |conn|
+      # `ssl` belongs to the connection options and not to `configure_faraday`: Faraday settles
+      # TLS when it builds the connection, so a middleware could never supply it.
+      @faraday = Faraday.new(url: base, ssl: configuration.ssl) do |conn|
         configuration.configure_faraday(conn)
       end
     end

--- a/samples/client/others/ruby-nextgen-qdrant/README.md
+++ b/samples/client/others/ruby-nextgen-qdrant/README.md
@@ -49,6 +49,9 @@ coexist in the same process — there is no global state.
 ```ruby
 client = Qdrant::Client.new(base_url: "http://localhost:6333") do |config|
   config.timeout = 10
+  # Handed to Faraday verbatim. Needed when the server presents a certificate issued by a
+  # private CA, which the default trust store does not know:
+  #   config.ssl = { ca_file: "/path/to/root.crt" }
   config.api_key = "YOUR_API_KEY"
   config.access_token = "YOUR_ACCESS_TOKEN"
 end

--- a/samples/client/others/ruby-nextgen-qdrant/lib/qdrant/configuration.rb
+++ b/samples/client/others/ruby-nextgen-qdrant/lib/qdrant/configuration.rb
@@ -2,13 +2,18 @@
 
 module Qdrant
   class Configuration
-    attr_accessor :base_url, :timeout, :logger, :debugging, :query_array_encoding, :api_key, :access_token
+    # `ssl` is handed to Faraday verbatim, e.g. `{ ca_file: "/path/to/root.crt" }` for a server
+    # whose certificate is issued by a private CA. Such a server is otherwise unreachable — the
+    # default trust store holds public authorities only — and no middleware can make up for it:
+    # TLS is settled when the connection is built, before any middleware runs.
+    attr_accessor :base_url, :timeout, :logger, :debugging, :query_array_encoding, :ssl, :api_key, :access_token
 
     def initialize(base_url: nil, **options)
       @base_url = base_url || 'http://localhost:6333'
       @timeout = 60
       @query_array_encoding = :repeat
       @debugging = false
+      @ssl = {}
       @middlewares = []
       options.each do |k, v|
         raise ArgumentError, "unknown configuration option: #{k}" unless respond_to?("#{k}=")

--- a/samples/client/others/ruby-nextgen-qdrant/lib/qdrant/connection.rb
+++ b/samples/client/others/ruby-nextgen-qdrant/lib/qdrant/connection.rb
@@ -10,7 +10,9 @@ module Qdrant
       # relative (their leading slash is stripped in #call) and resolved against it.
       base = configuration.base_url
       base += '/' unless base.end_with?('/')
-      @faraday = Faraday.new(url: base) do |conn|
+      # `ssl` belongs to the connection options and not to `configure_faraday`: Faraday settles
+      # TLS when it builds the connection, so a middleware could never supply it.
+      @faraday = Faraday.new(url: base, ssl: configuration.ssl) do |conn|
         configuration.configure_faraday(conn)
       end
     end

--- a/samples/client/petstore/ruby-nextgen/README.md
+++ b/samples/client/petstore/ruby-nextgen/README.md
@@ -49,6 +49,9 @@ coexist in the same process — there is no global state.
 ```ruby
 client = Petstore::Client.new(base_url: "http://petstore.swagger.io/v2") do |config|
   config.timeout = 10
+  # Handed to Faraday verbatim. Needed when the server presents a certificate issued by a
+  # private CA, which the default trust store does not know:
+  #   config.ssl = { ca_file: "/path/to/root.crt" }
   config.api_key = "YOUR_API_KEY"
 end
 ```

--- a/samples/client/petstore/ruby-nextgen/lib/petstore/configuration.rb
+++ b/samples/client/petstore/ruby-nextgen/lib/petstore/configuration.rb
@@ -2,13 +2,18 @@
 
 module Petstore
   class Configuration
-    attr_accessor :base_url, :timeout, :logger, :debugging, :query_array_encoding, :api_key
+    # `ssl` is handed to Faraday verbatim, e.g. `{ ca_file: "/path/to/root.crt" }` for a server
+    # whose certificate is issued by a private CA. Such a server is otherwise unreachable — the
+    # default trust store holds public authorities only — and no middleware can make up for it:
+    # TLS is settled when the connection is built, before any middleware runs.
+    attr_accessor :base_url, :timeout, :logger, :debugging, :query_array_encoding, :ssl, :api_key
 
     def initialize(base_url: nil, **options)
       @base_url = base_url || 'http://petstore.swagger.io/v2'
       @timeout = 60
       @query_array_encoding = :repeat
       @debugging = false
+      @ssl = {}
       @middlewares = []
       options.each do |k, v|
         raise ArgumentError, "unknown configuration option: #{k}" unless respond_to?("#{k}=")

--- a/samples/client/petstore/ruby-nextgen/lib/petstore/connection.rb
+++ b/samples/client/petstore/ruby-nextgen/lib/petstore/connection.rb
@@ -10,7 +10,9 @@ module Petstore
       # relative (their leading slash is stripped in #call) and resolved against it.
       base = configuration.base_url
       base += '/' unless base.end_with?('/')
-      @faraday = Faraday.new(url: base) do |conn|
+      # `ssl` belongs to the connection options and not to `configure_faraday`: Faraday settles
+      # TLS when it builds the connection, so a middleware could never supply it.
+      @faraday = Faraday.new(url: base, ssl: configuration.ssl) do |conn|
         configuration.configure_faraday(conn)
       end
     end


### PR DESCRIPTION
A server presenting a certificate issued by a private CA is unreachable by a generated client: the default trust store holds public authorities only, and `Configuration` exposed no way to say otherwise.

The escape hatch it does offer, `Configuration#use`, cannot help here — Faraday settles TLS when it builds the connection, before any middleware runs.

`ssl` is handed to Faraday verbatim, so anything the adapter understands works (`{ ca_file: ... }`, `{ verify: false }`, client certificates). It defaults to an empty hash, which is what Faraday assumes when the option is absent, so generated clients are unchanged unless they set it.

```ruby
client = Petstore::Client.new(base_url: "https://internal.example.org") do |config|
  config.ssl = { ca_file: "/path/to/root.crt" }
end
```

### Changes

- `configuration.mustache`: add the `:ssl` accessor, initialized to `{}`
- `connection.mustache`: pass it to `Faraday.new` as a connection option
- `README.mustache`: document it in the configuration example
- Regenerate the `petstore` and `qdrant` samples

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Samples regenerated for the affected generator (`bin/configs/ruby-nextgen.yaml`, `bin/configs/ruby-nextgen-qdrant.yaml`); no other generator output is touched by this change.
- [x] Targets `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds SSL options support to `ruby-nextgen` clients by carrying `Faraday` `ssl` settings in `Configuration` and passing them when the connection is built. This lets clients connect to servers using private CAs or client certificates without changing defaults.

- **New Features**
  - Add `Configuration.ssl` accessor (defaults to `{}`) for `Faraday` TLS options (e.g., `{ ca_file: "/path/to/root.crt" }`, `{ verify: false }`).
  - Pass `ssl` to `Faraday.new` so TLS is configured before middleware.
  - Update `README` and regenerate `petstore` and `qdrant` samples.

<sup>Written for commit 43fbcff24b2ea399d1e35c16f2c65ee202c8b3e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24536?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

