### PR TITLE
fix: keep allOf members that have properties alongside a validation keyword

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -2694,8 +2694,18 @@ public class ModelUtils {
         // dereference the schema
         schema = ModelUtils.getReferencedSchema(openAPI, schema);
 
-        if (schema.getTypes() == null && hasValidation(schema)) {
+        if (schema.getTypes() == null && schema.getType() == null && hasValidation(schema)
+                && (schema.getProperties() == null || schema.getProperties().isEmpty())) {
             // just validation without type
+            //
+            // A schema that carries properties is a model, even when it omits `type: object` --
+            // which is very common in 3.0 specs, e.g. `minProperties: 2` next to `properties: {...}`.
+            // Checking `getTypes() == null && hasValidation(schema)` alone classified those as
+            // unsupported, and as an allOf member their properties were then dropped from the
+            // composed model without any warning.
+            //
+            // getTypes() is only populated for 3.1, so getType() has to be checked as well for the
+            // 3.0 case to be recognised.
             return true;
         } else if (schema.getIf() != null && schema.getThen() != null) {
             // if, then in 3.1 spec

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/OpenAPINormalizerTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/OpenAPINormalizerTest.java
@@ -39,6 +39,41 @@ public class OpenAPINormalizerTest {
     private static final String X_INTERNAL = "x-internal";
 
     @Test
+    public void testAllOfMemberWithValidationAndPropertiesIsKept() {
+        // A schema carrying `properties` but omitting `type: object`, next to a validation keyword,
+        // is a model -- not "validation without a type". It used to be classified as unsupported and
+        // silently dropped from allOf, so every model inheriting it lost those properties.
+        OpenAPI openAPI = TestUtils.parseSpec(
+                "src/test/resources/3_0/allof-member-with-validation-and-properties.yaml");
+
+        Schema child = openAPI.getComponents().getSchemas().get("Child");
+        assertNotNull(child.getAllOf());
+        assertTrue(refsParent(child), "precondition: Child starts out referencing Parent");
+
+        OpenAPINormalizer openAPINormalizer = new OpenAPINormalizer(openAPI, new HashMap<>());
+        openAPINormalizer.normalize();
+
+        Schema normalizedChild = openAPI.getComponents().getSchemas().get("Child");
+        assertNotNull(normalizedChild.getAllOf(),
+                "the whole allOf was dropped, so Child lost the inherited properties");
+        assertTrue(refsParent(normalizedChild),
+                "the allOf member carrying alpha/beta was dropped, so Child lost those properties");
+    }
+
+    private static boolean refsParent(Schema schema) {
+        if (schema.getAllOf() == null) {
+            return false;
+        }
+        for (Object item : schema.getAllOf()) {
+            String ref = ((Schema) item).get$ref();
+            if (ref != null && ref.endsWith("/Parent")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Test
     public void testOpenAPINormalizerOtherThanObjectWithProperties()
     {
         // to test the rule REF_AS_PARENT_IN_ALLOF

--- a/modules/openapi-generator/src/test/resources/3_0/allof-member-with-validation-and-properties.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/allof-member-with-validation-and-properties.yaml
@@ -1,0 +1,32 @@
+openapi: 3.0.3
+info:
+  title: allOf member with validation and properties
+  version: 1.0.0
+paths:
+  /child:
+    get:
+      operationId: getChild
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Child"
+components:
+  schemas:
+    # `properties` without an explicit `type: object`, next to a validation keyword.
+    # This is a model, not "validation without a type".
+    Parent:
+      minProperties: 2
+      properties:
+        alpha:
+          type: string
+        beta:
+          type: string
+    Child:
+      allOf:
+        - $ref: "#/components/schemas/Parent"
+      properties:
+        gamma:
+          type: string


### PR DESCRIPTION
Fixes #24550

### What

A schema carrying `properties` but omitting `type: object`, next to a validation keyword, was classified as
"validation without a type" and **silently dropped from `allOf`**. Every model inheriting it lost those
properties — no error, no warning, just a smaller model and a broken JSON contract.

```yaml
Parent:
  minProperties: 2            # validation keyword, and no `type: object`
  properties:
    alpha: { type: string }
    beta:  { type: string }
Child:
  allOf: [{ $ref: '#/components/schemas/Parent' }]
  properties:
    gamma: { type: string }
```

```ts
// before
export interface Child { gamma?: string; }                              // alpha/beta gone

// after
export interface Child { alpha?: string; beta?: string; gamma?: string; }
```

Removing `minProperties` — or adding an explicit `type: object` — makes the properties reappear, which is
what makes this easy to hit without noticing.

### Why

[`OpenAPINormalizer.removeUnsupportedSchemasFromAllOf()`](https://github.com/OpenAPITools/openapi-generator/blob/4aed9c1c635/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java#L1221)
drops every allOf member for which `ModelUtils.isUnsupportedSchema()` returns true, and that check was:

```java
if (schema.getTypes() == null && hasValidation(schema)) {
    // just validation without type
    return true;
}
```

`getTypes()` is only populated for 3.1, so for a 3.0 spec it is always null. In practice that means *any*
3.0 schema with a validation keyword and no explicit type was judged unsupported — including ones that are
plainly models. Omitting `type: object` next to `properties` is very common in 3.0 specs.

### How

Also require that the schema has no `properties`, and check `getType()` alongside `getTypes()` so the 3.0
case is recognised at all. A schema with properties is a model, not bare validation.

The intent of the original check — skipping schemas that are *only* validation, and `if`/`then` schemas —
is preserved; the existing `isUnsupportedSchemaTest` assertions still pass unchanged.

### Testing

- `OpenAPINormalizerTest.testAllOfMemberWithValidationAndPropertiesIsKept` — asserts the allOf member
  referencing `Parent` survives normalization. Verified that this test **fails without the fix**
  (`the whole allOf was dropped, so Child lost the inherited properties`).
- Full `OpenAPINormalizerTest` (64 tests) and `ModelUtilsTest` (68 tests, including the existing
  `isUnsupportedSchemaTest`) pass.
- Regenerated **all 787 sample configs** (`./bin/generate-samples.sh ./bin/configs/*.yaml`) and
  `./bin/utils/export_docs_generators.sh` — **no diff**.

> Note on the full test run: `mvn test` on `modules/openapi-generator` reports one pre-existing failure,
> `OpenApiSchemaValidationsTest.testNullTypeInOas31_noWarning`. It fails identically on unmodified
> `master` (`4aed9c1c635`) — verified by reverting the patch and re-running — and is unrelated to this change.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ```
  Commit all changed files.
  (Both scripts were run; neither produced any change, so there is nothing to commit beyond the fix and its test.)
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

This is in the language-agnostic core (`OpenAPINormalizer` / `ModelUtils`), so it is not owned by one
language committee. CC @wing328

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dropped `allOf` members when a referenced schema has `properties` next to a validation keyword but omits `type: object`. Child models now inherit those properties, preserving the JSON contract.

- **Bug Fixes**
  - Updated `ModelUtils.isUnsupportedSchema()` to only treat a schema as validation-only when both `getTypes()` (OAS 3.1) and `getType()` (OAS 3.0) are null, it has validation keywords, and it has no `properties`.
  - Added `OpenAPINormalizerTest.testAllOfMemberWithValidationAndPropertiesIsKept` with a 3.0 sample; tests pass and regenerating samples shows no diffs.

<sup>Written for commit ec60128f0605ae782ed6d67197764a80f7dbb536. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24551?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

