### PR TITLE
chore: adjust logging message creation to ensure once() is applied as expected

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -1014,7 +1014,7 @@ public class DefaultCodegen implements CodegenConfig {
     @Override
     public void setOpenAPI(OpenAPI openAPI) {
         if (specVersionGreaterThanOrEqualTo310(openAPI)) {
-            LOGGER.warn(UNSUPPORTED_V310_SPEC_MSG);
+            once(LOGGER).warn(UNSUPPORTED_V310_SPEC_MSG);
         }
         this.openAPI = openAPI;
         // Set global settings such that helper functions in ModelUtils can lookup the value
@@ -1264,7 +1264,7 @@ public class DefaultCodegen implements CodegenConfig {
      */
     @Override
     public String escapeUnsafeCharacters(String input) {
-        LOGGER.warn("escapeUnsafeCharacters should be overridden in the code generator with proper logic to escape " +
+        once(LOGGER).warn("escapeUnsafeCharacters should be overridden in the code generator with proper logic to escape " +
                 "unsafe characters");
         // doing nothing by default and code generator should implement
         // the logic to prevent code injection
@@ -1281,7 +1281,7 @@ public class DefaultCodegen implements CodegenConfig {
      */
     @Override
     public String escapeQuotationMark(String input) {
-        LOGGER.warn("escapeQuotationMark should be overridden in the code generator with proper logic to escape " +
+        once(LOGGER).warn("escapeQuotationMark should be overridden in the code generator with proper logic to escape " +
                 "single/double quote");
         return input.replace("\"", "\\\"");
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -47,6 +47,7 @@ import org.openapitools.codegen.model.ModelMap;
 import org.openapitools.codegen.model.ModelsMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.helpers.MessageFormatter;
 
 import java.math.BigDecimal;
 import java.net.URI;
@@ -1588,7 +1589,7 @@ public class ModelUtils {
             Schema ref = allSchemas.get(simpleRef);
             if (ref == null) {
                 if (!isRefToSchemaWithProperties(schema.get$ref())) {
-                    once(LOGGER).warn("{} is not defined", schema.get$ref());
+                    once(LOGGER).warn(MessageFormatter.format("{} is not defined", schema.get$ref()).getMessage());
                 }
                 return schema;
             } else if (isEnumSchema(ref)) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/OnceLogger.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/OnceLogger.java
@@ -91,6 +91,12 @@ public class OnceLogger extends LoggerWrapper {
                 .build();
     }
 
+    /**
+     * This implementation currently only supports single-argument string literal log methods (e.g. {@link Logger#debug(String)}).
+     *
+     * @param logger The logger that should only log once for single-argument string literal log methods.
+     * @return The {@link OnceLogger}
+     */
     public static Logger once(Logger logger) {
         try {
             if (Boolean.parseBoolean(GlobalSettings.getProperty(ENABLE_ONCE_LOGGER_PROPERTY, "true"))) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/URLPathUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/URLPathUtils.java
@@ -25,6 +25,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.openapitools.codegen.CodegenConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.helpers.MessageFormatter;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -37,14 +38,21 @@ import static org.openapitools.codegen.utils.OnceLogger.once;
 public class URLPathUtils {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(URLPathUtils.class);
+    private static final String SERVER_NOT_SPECIFIED =
+            "'host' (OAS 2.0) or 'servers' (OAS 3.0) not defined in the spec. Default to [{}] for server URL [{}]";
+    private static final String SCHEME_NOT_DEFINED = "'scheme' not defined in the spec (2.0). Default to [http] for server URL [{}]";
+    private static final String NO_SERVER_INFO = "Server information not defined in the spec. Default to {}.";
+    private static final String INVALID_URL = "Not a valid URL: {}. Default to {}.";
     public static final String LOCAL_HOST = "http://localhost";
     public static final Pattern VARIABLE_PATTERN = Pattern.compile("(?<!\\$)\\{([^\\}]+)\\}");
+    public static final Pattern URL_WITH_SCHEME = Pattern.compile("[a-zA-Z][0-9a-zA-Z.+\\-]+://.+");
 
     // TODO: This should probably be moved into generator/workflow type rather than a static like this.
     public static URL getServerURL(OpenAPI openAPI, Map<String, String> userDefinedVariables) {
         final List<Server> servers = openAPI.getServers();
         if (servers == null || servers.isEmpty()) {
-            once(LOGGER).warn("Server information seems not defined in the spec. Default to {}.", LOCAL_HOST);
+            String message = MessageFormatter.format(NO_SERVER_INFO, LOCAL_HOST).getMessage();
+            once(LOGGER).warn(message);
             return getDefaultUrl();
         }
         // TODO need a way to obtain all server URLs
@@ -67,7 +75,8 @@ public class URLPathUtils {
             try {
                 return new URL(url);
             } catch (MalformedURLException e) {
-                once(LOGGER).warn("Not valid URL: {}. Default to {}.", server.getUrl(), LOCAL_HOST);
+                String malformedUrl = MessageFormatter.format(INVALID_URL, server.getUrl(), LOCAL_HOST).getMessage();
+                once(LOGGER).warn(malformedUrl);
             }
         }
         return getDefaultUrl();
@@ -206,19 +215,22 @@ public class URLPathUtils {
         if (url != null) {
             if (url.startsWith("//")) {
                 url = "http:" + url;
-                once(LOGGER).warn("'scheme' not defined in the spec (2.0). Default to [http] for server URL [{}]", url);
+                String missingScheme = MessageFormatter.format(SCHEME_NOT_DEFINED, url).getMessage();
+                once(LOGGER).warn(missingScheme);
             } else if (url.startsWith("/")) {
                 url = LOCAL_HOST + url;
-                once(LOGGER).info("'host' (OAS 2.0) or 'servers' (OAS 3.0) not defined in the spec. Default to [{}] for server URL [{}]", LOCAL_HOST, url);
-            } else if (!url.matches("[a-zA-Z][0-9a-zA-Z.+\\-]+://.+")) {
+                String serverDefaultToLocalhost = MessageFormatter.format(SERVER_NOT_SPECIFIED, LOCAL_HOST, url).getMessage();
+                once(LOGGER).info(serverDefaultToLocalhost);
+            } else if (!URL_WITH_SCHEME.matcher(url).matches()) {
                 // Add http scheme for urls without a scheme.
                 // 2.0 spec is restricted to the following schemes: "http", "https", "ws", "wss"
                 // 3.0 spec does not have an enumerated list of schemes
                 // This regex attempts to capture all schemes in IANA example schemes which
-                // can have alpha-numeric characters and [.+-]. Examples are here:
+                // can have alphanumeric characters and [.+-]. Examples are here:
                 // https://www.iana.org/assignments/uri-schemes/uri-schemes.xhtml
                 url = "http://" + url;
-                once(LOGGER).warn("'scheme' not defined in the spec (2.0). Default to [http] for server URL [{}]", url);
+                String missingScheme = MessageFormatter.format(SCHEME_NOT_DEFINED, url).getMessage();
+                once(LOGGER).warn(missingScheme);
             }
         }
         return url;


### PR DESCRIPTION
I found that several warn messages that I only expected to see once occurred many times, this is especially true when trying to go through any sample-run in the CI pipeline.

I found that the cause was incorrect usage of the `once()` logger. It currently [only supports](https://github.com/OpenAPITools/openapi-generator/blob/master/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/OnceLogger.java#L20) `... single-argument string literal log methods (e.g. {@link Logger#debug(String)}).`, but it was called with messages with arguments.

I have taken the messages that I saw repeated the most and made so that the message is created before the logger is invoked, ensuring that the message cache is hit and the message is not repeated.

Making `OnceLogger` support more signatures is out-of-scope since I do not know if we would like to prevent messages based on template alone. The other implementation possibility is to assume what message formatter that is used and and caching based upon that, but that of course means that we might have misses if the use a different formatter.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures `once()` actually logs a message once by pre-formatting strings and updating call sites. This reduces repeated warn/info logs in CI and sample runs without changing generator behavior.

- **Bug Fixes**
  - Pre-format log messages with `MessageFormatter` and standardized templates in `ModelUtils` and `URLPathUtils` before calling `once(LOGGER)`.
  - Use `once(LOGGER)` for the v3.1.0 spec warning and the `escapeUnsafeCharacters`/`escapeQuotationMark` notices in `DefaultCodegen`.
  - Clarify in `OnceLogger.once()` Javadoc that only single-argument string methods are supported.

<sup>Written for commit b688c86509ea751c82ea31f5c8e9b4304bcb753e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24557?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

