### PR TITLE
Revert "[scala-sttp4-jsoniter] add generic Option and Seq codecs for jsoniter-scala"

### DIFF
--- a/modules/openapi-generator/src/main/resources/scala-sttp4-jsoniter/jsonSupport.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-sttp4-jsoniter/jsonSupport.mustache
@@ -12,9 +12,6 @@ import com.github.plokhotnyuk.jsoniter_scala.circe.JsoniterScalaCodec.*
 object JsonSupport extends AdditionalTypeSerializers:
   inline given CodecMakerConfig = CodecMakerConfig.withAllowRecursiveTypes(true)
 
-  given [A](using JsonValueCodec[A]): JsonValueCodec[Option[A]] = deriveJsonCodec
-  given [A](using JsonValueCodec[A]): JsonValueCodec[Seq[A]] = deriveJsonCodec
-
   inline def deriveJsonCodec[A](using inline config: CodecMakerConfig): JsonValueCodec[A] =
     JsonCodecMaker.make(config)
 

--- a/samples/client/petstore/scala-sttp4-jsoniter/src/main/scala/org/openapitools/client/core/JsonSupport.scala
+++ b/samples/client/petstore/scala-sttp4-jsoniter/src/main/scala/org/openapitools/client/core/JsonSupport.scala
@@ -20,9 +20,6 @@ import com.github.plokhotnyuk.jsoniter_scala.circe.JsoniterScalaCodec.*
 object JsonSupport extends AdditionalTypeSerializers:
   inline given CodecMakerConfig = CodecMakerConfig.withAllowRecursiveTypes(true)
 
-  given [A](using JsonValueCodec[A]): JsonValueCodec[Option[A]] = deriveJsonCodec
-  given [A](using JsonValueCodec[A]): JsonValueCodec[Seq[A]] = deriveJsonCodec
-
   inline def deriveJsonCodec[A](using inline config: CodecMakerConfig): JsonValueCodec[A] =
     JsonCodecMaker.make(config)
 


### PR DESCRIPTION
Reverts OpenAPITools/openapi-generator#23800

The generic Option/Seq givens were redundant: the codegen already generates a
specific codec for every top-level array/optional body, and JsonCodecMaker
derives nested Seq/Option/Map inside each model codec.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the generic `Option[A]` and `Seq[A]` `JsonValueCodec` givens from `scala-sttp4-jsoniter`. The codegen already generates specific codecs for top-level arrays/options, and `jsoniter-scala`'s `JsonCodecMaker` derives nested collections inside model codecs.

<sup>Written for commit b316f220f8be9465885e2a7751e1e5354b688859. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24569?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

