### PR TITLE
[Java][WebClient][RestClient] Add toString to single-request-parameter class

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/restclient/single_request_parameter.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/restclient/single_request_parameter.mustache
@@ -56,6 +56,25 @@
             return Objects.hash({{#allParams}}{{#vendorExtensions.x-is-jackson-optional-nullable}}hashCodeNullable({{paramName}}){{/vendorExtensions.x-is-jackson-optional-nullable}}{{^vendorExtensions.x-is-jackson-optional-nullable}}{{^isByteArray}}{{paramName}}{{/isByteArray}}{{#isByteArray}}Arrays.hashCode({{paramName}}){{/isByteArray}}{{/vendorExtensions.x-is-jackson-optional-nullable}}{{^-last}}, {{/-last}}{{/allParams}});
         {{/useReflectionEqualsHashCode}}
         }
+
+        @Override
+        public String toString() {
+            StringBuilder sb = new StringBuilder();
+            sb.append("class {{#lambda.titlecase}}{{operationId}}{{/lambda.titlecase}}Request {\n");
+            {{#allParams}}
+            sb.append("    {{paramName}}: ").append({{#isPassword}}"*"{{/isPassword}}{{^isPassword}}toIndentedString({{paramName}}){{/isPassword}}).append("\n");
+            {{/allParams}}
+            sb.append("}");
+            return sb.toString();
+        }
+
+        /**
+        * Convert the given object to string with each line indented by 4 spaces
+        * (except the first line).
+        */
+        private{{#jsonb}} static{{/jsonb}} String toIndentedString(Object o) {
+            return o == null ? "null" : o.toString().replace("\n", "\n    ");
+        }
     }
     {{/staticRequest}}
 

--- a/modules/openapi-generator/src/main/resources/Java/libraries/webclient/single_request_parameter.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/webclient/single_request_parameter.mustache
@@ -52,6 +52,25 @@
             return Objects.hash({{#allParams}}{{#vendorExtensions.x-is-jackson-optional-nullable}}hashCodeNullable({{paramName}}){{/vendorExtensions.x-is-jackson-optional-nullable}}{{^vendorExtensions.x-is-jackson-optional-nullable}}{{^isByteArray}}{{paramName}}{{/isByteArray}}{{#isByteArray}}Arrays.hashCode({{paramName}}){{/isByteArray}}{{/vendorExtensions.x-is-jackson-optional-nullable}}{{^-last}}, {{/-last}}{{/allParams}});
         {{/useReflectionEqualsHashCode}}
         }
+
+        @Override
+        public String toString() {
+            StringBuilder sb = new StringBuilder();
+            sb.append("class {{#lambda.titlecase}}{{operationId}}{{/lambda.titlecase}}Request {\n");
+            {{#allParams}}
+            sb.append("    {{paramName}}: ").append({{#isPassword}}"*"{{/isPassword}}{{^isPassword}}toIndentedString({{paramName}}){{/isPassword}}).append("\n");
+            {{/allParams}}
+            sb.append("}");
+            return sb.toString();
+        }
+
+        /**
+        * Convert the given object to string with each line indented by 4 spaces
+        * (except the first line).
+        */
+        private{{#jsonb}} static{{/jsonb}} String toIndentedString(Object o) {
+            return o == null ? "null" : o.toString().replace("\n", "\n    ");
+        }
     }
 
     /**

--- a/samples/client/petstore/java/restclient-useSingleRequestParameter-static/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/restclient-useSingleRequestParameter-static/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -243,6 +243,25 @@ public class FakeApi {
         public int hashCode() {
             return Objects.hash(pet, query1, header1);
         }
+
+        @Override
+        public String toString() {
+            StringBuilder sb = new StringBuilder();
+            sb.append("class FakeHttpSignatureTestRequest {\n");
+            sb.append("    pet: ").append(toIndentedString(pet)).append("\n");
+            sb.append("    query1: ").append(toIndentedString(query1)).append("\n");
+            sb.append("    header1: ").append(toIndentedString(header1)).append("\n");
+            sb.append("}");
+            return sb.toString();
+        }
+
+        /**
+        * Convert the given object to string with each line indented by 4 spaces
+        * (except the first line).
+        */
+        private String toIndentedString(Object o) {
+            return o == null ? "null" : o.toString().replace("\n", "\n    ");
+        }
     }
 
     /**
@@ -974,6 +993,24 @@ public class FakeApi {
         public int hashCode() {
             return Objects.hash(query, user);
         }
+
+        @Override
+        public String toString() {
+            StringBuilder sb = new StringBuilder();
+            sb.append("class TestBodyWithQueryParamsRequest {\n");
+            sb.append("    query: ").append(toIndentedString(query)).append("\n");
+            sb.append("    user: ").append(toIndentedString(user)).append("\n");
+            sb.append("}");
+            return sb.toString();
+        }
+
+        /**
+        * Convert the given object to string with each line indented by 4 spaces
+        * (except the first line).
+        */
+        private String toIndentedString(Object o) {
+            return o == null ? "null" : o.toString().replace("\n", "\n    ");
+        }
     }
 
     /**
@@ -1341,6 +1378,36 @@ public class FakeApi {
         public int hashCode() {
             return Objects.hash(number, _double, patternWithoutDelimiter, Arrays.hashCode(_byte), integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback);
         }
+
+        @Override
+        public String toString() {
+            StringBuilder sb = new StringBuilder();
+            sb.append("class TestEndpointParametersRequest {\n");
+            sb.append("    number: ").append(toIndentedString(number)).append("\n");
+            sb.append("    _double: ").append(toIndentedString(_double)).append("\n");
+            sb.append("    patternWithoutDelimiter: ").append(toIndentedString(patternWithoutDelimiter)).append("\n");
+            sb.append("    _byte: ").append(toIndentedString(_byte)).append("\n");
+            sb.append("    integer: ").append(toIndentedString(integer)).append("\n");
+            sb.append("    int32: ").append(toIndentedString(int32)).append("\n");
+            sb.append("    int64: ").append(toIndentedString(int64)).append("\n");
+            sb.append("    _float: ").append(toIndentedString(_float)).append("\n");
+            sb.append("    string: ").append(toIndentedString(string)).append("\n");
+            sb.append("    binary: ").append(toIndentedString(binary)).append("\n");
+            sb.append("    date: ").append(toIndentedString(date)).append("\n");
+            sb.append("    dateTime: ").append(toIndentedString(dateTime)).append("\n");
+            sb.append("    password: ").append("*").append("\n");
+            sb.append("    paramCallback: ").append(toIndentedString(paramCallback)).append("\n");
+            sb.append("}");
+            return sb.toString();
+        }
+
+        /**
+        * Convert the given object to string with each line indented by 4 spaces
+        * (except the first line).
+        */
+        private String toIndentedString(Object o) {
+            return o == null ? "null" : o.toString().replace("\n", "\n    ");
+        }
     }
 
     /**
@@ -1668,6 +1735,31 @@ public class FakeApi {
         public int hashCode() {
             return Objects.hash(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumQueryModelArray, enumFormStringArray, enumFormString);
         }
+
+        @Override
+        public String toString() {
+            StringBuilder sb = new StringBuilder();
+            sb.append("class TestEnumParametersRequest {\n");
+            sb.append("    enumHeaderStringArray: ").append(toIndentedString(enumHeaderStringArray)).append("\n");
+            sb.append("    enumHeaderString: ").append(toIndentedString(enumHeaderString)).append("\n");
+            sb.append("    enumQueryStringArray: ").append(toIndentedString(enumQueryStringArray)).append("\n");
+            sb.append("    enumQueryString: ").append(toIndentedString(enumQueryString)).append("\n");
+            sb.append("    enumQueryInteger: ").append(toIndentedString(enumQueryInteger)).append("\n");
+            sb.append("    enumQueryDouble: ").append(toIndentedString(enumQueryDouble)).append("\n");
+            sb.append("    enumQueryModelArray: ").append(toIndentedString(enumQueryModelArray)).append("\n");
+            sb.append("    enumFormStringArray: ").append(toIndentedString(enumFormStringArray)).append("\n");
+            sb.append("    enumFormString: ").append(toIndentedString(enumFormString)).append("\n");
+            sb.append("}");
+            return sb.toString();
+        }
+
+        /**
+        * Convert the given object to string with each line indented by 4 spaces
+        * (except the first line).
+        */
+        private String toIndentedString(Object o) {
+            return o == null ? "null" : o.toString().replace("\n", "\n    ");
+        }
     }
 
     /**
@@ -1911,6 +2003,28 @@ public class FakeApi {
         @Override
         public int hashCode() {
             return Objects.hash(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder sb = new StringBuilder();
+            sb.append("class TestGroupParametersRequest {\n");
+            sb.append("    requiredStringGroup: ").append(toIndentedString(requiredStringGroup)).append("\n");
+            sb.append("    requiredBooleanGroup: ").append(toIndentedString(requiredBooleanGroup)).append("\n");
+            sb.append("    requiredInt64Group: ").append(toIndentedString(requiredInt64Group)).append("\n");
+            sb.append("    stringGroup: ").append(toIndentedString(stringGroup)).append("\n");
+            sb.append("    booleanGroup: ").append(toIndentedString(booleanGroup)).append("\n");
+            sb.append("    int64Group: ").append(toIndentedString(int64Group)).append("\n");
+            sb.append("}");
+            return sb.toString();
+        }
+
+        /**
+        * Convert the given object to string with each line indented by 4 spaces
+        * (except the first line).
+        */
+        private String toIndentedString(Object o) {
+            return o == null ? "null" : o.toString().replace("\n", "\n    ");
         }
     }
 
@@ -2237,6 +2351,24 @@ public class FakeApi {
         public int hashCode() {
             return Objects.hash(param, param2);
         }
+
+        @Override
+        public String toString() {
+            StringBuilder sb = new StringBuilder();
+            sb.append("class TestJsonFormDataRequest {\n");
+            sb.append("    param: ").append(toIndentedString(param)).append("\n");
+            sb.append("    param2: ").append(toIndentedString(param2)).append("\n");
+            sb.append("}");
+            return sb.toString();
+        }
+
+        /**
+        * Convert the given object to string with each line indented by 4 spaces
+        * (except the first line).
+        */
+        private String toIndentedString(Object o) {
+            return o == null ? "null" : o.toString().replace("\n", "\n    ");
+        }
     }
 
     /**
@@ -2524,6 +2656,29 @@ public class FakeApi {
         @Override
         public int hashCode() {
             return Objects.hash(pipe, ioutil, http, url, context, allowEmpty, language);
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder sb = new StringBuilder();
+            sb.append("class TestQueryParameterCollectionFormatRequest {\n");
+            sb.append("    pipe: ").append(toIndentedString(pipe)).append("\n");
+            sb.append("    ioutil: ").append(toIndentedString(ioutil)).append("\n");
+            sb.append("    http: ").append(toIndentedString(http)).append("\n");
+            sb.append("    url: ").append(toIndentedString(url)).append("\n");
+            sb.append("    context: ").append(toIndentedString(context)).append("\n");
+            sb.append("    allowEmpty: ").append(toIndentedString(allowEmpty)).append("\n");
+            sb.append("    language: ").append(toIndentedString(language)).append("\n");
+            sb.append("}");
+            return sb.toString();
+        }
+
+        /**
+        * Convert the given object to string with each line indented by 4 spaces
+        * (except the first line).
+        */
+        private String toIndentedString(Object o) {
+            return o == null ? "null" : o.toString().replace("\n", "\n    ");
         }
     }
 

--- a/samples/client/petstore/java/restclient-useSingleRequestParameter-static/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/restclient-useSingleRequestParameter-static/src/main/java/org/openapitools/client/api/PetApi.java
@@ -165,6 +165,24 @@ public class PetApi {
         public int hashCode() {
             return Objects.hash(petId, apiKey);
         }
+
+        @Override
+        public String toString() {
+            StringBuilder sb = new StringBuilder();
+            sb.append("class DeletePetRequest {\n");
+            sb.append("    petId: ").append(toIndentedString(petId)).append("\n");
+            sb.append("    apiKey: ").append(toIndentedString(apiKey)).append("\n");
+            sb.append("}");
+            return sb.toString();
+        }
+
+        /**
+        * Convert the given object to string with each line indented by 4 spaces
+        * (except the first line).
+        */
+        private String toIndentedString(Object o) {
+            return o == null ? "null" : o.toString().replace("\n", "\n    ");
+        }
     }
 
     /**
@@ -668,6 +686,25 @@ public class PetApi {
         public int hashCode() {
             return Objects.hash(petId, name, status);
         }
+
+        @Override
+        public String toString() {
+            StringBuilder sb = new StringBuilder();
+            sb.append("class UpdatePetWithFormRequest {\n");
+            sb.append("    petId: ").append(toIndentedString(petId)).append("\n");
+            sb.append("    name: ").append(toIndentedString(name)).append("\n");
+            sb.append("    status: ").append(toIndentedString(status)).append("\n");
+            sb.append("}");
+            return sb.toString();
+        }
+
+        /**
+        * Convert the given object to string with each line indented by 4 spaces
+        * (except the first line).
+        */
+        private String toIndentedString(Object o) {
+            return o == null ? "null" : o.toString().replace("\n", "\n    ");
+        }
     }
 
     /**
@@ -851,6 +888,25 @@ public class PetApi {
         public int hashCode() {
             return Objects.hash(petId, additionalMetadata, _file);
         }
+
+        @Override
+        public String toString() {
+            StringBuilder sb = new StringBuilder();
+            sb.append("class UploadFileRequest {\n");
+            sb.append("    petId: ").append(toIndentedString(petId)).append("\n");
+            sb.append("    additionalMetadata: ").append(toIndentedString(additionalMetadata)).append("\n");
+            sb.append("    _file: ").append(toIndentedString(_file)).append("\n");
+            sb.append("}");
+            return sb.toString();
+        }
+
+        /**
+        * Convert the given object to string with each line indented by 4 spaces
+        * (except the first line).
+        */
+        private String toIndentedString(Object o) {
+            return o == null ? "null" : o.toString().replace("\n", "\n    ");
+        }
     }
 
     /**
@@ -1033,6 +1089,25 @@ public class PetApi {
         @Override
         public int hashCode() {
             return Objects.hash(petId, requiredFile, additionalMetadata);
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder sb = new StringBuilder();
+            sb.append("class UploadFileWithRequiredFileRequest {\n");
+            sb.append("    petId: ").append(toIndentedString(petId)).append("\n");
+            sb.append("    requiredFile: ").append(toIndentedString(requiredFile)).append("\n");
+            sb.append("    additionalMetadata: ").append(toIndentedString(additionalMetadata)).append("\n");
+            sb.append("}");
+            return sb.toString();
+        }
+
+        /**
+        * Convert the given object to string with each line indented by 4 spaces
+        * (except the first line).
+        */
+        private String toIndentedString(Object o) {
+            return o == null ? "null" : o.toString().replace("\n", "\n    ");
         }
     }
 

--- a/samples/client/petstore/java/restclient-useSingleRequestParameter-static/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/restclient-useSingleRequestParameter-static/src/main/java/org/openapitools/client/api/UserApi.java
@@ -456,6 +456,24 @@ public class UserApi {
         public int hashCode() {
             return Objects.hash(username, password);
         }
+
+        @Override
+        public String toString() {
+            StringBuilder sb = new StringBuilder();
+            sb.append("class LoginUserRequest {\n");
+            sb.append("    username: ").append(toIndentedString(username)).append("\n");
+            sb.append("    password: ").append(toIndentedString(password)).append("\n");
+            sb.append("}");
+            return sb.toString();
+        }
+
+        /**
+        * Convert the given object to string with each line indented by 4 spaces
+        * (except the first line).
+        */
+        private String toIndentedString(Object o) {
+            return o == null ? "null" : o.toString().replace("\n", "\n    ");
+        }
     }
 
     /**
@@ -688,6 +706,24 @@ public class UserApi {
         @Override
         public int hashCode() {
             return Objects.hash(username, user);
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder sb = new StringBuilder();
+            sb.append("class UpdateUserRequest {\n");
+            sb.append("    username: ").append(toIndentedString(username)).append("\n");
+            sb.append("    user: ").append(toIndentedString(user)).append("\n");
+            sb.append("}");
+            return sb.toString();
+        }
+
+        /**
+        * Convert the given object to string with each line indented by 4 spaces
+        * (except the first line).
+        */
+        private String toIndentedString(Object o) {
+            return o == null ? "null" : o.toString().replace("\n", "\n    ");
         }
     }
 

--- a/samples/client/petstore/java/webclient-useSingleRequestParameter/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/webclient-useSingleRequestParameter/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -245,6 +245,25 @@ public class FakeApi {
         public int hashCode() {
             return Objects.hash(pet, query1, header1);
         }
+
+        @Override
+        public String toString() {
+            StringBuilder sb = new StringBuilder();
+            sb.append("class FakeHttpSignatureTestRequest {\n");
+            sb.append("    pet: ").append(toIndentedString(pet)).append("\n");
+            sb.append("    query1: ").append(toIndentedString(query1)).append("\n");
+            sb.append("    header1: ").append(toIndentedString(header1)).append("\n");
+            sb.append("}");
+            return sb.toString();
+        }
+
+        /**
+        * Convert the given object to string with each line indented by 4 spaces
+        * (except the first line).
+        */
+        private String toIndentedString(Object o) {
+            return o == null ? "null" : o.toString().replace("\n", "\n    ");
+        }
     }
 
     /**
@@ -977,6 +996,24 @@ public class FakeApi {
         public int hashCode() {
             return Objects.hash(query, user);
         }
+
+        @Override
+        public String toString() {
+            StringBuilder sb = new StringBuilder();
+            sb.append("class TestBodyWithQueryParamsRequest {\n");
+            sb.append("    query: ").append(toIndentedString(query)).append("\n");
+            sb.append("    user: ").append(toIndentedString(user)).append("\n");
+            sb.append("}");
+            return sb.toString();
+        }
+
+        /**
+        * Convert the given object to string with each line indented by 4 spaces
+        * (except the first line).
+        */
+        private String toIndentedString(Object o) {
+            return o == null ? "null" : o.toString().replace("\n", "\n    ");
+        }
     }
 
     /**
@@ -1345,6 +1382,36 @@ public class FakeApi {
         public int hashCode() {
             return Objects.hash(number, _double, patternWithoutDelimiter, Arrays.hashCode(_byte), integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback);
         }
+
+        @Override
+        public String toString() {
+            StringBuilder sb = new StringBuilder();
+            sb.append("class TestEndpointParametersRequest {\n");
+            sb.append("    number: ").append(toIndentedString(number)).append("\n");
+            sb.append("    _double: ").append(toIndentedString(_double)).append("\n");
+            sb.append("    patternWithoutDelimiter: ").append(toIndentedString(patternWithoutDelimiter)).append("\n");
+            sb.append("    _byte: ").append(toIndentedString(_byte)).append("\n");
+            sb.append("    integer: ").append(toIndentedString(integer)).append("\n");
+            sb.append("    int32: ").append(toIndentedString(int32)).append("\n");
+            sb.append("    int64: ").append(toIndentedString(int64)).append("\n");
+            sb.append("    _float: ").append(toIndentedString(_float)).append("\n");
+            sb.append("    string: ").append(toIndentedString(string)).append("\n");
+            sb.append("    binary: ").append(toIndentedString(binary)).append("\n");
+            sb.append("    date: ").append(toIndentedString(date)).append("\n");
+            sb.append("    dateTime: ").append(toIndentedString(dateTime)).append("\n");
+            sb.append("    password: ").append("*").append("\n");
+            sb.append("    paramCallback: ").append(toIndentedString(paramCallback)).append("\n");
+            sb.append("}");
+            return sb.toString();
+        }
+
+        /**
+        * Convert the given object to string with each line indented by 4 spaces
+        * (except the first line).
+        */
+        private String toIndentedString(Object o) {
+            return o == null ? "null" : o.toString().replace("\n", "\n    ");
+        }
     }
 
     /**
@@ -1673,6 +1740,31 @@ public class FakeApi {
         public int hashCode() {
             return Objects.hash(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumQueryModelArray, enumFormStringArray, enumFormString);
         }
+
+        @Override
+        public String toString() {
+            StringBuilder sb = new StringBuilder();
+            sb.append("class TestEnumParametersRequest {\n");
+            sb.append("    enumHeaderStringArray: ").append(toIndentedString(enumHeaderStringArray)).append("\n");
+            sb.append("    enumHeaderString: ").append(toIndentedString(enumHeaderString)).append("\n");
+            sb.append("    enumQueryStringArray: ").append(toIndentedString(enumQueryStringArray)).append("\n");
+            sb.append("    enumQueryString: ").append(toIndentedString(enumQueryString)).append("\n");
+            sb.append("    enumQueryInteger: ").append(toIndentedString(enumQueryInteger)).append("\n");
+            sb.append("    enumQueryDouble: ").append(toIndentedString(enumQueryDouble)).append("\n");
+            sb.append("    enumQueryModelArray: ").append(toIndentedString(enumQueryModelArray)).append("\n");
+            sb.append("    enumFormStringArray: ").append(toIndentedString(enumFormStringArray)).append("\n");
+            sb.append("    enumFormString: ").append(toIndentedString(enumFormString)).append("\n");
+            sb.append("}");
+            return sb.toString();
+        }
+
+        /**
+        * Convert the given object to string with each line indented by 4 spaces
+        * (except the first line).
+        */
+        private String toIndentedString(Object o) {
+            return o == null ? "null" : o.toString().replace("\n", "\n    ");
+        }
     }
 
     /**
@@ -1917,6 +2009,28 @@ public class FakeApi {
         @Override
         public int hashCode() {
             return Objects.hash(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder sb = new StringBuilder();
+            sb.append("class TestGroupParametersRequest {\n");
+            sb.append("    requiredStringGroup: ").append(toIndentedString(requiredStringGroup)).append("\n");
+            sb.append("    requiredBooleanGroup: ").append(toIndentedString(requiredBooleanGroup)).append("\n");
+            sb.append("    requiredInt64Group: ").append(toIndentedString(requiredInt64Group)).append("\n");
+            sb.append("    stringGroup: ").append(toIndentedString(stringGroup)).append("\n");
+            sb.append("    booleanGroup: ").append(toIndentedString(booleanGroup)).append("\n");
+            sb.append("    int64Group: ").append(toIndentedString(int64Group)).append("\n");
+            sb.append("}");
+            return sb.toString();
+        }
+
+        /**
+        * Convert the given object to string with each line indented by 4 spaces
+        * (except the first line).
+        */
+        private String toIndentedString(Object o) {
+            return o == null ? "null" : o.toString().replace("\n", "\n    ");
         }
     }
 
@@ -2244,6 +2358,24 @@ public class FakeApi {
         public int hashCode() {
             return Objects.hash(param, param2);
         }
+
+        @Override
+        public String toString() {
+            StringBuilder sb = new StringBuilder();
+            sb.append("class TestJsonFormDataRequest {\n");
+            sb.append("    param: ").append(toIndentedString(param)).append("\n");
+            sb.append("    param2: ").append(toIndentedString(param2)).append("\n");
+            sb.append("}");
+            return sb.toString();
+        }
+
+        /**
+        * Convert the given object to string with each line indented by 4 spaces
+        * (except the first line).
+        */
+        private String toIndentedString(Object o) {
+            return o == null ? "null" : o.toString().replace("\n", "\n    ");
+        }
     }
 
     /**
@@ -2532,6 +2664,29 @@ public class FakeApi {
         @Override
         public int hashCode() {
             return Objects.hash(pipe, ioutil, http, url, context, allowEmpty, language);
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder sb = new StringBuilder();
+            sb.append("class TestQueryParameterCollectionFormatRequest {\n");
+            sb.append("    pipe: ").append(toIndentedString(pipe)).append("\n");
+            sb.append("    ioutil: ").append(toIndentedString(ioutil)).append("\n");
+            sb.append("    http: ").append(toIndentedString(http)).append("\n");
+            sb.append("    url: ").append(toIndentedString(url)).append("\n");
+            sb.append("    context: ").append(toIndentedString(context)).append("\n");
+            sb.append("    allowEmpty: ").append(toIndentedString(allowEmpty)).append("\n");
+            sb.append("    language: ").append(toIndentedString(language)).append("\n");
+            sb.append("}");
+            return sb.toString();
+        }
+
+        /**
+        * Convert the given object to string with each line indented by 4 spaces
+        * (except the first line).
+        */
+        private String toIndentedString(Object o) {
+            return o == null ? "null" : o.toString().replace("\n", "\n    ");
         }
     }
 

--- a/samples/client/petstore/java/webclient-useSingleRequestParameter/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/webclient-useSingleRequestParameter/src/main/java/org/openapitools/client/api/PetApi.java
@@ -167,6 +167,24 @@ public class PetApi {
         public int hashCode() {
             return Objects.hash(petId, apiKey);
         }
+
+        @Override
+        public String toString() {
+            StringBuilder sb = new StringBuilder();
+            sb.append("class DeletePetRequest {\n");
+            sb.append("    petId: ").append(toIndentedString(petId)).append("\n");
+            sb.append("    apiKey: ").append(toIndentedString(apiKey)).append("\n");
+            sb.append("}");
+            return sb.toString();
+        }
+
+        /**
+        * Convert the given object to string with each line indented by 4 spaces
+        * (except the first line).
+        */
+        private String toIndentedString(Object o) {
+            return o == null ? "null" : o.toString().replace("\n", "\n    ");
+        }
     }
 
     /**
@@ -669,6 +687,25 @@ public class PetApi {
         public int hashCode() {
             return Objects.hash(petId, name, status);
         }
+
+        @Override
+        public String toString() {
+            StringBuilder sb = new StringBuilder();
+            sb.append("class UpdatePetWithFormRequest {\n");
+            sb.append("    petId: ").append(toIndentedString(petId)).append("\n");
+            sb.append("    name: ").append(toIndentedString(name)).append("\n");
+            sb.append("    status: ").append(toIndentedString(status)).append("\n");
+            sb.append("}");
+            return sb.toString();
+        }
+
+        /**
+        * Convert the given object to string with each line indented by 4 spaces
+        * (except the first line).
+        */
+        private String toIndentedString(Object o) {
+            return o == null ? "null" : o.toString().replace("\n", "\n    ");
+        }
     }
 
     /**
@@ -853,6 +890,25 @@ public class PetApi {
         public int hashCode() {
             return Objects.hash(petId, additionalMetadata, _file);
         }
+
+        @Override
+        public String toString() {
+            StringBuilder sb = new StringBuilder();
+            sb.append("class UploadFileRequest {\n");
+            sb.append("    petId: ").append(toIndentedString(petId)).append("\n");
+            sb.append("    additionalMetadata: ").append(toIndentedString(additionalMetadata)).append("\n");
+            sb.append("    _file: ").append(toIndentedString(_file)).append("\n");
+            sb.append("}");
+            return sb.toString();
+        }
+
+        /**
+        * Convert the given object to string with each line indented by 4 spaces
+        * (except the first line).
+        */
+        private String toIndentedString(Object o) {
+            return o == null ? "null" : o.toString().replace("\n", "\n    ");
+        }
     }
 
     /**
@@ -1036,6 +1092,25 @@ public class PetApi {
         @Override
         public int hashCode() {
             return Objects.hash(petId, requiredFile, additionalMetadata);
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder sb = new StringBuilder();
+            sb.append("class UploadFileWithRequiredFileRequest {\n");
+            sb.append("    petId: ").append(toIndentedString(petId)).append("\n");
+            sb.append("    requiredFile: ").append(toIndentedString(requiredFile)).append("\n");
+            sb.append("    additionalMetadata: ").append(toIndentedString(additionalMetadata)).append("\n");
+            sb.append("}");
+            return sb.toString();
+        }
+
+        /**
+        * Convert the given object to string with each line indented by 4 spaces
+        * (except the first line).
+        */
+        private String toIndentedString(Object o) {
+            return o == null ? "null" : o.toString().replace("\n", "\n    ");
         }
     }
 

--- a/samples/client/petstore/java/webclient-useSingleRequestParameter/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/webclient-useSingleRequestParameter/src/main/java/org/openapitools/client/api/UserApi.java
@@ -458,6 +458,24 @@ public class UserApi {
         public int hashCode() {
             return Objects.hash(username, password);
         }
+
+        @Override
+        public String toString() {
+            StringBuilder sb = new StringBuilder();
+            sb.append("class LoginUserRequest {\n");
+            sb.append("    username: ").append(toIndentedString(username)).append("\n");
+            sb.append("    password: ").append(toIndentedString(password)).append("\n");
+            sb.append("}");
+            return sb.toString();
+        }
+
+        /**
+        * Convert the given object to string with each line indented by 4 spaces
+        * (except the first line).
+        */
+        private String toIndentedString(Object o) {
+            return o == null ? "null" : o.toString().replace("\n", "\n    ");
+        }
     }
 
     /**
@@ -691,6 +709,24 @@ public class UserApi {
         @Override
         public int hashCode() {
             return Objects.hash(username, user);
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder sb = new StringBuilder();
+            sb.append("class UpdateUserRequest {\n");
+            sb.append("    username: ").append(toIndentedString(username)).append("\n");
+            sb.append("    user: ").append(toIndentedString(user)).append("\n");
+            sb.append("}");
+            return sb.toString();
+        }
+
+        /**
+        * Convert the given object to string with each line indented by 4 spaces
+        * (except the first line).
+        */
+        private String toIndentedString(Object o) {
+            return o == null ? "null" : o.toString().replace("\n", "\n    ");
         }
     }
 


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Adds a `.toString` to the `singleRequestParameter` class. This is for example helpful when the class is used within the JUnit testing framework, which relies on the .toString to showcase the difference between an expected and actual test value match.

The implementation is an [adaptation of the toString that is used for](https://github.com/OpenAPITools/openapi-generator/blob/master/modules/openapi-generator/src/main/resources/Java/libraries/restclient/pojo.mustache#L346) `pojos` (models).

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

Java technical committee since I assume the Spring one is tied to the server generation.
@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10) @martin-mfg (2023/08) @KannaKim (2026/07)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add toString to generated single-request-parameter classes for Java `restclient` and `webclient`. This makes request objects readable in logs and JUnit diffs while masking passwords.

- **New Features**
  - toString matches model POJO style with a multi-line, indented field list.
  - Password fields are masked; values are safely stringified.
  - Regenerated Java petstore samples to include the new method.

<sup>Written for commit a7c52d2f267ca560da7be9c33023178c3c53d97b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24568?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

