### PR TITLE
fix(typescript-fetch): qualify anyToJSON for any-typed form parameters

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
@@ -285,7 +285,7 @@ export class {{classname}} extends runtime.BaseAPI {
             {{^isEnumRef}}
             {{^withoutRuntimeChecks}}
             {{^isContainer}}
-            formParams.append('{{baseName}}', new Blob([JSON.stringify({{#isFreeFormObject}}runtime.anyToJSON{{/isFreeFormObject}}{{^isFreeFormObject}}{{{dataType}}}ToJSON{{/isFreeFormObject}}(requestParameters['{{paramName}}']))], { type: "application/json", }));
+            formParams.append('{{baseName}}', new Blob([JSON.stringify({{#isFreeFormObject}}runtime.anyToJSON{{/isFreeFormObject}}{{^isFreeFormObject}}{{#isAnyType}}runtime.anyToJSON{{/isAnyType}}{{^isAnyType}}{{{dataType}}}ToJSON{{/isAnyType}}{{/isFreeFormObject}}(requestParameters['{{paramName}}']))], { type: "application/json", }));
             {{/isContainer}}
             {{#isContainer}}
             formParams.append('{{baseName}}', new Blob([JSON.stringify(requestParameters['{{paramName}}'])], { type: "application/json", }));

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/apisFormParams.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/apisFormParams.mustache
@@ -50,7 +50,7 @@
             {{^isEnumRef}}
             {{^withoutRuntimeChecks}}
             {{^isContainer}}
-            formParams.append('{{baseName}}', new Blob([JSON.stringify({{#isFreeFormObject}}runtime.anyToJSON{{/isFreeFormObject}}{{^isFreeFormObject}}{{{dataType}}}ToJSON{{/isFreeFormObject}}(requestParameters['{{paramName}}']))], { type: "application/json", }));
+            formParams.append('{{baseName}}', new Blob([JSON.stringify({{#isFreeFormObject}}runtime.anyToJSON{{/isFreeFormObject}}{{^isFreeFormObject}}{{#isAnyType}}runtime.anyToJSON{{/isAnyType}}{{^isAnyType}}{{{dataType}}}ToJSON{{/isAnyType}}{{/isFreeFormObject}}(requestParameters['{{paramName}}']))], { type: "application/json", }));
             {{/isContainer}}
             {{#isContainer}}
             formParams.append('{{baseName}}', new Blob([JSON.stringify(requestParameters['{{paramName}}'])], { type: "application/json", }));

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchClientCodegenTest.java
@@ -68,6 +68,32 @@ public class TypeScriptFetchClientCodegenTest {
     }
 
     @Test
+    public void testAnyTypeFormParamUsesQualifiedAnyToJSON() throws IOException {
+        // A form parameter with no type at all is "any type", not a free-form object. dataType is
+        // `any`, so `{{dataType}}ToJSON` renders as a bare `anyToJSON` -- but apis.ts only imports
+        // the runtime as `* as runtime`, so that identifier does not exist and the output does not
+        // compile. anyToJSON has to be referenced through the runtime namespace, the same way the
+        // free-form object case already does.
+        final String specPath = "src/test/resources/3_0/typescript-fetch/any-type-form-param.yaml";
+
+        File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("typescript-fetch")
+                .setInputSpec(specPath)
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+        Generator generator = new DefaultGenerator();
+        List<File> files = generator.opts(configurator.toClientOptInput()).generate();
+        files.forEach(File::deleteOnExit);
+
+        Path api = Paths.get(output + "/apis/DefaultApi.ts");
+        TestUtils.assertFileContains(api, "runtime.anyToJSON(requestParameters['meta'])");
+        TestUtils.assertFileNotContains(api, "JSON.stringify(anyToJSON(");
+    }
+
+    @Test
     public void testMergesContentTypeVariantsIntoOneMethod() throws IOException {
         File output = Files.createTempDirectory("test").toFile();
         output.deleteOnExit();

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchClientCodegenTest.java
@@ -68,6 +68,32 @@ public class TypeScriptFetchClientCodegenTest {
     }
 
     @Test
+    public void testAnyTypeFormParamUsesQualifiedAnyToJSON() throws IOException {
+        // A form parameter with no type at all is "any type", not a free-form object. dataType is
+        // `any`, so `{{dataType}}ToJSON` renders as a bare `anyToJSON` -- but apis.ts only imports
+        // the runtime as `* as runtime`, so that identifier does not exist and the output does not
+        // compile. anyToJSON has to be referenced through the runtime namespace, the same way the
+        // free-form object case already does.
+        final String specPath = "src/test/resources/3_0/typescript-fetch/any-type-form-param.yaml";
+
+        File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("typescript-fetch")
+                .setInputSpec(specPath)
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+        Generator generator = new DefaultGenerator();
+        List<File> files = generator.opts(configurator.toClientOptInput()).generate();
+        files.forEach(File::deleteOnExit);
+
+        Path api = Paths.get(output + "/apis/DefaultApi.ts");
+        TestUtils.assertFileContains(api, "runtime.anyToJSON(requestParameters['meta'])");
+        TestUtils.assertFileNotContains(api, "JSON.stringify(anyToJSON(");
+    }
+
+    @Test
     public void testModelsWithoutPaths() throws IOException {
         final String specPath = "src/test/resources/3_1/reusable-components-without-paths.yaml";
 

--- a/modules/openapi-generator/src/test/resources/3_0/typescript-fetch/any-type-form-param.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/typescript-fetch/any-type-form-param.yaml
@@ -1,0 +1,23 @@
+openapi: 3.0.3
+info:
+  title: any-typed multipart form parameter
+  version: 1.0.0
+paths:
+  /upload:
+    post:
+      operationId: upload
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                file:
+                  type: string
+                  format: binary
+                # no type at all -> "any type", not a free-form object
+                meta:
+                  description: can be any type
+      responses:
+        "200":
+          description: ok


### PR DESCRIPTION
Fixes #24552

### What

A `multipart/form-data` parameter with **no type at all** ("any type") made the generated `apis/*.ts` call
a bare `anyToJSON(...)`. The file only imports the runtime as `* as runtime`, so that identifier does not
exist and the output does not compile.

```ts
import * as runtime from '../runtime';
...
// before -- TS2304: Cannot find name 'anyToJSON'
formParams.append('meta', new Blob([JSON.stringify(anyToJSON(requestParameters['meta']))], { type: "application/json", }));

// after
formParams.append('meta', new Blob([JSON.stringify(runtime.anyToJSON(requestParameters['meta']))], { type: "application/json", }));
```

### Why

[`apis.mustache#L288`](https://github.com/OpenAPITools/openapi-generator/blob/4aed9c1c635/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache#L288):

```mustache
{{#isFreeFormObject}}runtime.anyToJSON{{/isFreeFormObject}}{{^isFreeFormObject}}{{{dataType}}}ToJSON{{/isFreeFormObject}}
```

The free-form object case (added with `anyToJSON` in #1877) is qualified correctly. The any-type case falls
through to `{{dataType}}ToJSON`, and for an any-typed parameter `dataType` is `any`, so it renders as the
unqualified `anyToJSON`.

### How

Add an `isAnyType` branch that also uses `runtime.anyToJSON`. Everything else keeps rendering
`{{dataType}}ToJSON` exactly as before.

### Testing

- `TypeScriptFetchClientCodegenTest.testAnyTypeFormParamUsesQualifiedAnyToJSON` — asserts the generated
  call is namespace-qualified and that the bare form is gone. Verified that this test **fails without the
  fix** (`does not contain line [runtime.anyToJSON(requestParameters['meta'])]`).
- Full `TypeScriptFetchClientCodegenTest` (35 tests) passes.
- Regenerated **all 787 sample configs** (`./bin/generate-samples.sh ./bin/configs/*.yaml`) and
  `./bin/utils/export_docs_generators.sh` — **no diff**. No existing sample has an any-typed form
  parameter, which is why this went unnoticed.

> Note on the full test run: `mvn test` on `modules/openapi-generator` reports one pre-existing failure,
> `OpenApiSchemaValidationsTest.testNullTypeInOas31_noWarning`. It fails identically on unmodified
> `master` (`4aed9c1c635`) — verified by reverting the patch and re-running — and is unrelated to this change.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ```
  Commit all changed files.
  (Both scripts were run; neither produced any change, so there is nothing to commit beyond the fix and its test.)
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

TypeScript technical committee:
@TiFu @taxpon @sebastianhaas @kenisteward @Vrolijkx @macjohnny @topce @akehir @petejohansonxo @amakhrov @davidgamero @mkusaka @joscha

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Qualifies `anyToJSON` as `runtime.anyToJSON` for multipart/form-data parameters with no type in `typescript-fetch` clients. Previously the template emitted a bare `anyToJSON(...)`, causing a compile error; now it uses the runtime-qualified call and other cases still use `{{dataType}}ToJSON`.

- **Changes**
  - Update `apisFormParams.mustache` to use `runtime.anyToJSON` when `isAnyType` is true; preserve existing `isFreeFormObject` and default `{{dataType}}ToJSON` paths.
  - Add test `testAnyTypeFormParamUsesQualifiedAnyToJSON` with `any-type-form-param.yaml`.
  - Regenerate samples; no diffs.

<sup>Written for commit f77405786d0298576c4cce2775db6b3808ca8090. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24553?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

