### PR TITLE
[jaxrs-spec] Fix builder field type for JsonNullable properties

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/pojo.mustache
@@ -367,7 +367,12 @@ public {{>sealed}}class {{classname}} {{#parent}}extends {{{.}}}{{/parent}} {{#v
 
   public static abstract class {{classname}}Builder<C extends {{classname}}, B extends {{classname}}Builder<C, B>> {{#parent}}extends {{{.}}}Builder<C, B>{{/parent}} {
     {{#vars}}
+    {{#vendorExtensions.x-is-jackson-optional-nullable}}
+    private JsonNullable<{{#removeAnnotations}}{{{datatypeWithEnum}}}{{/removeAnnotations}}> {{name}} = JsonNullable.<{{#removeAnnotations}}{{{datatypeWithEnum}}}{{/removeAnnotations}}>{{#isContainer}}undefined(){{/isContainer}}{{^isContainer}}{{#defaultValue}}of({{{.}}}){{/defaultValue}}{{^defaultValue}}undefined(){{/defaultValue}}{{/isContainer}};
+    {{/vendorExtensions.x-is-jackson-optional-nullable}}
+    {{^vendorExtensions.x-is-jackson-optional-nullable}}
     private {{#removeAnnotations}}{{{datatypeWithEnum}}}{{/removeAnnotations}} {{name}}{{#defaultValue}} = {{{.}}}{{/defaultValue}};
+    {{/vendorExtensions.x-is-jackson-optional-nullable}}
     {{/vars}}
   {{^parent}}
     protected abstract B self();
@@ -380,7 +385,12 @@ public {{>sealed}}class {{classname}} {{#parent}}extends {{{.}}}{{/parent}} {{#v
     @Deprecated
     {{/deprecated}}
     public B {{name}}({{#removeAnnotations}}{{{datatypeWithEnum}}}{{/removeAnnotations}} {{name}}) {
+    {{#vendorExtensions.x-is-jackson-optional-nullable}}
+      this.{{name}} = JsonNullable.<{{#removeAnnotations}}{{{datatypeWithEnum}}}{{/removeAnnotations}}>of({{name}});
+    {{/vendorExtensions.x-is-jackson-optional-nullable}}
+    {{^vendorExtensions.x-is-jackson-optional-nullable}}
       this.{{name}} = {{name}};
+    {{/vendorExtensions.x-is-jackson-optional-nullable}}
       return self();
     }
     {{/vars}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/jaxrs/JavaJAXRSSpecServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/jaxrs/JavaJAXRSSpecServerCodegenTest.java
@@ -284,6 +284,45 @@ public class JavaJAXRSSpecServerCodegenTest extends JavaJaxrsBaseTest {
     }
 
     @Test
+    public void testBuilderFieldMatchesJsonNullableFieldType_issue24561() throws Exception {
+        final File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(org.openapitools.codegen.languages.AbstractJavaCodegen.GENERATE_BUILDERS, true);
+        properties.put(org.openapitools.codegen.languages.AbstractJavaCodegen.OPENAPI_NULLABLE, true);
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("jaxrs-spec")
+                .setAdditionalProperties(properties)
+                .setInputSpec("src/test/resources/bugs/issue_24561.yaml")
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+        List<File> files = new DefaultGenerator().opts(configurator.toClientOptInput()).generate();
+
+        // The pojo field is JsonNullable<String>, so the builder field must be too: the
+        // generated copy constructor does `this.nullableProperty = b.nullableProperty`, which
+        // did not compile while the builder declared a plain String. The builder's setter still
+        // takes the raw type and wraps it, matching the pojo's own fluent setter.
+        validateJavaSourceFiles(files);
+
+        Path path = Paths.get(output.toPath() + "/src/gen/java/org/openapitools/model/Thing.java");
+        String thing = Files.readString(path);
+        String builder = thing.substring(thing.indexOf("public static abstract class ThingBuilder"));
+
+        // The builder field must be JsonNullable<String>, matching the pojo field it is copied
+        // into. It previously declared a plain String, so `this.x = b.x` did not compile.
+        assertTrue(builder.contains("private JsonNullable<String> nullableProperty = JsonNullable.<String>undefined();"),
+                "builder field for a JsonNullable property must be JsonNullable, but was:\n" + builder);
+        // The setter still takes the raw type and wraps it, like the pojo's fluent setter.
+        assertTrue(builder.contains("this.nullableProperty = JsonNullable.<String>of(nullableProperty);"),
+                "builder setter must wrap with JsonNullable.of(), but was:\n" + builder);
+        // A property without the extension is untouched.
+        assertTrue(builder.contains("private String plainProperty;"),
+                "plain property must keep its raw type in the builder, but was:\n" + builder);
+    }
+
+    @Test
     public void testGeneratePingNoSpecFile() throws Exception {
         Map<String, Object> properties = new HashMap<>();
         properties.put(JavaJAXRSSpecServerCodegen.OPEN_API_SPEC_FILE_LOCATION, "");

--- a/modules/openapi-generator/src/test/resources/bugs/issue_24561.yaml
+++ b/modules/openapi-generator/src/test/resources/bugs/issue_24561.yaml
@@ -1,0 +1,27 @@
+openapi: 3.0.3
+info:
+  title: generateBuilders with a JsonNullable property
+  version: 1.0.0
+paths:
+  /thing:
+    get:
+      operationId: getThing
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Thing"
+components:
+  schemas:
+    Thing:
+      type: object
+      properties:
+        # The pojo field for this property is JsonNullable<String>. The builder
+        # field has to match, or the generated `this.x = b.x` does not compile.
+        nullableProperty:
+          type: string
+          x-is-jackson-optional-nullable: true
+        plainProperty:
+          type: string


### PR DESCRIPTION
With `generateBuilders=true`, a property carrying
`x-is-jackson-optional-nullable` produces a jaxrs-spec model that does not
compile:

```
error: incompatible types: String cannot be converted to JsonNullable<String>
```

The pojo field is rendered as `JsonNullable<T>`, but the generated builder
declared the property with its **raw** type, so the builder copy constructor's
`this.x = b.x` mismatched:

```java
private JsonNullable<String> microchipId = JsonNullable.<String>undefined();  // pojo field
...
this.microchipId = b.microchipId;   // <-- does not compile
...
private String microchipId;         // builder field
```

## Fix

Declare the builder field as `JsonNullable<T>`, defaulting to `undefined()` (or
`of(default)` for a non-container with a default), mirroring the pojo field. The
builder's setter still takes the raw type and wraps it, mirroring the pojo's own
fluent setter — so the builder API is unchanged for callers.

## Why this was not caught

No existing sample combines `generateBuilders` with a `JsonNullable` property.
Regenerating the jaxrs samples produces **zero** diff.

Reproduced on a minimal 3.0 spec with no records, oneOf or inheritance involved —
only `generateBuilders=true` plus the extension is required.

## Tests

New `testBuilderFieldMatchesJsonNullableFieldType_issue24561`, which fails on
master and passes with the fix. `JavaJAXRSSpecServerCodegenTest` 152 green.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a compile error in `jaxrs-spec` when `generateBuilders=true` and a property uses `x-is-jackson-optional-nullable` by aligning builder field types with the POJO. The builder setter still accepts the raw type and wraps it, so the API does not change.

- **Bug Fixes**
  - Builder fields for nullable properties now use `JsonNullable<T>` with `undefined()` or `of(default)` to match the POJO.
  - Builder setters wrap raw values with `JsonNullable.of(...)`.
  - Added a failing test and a minimal spec to cover the case.

<sup>Written for commit abeb86ecd767cff9d222fe172e6d5268f9bd39b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24561?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

