### PR TITLE
fix(spring): avoid duplicate Tag import when a model is named Tag

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java
@@ -977,6 +977,16 @@ public class SpringCodegen extends AbstractJavaCodegen
 
     @Override
     public OperationsMap postProcessOperationsWithModels(OperationsMap objs, List<ModelMap> allModels) {
+        // A model named `Tag` collides with io.swagger.v3.oas.annotations.tags.Tag. When this file
+        // imports the model, importing the annotation too is a duplicate single-type-import, which
+        // javac rejects outright. Reference the annotation by its fully qualified name instead and
+        // skip its import -- only for the files that actually hit the clash.
+        final String tagModelImport = modelPackage() + ".Tag";
+        if (objs.getImports() != null
+                && objs.getImports().stream().anyMatch(imp -> tagModelImport.equals(imp.get("import")))) {
+            objs.put("qualifySwaggerTagAnnotation", true);
+        }
+
         final OperationMap operations = objs.getOperations();
         if (operations != null) {
             final List<CodegenOperation> ops = operations.getOperation();

--- a/modules/openapi-generator/src/main/resources/JavaSpring/api.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/api.mustache
@@ -17,7 +17,9 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+{{^qualifySwaggerTagAnnotation}}
 import io.swagger.v3.oas.annotations.tags.Tag;
+{{/qualifySwaggerTagAnnotation}}
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 {{/swagger2AnnotationLibrary}}
@@ -106,7 +108,7 @@ import {{javaxPackage}}.annotation.Generated;
 {{/useResponseEntity}}
 {{/useSpringController}}
 {{#swagger2AnnotationLibrary}}
-@Tag(name = "{{{tagName}}}", description = {{#tagDescription}}"{{{.}}}"{{/tagDescription}}{{^tagDescription}}"the {{{tagName}}} API"{{/tagDescription}})
+{{#qualifySwaggerTagAnnotation}}@io.swagger.v3.oas.annotations.tags.Tag{{/qualifySwaggerTagAnnotation}}{{^qualifySwaggerTagAnnotation}}@Tag{{/qualifySwaggerTagAnnotation}}(name = "{{{tagName}}}", description = {{#tagDescription}}"{{{.}}}"{{/tagDescription}}{{^tagDescription}}"the {{{tagName}}} API"{{/tagDescription}})
 {{/swagger2AnnotationLibrary}}
 {{#swagger1AnnotationLibrary}}
 @Api(value = "{{{tagName}}}", description = {{#tagDescription}}"{{{.}}}"{{/tagDescription}}{{^tagDescription}}"the {{{tagName}}} API"{{/tagDescription}})

--- a/modules/openapi-generator/src/main/resources/JavaSpring/apiController.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/apiController.mustache
@@ -11,7 +11,9 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+{{^qualifySwaggerTagAnnotation}}
 import io.swagger.v3.oas.annotations.tags.Tag;
+{{/qualifySwaggerTagAnnotation}}
 {{/swagger2AnnotationLibrary}}
 {{#swagger1AnnotationLibrary}}
 import io.swagger.annotations.*;

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
@@ -1207,6 +1207,35 @@ public class SpringCodegenTest {
 
 
     @Test
+    public void modelNamedTagDoesNotClashWithSwaggerTagAnnotation() throws IOException {
+        // A model named `Tag` collides with io.swagger.v3.oas.annotations.tags.Tag. Importing both
+        // is a duplicate single-type-import, which javac rejects outright, so the generated api
+        // must fall back to the fully qualified annotation name and skip the import.
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+
+        OpenAPI openAPI = new OpenAPIParser()
+                .readLocation("src/test/resources/3_0/spring/model-named-tag.yaml", null, new ParseOptions())
+                .getOpenAPI();
+        SpringCodegen codegen = new SpringCodegen();
+        codegen.setOutputDir(output.getAbsolutePath());
+        codegen.additionalProperties().put(INTERFACE_ONLY, "true");
+
+        ClientOptInput input = new ClientOptInput().openAPI(openAPI).config(codegen);
+        DefaultGenerator generator = new DefaultGenerator();
+        generator.setGenerateMetadata(false);
+
+        Map<String, File> files = generator.opts(input).generate().stream()
+                .collect(Collectors.toMap(File::getName, Function.identity()));
+
+        Path api = files.get("TagApi.java").toPath();
+        assertFileNotContains(api, "import io.swagger.v3.oas.annotations.tags.Tag;");
+        assertFileContains(api, "@io.swagger.v3.oas.annotations.tags.Tag(name = \"pets\"");
+        // the model import must still be there -- that is the type actually used in signatures
+        assertFileContains(api, "import org.openapitools.model.Tag;");
+    }
+
+    @Test
     public void shouldUseTagsForClassname() throws IOException {
         File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
         output.deleteOnExit();

--- a/modules/openapi-generator/src/test/resources/3_0/spring/model-named-tag.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/spring/model-named-tag.yaml
@@ -1,0 +1,25 @@
+openapi: 3.0.3
+info:
+  title: model named Tag
+  version: 1.0.0
+tags:
+  - name: pets
+paths:
+  /tag:
+    get:
+      tags:
+        - pets
+      operationId: getTag
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Tag"
+components:
+  schemas:
+    Tag:
+      properties:
+        id:
+          type: string


### PR DESCRIPTION
Fixes #24554

### What

If the spec defines a model named `Tag` and an api uses it, the generated Spring api imported both the
model and `io.swagger.v3.oas.annotations.tags.Tag`. Two single-type-imports of the same simple name is a
hard javac error, so the generated code did not compile.

```java
// before
import org.openapitools.model.Tag;                    // line 8
import io.swagger.v3.oas.annotations.tags.Tag;        // line 18
@Tag(name = "pets", description = "the pets API")
public interface TagApi {
    default ResponseEntity<Tag> getTag(...)
```

```
error: a type with the same simple name is already defined by the single-type-import of Tag
```

```java
// after
import org.openapitools.model.Tag;
@io.swagger.v3.oas.annotations.tags.Tag(name = "pets", description = "the pets API")
public interface TagApi {
    default ResponseEntity<Tag> getTag(...)
```

This is not an ambiguity a wildcard import could resolve — both imports are explicit.

### How

`SpringCodegen.postProcessOperationsWithModels` sets `qualifySwaggerTagAnnotation` when the file being
generated imports the model `Tag`; `JavaSpring/api.mustache` and `JavaSpring/apiController.mustache` then
emit the fully qualified annotation and skip the annotation import.

The model import is kept — it is the type actually used in the signatures.

**Scoping matters here.** My first attempt keyed off "the spec contains a model named `Tag`" and stored the
flag in `additionalProperties`. That is both too broad and sticky across files: the petstore sample defines
a `Tag` model, so *every* spring sample got the qualified annotation even though most api files never
import the model. It rewrote 171 sample files and broke `testNoRequestMappingAnnotation` and
`testNoRequestMappingAnnotation_spring_cloud_default`. The committed version checks
`objs.getImports()` for `modelPackage() + ".Tag"` and stores the flag per operations map, so only the files
that actually hit the clash change.

### Testing

- `SpringCodegenTest.modelNamedTagDoesNotClashWithSwaggerTagAnnotation` — asserts the annotation import is
  gone, the annotation is fully qualified, and the model import is still present. Verified that this test
  **fails without the fix**.
- Full `SpringCodegenTest` (294 tests) passes, including the two cases the over-broad first attempt broke.
- Regenerated **all 787 sample configs** (`./bin/generate-samples.sh ./bin/configs/*.yaml`) and
  `./bin/utils/export_docs_generators.sh` — **no diff**.

> Note on the full test run: `mvn test` on `modules/openapi-generator` reports one pre-existing failure,
> `OpenApiSchemaValidationsTest.testNullTypeInOas31_noWarning`. It fails identically on unmodified
> `master` (`4aed9c1c635`) — verified by reverting the patch and re-running — and is unrelated to this change.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ```
  Commit all changed files.
  (Both scripts were run; neither produced any change, so there is nothing to commit beyond the fix and its test.)
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

Java/Spring technical committee:
@bbdouglas @sreeshas @jfiala @lukoyanov @cbornet @jeff9finger @karismann @Zomzog @lwlee2608 @martin-mfg

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a compile error in generated Spring APIs when a schema is named `Tag` by fully qualifying the Swagger `@Tag` annotation only in files that import the model `Tag`. This prevents duplicate single-type imports and restores compilation.

- **Bug Fixes**
  - Detect the clash per API file by checking for `modelPackage.Tag` imports and set `qualifySwaggerTagAnnotation` in `SpringCodegen.postProcessOperationsWithModels`.
  - In `JavaSpring/api.mustache`, render `@io.swagger.v3.oas.annotations.tags.Tag` and skip its import when flagged; in `JavaSpring/apiController.mustache`, skip the annotation import when flagged. Keep `org.openapitools.model.Tag` imported.
  - Added test `modelNamedTagDoesNotClashWithSwaggerTagAnnotation`; all Spring tests pass and regenerating samples shows no diff.

<sup>Written for commit 4516b9e9f4664ee38f6af91745a0665547bca2b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24555?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

