### PR TITLE
Normalize map schema (3.1 spec)

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -2924,7 +2924,7 @@ public class DefaultCodegen implements CodegenConfig {
             addAdditionPropertiesToCodeGenModel(m, schema);
         }
 
-        if (Boolean.TRUE.equals(schema.getNullable())) {
+        if (ModelUtils.isNullable(schema)) {
             m.isNullable = Boolean.TRUE;
         }
 
@@ -3924,8 +3924,8 @@ public class DefaultCodegen implements CodegenConfig {
         if (p.getWriteOnly() != null) {
             property.isWriteOnly = p.getWriteOnly();
         }
-        if (p.getNullable() != null) {
-            property.isNullable = p.getNullable();
+        if (ModelUtils.isNullable(p)) {
+            property.isNullable = true;
         }
 
         if (p.getExtensions() != null && !p.getExtensions().isEmpty()) {
@@ -3975,12 +3975,8 @@ public class DefaultCodegen implements CodegenConfig {
             }
         }
 
-        // set isNullable using nullable or x-nullable in the schema
-        if (referencedSchema.getNullable() != null) {
-            property.isNullable = referencedSchema.getNullable();
-        } else if (referencedSchema.getExtensions() != null &&
-                referencedSchema.getExtensions().containsKey(X_NULLABLE)) {
-            property.isNullable = (Boolean) referencedSchema.getExtensions().get(X_NULLABLE);
+        if (ModelUtils.isNullable(referencedSchema)) {
+            property.isNullable = true;
         }
 
         final XML referencedSchemaXml = referencedSchema.getXml();
@@ -4079,10 +4075,8 @@ public class DefaultCodegen implements CodegenConfig {
         if (original != null) {
             p = original;
             // evaluate common attributes if defined in the top level
-            if (p.getNullable() != null) {
-                property.isNullable = p.getNullable();
-            } else if (p.getExtensions() != null && p.getExtensions().containsKey(X_NULLABLE)) {
-                property.isNullable = (Boolean) p.getExtensions().get(X_NULLABLE);
+            if (ModelUtils.isNullable(p)) {
+                property.isNullable = true;
             }
 
             if (p.getReadOnly() != null) {
@@ -5286,7 +5280,7 @@ public class DefaultCodegen implements CodegenConfig {
         codegenParameter.setTypeProperties(parameterSchema, openAPI);
         codegenParameter.setComposedSchemas(getComposedSchemas(parameterSchema));
 
-        if (Boolean.TRUE.equals(parameterSchema.getNullable())) { // use nullable defined in the spec
+        if (ModelUtils.isNullable(parameterSchema)) { // use nullable defined in the spec
             codegenParameter.isNullable = true;
         }
 
@@ -8057,10 +8051,8 @@ public class DefaultCodegen implements CodegenConfig {
         // restore original schema with description, extensions etc
         if (original != null) {
             // evaluate common attributes such as description if defined in the top level
-            if (original.getNullable() != null) {
-                codegenParameter.isNullable = original.getNullable();
-            } else if (original.getExtensions() != null && original.getExtensions().containsKey(X_NULLABLE)) {
-                codegenParameter.isNullable = (Boolean) original.getExtensions().get(X_NULLABLE);
+            if (ModelUtils.isNullable(original)) {
+                codegenParameter.isNullable = true;
             }
 
             if (original.getExtensions() != null) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -8051,7 +8051,11 @@ public class DefaultCodegen implements CodegenConfig {
         // restore original schema with description, extensions etc
         if (original != null) {
             // evaluate common attributes such as description if defined in the top level
-            if (ModelUtils.isNullable(original)) {
+            if (original.getNullable() != null) {
+                codegenParameter.isNullable = original.getNullable();
+            } else if (original.getExtensions() != null && original.getExtensions().containsKey(X_NULLABLE)) {
+                codegenParameter.isNullable = Boolean.parseBoolean(String.valueOf(original.getExtensions().get(X_NULLABLE)));
+            } else if (ModelUtils.isNullable(original)) {
                 codegenParameter.isNullable = true;
             }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -3924,9 +3924,7 @@ public class DefaultCodegen implements CodegenConfig {
         if (p.getWriteOnly() != null) {
             property.isWriteOnly = p.getWriteOnly();
         }
-        if (ModelUtils.isNullable(p)) {
-            property.isNullable = true;
-        } else if (p.getNullable() != null) {
+        if (p.getNullable() != null) {
             property.isNullable = p.getNullable();
         }
 
@@ -3978,9 +3976,7 @@ public class DefaultCodegen implements CodegenConfig {
         }
 
         // set isNullable using nullable or x-nullable in the schema
-        if (ModelUtils.isNullable(referencedSchema)) {
-            property.isNullable = true;
-        } else if (referencedSchema.getNullable() != null) {
+        if (referencedSchema.getNullable() != null) {
             property.isNullable = referencedSchema.getNullable();
         } else if (referencedSchema.getExtensions() != null &&
                 referencedSchema.getExtensions().containsKey(X_NULLABLE)) {
@@ -4083,9 +4079,7 @@ public class DefaultCodegen implements CodegenConfig {
         if (original != null) {
             p = original;
             // evaluate common attributes if defined in the top level
-            if (ModelUtils.isNullable(p)) {
-                property.isNullable = true;
-            } else if (p.getNullable() != null) {
+            if (p.getNullable() != null) {
                 property.isNullable = p.getNullable();
             } else if (p.getExtensions() != null && p.getExtensions().containsKey(X_NULLABLE)) {
                 property.isNullable = (Boolean) p.getExtensions().get(X_NULLABLE);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
@@ -1105,7 +1105,8 @@ public class OpenAPINormalizer {
     }
 
     protected Schema normalizeMapSchema(Schema schema) {
-        return processSetMapToNullable(schema);
+        Schema result = processNormalize31Spec(schema, new HashSet<>());
+        return processSetMapToNullable(result);
     }
 
     protected Schema normalizeSimpleSchema(Schema schema, Set<Schema> visitedSchemas) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
@@ -998,8 +998,8 @@ public class OpenAPINormalizer {
             }
             normalizeProperties(schema, visitedSchemas);
         } else if (schema.getAdditionalProperties() instanceof Schema) { // map
-            normalizeMapSchema(schema);
-            Schema additionalProperties = (Schema) schema.getAdditionalProperties();
+            Schema result = normalizeMapSchema(schema);
+            Schema additionalProperties = (Schema) result.getAdditionalProperties();
             if (getRule(NORMALIZE_31SPEC) && ModelUtils.isNullTypeSchema(openAPI, additionalProperties)) {
                 // OAS 3.1 allows a map value schema of `type: "null"` (e.g.
                 // `additionalProperties: { type: "null" }`). There's no OAS 3.0 equivalent type,
@@ -1008,15 +1008,17 @@ public class OpenAPINormalizer {
                 // generated as a normal (nullable) object instead.
                 Schema anyTypeNullable = new Schema();
                 anyTypeNullable.setNullable(true);
-                schema.setAdditionalProperties(anyTypeNullable);
+                result.setAdditionalProperties(anyTypeNullable);
             } else {
                 Schema normalized = normalizeSchema(additionalProperties, visitedSchemas);
                 if (getRule(NORMALIZE_31SPEC)) {
                     // capture the normalized value schema (e.g. an OAS 3.1 `type: [array, "null"]`
                     // value is rewritten to a proper array schema), which would otherwise be lost.
-                    schema.setAdditionalProperties(normalized);
+                    result.setAdditionalProperties(normalized);
                 }
             }
+
+            return result;
         } else if (schema instanceof BooleanSchema) {
             normalizeBooleanSchema(schema, visitedSchemas);
         } else if (schema instanceof IntegerSchema) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -2001,9 +2001,7 @@ public class ModelUtils {
         if (schema.getExtensions() != null && schema.getExtensions().get(X_NULLABLE) != null) {
             return Boolean.parseBoolean(schema.getExtensions().get(X_NULLABLE).toString());
         }
-        if (schema.getTypes() != null && schema.getTypes().contains("null")) {
-            return true;
-        }
+
         // In OAS 3.1, the recommended way to define a nullable property or object is to use oneOf.
         if (isComposedSchema(schema)) {
             return isNullableComposedSchema(schema);

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/validations/oas/OpenApiSchemaValidationsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/validations/oas/OpenApiSchemaValidationsTest.java
@@ -96,7 +96,7 @@ public class OpenApiSchemaValidationsTest {
     /**
      * The nullable-deprecated warning must NOT fire for an OAS 3.1 spec using the correct 3.1 null type syntax.
      */
-    @Test(enabled = false, description = "correct OAS 3.1 null type syntax (type: [string, null]) must NOT trigger the nullable-deprecated warning")
+    @Test(description = "correct OAS 3.1 null type syntax (type: [string, null]) must NOT trigger the nullable-deprecated warning")
     public void testNullTypeInOas31_noWarning() {
         OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_1/null-types-simple.yaml");
         Schema<?> stringDataOrNull = (Schema<?>) openAPI.getComponents().getSchemas().get("WithNullableType").getProperties().get("stringDataOrNull");

--- a/samples/client/petstore/java/okhttp-gson-3.1/api/openapi.yaml
+++ b/samples/client/petstore/java/okhttp-gson-3.1/api/openapi.yaml
@@ -325,6 +325,7 @@ paths:
                 additionalProperties:
                   format: int32
                   type: integer
+                type: object
           description: successful operation
       security:
       - api_key: []


### PR DESCRIPTION
a follow up PR to https://github.com/OpenAPITools/openapi-generator/pull/23778

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize OAS 3.1 map schemas and centralize nullable handling via `ModelUtils.isNullable` to avoid false warnings and ensure correct codegen behavior. Tests and samples updated to verify 3.1 null types and map objects.

- **Bug Fixes**
  - In `OpenAPINormalizer`, run `processNormalize31Spec` before `processSetMapToNullable` for map schemas, and return the updated schema so `additionalProperties` changes persist.
  - In `DefaultCodegen`, use `ModelUtils.isNullable` for models, properties, and parameters; for request bodies, parse `x-nullable` safely and fall back to `ModelUtils.isNullable`.
  - In `ModelUtils.isNullable`, remove `type: ["...", "null"]` inference; rely on composed schemas or `x-nullable`.
  - Enable the OAS 3.1 test so `type: [string, null]` does not trigger the nullable-deprecated warning.
  - Update petstore 3.1 sample: add `type: object` to map response schema to match normalization.

<sup>Written for commit 671ad55657baacfbcadc10ad80bc41e6d7b09608. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24558?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

