### PR TITLE
fix: keep allOf-inherited "any type" maps from degrading to free-form object

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -2582,7 +2582,67 @@ public class ModelUtils {
             Schema result = AnnotationsUtils.clone(schema, openapi31);
             schema.setType(schemaType);
             result.setType(schemaType);
+            restoreTypelessSubSchemas(schema, result,
+                    Collections.newSetFromMap(new IdentityHashMap<>()));
             return result;
+        }
+    }
+
+    /**
+     * Restores the "typeless" nature of sub-schemas after {@link #cloneSchema(Schema, boolean)}.
+     *
+     * <p>{@code AnnotationsUtils.clone} round-trips the schema through JSON. A sub-schema that
+     * declares no {@code type} (e.g. {@code additionalProperties: {description: can be any type}})
+     * is deserialized back as an {@link ObjectSchema} with {@code type: object}, which turns an
+     * "any type" schema into a free-form object. Downstream that flips
+     * {@link #isAnyType(Schema)} to false and {@link #isFreeFormObject(Schema, OpenAPI)} to true,
+     * so the resolved data type silently changes (for typescript: {@code any} becomes
+     * {@code object}).
+     *
+     * <p>The top-level type is already preserved by the caller; this walks the sub-schemas and
+     * clears the type wherever the original did not declare one.
+     *
+     * @param original the schema that was cloned
+     * @param clone    the clone to fix up, structurally identical to {@code original}
+     * @param visited  identity set of already visited original schemas, guards against cycles
+     */
+    private static void restoreTypelessSubSchemas(Schema original, Schema clone, Set<Schema> visited) {
+        if (original == null || clone == null || !visited.add(original)) {
+            return;
+        }
+
+        if (original.getType() == null && clone.getType() != null) {
+            clone.setType(null);
+            if (original.getTypes() == null) {
+                clone.setTypes(null);
+            }
+        }
+
+        if (original.getAdditionalProperties() instanceof Schema
+                && clone.getAdditionalProperties() instanceof Schema) {
+            restoreTypelessSubSchemas((Schema) original.getAdditionalProperties(),
+                    (Schema) clone.getAdditionalProperties(), visited);
+        }
+        restoreTypelessSubSchemas(original.getItems(), clone.getItems(), visited);
+        restoreTypelessSubSchemas(original.getNot(), clone.getNot(), visited);
+
+        if (original.getProperties() != null && clone.getProperties() != null) {
+            Map<String, Schema> cloneProperties = clone.getProperties();
+            ((Map<String, Schema>) original.getProperties()).forEach((name, originalProperty) ->
+                    restoreTypelessSubSchemas(originalProperty, cloneProperties.get(name), visited));
+        }
+
+        restoreTypelessSubSchemas(original.getAllOf(), clone.getAllOf(), visited);
+        restoreTypelessSubSchemas(original.getAnyOf(), clone.getAnyOf(), visited);
+        restoreTypelessSubSchemas(original.getOneOf(), clone.getOneOf(), visited);
+    }
+
+    private static void restoreTypelessSubSchemas(List<Schema> original, List<Schema> clone, Set<Schema> visited) {
+        if (original == null || clone == null || original.size() != clone.size()) {
+            return;
+        }
+        for (int i = 0; i < original.size(); i++) {
+            restoreTypelessSubSchemas(original.get(i), clone.get(i), visited);
         }
     }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -2537,7 +2537,67 @@ public class ModelUtils {
             Schema result = AnnotationsUtils.clone(schema, openapi31);
             schema.setType(schemaType);
             result.setType(schemaType);
+            restoreTypelessSubSchemas(schema, result,
+                    Collections.newSetFromMap(new IdentityHashMap<>()));
             return result;
+        }
+    }
+
+    /**
+     * Restores the "typeless" nature of sub-schemas after {@link #cloneSchema(Schema, boolean)}.
+     *
+     * <p>{@code AnnotationsUtils.clone} round-trips the schema through JSON. A sub-schema that
+     * declares no {@code type} (e.g. {@code additionalProperties: {description: can be any type}})
+     * is deserialized back as an {@link ObjectSchema} with {@code type: object}, which turns an
+     * "any type" schema into a free-form object. Downstream that flips
+     * {@link #isAnyType(Schema)} to false and {@link #isFreeFormObject(Schema, OpenAPI)} to true,
+     * so the resolved data type silently changes (for typescript: {@code any} becomes
+     * {@code object}).
+     *
+     * <p>The top-level type is already preserved by the caller; this walks the sub-schemas and
+     * clears the type wherever the original did not declare one.
+     *
+     * @param original the schema that was cloned
+     * @param clone    the clone to fix up, structurally identical to {@code original}
+     * @param visited  identity set of already visited original schemas, guards against cycles
+     */
+    private static void restoreTypelessSubSchemas(Schema original, Schema clone, Set<Schema> visited) {
+        if (original == null || clone == null || !visited.add(original)) {
+            return;
+        }
+
+        if (original.getType() == null && clone.getType() != null) {
+            clone.setType(null);
+            if (original.getTypes() == null) {
+                clone.setTypes(null);
+            }
+        }
+
+        if (original.getAdditionalProperties() instanceof Schema
+                && clone.getAdditionalProperties() instanceof Schema) {
+            restoreTypelessSubSchemas((Schema) original.getAdditionalProperties(),
+                    (Schema) clone.getAdditionalProperties(), visited);
+        }
+        restoreTypelessSubSchemas(original.getItems(), clone.getItems(), visited);
+        restoreTypelessSubSchemas(original.getNot(), clone.getNot(), visited);
+
+        if (original.getProperties() != null && clone.getProperties() != null) {
+            Map<String, Schema> cloneProperties = clone.getProperties();
+            ((Map<String, Schema>) original.getProperties()).forEach((name, originalProperty) ->
+                    restoreTypelessSubSchemas(originalProperty, cloneProperties.get(name), visited));
+        }
+
+        restoreTypelessSubSchemas(original.getAllOf(), clone.getAllOf(), visited);
+        restoreTypelessSubSchemas(original.getAnyOf(), clone.getAnyOf(), visited);
+        restoreTypelessSubSchemas(original.getOneOf(), clone.getOneOf(), visited);
+    }
+
+    private static void restoreTypelessSubSchemas(List<Schema> original, List<Schema> clone, Set<Schema> visited) {
+        if (original == null || clone == null || original.size() != clone.size()) {
+            return;
+        }
+        for (int i = 0; i < original.size(); i++) {
+            restoreTypelessSubSchemas(original.get(i), clone.get(i), visited);
         }
     }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -2604,10 +2604,14 @@ public class ModelUtils {
      *
      * @param original the schema that was cloned
      * @param clone    the clone to fix up, structurally identical to {@code original}
-     * @param visited  identity set of already visited original schemas, guards against cycles
+     * @param visited  identity set of already visited clone nodes
      */
     private static void restoreTypelessSubSchemas(Schema original, Schema clone, Set<Schema> visited) {
-        if (original == null || clone == null || !visited.add(original)) {
+        // Keyed on the clone, not the original: the parser reuses a single Schema instance across
+        // several places in a spec, while the JSON round-trip gives each of those places its own
+        // clone. Keying on the original would fix up only the first occurrence and silently skip
+        // the rest.
+        if (original == null || clone == null || !visited.add(clone)) {
             return;
         }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -2559,10 +2559,14 @@ public class ModelUtils {
      *
      * @param original the schema that was cloned
      * @param clone    the clone to fix up, structurally identical to {@code original}
-     * @param visited  identity set of already visited original schemas, guards against cycles
+     * @param visited  identity set of already visited clone nodes
      */
     private static void restoreTypelessSubSchemas(Schema original, Schema clone, Set<Schema> visited) {
-        if (original == null || clone == null || !visited.add(original)) {
+        // Keyed on the clone, not the original: the parser reuses a single Schema instance across
+        // several places in a spec, while the JSON round-trip gives each of those places its own
+        // clone. Keying on the original would fix up only the first occurrence and silently skip
+        // the rest.
+        if (original == null || clone == null || !visited.add(clone)) {
             return;
         }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchClientCodegenTest.java
@@ -94,6 +94,37 @@ public class TypeScriptFetchClientCodegenTest {
     }
 
     @Test
+    public void testAllOfInheritedFreeFormMapStaysAny() throws IOException {
+        // A property whose additionalProperties schema declares no type is "any type". Inheriting
+        // it through allOf must not change that: the allOf composition path clones the inherited
+        // property schemas, and the clone used to come back as a free-form object (`object`).
+        final String specPath = "src/test/resources/3_0/typescript-fetch/allof-inherited-free-form-map.yaml";
+
+        File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("typescript-fetch")
+                .setInputSpec(specPath)
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+        Generator generator = new DefaultGenerator();
+        List<File> files = generator.opts(configurator.toClientOptInput()).generate();
+        files.forEach(File::deleteOnExit);
+
+        Path base = Paths.get(output + "/models/Base.ts");
+        TestUtils.assertFileContains(base, "requiredLoose: { [key: string]: any; };");
+        TestUtils.assertFileContains(base, "optionalLoose?: { [key: string]: any; };");
+        TestUtils.assertFileContains(base, "realObject?: { [key: string]: object; };");
+
+        // Child inherits all three through allOf -- the types must be identical to Base's
+        Path child = Paths.get(output + "/models/Child.ts");
+        TestUtils.assertFileContains(child, "requiredLoose: { [key: string]: any; };");
+        TestUtils.assertFileContains(child, "optionalLoose?: { [key: string]: any; };");
+        TestUtils.assertFileContains(child, "realObject?: { [key: string]: object; };");
+    }
+
+    @Test
     public void testMergesContentTypeVariantsIntoOneMethod() throws IOException {
         File output = Files.createTempDirectory("test").toFile();
         output.deleteOnExit();

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchClientCodegenTest.java
@@ -68,6 +68,37 @@ public class TypeScriptFetchClientCodegenTest {
     }
 
     @Test
+    public void testAllOfInheritedFreeFormMapStaysAny() throws IOException {
+        // A property whose additionalProperties schema declares no type is "any type". Inheriting
+        // it through allOf must not change that: the allOf composition path clones the inherited
+        // property schemas, and the clone used to come back as a free-form object (`object`).
+        final String specPath = "src/test/resources/3_0/typescript-fetch/allof-inherited-free-form-map.yaml";
+
+        File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("typescript-fetch")
+                .setInputSpec(specPath)
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+        Generator generator = new DefaultGenerator();
+        List<File> files = generator.opts(configurator.toClientOptInput()).generate();
+        files.forEach(File::deleteOnExit);
+
+        Path base = Paths.get(output + "/models/Base.ts");
+        TestUtils.assertFileContains(base, "requiredLoose: { [key: string]: any; };");
+        TestUtils.assertFileContains(base, "optionalLoose?: { [key: string]: any; };");
+        TestUtils.assertFileContains(base, "realObject?: { [key: string]: object; };");
+
+        // Child inherits all three through allOf -- the types must be identical to Base's
+        Path child = Paths.get(output + "/models/Child.ts");
+        TestUtils.assertFileContains(child, "requiredLoose: { [key: string]: any; };");
+        TestUtils.assertFileContains(child, "optionalLoose?: { [key: string]: any; };");
+        TestUtils.assertFileContains(child, "realObject?: { [key: string]: object; };");
+    }
+
+    @Test
     public void testModelsWithoutPaths() throws IOException {
         final String specPath = "src/test/resources/3_1/reusable-components-without-paths.yaml";
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/ModelUtilsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/ModelUtilsTest.java
@@ -483,6 +483,55 @@ public class ModelUtilsTest {
     }
 
     @Test
+    public void testCloneKeepsTypelessAdditionalPropertiesTypeless() {
+        // additionalProperties: {description: can be any type} -- a schema with no type at all.
+        // The JSON round-trip inside AnnotationsUtils.clone used to bring it back as an
+        // ObjectSchema with type=object, turning "any type" into a free-form object.
+        Schema anyType = new Schema().description("can be any type");
+        Schema schema = new ObjectSchema().additionalProperties(anyType);
+
+        Schema deepCopy = ModelUtils.cloneSchema(schema, false);
+
+        Schema copiedAdditionalProperties = (Schema) deepCopy.getAdditionalProperties();
+        Assert.assertNotSame(copiedAdditionalProperties, anyType);
+        Assert.assertNull(copiedAdditionalProperties.getType());
+        Assert.assertTrue(ModelUtils.isAnyType(copiedAdditionalProperties));
+        Assert.assertFalse(ModelUtils.isFreeFormObject(copiedAdditionalProperties, null));
+    }
+
+    @Test
+    public void testCloneKeepsTypelessNestedSchemasTypeless() {
+        Schema typelessProperty = new Schema().description("can be any type");
+        Schema typelessItem = new Schema().description("can be any type");
+        Schema schema = new ObjectSchema()
+                .addProperty("loose", typelessProperty)
+                .addProperty("list", new ArraySchema().items(typelessItem));
+
+        Schema deepCopy = ModelUtils.cloneSchema(schema, false);
+
+        Schema copiedProperty = (Schema) deepCopy.getProperties().get("loose");
+        Assert.assertNull(copiedProperty.getType());
+        Assert.assertTrue(ModelUtils.isAnyType(copiedProperty));
+
+        Schema copiedItems = ((Schema) deepCopy.getProperties().get("list")).getItems();
+        Assert.assertNull(copiedItems.getType());
+        Assert.assertTrue(ModelUtils.isAnyType(copiedItems));
+    }
+
+    @Test
+    public void testCloneKeepsDeclaredObjectTypeIntact() {
+        // a schema that really does declare `type: object` must stay a free-form object
+        Schema declaredObject = new ObjectSchema().description("a real object");
+        Schema schema = new ObjectSchema().additionalProperties(declaredObject);
+
+        Schema deepCopy = ModelUtils.cloneSchema(schema, false);
+
+        Schema copiedAdditionalProperties = (Schema) deepCopy.getAdditionalProperties();
+        Assert.assertEquals(copiedAdditionalProperties.getType(), "object");
+        Assert.assertFalse(ModelUtils.isAnyType(copiedAdditionalProperties));
+    }
+
+    @Test
     public void testCloneDateTimeSchemaWithExample() {
         Schema schema = new DateTimeSchema()
                 .example("2020-02-02T20:20:20.000222Z");

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/ModelUtilsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/ModelUtilsTest.java
@@ -519,6 +519,25 @@ public class ModelUtilsTest {
     }
 
     @Test
+    public void testCloneKeepsEveryOccurrenceOfAReusedTypelessSchemaTypeless() {
+        // The parser reuses a single Schema instance across several places in a spec, while the
+        // JSON round-trip inside the clone gives each place its own object. Every one of them has
+        // to be fixed up, not just the first one that is reached.
+        Schema sharedAnyType = new Schema().description("can be any type");
+        Schema schema = new ObjectSchema()
+                .addProperty("first", new ObjectSchema().additionalProperties(sharedAnyType))
+                .addProperty("second", new ObjectSchema().additionalProperties(sharedAnyType));
+
+        Schema deepCopy = ModelUtils.cloneSchema(schema, false);
+
+        for (String name : new String[]{"first", "second"}) {
+            Schema copied = (Schema) ((Schema) deepCopy.getProperties().get(name)).getAdditionalProperties();
+            Assert.assertNull(copied.getType(), name + " kept type: " + copied.getType());
+            Assert.assertTrue(ModelUtils.isAnyType(copied), name + " is no longer an any-type schema");
+        }
+    }
+
+    @Test
     public void testCloneKeepsDeclaredObjectTypeIntact() {
         // a schema that really does declare `type: object` must stay a free-form object
         Schema declaredObject = new ObjectSchema().description("a real object");

--- a/modules/openapi-generator/src/test/resources/3_0/typescript-fetch/allof-inherited-free-form-map.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/typescript-fetch/allof-inherited-free-form-map.yaml
@@ -1,0 +1,39 @@
+openapi: 3.0.3
+info:
+  title: allOf inherited free-form map
+  version: 1.0.0
+paths:
+  /child:
+    get:
+      operationId: getChild
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Child"
+components:
+  schemas:
+    Base:
+      required:
+        - requiredLoose
+      properties:
+        requiredLoose:
+          type: object
+          additionalProperties:
+            description: can be any type
+        optionalLoose:
+          type: object
+          additionalProperties:
+            description: can be any type
+        realObject:
+          type: object
+          additionalProperties:
+            type: object
+    Child:
+      allOf:
+        - $ref: "#/components/schemas/Base"
+      properties:
+        extra:
+          type: string


### PR DESCRIPTION
Fixes #24546

### What

A property whose `additionalProperties` schema declares no `type` is an "any type" map. When such a
property is **inherited through `allOf`**, the generated value type silently changed from "any" to
"free-form object" — so the same property produced two different data types in the same run:

```yaml
Base:
  properties:
    style: { type: object, additionalProperties: { description: can be any type } }
Child:
  allOf: [{ $ref: '#/components/schemas/Base' }]
```

```ts
// before
Base.style:  { [key: string]: any; }      // declared here
Child.style: { [key: string]: object; }   // inherited via allOf

// after
Base.style:  { [key: string]: any; }
Child.style: { [key: string]: any; }
```

### Why

The `allOf` **composition** branch in `DefaultCodegen.fromModel` calls `mergeProperties()`, which
deep-copies every inherited property schema via `ModelUtils.cloneSchema()`. `cloneSchema` delegates to
`AnnotationsUtils.clone` — a JSON round-trip — and swagger-core's deserializer materializes a sub-schema
that has no `type` as an `ObjectSchema` (`type: object`):

```java
Schema inner = new Schema().description("can be any type");
Schema outer = new ObjectSchema().additionalProperties(inner);

// before: class = Schema,       type = null,   isFreeFormObject = false
Schema cloned = ModelUtils.cloneSchema(outer, false);
// after:  class = ObjectSchema, type = object, isFreeFormObject = true
```

`DefaultCodegen.getPrimitiveType()` then matches the `ModelUtils.isFreeFormObject(...)` branch and returns
`"object"`, never reaching the `ModelUtils.isAnyType(...)` branch that returns `"AnyType"` (mapped to `any`
by the TypeScript generators).

This is generator-agnostic — `typescript-fetch` is just where it is most visible.

### How

`cloneSchema()` already guards a **custom top-level** type across the round-trip, but does not cover
sub-schemas. This extends the same idea: after cloning, walk the schema tree and clear the type wherever
the original did not declare one (`additionalProperties`, `items`, `properties`, `allOf`/`anyOf`/`oneOf`,
`not`). An identity-based visited set guards against cycles.

Schemas that genuinely declare `type: object` are untouched — there is an explicit test for that so the fix
cannot over-reach.

### Testing

- `ModelUtilsTest` — 3 new cases: typeless `additionalProperties`, nested typeless schemas
  (`properties` / `items`), and a declared `type: object` that must stay an object.
- `TypeScriptFetchClientCodegenTest.testAllOfInheritedFreeFormMapStaysAny` — end-to-end, asserts the
  inherited properties on `Child` carry exactly the same types as the ones declared on `Base`.
  Verified that this test **fails without the fix**.
- Regenerated **all 787 sample configs** (`./bin/generate-samples.sh ./bin/configs/*.yaml`) and
  `./bin/utils/export_docs_generators.sh` — **no diff**. The fix is inert on the entire existing sample
  corpus; only the buggy case changes.

> Note on the full test run: `mvn test` on `modules/openapi-generator` reports one pre-existing failure,
> `OpenApiSchemaValidationsTest.testNullTypeInOas31_noWarning`. It fails identically on unmodified
> `master` (`4aed9c1c635`) — I verified by reverting the patch and re-running — and is unrelated to this
> change, which only touches the non-3.1 branch of `cloneSchema`.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ```
  Commit all changed files.
  (Both scripts were run; neither produced any change, so there is nothing to commit beyond the fix and its tests.)
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

The change is in the language-agnostic core (`ModelUtils`), so it is not owned by one language committee.
Pinging the TypeScript technical committee since that is where the symptom shows up:
@TiFu @taxpon @sebastianhaas @kenisteward @Vrolijkx @macjohnny @topce @akehir @petejohansonxo @amakhrov @davidgamero @mkusaka @joscha

CC also @wing328 as this touches shared codegen behaviour.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where “any type” maps inherited via `allOf` were emitted as free-form `object` in the child while staying `any` in the parent. Now both parent and child keep `{ [key: string]: any; }`, consistent across generators (notably `typescript-fetch`).

- In `ModelUtils.cloneSchema`, after cloning, walk sub-schemas and clear `type` wherever the original had none (`additionalProperties`, `items`, `properties`, `allOf`/`anyOf`/`oneOf`, `not`); use a visited set keyed on the clone to fix every occurrence of reused schemas. Declared `type: object` stays intact.
- Tests: new `ModelUtilsTest` cases (typeless `additionalProperties`, nested typeless schemas, reused typeless schema occurrences, and a declared `type: object` that must remain an object) and an end-to-end `typescript-fetch` test asserting identical parent/child types. Regenerating samples produced no diffs.

<sup>Written for commit c6bc6a742fc35b8a09ada28b96324447d8db43cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24547?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

