### PR TITLE
[Spring] fix missing @Nullable on toIndentedString param when useJspecify=true

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaSpring/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/pojo.mustache
@@ -348,7 +348,7 @@ public {{>sealed}}class {{classname}}{{#parent}} extends {{{parent}}}{{/parent}}
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString({{>nullableAnnotation}}{{#lambda.jSpecifyDatatype}}Object{{/lambda.jSpecifyDatatype}} o) {
+  private String toIndentedString(@Nullable Object o) {
     return o == null ? "null" : o.toString().replace("\n", "\n    ");
   }
   {{/lombok.ToString}}

--- a/modules/openapi-generator/src/main/resources/JavaSpring/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/pojo.mustache
@@ -348,7 +348,7 @@ public {{>sealed}}class {{classname}}{{#parent}} extends {{{parent}}}{{/parent}}
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString({{>nullableAnnotation}}Object o) {
+  private String toIndentedString({{>nullableAnnotation}}{{#lambda.jSpecifyDatatype}}Object{{/lambda.jSpecifyDatatype}} o) {
     return o == null ? "null" : o.toString().replace("\n", "\n    ");
   }
   {{/lombok.ToString}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
@@ -7069,7 +7069,8 @@ public class SpringCodegenTest {
                 .fileContains(
                         "private java.time.@Nullable Instant dt;",
                         "private org.springframework.core.io.@Nullable Resource binary",
-                        "setBinary(org.springframework.core.io.@Nullable Resource binary)"
+                        "setBinary(org.springframework.core.io.@Nullable Resource binary)",
+                        "private String toIndentedString(@Nullable Object o)"
                 );
         JavaFileAssert.assertThat(files.get(fooApiFilename))
                 .assertTypeAnnotations().doesImportAnnotation("org.jspecify.annotations.Nullable").toType()

--- a/samples/openapi3/client/petstore/spring-cloud-3-with-optional/src/main/java/org/openapitools/model/Category.java
+++ b/samples/openapi3/client/petstore/spring-cloud-3-with-optional/src/main/java/org/openapitools/model/Category.java
@@ -100,7 +100,7 @@ public class Category {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(@Nullable Object o) {
     return o == null ? "null" : o.toString().replace("\n", "\n    ");
   }
 }

--- a/samples/openapi3/client/petstore/spring-cloud-3-with-optional/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/openapi3/client/petstore/spring-cloud-3-with-optional/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -127,7 +127,7 @@ public class ModelApiResponse {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(@Nullable Object o) {
     return o == null ? "null" : o.toString().replace("\n", "\n    ");
   }
 }

--- a/samples/openapi3/client/petstore/spring-cloud-3-with-optional/src/main/java/org/openapitools/model/Order.java
+++ b/samples/openapi3/client/petstore/spring-cloud-3-with-optional/src/main/java/org/openapitools/model/Order.java
@@ -241,7 +241,7 @@ public class Order {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(@Nullable Object o) {
     return o == null ? "null" : o.toString().replace("\n", "\n    ");
   }
 }

--- a/samples/openapi3/client/petstore/spring-cloud-3-with-optional/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/client/petstore/spring-cloud-3-with-optional/src/main/java/org/openapitools/model/Pet.java
@@ -276,7 +276,7 @@ public class Pet {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(@Nullable Object o) {
     return o == null ? "null" : o.toString().replace("\n", "\n    ");
   }
 }

--- a/samples/openapi3/client/petstore/spring-cloud-3-with-optional/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/openapi3/client/petstore/spring-cloud-3-with-optional/src/main/java/org/openapitools/model/Tag.java
@@ -100,7 +100,7 @@ public class Tag {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(@Nullable Object o) {
     return o == null ? "null" : o.toString().replace("\n", "\n    ");
   }
 }

--- a/samples/openapi3/client/petstore/spring-cloud-3-with-optional/src/main/java/org/openapitools/model/User.java
+++ b/samples/openapi3/client/petstore/spring-cloud-3-with-optional/src/main/java/org/openapitools/model/User.java
@@ -250,7 +250,7 @@ public class User {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(@Nullable Object o) {
     return o == null ? "null" : o.toString().replace("\n", "\n    ");
   }
 }

--- a/samples/openapi3/client/petstore/spring-cloud-4-with-optional/src/main/java/org/openapitools/model/Category.java
+++ b/samples/openapi3/client/petstore/spring-cloud-4-with-optional/src/main/java/org/openapitools/model/Category.java
@@ -103,7 +103,7 @@ public class Category {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(@Nullable Object o) {
     return o == null ? "null" : o.toString().replace("\n", "\n    ");
   }
 }

--- a/samples/openapi3/client/petstore/spring-cloud-4-with-optional/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/openapi3/client/petstore/spring-cloud-4-with-optional/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -131,7 +131,7 @@ public class ModelApiResponse {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(@Nullable Object o) {
     return o == null ? "null" : o.toString().replace("\n", "\n    ");
   }
 }

--- a/samples/openapi3/client/petstore/spring-cloud-4-with-optional/src/main/java/org/openapitools/model/Order.java
+++ b/samples/openapi3/client/petstore/spring-cloud-4-with-optional/src/main/java/org/openapitools/model/Order.java
@@ -248,7 +248,7 @@ public class Order {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(@Nullable Object o) {
     return o == null ? "null" : o.toString().replace("\n", "\n    ");
   }
 }

--- a/samples/openapi3/client/petstore/spring-cloud-4-with-optional/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/client/petstore/spring-cloud-4-with-optional/src/main/java/org/openapitools/model/Pet.java
@@ -281,7 +281,7 @@ public class Pet {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(@Nullable Object o) {
     return o == null ? "null" : o.toString().replace("\n", "\n    ");
   }
 }

--- a/samples/openapi3/client/petstore/spring-cloud-4-with-optional/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/openapi3/client/petstore/spring-cloud-4-with-optional/src/main/java/org/openapitools/model/Tag.java
@@ -103,7 +103,7 @@ public class Tag {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(@Nullable Object o) {
     return o == null ? "null" : o.toString().replace("\n", "\n    ");
   }
 }

--- a/samples/openapi3/client/petstore/spring-cloud-4-with-optional/src/main/java/org/openapitools/model/User.java
+++ b/samples/openapi3/client/petstore/spring-cloud-4-with-optional/src/main/java/org/openapitools/model/User.java
@@ -259,7 +259,7 @@ public class User {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(@Nullable Object o) {
     return o == null ? "null" : o.toString().replace("\n", "\n    ");
   }
 }

--- a/samples/openapi3/server/petstore/springboot-4-jspecify/src/main/java/org/openapitools/model/Foo.java
+++ b/samples/openapi3/server/petstore/springboot-4-jspecify/src/main/java/org/openapitools/model/Foo.java
@@ -288,7 +288,7 @@ public class Foo {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(@Nullable Object o) {
     return o == null ? "null" : o.toString().replace("\n", "\n    ");
   }
   

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesAnyType.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesAnyType.java
@@ -121,7 +121,7 @@ public class AdditionalPropertiesAnyType {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(@Nullable Object o) {
     return o == null ? "null" : o.toString().replace("\n", "\n    ");
   }
   

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesArray.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesArray.java
@@ -122,7 +122,7 @@ public class AdditionalPropertiesArray {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(@Nullable Object o) {
     return o == null ? "null" : o.toString().replace("\n", "\n    ");
   }
   

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesBoolean.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesBoolean.java
@@ -121,7 +121,7 @@ public class AdditionalPropertiesBoolean {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(@Nullable Object o) {
     return o == null ? "null" : o.toString().replace("\n", "\n    ");
   }
   

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -418,7 +418,7 @@ public class AdditionalPropertiesClass {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(@Nullable Object o) {
     return o == null ? "null" : o.toString().replace("\n", "\n    ");
   }
   

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesInteger.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesInteger.java
@@ -121,7 +121,7 @@ public class AdditionalPropertiesInteger {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(@Nullable Object o) {
     return o == null ? "null" : o.toString().replace("\n", "\n    ");
   }
   

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesNumber.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesNumber.java
@@ -122,7 +122,7 @@ public class AdditionalPropertiesNumber {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(@Nullable Object o) {
     return o == null ? "null" : o.toString().replace("\n", "\n    ");
   }
   

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesObject.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesObject.java
@@ -122,7 +122,7 @@ public class AdditionalPropertiesObject {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(@Nullable Object o) {
     return o == null ? "null" : o.toString().replace("\n", "\n    ");
   }
   

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesString.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesString.java
@@ -121,7 +121,7 @@ public class AdditionalPropertiesString {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(@Nullable Object o) {
     return o == null ? "null" : o.toString().replace("\n", "\n    ");
   }
   

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Animal.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Animal.java
@@ -127,7 +127,7 @@ public class Animal {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(@Nullable Object o) {
     return o == null ? "null" : o.toString().replace("\n", "\n    ");
   }
   

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
@@ -89,7 +89,7 @@ public class ArrayOfArrayOfNumberOnly {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(@Nullable Object o) {
     return o == null ? "null" : o.toString().replace("\n", "\n    ");
   }
   

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
@@ -89,7 +89,7 @@ public class ArrayOfNumberOnly {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(@Nullable Object o) {
     return o == null ? "null" : o.toString().replace("\n", "\n    ");
   }
   

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ArrayTest.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ArrayTest.java
@@ -157,7 +157,7 @@ public class ArrayTest {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(@Nullable Object o) {
     return o == null ? "null" : o.toString().replace("\n", "\n    ");
   }
   

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/BigCat.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/BigCat.java
@@ -150,7 +150,7 @@ public class BigCat extends Cat {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(@Nullable Object o) {
     return o == null ? "null" : o.toString().replace("\n", "\n    ");
   }
   

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Capitalization.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Capitalization.java
@@ -207,7 +207,7 @@ public class Capitalization {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(@Nullable Object o) {
     return o == null ? "null" : o.toString().replace("\n", "\n    ");
   }
   

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Cat.java
@@ -113,7 +113,7 @@ public class Cat extends Animal {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(@Nullable Object o) {
     return o == null ? "null" : o.toString().replace("\n", "\n    ");
   }
   

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Category.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Category.java
@@ -113,7 +113,7 @@ public class Category {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(@Nullable Object o) {
     return o == null ? "null" : o.toString().replace("\n", "\n    ");
   }
   

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ChildWithNullable.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ChildWithNullable.java
@@ -108,7 +108,7 @@ public class ChildWithNullable extends ParentWithNullable {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(@Nullable Object o) {
     return o == null ? "null" : o.toString().replace("\n", "\n    ");
   }
   

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ClassModel.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ClassModel.java
@@ -78,7 +78,7 @@ public class ClassModel {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(@Nullable Object o) {
     return o == null ? "null" : o.toString().replace("\n", "\n    ");
   }
   

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Client.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Client.java
@@ -77,7 +77,7 @@ public class Client {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(@Nullable Object o) {
     return o == null ? "null" : o.toString().replace("\n", "\n    ");
   }
   

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ContainerDefaultValue.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ContainerDefaultValue.java
@@ -211,7 +211,7 @@ public class ContainerDefaultValue {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(@Nullable Object o) {
     return o == null ? "null" : o.toString().replace("\n", "\n    ");
   }
   

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Dog.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Dog.java
@@ -105,7 +105,7 @@ public class Dog extends Animal {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(@Nullable Object o) {
     return o == null ? "null" : o.toString().replace("\n", "\n    ");
   }
   

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/EnumArrays.java
@@ -185,7 +185,7 @@ public class EnumArrays {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(@Nullable Object o) {
     return o == null ? "null" : o.toString().replace("\n", "\n    ");
   }
   

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/EnumTest.java
@@ -339,7 +339,7 @@ public class EnumTest {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(@Nullable Object o) {
     return o == null ? "null" : o.toString().replace("\n", "\n    ");
   }
   

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/File.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/File.java
@@ -78,7 +78,7 @@ public class File {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(@Nullable Object o) {
     return o == null ? "null" : o.toString().replace("\n", "\n    ");
   }
   

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/FileSchemaTestClass.java
@@ -115,7 +115,7 @@ public class FileSchemaTestClass {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(@Nullable Object o) {
     return o == null ? "null" : o.toString().replace("\n", "\n    ");
   }
   

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/FormatTest.java
@@ -445,7 +445,7 @@ public class FormatTest {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(@Nullable Object o) {
     return o == null ? "null" : o.toString().replace("\n", "\n    ");
   }
   

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -105,7 +105,7 @@ public class HasOnlyReadOnly {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(@Nullable Object o) {
     return o == null ? "null" : o.toString().replace("\n", "\n    ");
   }
   

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/MapTest.java
@@ -225,7 +225,7 @@ public class MapTest {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(@Nullable Object o) {
     return o == null ? "null" : o.toString().replace("\n", "\n    ");
   }
   

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -144,7 +144,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(@Nullable Object o) {
     return o == null ? "null" : o.toString().replace("\n", "\n    ");
   }
   

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Model200Response.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Model200Response.java
@@ -106,7 +106,7 @@ public class Model200Response {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(@Nullable Object o) {
     return o == null ? "null" : o.toString().replace("\n", "\n    ");
   }
   

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -131,7 +131,7 @@ public class ModelApiResponse {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(@Nullable Object o) {
     return o == null ? "null" : o.toString().replace("\n", "\n    ");
   }
   

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ModelList.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ModelList.java
@@ -79,7 +79,7 @@ public class ModelList {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(@Nullable Object o) {
     return o == null ? "null" : o.toString().replace("\n", "\n    ");
   }
   

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ModelReturn.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ModelReturn.java
@@ -80,7 +80,7 @@ public class ModelReturn {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(@Nullable Object o) {
     return o == null ? "null" : o.toString().replace("\n", "\n    ");
   }
   

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Name.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Name.java
@@ -166,7 +166,7 @@ public class Name {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(@Nullable Object o) {
     return o == null ? "null" : o.toString().replace("\n", "\n    ");
   }
   

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/NullableMapProperty.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/NullableMapProperty.java
@@ -100,7 +100,7 @@ public class NullableMapProperty {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(@Nullable Object o) {
     return o == null ? "null" : o.toString().replace("\n", "\n    ");
   }
   

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/NumberOnly.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/NumberOnly.java
@@ -78,7 +78,7 @@ public class NumberOnly {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(@Nullable Object o) {
     return o == null ? "null" : o.toString().replace("\n", "\n    ");
   }
   

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Order.java
@@ -248,7 +248,7 @@ public class Order {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(@Nullable Object o) {
     return o == null ? "null" : o.toString().replace("\n", "\n    ");
   }
   

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/OuterComposite.java
@@ -130,7 +130,7 @@ public class OuterComposite {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(@Nullable Object o) {
     return o == null ? "null" : o.toString().replace("\n", "\n    ");
   }
   

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ParentWithNullable.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ParentWithNullable.java
@@ -162,7 +162,7 @@ public class ParentWithNullable {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(@Nullable Object o) {
     return o == null ? "null" : o.toString().replace("\n", "\n    ");
   }
   

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Pet.java
@@ -287,7 +287,7 @@ public class Pet {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(@Nullable Object o) {
     return o == null ? "null" : o.toString().replace("\n", "\n    ");
   }
   

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ReadOnlyFirst.java
@@ -103,7 +103,7 @@ public class ReadOnlyFirst {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(@Nullable Object o) {
     return o == null ? "null" : o.toString().replace("\n", "\n    ");
   }
   

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ResponseObjectWithDifferentFieldNames.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ResponseObjectWithDifferentFieldNames.java
@@ -155,7 +155,7 @@ public class ResponseObjectWithDifferentFieldNames {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(@Nullable Object o) {
     return o == null ? "null" : o.toString().replace("\n", "\n    ");
   }
   

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/SpecialModelName.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/SpecialModelName.java
@@ -79,7 +79,7 @@ public class SpecialModelName {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(@Nullable Object o) {
     return o == null ? "null" : o.toString().replace("\n", "\n    ");
   }
   

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Tag.java
@@ -103,7 +103,7 @@ public class Tag {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(@Nullable Object o) {
     return o == null ? "null" : o.toString().replace("\n", "\n    ");
   }
   

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/TypeHolderDefault.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/TypeHolderDefault.java
@@ -202,7 +202,7 @@ public class TypeHolderDefault {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(@Nullable Object o) {
     return o == null ? "null" : o.toString().replace("\n", "\n    ");
   }
   

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/TypeHolderExample.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/TypeHolderExample.java
@@ -228,7 +228,7 @@ public class TypeHolderExample {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(@Nullable Object o) {
     return o == null ? "null" : o.toString().replace("\n", "\n    ");
   }
   

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/User.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/User.java
@@ -259,7 +259,7 @@ public class User {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(@Nullable Object o) {
     return o == null ? "null" : o.toString().replace("\n", "\n    ");
   }
   

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/XmlItem.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/XmlItem.java
@@ -881,7 +881,7 @@ public class XmlItem {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(@Nullable Object o) {
     return o == null ? "null" : o.toString().replace("\n", "\n    ");
   }
   


### PR DESCRIPTION
With useJspecify=true, toIndentedString(Object o) is generated without @Nullable. The nullableAnnotation partial strips the annotation and nothing puts it back, since Object is not wrapped in the jSpecifyDatatype lambda. Without jspecify the output is @Nullable Object o, so the two modes disagree.

This matters because the model package is @NullMarked and toString() passes nullable fields into this method. NullAway and IntelliJ report an error on every generated model.

Fix: wrap Object in the jSpecifyDatatype lambda, same pattern as the rest of the template. This complements #24563 which fixes the constructor and fluent setter spots. Relates to #23848.

Checked both modes. jspecify=true now gives @Nullable Object o with the import. jspecify=false output is byte identical to before. Added an assertion to SpringCodegenTest#testJspecify, all 8 combos pass. Regenerated samples for bin/configs/spring-boot-4-jspecify.yaml, the diff is one line.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ```
  (Scoped sample regeneration to the affected config, spring-boot-4-jspecify.yaml. No generator options or docs changed, so export_docs_generators was not needed.)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc Java Spring technical committee: @cachescrubber @welshm @MelleD @atextor @manedev79 @javisst @borsch @banlevente @Zomzog @martin-mfg @KannaKim

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing @Nullable on toIndentedString(Object o) when `useJspecify=true` by hardcoding the annotation in the Spring POJO template. This aligns jspecify and non-jspecify outputs and removes nullness errors in `@NullMarked` models. Complements #24563 and relates to #23848.

- **Bug Fixes**
  - Hardcode `@Nullable` on `toIndentedString(@Nullable Object o)` in `pojo.mustache` instead of using the `nullableAnnotation` partial, avoiding context side effects and applying the fix to use-optional variants too.
  - Add a test assertion for the method signature and the import of `org.jspecify.annotations.Nullable`; regenerate affected samples.

<sup>Written for commit 6bd8ee2e8536519d91055562e3855ff0f33a60ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24567?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

