### PR TITLE
[java][microprofile] Don't emit JsonNullable helper calls that are never defined

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/microprofile/pojoOverrides.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/microprofile/pojoOverrides.mustache
@@ -11,7 +11,7 @@
       return false;
     }{{#hasVars}}
     {{classname}} {{classVarName}} = ({{classname}}) o;
-    return {{#vars}}{{#vendorExtensions.x-is-jackson-optional-nullable}}equalsNullable(this.{{name}}, {{classVarName}}.{{name}}){{/vendorExtensions.x-is-jackson-optional-nullable}}{{^vendorExtensions.x-is-jackson-optional-nullable}}{{#isByteArray}}Arrays{{/isByteArray}}{{^isByteArray}}Objects{{/isByteArray}}.equals(this.{{name}}, {{classVarName}}.{{name}}){{/vendorExtensions.x-is-jackson-optional-nullable}}{{^-last}} &&
+    return {{#vars}}{{#vendorExtensions.x-is-jackson-optional-nullable}}{{#x-jackson-optional-nullable-helpers}}equalsNullable(this.{{name}}, {{classVarName}}.{{name}}){{/x-jackson-optional-nullable-helpers}}{{^x-jackson-optional-nullable-helpers}}Objects.equals(this.{{name}}, {{classVarName}}.{{name}}){{/x-jackson-optional-nullable-helpers}}{{/vendorExtensions.x-is-jackson-optional-nullable}}{{^vendorExtensions.x-is-jackson-optional-nullable}}{{#isByteArray}}Arrays{{/isByteArray}}{{^isByteArray}}Objects{{/isByteArray}}.equals(this.{{name}}, {{classVarName}}.{{name}}){{/vendorExtensions.x-is-jackson-optional-nullable}}{{^-last}} &&
         {{/-last}}{{/vars}}{{#additionalPropertiesType}} &&
         Objects.equals(this.additionalProperties, {{classVarName}}.additionalProperties){{/additionalPropertiesType}}{{#parent}} &&
         super.equals(o){{/parent}};{{/hasVars}}{{^hasVars}}
@@ -29,7 +29,7 @@
     return HashCodeBuilder.reflectionHashCode(this);
   {{/useReflectionEqualsHashCode}}
   {{^useReflectionEqualsHashCode}}
-    return Objects.hash({{#vars}}{{#vendorExtensions.x-is-jackson-optional-nullable}}hashCodeNullable({{name}}){{/vendorExtensions.x-is-jackson-optional-nullable}}{{^vendorExtensions.x-is-jackson-optional-nullable}}{{^isByteArray}}{{name}}{{/isByteArray}}{{#isByteArray}}Arrays.hashCode({{name}}){{/isByteArray}}{{/vendorExtensions.x-is-jackson-optional-nullable}}{{^-last}}, {{/-last}}{{/vars}}{{#parent}}{{#hasVars}}, {{/hasVars}}super.hashCode(){{/parent}}{{#additionalPropertiesType}}, additionalProperties{{/additionalPropertiesType}});
+    return Objects.hash({{#vars}}{{#vendorExtensions.x-is-jackson-optional-nullable}}{{#x-jackson-optional-nullable-helpers}}hashCodeNullable({{name}}){{/x-jackson-optional-nullable-helpers}}{{^x-jackson-optional-nullable-helpers}}{{name}}{{/x-jackson-optional-nullable-helpers}}{{/vendorExtensions.x-is-jackson-optional-nullable}}{{^vendorExtensions.x-is-jackson-optional-nullable}}{{^isByteArray}}{{name}}{{/isByteArray}}{{#isByteArray}}Arrays.hashCode({{name}}){{/isByteArray}}{{/vendorExtensions.x-is-jackson-optional-nullable}}{{^-last}}, {{/-last}}{{/vars}}{{#parent}}{{#hasVars}}, {{/hasVars}}super.hashCode(){{/parent}}{{#additionalPropertiesType}}, additionalProperties{{/additionalPropertiesType}});
   {{/useReflectionEqualsHashCode}}
   }{{#vendorExtensions.x-jackson-optional-nullable-helpers}}
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -1770,6 +1770,33 @@ public class JavaClientCodegenTest {
     }
 
     @Test
+    public void testMicroprofileIgnoresJacksonOptionalNullableExtension_issue24560() {
+        final Path output = newTempFolder();
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setAdditionalProperties(Map.of(
+                        JavaClientCodegen.MICROPROFILE_REST_CLIENT_VERSION, "3.0",
+                        CodegenConstants.SERIALIZATION_LIBRARY, "jackson",
+                        AbstractJavaCodegen.OPENAPI_NULLABLE, "true"))
+                .setGeneratorName(JAVA_GENERATOR)
+                .setLibrary(JavaClientCodegen.MICROPROFILE)
+                .setInputSpec("src/test/resources/bugs/issue_24560.yaml")
+                .setOutputDir(output.toString().replace("\\", "/"));
+
+        List<File> files = new DefaultGenerator().opts(configurator.toClientOptInput()).generate();
+
+        // The microprofile library does not support JsonNullable, so the field stays a plain
+        // String. equals/hashCode must therefore not call equalsNullable/hashCodeNullable: those
+        // helpers are only defined when the model carries x-jackson-optional-nullable-helpers,
+        // which core sets from the schema's own nullability rather than from this extension.
+        // Emitting the calls without the definitions produced code that did not compile.
+        validateJavaSourceFiles(files);
+        assertThat(output.resolve("src/main/java/org/openapitools/client/model/Thing.java")).content()
+                .contains("Objects.equals(this.nullableProperty, thing.nullableProperty)")
+                .doesNotContain("equalsNullable")
+                .doesNotContain("hashCodeNullable");
+    }
+
+    @Test
     public void testMicroprofileGenerateCorrectJsonbCreator_issue12622() {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()

--- a/modules/openapi-generator/src/test/resources/bugs/issue_24560.yaml
+++ b/modules/openapi-generator/src/test/resources/bugs/issue_24560.yaml
@@ -1,0 +1,31 @@
+openapi: 3.0.3
+info:
+  title: x-is-jackson-optional-nullable on the microprofile client
+  version: 1.0.0
+paths:
+  /thing:
+    get:
+      operationId: getThing
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Thing"
+components:
+  schemas:
+    Thing:
+      type: object
+      properties:
+        # Hand-written vendor extension. This is the only way to request a
+        # JsonNullable property in the jaxrs-spec generator, and vendor
+        # extensions are spec-level, so a shared spec reaching the microprofile
+        # client carries it too. The microprofile library does not support
+        # JsonNullable, so it must degrade gracefully rather than emit calls to
+        # helper methods it never defines.
+        nullableProperty:
+          type: string
+          x-is-jackson-optional-nullable: true
+        plainProperty:
+          type: string


### PR DESCRIPTION
The microprofile client does not support the Jackson Nullable library — the
generator documents this itself:

> `openApiNullable` — Enable OpenAPI Jackson Nullable library. **Not supported by `microprofile` library.**

So a property carrying `x-is-jackson-optional-nullable` is still rendered as a
plain field. But `equals`/`hashCode` emitted `equalsNullable(...)` /
`hashCodeNullable(...)` for it anyway, while the helper *definitions* are gated
on a different, model-level extension (`x-jackson-optional-nullable-helpers`)
that core only sets from the schema's own nullability. When the two disagree the
generated model does not compile:

```
error: cannot find symbol
  symbol:   method equalsNullable(String,String)
  location: class CatResponseV2
```

## When this happens

The two extensions diverge whenever a spec author writes
`x-is-jackson-optional-nullable` by hand — which is the **only** way to request a
`JsonNullable` property from the jaxrs-spec generator, since
`AbstractJavaCodegen.isAddNullableImports()` is called solely by
`JavaClientCodegen` and `SpringCodegen`.

Vendor extensions live in the spec, so they apply to every generator task
reading it. A spec shared between a jaxrs-spec server and a microprofile client
carries the extension into both, and the client stops compiling.

Reproduced on a minimal spec with all three nullability spellings (3.1 type
union, union + extension, `nullable: true` + extension): the microprofile field
is a plain `String` in every case, so `openApiNullable` cannot rescue it.

## Fix

Gate the call sites in `microprofile/pojoOverrides.mustache` on the same
model-level extension as the definitions, so they can no longer disagree,
falling back to `Objects.equals` / the bare field name.

This only changes output that previously failed to compile — regenerating all
14 microprofile sample configs produces **zero** diff.

## Tests

New `testMicroprofileIgnoresJacksonOptionalNullableExtension_issue24560`, which
fails on master and passes with the fix. `JavaClientCodegenTest` 266 green.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix compile errors in the `microprofile` client when specs use `x-is-jackson-optional-nullable`. `equals`/`hashCode` now call JsonNullable helpers only when `x-jackson-optional-nullable-helpers` is present, otherwise they use standard comparisons.

- **Bug Fixes**
  - Gate `equalsNullable`/`hashCodeNullable` calls in `microprofile/pojoOverrides.mustache` on `x-jackson-optional-nullable-helpers`; fall back to `Objects.equals`, raw field, or `Arrays.hashCode` for byte arrays.
  - Add test `testMicroprofileIgnoresJacksonOptionalNullableExtension_issue24560` with a minimal spec to verify no undefined helper calls are emitted and code compiles.
  - No diffs in existing `microprofile` samples.

<sup>Written for commit 3306e58a4853314c38e7e8db51ca3ba0111e8c1b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24560?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

