### PR TITLE
fix(typescript-fetch): emit erasable syntax in the runtime template

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
@@ -18,7 +18,11 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+    private configuration: ConfigurationParameters;
+
+    constructor(configuration: ConfigurationParameters = {}) {
+        this.configuration = configuration;
+    }
 
     set config(configuration: Configuration) {
         this.configuration = configuration;
@@ -82,8 +86,10 @@ export class BaseAPI {
 
     private static readonly jsonRegex = /^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$/i;
     private middleware: Middleware[];
+    protected configuration: Configuration;
 
-    constructor(protected configuration = DefaultConfig) {
+    constructor(configuration: Configuration = DefaultConfig) {
+        this.configuration = configuration;
         this.middleware = configuration.middleware;
     }
 
@@ -248,8 +254,10 @@ function isFormData(value: any): value is FormData {
 
 export class ResponseError extends Error {
     override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
+    response: Response;
+    constructor(response: Response, msg?: string) {
         super(msg);
+        this.response = response;
 
         // restore prototype chain
         const actualProto = new.target.prototype;
@@ -259,10 +267,17 @@ export class ResponseError extends Error {
     }
 }
 
+// `cause` is declared through an interface so that it stays compatible with lib targets
+// that already declare `Error.cause` (ES2022+) as well as the ones that do not
+export interface FetchError {
+    cause: Error;
+}
+
 export class FetchError extends Error {
     override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
+    constructor(cause: Error, msg?: string) {
         super(msg);
+        this.cause = cause;
 
         // restore prototype chain
         const actualProto = new.target.prototype;
@@ -274,8 +289,10 @@ export class FetchError extends Error {
 
 export class RequiredError extends Error {
     override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
+    field: string;
+    constructor(field: string, msg?: string) {
         super(msg);
+        this.field = field;
 
         // restore prototype chain
         const actualProto = new.target.prototype;
@@ -414,7 +431,13 @@ export interface ResponseTransformer<T> {
 }
 
 export class JSONApiResponse<T> {
-    constructor(public raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {}
+    raw: Response;
+    private transformer: ResponseTransformer<T>;
+
+    constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+        this.raw = raw;
+        this.transformer = transformer;
+    }
 
     async value(): Promise<T> {
         return this.transformer(await this.raw.json());
@@ -422,7 +445,11 @@ export class JSONApiResponse<T> {
 }
 
 export class VoidApiResponse {
-    constructor(public raw: Response) {}
+    raw: Response;
+
+    constructor(raw: Response) {
+        this.raw = raw;
+    }
 
     async value(): Promise<void> {
         return undefined;
@@ -430,7 +457,11 @@ export class VoidApiResponse {
 }
 
 export class BlobApiResponse {
-    constructor(public raw: Response) {}
+    raw: Response;
+
+    constructor(raw: Response) {
+        this.raw = raw;
+    }
 
     async value(): Promise<Blob> {
         return await this.raw.blob();
@@ -438,7 +469,11 @@ export class BlobApiResponse {
 }
 
 export class TextApiResponse {
-    constructor(public raw: Response) {}
+    raw: Response;
+
+    constructor(raw: Response) {
+        this.raw = raw;
+    }
 
     async value(): Promise<string> {
         return await this.raw.text();

--- a/samples/client/others/typescript-fetch/additional-properties-in-multipart-issue/runtime.ts
+++ b/samples/client/others/typescript-fetch/additional-properties-in-multipart-issue/runtime.ts
@@ -28,7 +28,11 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+    private configuration: ConfigurationParameters;
+
+    constructor(configuration: ConfigurationParameters = {}) {
+        this.configuration = configuration;
+    }
 
     set config(configuration: Configuration) {
         this.configuration = configuration;
@@ -92,8 +96,10 @@ export class BaseAPI {
 
     private static readonly jsonRegex = /^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$/i;
     private middleware: Middleware[];
+    protected configuration: Configuration;
 
-    constructor(protected configuration = DefaultConfig) {
+    constructor(configuration: Configuration = DefaultConfig) {
+        this.configuration = configuration;
         this.middleware = configuration.middleware;
     }
 
@@ -258,8 +264,10 @@ function isFormData(value: any): value is FormData {
 
 export class ResponseError extends Error {
     override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
+    response: Response;
+    constructor(response: Response, msg?: string) {
         super(msg);
+        this.response = response;
 
         // restore prototype chain
         const actualProto = new.target.prototype;
@@ -269,10 +277,17 @@ export class ResponseError extends Error {
     }
 }
 
+// `cause` is declared through an interface so that it stays compatible with lib targets
+// that already declare `Error.cause` (ES2022+) as well as the ones that do not
+export interface FetchError {
+    cause: Error;
+}
+
 export class FetchError extends Error {
     override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
+    constructor(cause: Error, msg?: string) {
         super(msg);
+        this.cause = cause;
 
         // restore prototype chain
         const actualProto = new.target.prototype;
@@ -284,8 +299,10 @@ export class FetchError extends Error {
 
 export class RequiredError extends Error {
     override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
+    field: string;
+    constructor(field: string, msg?: string) {
         super(msg);
+        this.field = field;
 
         // restore prototype chain
         const actualProto = new.target.prototype;
@@ -422,7 +439,13 @@ export interface ResponseTransformer<T> {
 }
 
 export class JSONApiResponse<T> {
-    constructor(public raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {}
+    raw: Response;
+    private transformer: ResponseTransformer<T>;
+
+    constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+        this.raw = raw;
+        this.transformer = transformer;
+    }
 
     async value(): Promise<T> {
         return this.transformer(await this.raw.json());
@@ -430,7 +453,11 @@ export class JSONApiResponse<T> {
 }
 
 export class VoidApiResponse {
-    constructor(public raw: Response) {}
+    raw: Response;
+
+    constructor(raw: Response) {
+        this.raw = raw;
+    }
 
     async value(): Promise<void> {
         return undefined;
@@ -438,7 +465,11 @@ export class VoidApiResponse {
 }
 
 export class BlobApiResponse {
-    constructor(public raw: Response) {}
+    raw: Response;
+
+    constructor(raw: Response) {
+        this.raw = raw;
+    }
 
     async value(): Promise<Blob> {
         return await this.raw.blob();
@@ -446,7 +477,11 @@ export class BlobApiResponse {
 }
 
 export class TextApiResponse {
-    constructor(public raw: Response) {}
+    raw: Response;
+
+    constructor(raw: Response) {
+        this.raw = raw;
+    }
 
     async value(): Promise<string> {
         return await this.raw.text();

--- a/samples/client/others/typescript-fetch/infinite-recursion-issue/runtime.ts
+++ b/samples/client/others/typescript-fetch/infinite-recursion-issue/runtime.ts
@@ -28,7 +28,11 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+    private configuration: ConfigurationParameters;
+
+    constructor(configuration: ConfigurationParameters = {}) {
+        this.configuration = configuration;
+    }
 
     set config(configuration: Configuration) {
         this.configuration = configuration;
@@ -92,8 +96,10 @@ export class BaseAPI {
 
     private static readonly jsonRegex = /^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$/i;
     private middleware: Middleware[];
+    protected configuration: Configuration;
 
-    constructor(protected configuration = DefaultConfig) {
+    constructor(configuration: Configuration = DefaultConfig) {
+        this.configuration = configuration;
         this.middleware = configuration.middleware;
     }
 
@@ -258,8 +264,10 @@ function isFormData(value: any): value is FormData {
 
 export class ResponseError extends Error {
     override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
+    response: Response;
+    constructor(response: Response, msg?: string) {
         super(msg);
+        this.response = response;
 
         // restore prototype chain
         const actualProto = new.target.prototype;
@@ -269,10 +277,17 @@ export class ResponseError extends Error {
     }
 }
 
+// `cause` is declared through an interface so that it stays compatible with lib targets
+// that already declare `Error.cause` (ES2022+) as well as the ones that do not
+export interface FetchError {
+    cause: Error;
+}
+
 export class FetchError extends Error {
     override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
+    constructor(cause: Error, msg?: string) {
         super(msg);
+        this.cause = cause;
 
         // restore prototype chain
         const actualProto = new.target.prototype;
@@ -284,8 +299,10 @@ export class FetchError extends Error {
 
 export class RequiredError extends Error {
     override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
+    field: string;
+    constructor(field: string, msg?: string) {
         super(msg);
+        this.field = field;
 
         // restore prototype chain
         const actualProto = new.target.prototype;
@@ -422,7 +439,13 @@ export interface ResponseTransformer<T> {
 }
 
 export class JSONApiResponse<T> {
-    constructor(public raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {}
+    raw: Response;
+    private transformer: ResponseTransformer<T>;
+
+    constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+        this.raw = raw;
+        this.transformer = transformer;
+    }
 
     async value(): Promise<T> {
         return this.transformer(await this.raw.json());
@@ -430,7 +453,11 @@ export class JSONApiResponse<T> {
 }
 
 export class VoidApiResponse {
-    constructor(public raw: Response) {}
+    raw: Response;
+
+    constructor(raw: Response) {
+        this.raw = raw;
+    }
 
     async value(): Promise<void> {
         return undefined;
@@ -438,7 +465,11 @@ export class VoidApiResponse {
 }
 
 export class BlobApiResponse {
-    constructor(public raw: Response) {}
+    raw: Response;
+
+    constructor(raw: Response) {
+        this.raw = raw;
+    }
 
     async value(): Promise<Blob> {
         return await this.raw.blob();
@@ -446,7 +477,11 @@ export class BlobApiResponse {
 }
 
 export class TextApiResponse {
-    constructor(public raw: Response) {}
+    raw: Response;
+
+    constructor(raw: Response) {
+        this.raw = raw;
+    }
 
     async value(): Promise<string> {
         return await this.raw.text();

--- a/samples/client/others/typescript-fetch/multipart-file-array/runtime.ts
+++ b/samples/client/others/typescript-fetch/multipart-file-array/runtime.ts
@@ -28,7 +28,11 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+    private configuration: ConfigurationParameters;
+
+    constructor(configuration: ConfigurationParameters = {}) {
+        this.configuration = configuration;
+    }
 
     set config(configuration: Configuration) {
         this.configuration = configuration;
@@ -92,8 +96,10 @@ export class BaseAPI {
 
     private static readonly jsonRegex = /^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$/i;
     private middleware: Middleware[];
+    protected configuration: Configuration;
 
-    constructor(protected configuration = DefaultConfig) {
+    constructor(configuration: Configuration = DefaultConfig) {
+        this.configuration = configuration;
         this.middleware = configuration.middleware;
     }
 
@@ -258,8 +264,10 @@ function isFormData(value: any): value is FormData {
 
 export class ResponseError extends Error {
     override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
+    response: Response;
+    constructor(response: Response, msg?: string) {
         super(msg);
+        this.response = response;
 
         // restore prototype chain
         const actualProto = new.target.prototype;
@@ -269,10 +277,17 @@ export class ResponseError extends Error {
     }
 }
 
+// `cause` is declared through an interface so that it stays compatible with lib targets
+// that already declare `Error.cause` (ES2022+) as well as the ones that do not
+export interface FetchError {
+    cause: Error;
+}
+
 export class FetchError extends Error {
     override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
+    constructor(cause: Error, msg?: string) {
         super(msg);
+        this.cause = cause;
 
         // restore prototype chain
         const actualProto = new.target.prototype;
@@ -284,8 +299,10 @@ export class FetchError extends Error {
 
 export class RequiredError extends Error {
     override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
+    field: string;
+    constructor(field: string, msg?: string) {
         super(msg);
+        this.field = field;
 
         // restore prototype chain
         const actualProto = new.target.prototype;
@@ -422,7 +439,13 @@ export interface ResponseTransformer<T> {
 }
 
 export class JSONApiResponse<T> {
-    constructor(public raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {}
+    raw: Response;
+    private transformer: ResponseTransformer<T>;
+
+    constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+        this.raw = raw;
+        this.transformer = transformer;
+    }
 
     async value(): Promise<T> {
         return this.transformer(await this.raw.json());
@@ -430,7 +453,11 @@ export class JSONApiResponse<T> {
 }
 
 export class VoidApiResponse {
-    constructor(public raw: Response) {}
+    raw: Response;
+
+    constructor(raw: Response) {
+        this.raw = raw;
+    }
 
     async value(): Promise<void> {
         return undefined;
@@ -438,7 +465,11 @@ export class VoidApiResponse {
 }
 
 export class BlobApiResponse {
-    constructor(public raw: Response) {}
+    raw: Response;
+
+    constructor(raw: Response) {
+        this.raw = raw;
+    }
 
     async value(): Promise<Blob> {
         return await this.raw.blob();
@@ -446,7 +477,11 @@ export class BlobApiResponse {
 }
 
 export class TextApiResponse {
-    constructor(public raw: Response) {}
+    raw: Response;
+
+    constructor(raw: Response) {
+        this.raw = raw;
+    }
 
     async value(): Promise<string> {
         return await this.raw.text();

--- a/samples/client/others/typescript-fetch/self-import-issue/runtime.ts
+++ b/samples/client/others/typescript-fetch/self-import-issue/runtime.ts
@@ -28,7 +28,11 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+    private configuration: ConfigurationParameters;
+
+    constructor(configuration: ConfigurationParameters = {}) {
+        this.configuration = configuration;
+    }
 
     set config(configuration: Configuration) {
         this.configuration = configuration;
@@ -92,8 +96,10 @@ export class BaseAPI {
 
     private static readonly jsonRegex = /^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$/i;
     private middleware: Middleware[];
+    protected configuration: Configuration;
 
-    constructor(protected configuration = DefaultConfig) {
+    constructor(configuration: Configuration = DefaultConfig) {
+        this.configuration = configuration;
         this.middleware = configuration.middleware;
     }
 
@@ -258,8 +264,10 @@ function isFormData(value: any): value is FormData {
 
 export class ResponseError extends Error {
     override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
+    response: Response;
+    constructor(response: Response, msg?: string) {
         super(msg);
+        this.response = response;
 
         // restore prototype chain
         const actualProto = new.target.prototype;
@@ -269,10 +277,17 @@ export class ResponseError extends Error {
     }
 }
 
+// `cause` is declared through an interface so that it stays compatible with lib targets
+// that already declare `Error.cause` (ES2022+) as well as the ones that do not
+export interface FetchError {
+    cause: Error;
+}
+
 export class FetchError extends Error {
     override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
+    constructor(cause: Error, msg?: string) {
         super(msg);
+        this.cause = cause;
 
         // restore prototype chain
         const actualProto = new.target.prototype;
@@ -284,8 +299,10 @@ export class FetchError extends Error {
 
 export class RequiredError extends Error {
     override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
+    field: string;
+    constructor(field: string, msg?: string) {
         super(msg);
+        this.field = field;
 
         // restore prototype chain
         const actualProto = new.target.prototype;
@@ -422,7 +439,13 @@ export interface ResponseTransformer<T> {
 }
 
 export class JSONApiResponse<T> {
-    constructor(public raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {}
+    raw: Response;
+    private transformer: ResponseTransformer<T>;
+
+    constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+        this.raw = raw;
+        this.transformer = transformer;
+    }
 
     async value(): Promise<T> {
         return this.transformer(await this.raw.json());
@@ -430,7 +453,11 @@ export class JSONApiResponse<T> {
 }
 
 export class VoidApiResponse {
-    constructor(public raw: Response) {}
+    raw: Response;
+
+    constructor(raw: Response) {
+        this.raw = raw;
+    }
 
     async value(): Promise<void> {
         return undefined;
@@ -438,7 +465,11 @@ export class VoidApiResponse {
 }
 
 export class BlobApiResponse {
-    constructor(public raw: Response) {}
+    raw: Response;
+
+    constructor(raw: Response) {
+        this.raw = raw;
+    }
 
     async value(): Promise<Blob> {
         return await this.raw.blob();
@@ -446,7 +477,11 @@ export class BlobApiResponse {
 }
 
 export class TextApiResponse {
-    constructor(public raw: Response) {}
+    raw: Response;
+
+    constructor(raw: Response) {
+        this.raw = raw;
+    }
 
     async value(): Promise<string> {
         return await this.raw.text();

--- a/samples/client/petstore/typescript-fetch/builds/allOf-nullable/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/allOf-nullable/runtime.ts
@@ -28,7 +28,11 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+    private configuration: ConfigurationParameters;
+
+    constructor(configuration: ConfigurationParameters = {}) {
+        this.configuration = configuration;
+    }
 
     set config(configuration: Configuration) {
         this.configuration = configuration;
@@ -92,8 +96,10 @@ export class BaseAPI {
 
     private static readonly jsonRegex = /^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$/i;
     private middleware: Middleware[];
+    protected configuration: Configuration;
 
-    constructor(protected configuration = DefaultConfig) {
+    constructor(configuration: Configuration = DefaultConfig) {
+        this.configuration = configuration;
         this.middleware = configuration.middleware;
     }
 
@@ -258,8 +264,10 @@ function isFormData(value: any): value is FormData {
 
 export class ResponseError extends Error {
     override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
+    response: Response;
+    constructor(response: Response, msg?: string) {
         super(msg);
+        this.response = response;
 
         // restore prototype chain
         const actualProto = new.target.prototype;
@@ -269,10 +277,17 @@ export class ResponseError extends Error {
     }
 }
 
+// `cause` is declared through an interface so that it stays compatible with lib targets
+// that already declare `Error.cause` (ES2022+) as well as the ones that do not
+export interface FetchError {
+    cause: Error;
+}
+
 export class FetchError extends Error {
     override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
+    constructor(cause: Error, msg?: string) {
         super(msg);
+        this.cause = cause;
 
         // restore prototype chain
         const actualProto = new.target.prototype;
@@ -284,8 +299,10 @@ export class FetchError extends Error {
 
 export class RequiredError extends Error {
     override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
+    field: string;
+    constructor(field: string, msg?: string) {
         super(msg);
+        this.field = field;
 
         // restore prototype chain
         const actualProto = new.target.prototype;
@@ -422,7 +439,13 @@ export interface ResponseTransformer<T> {
 }
 
 export class JSONApiResponse<T> {
-    constructor(public raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {}
+    raw: Response;
+    private transformer: ResponseTransformer<T>;
+
+    constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+        this.raw = raw;
+        this.transformer = transformer;
+    }
 
     async value(): Promise<T> {
         return this.transformer(await this.raw.json());
@@ -430,7 +453,11 @@ export class JSONApiResponse<T> {
 }
 
 export class VoidApiResponse {
-    constructor(public raw: Response) {}
+    raw: Response;
+
+    constructor(raw: Response) {
+        this.raw = raw;
+    }
 
     async value(): Promise<void> {
         return undefined;
@@ -438,7 +465,11 @@ export class VoidApiResponse {
 }
 
 export class BlobApiResponse {
-    constructor(public raw: Response) {}
+    raw: Response;
+
+    constructor(raw: Response) {
+        this.raw = raw;
+    }
 
     async value(): Promise<Blob> {
         return await this.raw.blob();
@@ -446,7 +477,11 @@ export class BlobApiResponse {
 }
 
 export class TextApiResponse {
-    constructor(public raw: Response) {}
+    raw: Response;
+
+    constructor(raw: Response) {
+        this.raw = raw;
+    }
 
     async value(): Promise<string> {
         return await this.raw.text();

--- a/samples/client/petstore/typescript-fetch/builds/allOf-readonly/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/allOf-readonly/runtime.ts
@@ -28,7 +28,11 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+    private configuration: ConfigurationParameters;
+
+    constructor(configuration: ConfigurationParameters = {}) {
+        this.configuration = configuration;
+    }
 
     set config(configuration: Configuration) {
         this.configuration = configuration;
@@ -92,8 +96,10 @@ export class BaseAPI {
 
     private static readonly jsonRegex = /^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$/i;
     private middleware: Middleware[];
+    protected configuration: Configuration;
 
-    constructor(protected configuration = DefaultConfig) {
+    constructor(configuration: Configuration = DefaultConfig) {
+        this.configuration = configuration;
         this.middleware = configuration.middleware;
     }
 
@@ -258,8 +264,10 @@ function isFormData(value: any): value is FormData {
 
 export class ResponseError extends Error {
     override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
+    response: Response;
+    constructor(response: Response, msg?: string) {
         super(msg);
+        this.response = response;
 
         // restore prototype chain
         const actualProto = new.target.prototype;
@@ -269,10 +277,17 @@ export class ResponseError extends Error {
     }
 }
 
+// `cause` is declared through an interface so that it stays compatible with lib targets
+// that already declare `Error.cause` (ES2022+) as well as the ones that do not
+export interface FetchError {
+    cause: Error;
+}
+
 export class FetchError extends Error {
     override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
+    constructor(cause: Error, msg?: string) {
         super(msg);
+        this.cause = cause;
 
         // restore prototype chain
         const actualProto = new.target.prototype;
@@ -284,8 +299,10 @@ export class FetchError extends Error {
 
 export class RequiredError extends Error {
     override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
+    field: string;
+    constructor(field: string, msg?: string) {
         super(msg);
+        this.field = field;
 
         // restore prototype chain
         const actualProto = new.target.prototype;
@@ -422,7 +439,13 @@ export interface ResponseTransformer<T> {
 }
 
 export class JSONApiResponse<T> {
-    constructor(public raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {}
+    raw: Response;
+    private transformer: ResponseTransformer<T>;
+
+    constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+        this.raw = raw;
+        this.transformer = transformer;
+    }
 
     async value(): Promise<T> {
         return this.transformer(await this.raw.json());
@@ -430,7 +453,11 @@ export class JSONApiResponse<T> {
 }
 
 export class VoidApiResponse {
-    constructor(public raw: Response) {}
+    raw: Response;
+
+    constructor(raw: Response) {
+        this.raw = raw;
+    }
 
     async value(): Promise<void> {
         return undefined;
@@ -438,7 +465,11 @@ export class VoidApiResponse {
 }
 
 export class BlobApiResponse {
-    constructor(public raw: Response) {}
+    raw: Response;
+
+    constructor(raw: Response) {
+        this.raw = raw;
+    }
 
     async value(): Promise<Blob> {
         return await this.raw.blob();
@@ -446,7 +477,11 @@ export class BlobApiResponse {
 }
 
 export class TextApiResponse {
-    constructor(public raw: Response) {}
+    raw: Response;
+
+    constructor(raw: Response) {
+        this.raw = raw;
+    }
 
     async value(): Promise<string> {
         return await this.raw.text();

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/runtime.ts
@@ -28,7 +28,11 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+    private configuration: ConfigurationParameters;
+
+    constructor(configuration: ConfigurationParameters = {}) {
+        this.configuration = configuration;
+    }
 
     set config(configuration: Configuration) {
         this.configuration = configuration;
@@ -92,8 +96,10 @@ export class BaseAPI {
 
     private static readonly jsonRegex = /^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$/i;
     private middleware: Middleware[];
+    protected configuration: Configuration;
 
-    constructor(protected configuration = DefaultConfig) {
+    constructor(configuration: Configuration = DefaultConfig) {
+        this.configuration = configuration;
         this.middleware = configuration.middleware;
     }
 
@@ -258,8 +264,10 @@ function isFormData(value: any): value is FormData {
 
 export class ResponseError extends Error {
     override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
+    response: Response;
+    constructor(response: Response, msg?: string) {
         super(msg);
+        this.response = response;
 
         // restore prototype chain
         const actualProto = new.target.prototype;
@@ -269,10 +277,17 @@ export class ResponseError extends Error {
     }
 }
 
+// `cause` is declared through an interface so that it stays compatible with lib targets
+// that already declare `Error.cause` (ES2022+) as well as the ones that do not
+export interface FetchError {
+    cause: Error;
+}
+
 export class FetchError extends Error {
     override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
+    constructor(cause: Error, msg?: string) {
         super(msg);
+        this.cause = cause;
 
         // restore prototype chain
         const actualProto = new.target.prototype;
@@ -284,8 +299,10 @@ export class FetchError extends Error {
 
 export class RequiredError extends Error {
     override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
+    field: string;
+    constructor(field: string, msg?: string) {
         super(msg);
+        this.field = field;
 
         // restore prototype chain
         const actualProto = new.target.prototype;
@@ -422,7 +439,13 @@ export interface ResponseTransformer<T> {
 }
 
 export class JSONApiResponse<T> {
-    constructor(public raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {}
+    raw: Response;
+    private transformer: ResponseTransformer<T>;
+
+    constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+        this.raw = raw;
+        this.transformer = transformer;
+    }
 
     async value(): Promise<T> {
         return this.transformer(await this.raw.json());
@@ -430,7 +453,11 @@ export class JSONApiResponse<T> {
 }
 
 export class VoidApiResponse {
-    constructor(public raw: Response) {}
+    raw: Response;
+
+    constructor(raw: Response) {
+        this.raw = raw;
+    }
 
     async value(): Promise<void> {
         return undefined;
@@ -438,7 +465,11 @@ export class VoidApiResponse {
 }
 
 export class BlobApiResponse {
-    constructor(public raw: Response) {}
+    raw: Response;
+
+    constructor(raw: Response) {
+        this.raw = raw;
+    }
 
     async value(): Promise<Blob> {
         return await this.raw.blob();
@@ -446,7 +477,11 @@ export class BlobApiResponse {
 }
 
 export class TextApiResponse {
-    constructor(public raw: Response) {}
+    raw: Response;
+
+    constructor(raw: Response) {
+        this.raw = raw;
+    }
 
     async value(): Promise<string> {
         return await this.raw.text();

--- a/samples/client/petstore/typescript-fetch/builds/default/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/runtime.ts
@@ -28,7 +28,11 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+    private configuration: ConfigurationParameters;
+
+    constructor(configuration: ConfigurationParameters = {}) {
+        this.configuration = configuration;
+    }
 
     set config(configuration: Configuration) {
         this.configuration = configuration;
@@ -92,8 +96,10 @@ export class BaseAPI {
 
     private static readonly jsonRegex = /^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$/i;
     private middleware: Middleware[];
+    protected configuration: Configuration;
 
-    constructor(protected configuration = DefaultConfig) {
+    constructor(configuration: Configuration = DefaultConfig) {
+        this.configuration = configuration;
         this.middleware = configuration.middleware;
     }
 
@@ -258,8 +264,10 @@ function isFormData(value: any): value is FormData {
 
 export class ResponseError extends Error {
     override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
+    response: Response;
+    constructor(response: Response, msg?: string) {
         super(msg);
+        this.response = response;
 
         // restore prototype chain
         const actualProto = new.target.prototype;
@@ -269,10 +277,17 @@ export class ResponseError extends Error {
     }
 }
 
+// `cause` is declared through an interface so that it stays compatible with lib targets
+// that already declare `Error.cause` (ES2022+) as well as the ones that do not
+export interface FetchError {
+    cause: Error;
+}
+
 export class FetchError extends Error {
     override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
+    constructor(cause: Error, msg?: string) {
         super(msg);
+        this.cause = cause;
 
         // restore prototype chain
         const actualProto = new.target.prototype;
@@ -284,8 +299,10 @@ export class FetchError extends Error {
 
 export class RequiredError extends Error {
     override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
+    field: string;
+    constructor(field: string, msg?: string) {
         super(msg);
+        this.field = field;
 
         // restore prototype chain
         const actualProto = new.target.prototype;
@@ -422,7 +439,13 @@ export interface ResponseTransformer<T> {
 }
 
 export class JSONApiResponse<T> {
-    constructor(public raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {}
+    raw: Response;
+    private transformer: ResponseTransformer<T>;
+
+    constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+        this.raw = raw;
+        this.transformer = transformer;
+    }
 
     async value(): Promise<T> {
         return this.transformer(await this.raw.json());
@@ -430,7 +453,11 @@ export class JSONApiResponse<T> {
 }
 
 export class VoidApiResponse {
-    constructor(public raw: Response) {}
+    raw: Response;
+
+    constructor(raw: Response) {
+        this.raw = raw;
+    }
 
     async value(): Promise<void> {
         return undefined;
@@ -438,7 +465,11 @@ export class VoidApiResponse {
 }
 
 export class BlobApiResponse {
-    constructor(public raw: Response) {}
+    raw: Response;
+
+    constructor(raw: Response) {
+        this.raw = raw;
+    }
 
     async value(): Promise<Blob> {
         return await this.raw.blob();
@@ -446,7 +477,11 @@ export class BlobApiResponse {
 }
 
 export class TextApiResponse {
-    constructor(public raw: Response) {}
+    raw: Response;
+
+    constructor(raw: Response) {
+        this.raw = raw;
+    }
 
     async value(): Promise<string> {
         return await this.raw.text();

--- a/samples/client/petstore/typescript-fetch/builds/enum/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/runtime.ts
@@ -28,7 +28,11 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+    private configuration: ConfigurationParameters;
+
+    constructor(configuration: ConfigurationParameters = {}) {
+        this.configuration = configuration;
+    }
 
     set config(configuration: Configuration) {
         this.configuration = configuration;
@@ -92,8 +96,10 @@ export class BaseAPI {
 
     private static readonly jsonRegex = /^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$/i;
     private middleware: Middleware[];
+    protected configuration: Configuration;
 
-    constructor(protected configuration = DefaultConfig) {
+    constructor(configuration: Configuration = DefaultConfig) {
+        this.configuration = configuration;
         this.middleware = configuration.middleware;
     }
 
@@ -258,8 +264,10 @@ function isFormData(value: any): value is FormData {
 
 export class ResponseError extends Error {
     override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
+    response: Response;
+    constructor(response: Response, msg?: string) {
         super(msg);
+        this.response = response;
 
         // restore prototype chain
         const actualProto = new.target.prototype;
@@ -269,10 +277,17 @@ export class ResponseError extends Error {
     }
 }
 
+// `cause` is declared through an interface so that it stays compatible with lib targets
+// that already declare `Error.cause` (ES2022+) as well as the ones that do not
+export interface FetchError {
+    cause: Error;
+}
+
 export class FetchError extends Error {
     override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
+    constructor(cause: Error, msg?: string) {
         super(msg);
+        this.cause = cause;
 
         // restore prototype chain
         const actualProto = new.target.prototype;
@@ -284,8 +299,10 @@ export class FetchError extends Error {
 
 export class RequiredError extends Error {
     override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
+    field: string;
+    constructor(field: string, msg?: string) {
         super(msg);
+        this.field = field;
 
         // restore prototype chain
         const actualProto = new.target.prototype;
@@ -422,7 +439,13 @@ export interface ResponseTransformer<T> {
 }
 
 export class JSONApiResponse<T> {
-    constructor(public raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {}
+    raw: Response;
+    private transformer: ResponseTransformer<T>;
+
+    constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+        this.raw = raw;
+        this.transformer = transformer;
+    }
 
     async value(): Promise<T> {
         return this.transformer(await this.raw.json());
@@ -430,7 +453,11 @@ export class JSONApiResponse<T> {
 }
 
 export class VoidApiResponse {
-    constructor(public raw: Response) {}
+    raw: Response;
+
+    constructor(raw: Response) {
+        this.raw = raw;
+    }
 
     async value(): Promise<void> {
         return undefined;
@@ -438,7 +465,11 @@ export class VoidApiResponse {
 }
 
 export class BlobApiResponse {
-    constructor(public raw: Response) {}
+    raw: Response;
+
+    constructor(raw: Response) {
+        this.raw = raw;
+    }
 
     async value(): Promise<Blob> {
         return await this.raw.blob();
@@ -446,7 +477,11 @@ export class BlobApiResponse {
 }
 
 export class TextApiResponse {
-    constructor(public raw: Response) {}
+    raw: Response;
+
+    constructor(raw: Response) {
+        this.raw = raw;
+    }
 
     async value(): Promise<string> {
         return await this.raw.text();

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/runtime.ts
@@ -28,7 +28,11 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+    private configuration: ConfigurationParameters;
+
+    constructor(configuration: ConfigurationParameters = {}) {
+        this.configuration = configuration;
+    }
 
     set config(configuration: Configuration) {
         this.configuration = configuration;
@@ -92,8 +96,10 @@ export class BaseAPI {
 
     private static readonly jsonRegex = /^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$/i;
     private middleware: Middleware[];
+    protected configuration: Configuration;
 
-    constructor(protected configuration = DefaultConfig) {
+    constructor(configuration: Configuration = DefaultConfig) {
+        this.configuration = configuration;
         this.middleware = configuration.middleware;
     }
 
@@ -258,8 +264,10 @@ function isFormData(value: any): value is FormData {
 
 export class ResponseError extends Error {
     override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
+    response: Response;
+    constructor(response: Response, msg?: string) {
         super(msg);
+        this.response = response;
 
         // restore prototype chain
         const actualProto = new.target.prototype;
@@ -269,10 +277,17 @@ export class ResponseError extends Error {
     }
 }
 
+// `cause` is declared through an interface so that it stays compatible with lib targets
+// that already declare `Error.cause` (ES2022+) as well as the ones that do not
+export interface FetchError {
+    cause: Error;
+}
+
 export class FetchError extends Error {
     override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
+    constructor(cause: Error, msg?: string) {
         super(msg);
+        this.cause = cause;
 
         // restore prototype chain
         const actualProto = new.target.prototype;
@@ -284,8 +299,10 @@ export class FetchError extends Error {
 
 export class RequiredError extends Error {
     override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
+    field: string;
+    constructor(field: string, msg?: string) {
         super(msg);
+        this.field = field;
 
         // restore prototype chain
         const actualProto = new.target.prototype;
@@ -422,7 +439,13 @@ export interface ResponseTransformer<T> {
 }
 
 export class JSONApiResponse<T> {
-    constructor(public raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {}
+    raw: Response;
+    private transformer: ResponseTransformer<T>;
+
+    constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+        this.raw = raw;
+        this.transformer = transformer;
+    }
 
     async value(): Promise<T> {
         return this.transformer(await this.raw.json());
@@ -430,7 +453,11 @@ export class JSONApiResponse<T> {
 }
 
 export class VoidApiResponse {
-    constructor(public raw: Response) {}
+    raw: Response;
+
+    constructor(raw: Response) {
+        this.raw = raw;
+    }
 
     async value(): Promise<void> {
         return undefined;
@@ -438,7 +465,11 @@ export class VoidApiResponse {
 }
 
 export class BlobApiResponse {
-    constructor(public raw: Response) {}
+    raw: Response;
+
+    constructor(raw: Response) {
+        this.raw = raw;
+    }
 
     async value(): Promise<Blob> {
         return await this.raw.blob();
@@ -446,7 +477,11 @@ export class BlobApiResponse {
 }
 
 export class TextApiResponse {
-    constructor(public raw: Response) {}
+    raw: Response;
+
+    constructor(raw: Response) {
+        this.raw = raw;
+    }
 
     async value(): Promise<string> {
         return await this.raw.text();

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/runtime.ts
@@ -28,7 +28,11 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+    private configuration: ConfigurationParameters;
+
+    constructor(configuration: ConfigurationParameters = {}) {
+        this.configuration = configuration;
+    }
 
     set config(configuration: Configuration) {
         this.configuration = configuration;
@@ -92,8 +96,10 @@ export class BaseAPI {
 
     private static readonly jsonRegex = /^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$/i;
     private middleware: Middleware[];
+    protected configuration: Configuration;
 
-    constructor(protected configuration = DefaultConfig) {
+    constructor(configuration: Configuration = DefaultConfig) {
+        this.configuration = configuration;
         this.middleware = configuration.middleware;
     }
 
@@ -258,8 +264,10 @@ function isFormData(value: any): value is FormData {
 
 export class ResponseError extends Error {
     override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
+    response: Response;
+    constructor(response: Response, msg?: string) {
         super(msg);
+        this.response = response;
 
         // restore prototype chain
         const actualProto = new.target.prototype;
@@ -269,10 +277,17 @@ export class ResponseError extends Error {
     }
 }
 
+// `cause` is declared through an interface so that it stays compatible with lib targets
+// that already declare `Error.cause` (ES2022+) as well as the ones that do not
+export interface FetchError {
+    cause: Error;
+}
+
 export class FetchError extends Error {
     override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
+    constructor(cause: Error, msg?: string) {
         super(msg);
+        this.cause = cause;
 
         // restore prototype chain
         const actualProto = new.target.prototype;
@@ -284,8 +299,10 @@ export class FetchError extends Error {
 
 export class RequiredError extends Error {
     override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
+    field: string;
+    constructor(field: string, msg?: string) {
         super(msg);
+        this.field = field;
 
         // restore prototype chain
         const actualProto = new.target.prototype;
@@ -422,7 +439,13 @@ export interface ResponseTransformer<T> {
 }
 
 export class JSONApiResponse<T> {
-    constructor(public raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {}
+    raw: Response;
+    private transformer: ResponseTransformer<T>;
+
+    constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+        this.raw = raw;
+        this.transformer = transformer;
+    }
 
     async value(): Promise<T> {
         return this.transformer(await this.raw.json());
@@ -430,7 +453,11 @@ export class JSONApiResponse<T> {
 }
 
 export class VoidApiResponse {
-    constructor(public raw: Response) {}
+    raw: Response;
+
+    constructor(raw: Response) {
+        this.raw = raw;
+    }
 
     async value(): Promise<void> {
         return undefined;
@@ -438,7 +465,11 @@ export class VoidApiResponse {
 }
 
 export class BlobApiResponse {
-    constructor(public raw: Response) {}
+    raw: Response;
+
+    constructor(raw: Response) {
+        this.raw = raw;
+    }
 
     async value(): Promise<Blob> {
         return await this.raw.blob();
@@ -446,7 +477,11 @@ export class BlobApiResponse {
 }
 
 export class TextApiResponse {
-    constructor(public raw: Response) {}
+    raw: Response;
+
+    constructor(raw: Response) {
+        this.raw = raw;
+    }
 
     async value(): Promise<string> {
         return await this.raw.text();

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/runtime.ts
@@ -28,7 +28,11 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+    private configuration: ConfigurationParameters;
+
+    constructor(configuration: ConfigurationParameters = {}) {
+        this.configuration = configuration;
+    }
 
     set config(configuration: Configuration) {
         this.configuration = configuration;
@@ -92,8 +96,10 @@ export class BaseAPI {
 
     private static readonly jsonRegex = /^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$/i;
     private middleware: Middleware[];
+    protected configuration: Configuration;
 
-    constructor(protected configuration = DefaultConfig) {
+    constructor(configuration: Configuration = DefaultConfig) {
+        this.configuration = configuration;
         this.middleware = configuration.middleware;
     }
 
@@ -258,8 +264,10 @@ function isFormData(value: any): value is FormData {
 
 export class ResponseError extends Error {
     override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
+    response: Response;
+    constructor(response: Response, msg?: string) {
         super(msg);
+        this.response = response;
 
         // restore prototype chain
         const actualProto = new.target.prototype;
@@ -269,10 +277,17 @@ export class ResponseError extends Error {
     }
 }
 
+// `cause` is declared through an interface so that it stays compatible with lib targets
+// that already declare `Error.cause` (ES2022+) as well as the ones that do not
+export interface FetchError {
+    cause: Error;
+}
+
 export class FetchError extends Error {
     override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
+    constructor(cause: Error, msg?: string) {
         super(msg);
+        this.cause = cause;
 
         // restore prototype chain
         const actualProto = new.target.prototype;
@@ -284,8 +299,10 @@ export class FetchError extends Error {
 
 export class RequiredError extends Error {
     override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
+    field: string;
+    constructor(field: string, msg?: string) {
         super(msg);
+        this.field = field;
 
         // restore prototype chain
         const actualProto = new.target.prototype;
@@ -422,7 +439,13 @@ export interface ResponseTransformer<T> {
 }
 
 export class JSONApiResponse<T> {
-    constructor(public raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {}
+    raw: Response;
+    private transformer: ResponseTransformer<T>;
+
+    constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+        this.raw = raw;
+        this.transformer = transformer;
+    }
 
     async value(): Promise<T> {
         return this.transformer(await this.raw.json());
@@ -430,7 +453,11 @@ export class JSONApiResponse<T> {
 }
 
 export class VoidApiResponse {
-    constructor(public raw: Response) {}
+    raw: Response;
+
+    constructor(raw: Response) {
+        this.raw = raw;
+    }
 
     async value(): Promise<void> {
         return undefined;
@@ -438,7 +465,11 @@ export class VoidApiResponse {
 }
 
 export class BlobApiResponse {
-    constructor(public raw: Response) {}
+    raw: Response;
+
+    constructor(raw: Response) {
+        this.raw = raw;
+    }
 
     async value(): Promise<Blob> {
         return await this.raw.blob();
@@ -446,7 +477,11 @@ export class BlobApiResponse {
 }
 
 export class TextApiResponse {
-    constructor(public raw: Response) {}
+    raw: Response;
+
+    constructor(raw: Response) {
+        this.raw = raw;
+    }
 
     async value(): Promise<string> {
         return await this.raw.text();

--- a/samples/client/petstore/typescript-fetch/builds/oneOf/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/oneOf/runtime.ts
@@ -28,7 +28,11 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+    private configuration: ConfigurationParameters;
+
+    constructor(configuration: ConfigurationParameters = {}) {
+        this.configuration = configuration;
+    }
 
     set config(configuration: Configuration) {
         this.configuration = configuration;
@@ -92,8 +96,10 @@ export class BaseAPI {
 
     private static readonly jsonRegex = /^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$/i;
     private middleware: Middleware[];
+    protected configuration: Configuration;
 
-    constructor(protected configuration = DefaultConfig) {
+    constructor(configuration: Configuration = DefaultConfig) {
+        this.configuration = configuration;
         this.middleware = configuration.middleware;
     }
 
@@ -258,8 +264,10 @@ function isFormData(value: any): value is FormData {
 
 export class ResponseError extends Error {
     override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
+    response: Response;
+    constructor(response: Response, msg?: string) {
         super(msg);
+        this.response = response;
 
         // restore prototype chain
         const actualProto = new.target.prototype;
@@ -269,10 +277,17 @@ export class ResponseError extends Error {
     }
 }
 
+// `cause` is declared through an interface so that it stays compatible with lib targets
+// that already declare `Error.cause` (ES2022+) as well as the ones that do not
+export interface FetchError {
+    cause: Error;
+}
+
 export class FetchError extends Error {
     override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
+    constructor(cause: Error, msg?: string) {
         super(msg);
+        this.cause = cause;
 
         // restore prototype chain
         const actualProto = new.target.prototype;
@@ -284,8 +299,10 @@ export class FetchError extends Error {
 
 export class RequiredError extends Error {
     override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
+    field: string;
+    constructor(field: string, msg?: string) {
         super(msg);
+        this.field = field;
 
         // restore prototype chain
         const actualProto = new.target.prototype;
@@ -422,7 +439,13 @@ export interface ResponseTransformer<T> {
 }
 
 export class JSONApiResponse<T> {
-    constructor(public raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {}
+    raw: Response;
+    private transformer: ResponseTransformer<T>;
+
+    constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+        this.raw = raw;
+        this.transformer = transformer;
+    }
 
     async value(): Promise<T> {
         return this.transformer(await this.raw.json());
@@ -430,7 +453,11 @@ export class JSONApiResponse<T> {
 }
 
 export class VoidApiResponse {
-    constructor(public raw: Response) {}
+    raw: Response;
+
+    constructor(raw: Response) {
+        this.raw = raw;
+    }
 
     async value(): Promise<void> {
         return undefined;
@@ -438,7 +465,11 @@ export class VoidApiResponse {
 }
 
 export class BlobApiResponse {
-    constructor(public raw: Response) {}
+    raw: Response;
+
+    constructor(raw: Response) {
+        this.raw = raw;
+    }
 
     async value(): Promise<Blob> {
         return await this.raw.blob();
@@ -446,7 +477,11 @@ export class BlobApiResponse {
 }
 
 export class TextApiResponse {
-    constructor(public raw: Response) {}
+    raw: Response;
+
+    constructor(raw: Response) {
+        this.raw = raw;
+    }
 
     async value(): Promise<string> {
         return await this.raw.text();

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/runtime.ts
@@ -28,7 +28,11 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+    private configuration: ConfigurationParameters;
+
+    constructor(configuration: ConfigurationParameters = {}) {
+        this.configuration = configuration;
+    }
 
     set config(configuration: Configuration) {
         this.configuration = configuration;
@@ -92,8 +96,10 @@ export class BaseAPI {
 
     private static readonly jsonRegex = /^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$/i;
     private middleware: Middleware[];
+    protected configuration: Configuration;
 
-    constructor(protected configuration = DefaultConfig) {
+    constructor(configuration: Configuration = DefaultConfig) {
+        this.configuration = configuration;
         this.middleware = configuration.middleware;
     }
 
@@ -258,8 +264,10 @@ function isFormData(value: any): value is FormData {
 
 export class ResponseError extends Error {
     override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
+    response: Response;
+    constructor(response: Response, msg?: string) {
         super(msg);
+        this.response = response;
 
         // restore prototype chain
         const actualProto = new.target.prototype;
@@ -269,10 +277,17 @@ export class ResponseError extends Error {
     }
 }
 
+// `cause` is declared through an interface so that it stays compatible with lib targets
+// that already declare `Error.cause` (ES2022+) as well as the ones that do not
+export interface FetchError {
+    cause: Error;
+}
+
 export class FetchError extends Error {
     override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
+    constructor(cause: Error, msg?: string) {
         super(msg);
+        this.cause = cause;
 
         // restore prototype chain
         const actualProto = new.target.prototype;
@@ -284,8 +299,10 @@ export class FetchError extends Error {
 
 export class RequiredError extends Error {
     override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
+    field: string;
+    constructor(field: string, msg?: string) {
         super(msg);
+        this.field = field;
 
         // restore prototype chain
         const actualProto = new.target.prototype;
@@ -422,7 +439,13 @@ export interface ResponseTransformer<T> {
 }
 
 export class JSONApiResponse<T> {
-    constructor(public raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {}
+    raw: Response;
+    private transformer: ResponseTransformer<T>;
+
+    constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+        this.raw = raw;
+        this.transformer = transformer;
+    }
 
     async value(): Promise<T> {
         return this.transformer(await this.raw.json());
@@ -430,7 +453,11 @@ export class JSONApiResponse<T> {
 }
 
 export class VoidApiResponse {
-    constructor(public raw: Response) {}
+    raw: Response;
+
+    constructor(raw: Response) {
+        this.raw = raw;
+    }
 
     async value(): Promise<void> {
         return undefined;
@@ -438,7 +465,11 @@ export class VoidApiResponse {
 }
 
 export class BlobApiResponse {
-    constructor(public raw: Response) {}
+    raw: Response;
+
+    constructor(raw: Response) {
+        this.raw = raw;
+    }
 
     async value(): Promise<Blob> {
         return await this.raw.blob();
@@ -446,7 +477,11 @@ export class BlobApiResponse {
 }
 
 export class TextApiResponse {
-    constructor(public raw: Response) {}
+    raw: Response;
+
+    constructor(raw: Response) {
+        this.raw = raw;
+    }
 
     async value(): Promise<string> {
         return await this.raw.text();

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/runtime.ts
@@ -28,7 +28,11 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+    private configuration: ConfigurationParameters;
+
+    constructor(configuration: ConfigurationParameters = {}) {
+        this.configuration = configuration;
+    }
 
     set config(configuration: Configuration) {
         this.configuration = configuration;
@@ -92,8 +96,10 @@ export class BaseAPI {
 
     private static readonly jsonRegex = /^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$/i;
     private middleware: Middleware[];
+    protected configuration: Configuration;
 
-    constructor(protected configuration = DefaultConfig) {
+    constructor(configuration: Configuration = DefaultConfig) {
+        this.configuration = configuration;
         this.middleware = configuration.middleware;
     }
 
@@ -258,8 +264,10 @@ function isFormData(value: any): value is FormData {
 
 export class ResponseError extends Error {
     override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
+    response: Response;
+    constructor(response: Response, msg?: string) {
         super(msg);
+        this.response = response;
 
         // restore prototype chain
         const actualProto = new.target.prototype;
@@ -269,10 +277,17 @@ export class ResponseError extends Error {
     }
 }
 
+// `cause` is declared through an interface so that it stays compatible with lib targets
+// that already declare `Error.cause` (ES2022+) as well as the ones that do not
+export interface FetchError {
+    cause: Error;
+}
+
 export class FetchError extends Error {
     override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
+    constructor(cause: Error, msg?: string) {
         super(msg);
+        this.cause = cause;
 
         // restore prototype chain
         const actualProto = new.target.prototype;
@@ -284,8 +299,10 @@ export class FetchError extends Error {
 
 export class RequiredError extends Error {
     override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
+    field: string;
+    constructor(field: string, msg?: string) {
         super(msg);
+        this.field = field;
 
         // restore prototype chain
         const actualProto = new.target.prototype;
@@ -422,7 +439,13 @@ export interface ResponseTransformer<T> {
 }
 
 export class JSONApiResponse<T> {
-    constructor(public raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {}
+    raw: Response;
+    private transformer: ResponseTransformer<T>;
+
+    constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+        this.raw = raw;
+        this.transformer = transformer;
+    }
 
     async value(): Promise<T> {
         return this.transformer(await this.raw.json());
@@ -430,7 +453,11 @@ export class JSONApiResponse<T> {
 }
 
 export class VoidApiResponse {
-    constructor(public raw: Response) {}
+    raw: Response;
+
+    constructor(raw: Response) {
+        this.raw = raw;
+    }
 
     async value(): Promise<void> {
         return undefined;
@@ -438,7 +465,11 @@ export class VoidApiResponse {
 }
 
 export class BlobApiResponse {
-    constructor(public raw: Response) {}
+    raw: Response;
+
+    constructor(raw: Response) {
+        this.raw = raw;
+    }
 
     async value(): Promise<Blob> {
         return await this.raw.blob();
@@ -446,7 +477,11 @@ export class BlobApiResponse {
 }
 
 export class TextApiResponse {
-    constructor(public raw: Response) {}
+    raw: Response;
+
+    constructor(raw: Response) {
+        this.raw = raw;
+    }
 
     async value(): Promise<string> {
         return await this.raw.text();

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/runtime.ts
@@ -28,7 +28,11 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+    private configuration: ConfigurationParameters;
+
+    constructor(configuration: ConfigurationParameters = {}) {
+        this.configuration = configuration;
+    }
 
     set config(configuration: Configuration) {
         this.configuration = configuration;
@@ -92,8 +96,10 @@ export class BaseAPI {
 
     private static readonly jsonRegex = /^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$/i;
     private middleware: Middleware[];
+    protected configuration: Configuration;
 
-    constructor(protected configuration = DefaultConfig) {
+    constructor(configuration: Configuration = DefaultConfig) {
+        this.configuration = configuration;
         this.middleware = configuration.middleware;
     }
 
@@ -258,8 +264,10 @@ function isFormData(value: any): value is FormData {
 
 export class ResponseError extends Error {
     override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
+    response: Response;
+    constructor(response: Response, msg?: string) {
         super(msg);
+        this.response = response;
 
         // restore prototype chain
         const actualProto = new.target.prototype;
@@ -269,10 +277,17 @@ export class ResponseError extends Error {
     }
 }
 
+// `cause` is declared through an interface so that it stays compatible with lib targets
+// that already declare `Error.cause` (ES2022+) as well as the ones that do not
+export interface FetchError {
+    cause: Error;
+}
+
 export class FetchError extends Error {
     override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
+    constructor(cause: Error, msg?: string) {
         super(msg);
+        this.cause = cause;
 
         // restore prototype chain
         const actualProto = new.target.prototype;
@@ -284,8 +299,10 @@ export class FetchError extends Error {
 
 export class RequiredError extends Error {
     override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
+    field: string;
+    constructor(field: string, msg?: string) {
         super(msg);
+        this.field = field;
 
         // restore prototype chain
         const actualProto = new.target.prototype;
@@ -422,7 +439,13 @@ export interface ResponseTransformer<T> {
 }
 
 export class JSONApiResponse<T> {
-    constructor(public raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {}
+    raw: Response;
+    private transformer: ResponseTransformer<T>;
+
+    constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+        this.raw = raw;
+        this.transformer = transformer;
+    }
 
     async value(): Promise<T> {
         return this.transformer(await this.raw.json());
@@ -430,7 +453,11 @@ export class JSONApiResponse<T> {
 }
 
 export class VoidApiResponse {
-    constructor(public raw: Response) {}
+    raw: Response;
+
+    constructor(raw: Response) {
+        this.raw = raw;
+    }
 
     async value(): Promise<void> {
         return undefined;
@@ -438,7 +465,11 @@ export class VoidApiResponse {
 }
 
 export class BlobApiResponse {
-    constructor(public raw: Response) {}
+    raw: Response;
+
+    constructor(raw: Response) {
+        this.raw = raw;
+    }
 
     async value(): Promise<Blob> {
         return await this.raw.blob();
@@ -446,7 +477,11 @@ export class BlobApiResponse {
 }
 
 export class TextApiResponse {
-    constructor(public raw: Response) {}
+    raw: Response;
+
+    constructor(raw: Response) {
+        this.raw = raw;
+    }
 
     async value(): Promise<string> {
         return await this.raw.text();

--- a/samples/client/petstore/typescript-fetch/builds/validation-attributes/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/validation-attributes/runtime.ts
@@ -28,7 +28,11 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+    private configuration: ConfigurationParameters;
+
+    constructor(configuration: ConfigurationParameters = {}) {
+        this.configuration = configuration;
+    }
 
     set config(configuration: Configuration) {
         this.configuration = configuration;
@@ -92,8 +96,10 @@ export class BaseAPI {
 
     private static readonly jsonRegex = /^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$/i;
     private middleware: Middleware[];
+    protected configuration: Configuration;
 
-    constructor(protected configuration = DefaultConfig) {
+    constructor(configuration: Configuration = DefaultConfig) {
+        this.configuration = configuration;
         this.middleware = configuration.middleware;
     }
 
@@ -258,8 +264,10 @@ function isFormData(value: any): value is FormData {
 
 export class ResponseError extends Error {
     override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
+    response: Response;
+    constructor(response: Response, msg?: string) {
         super(msg);
+        this.response = response;
 
         // restore prototype chain
         const actualProto = new.target.prototype;
@@ -269,10 +277,17 @@ export class ResponseError extends Error {
     }
 }
 
+// `cause` is declared through an interface so that it stays compatible with lib targets
+// that already declare `Error.cause` (ES2022+) as well as the ones that do not
+export interface FetchError {
+    cause: Error;
+}
+
 export class FetchError extends Error {
     override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
+    constructor(cause: Error, msg?: string) {
         super(msg);
+        this.cause = cause;
 
         // restore prototype chain
         const actualProto = new.target.prototype;
@@ -284,8 +299,10 @@ export class FetchError extends Error {
 
 export class RequiredError extends Error {
     override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
+    field: string;
+    constructor(field: string, msg?: string) {
         super(msg);
+        this.field = field;
 
         // restore prototype chain
         const actualProto = new.target.prototype;
@@ -422,7 +439,13 @@ export interface ResponseTransformer<T> {
 }
 
 export class JSONApiResponse<T> {
-    constructor(public raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {}
+    raw: Response;
+    private transformer: ResponseTransformer<T>;
+
+    constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+        this.raw = raw;
+        this.transformer = transformer;
+    }
 
     async value(): Promise<T> {
         return this.transformer(await this.raw.json());
@@ -430,7 +453,11 @@ export class JSONApiResponse<T> {
 }
 
 export class VoidApiResponse {
-    constructor(public raw: Response) {}
+    raw: Response;
+
+    constructor(raw: Response) {
+        this.raw = raw;
+    }
 
     async value(): Promise<void> {
         return undefined;
@@ -438,7 +465,11 @@ export class VoidApiResponse {
 }
 
 export class BlobApiResponse {
-    constructor(public raw: Response) {}
+    raw: Response;
+
+    constructor(raw: Response) {
+        this.raw = raw;
+    }
 
     async value(): Promise<Blob> {
         return await this.raw.blob();
@@ -446,7 +477,11 @@ export class BlobApiResponse {
 }
 
 export class TextApiResponse {
-    constructor(public raw: Response) {}
+    raw: Response;
+
+    constructor(raw: Response) {
+        this.raw = raw;
+    }
 
     async value(): Promise<string> {
         return await this.raw.text();

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/runtime.ts
@@ -28,7 +28,11 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+    private configuration: ConfigurationParameters;
+
+    constructor(configuration: ConfigurationParameters = {}) {
+        this.configuration = configuration;
+    }
 
     set config(configuration: Configuration) {
         this.configuration = configuration;
@@ -92,8 +96,10 @@ export class BaseAPI {
 
     private static readonly jsonRegex = /^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$/i;
     private middleware: Middleware[];
+    protected configuration: Configuration;
 
-    constructor(protected configuration = DefaultConfig) {
+    constructor(configuration: Configuration = DefaultConfig) {
+        this.configuration = configuration;
         this.middleware = configuration.middleware;
     }
 
@@ -258,8 +264,10 @@ function isFormData(value: any): value is FormData {
 
 export class ResponseError extends Error {
     override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
+    response: Response;
+    constructor(response: Response, msg?: string) {
         super(msg);
+        this.response = response;
 
         // restore prototype chain
         const actualProto = new.target.prototype;
@@ -269,10 +277,17 @@ export class ResponseError extends Error {
     }
 }
 
+// `cause` is declared through an interface so that it stays compatible with lib targets
+// that already declare `Error.cause` (ES2022+) as well as the ones that do not
+export interface FetchError {
+    cause: Error;
+}
+
 export class FetchError extends Error {
     override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
+    constructor(cause: Error, msg?: string) {
         super(msg);
+        this.cause = cause;
 
         // restore prototype chain
         const actualProto = new.target.prototype;
@@ -284,8 +299,10 @@ export class FetchError extends Error {
 
 export class RequiredError extends Error {
     override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
+    field: string;
+    constructor(field: string, msg?: string) {
         super(msg);
+        this.field = field;
 
         // restore prototype chain
         const actualProto = new.target.prototype;
@@ -422,7 +439,13 @@ export interface ResponseTransformer<T> {
 }
 
 export class JSONApiResponse<T> {
-    constructor(public raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {}
+    raw: Response;
+    private transformer: ResponseTransformer<T>;
+
+    constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+        this.raw = raw;
+        this.transformer = transformer;
+    }
 
     async value(): Promise<T> {
         return this.transformer(await this.raw.json());
@@ -430,7 +453,11 @@ export class JSONApiResponse<T> {
 }
 
 export class VoidApiResponse {
-    constructor(public raw: Response) {}
+    raw: Response;
+
+    constructor(raw: Response) {
+        this.raw = raw;
+    }
 
     async value(): Promise<void> {
         return undefined;
@@ -438,7 +465,11 @@ export class VoidApiResponse {
 }
 
 export class BlobApiResponse {
-    constructor(public raw: Response) {}
+    raw: Response;
+
+    constructor(raw: Response) {
+        this.raw = raw;
+    }
 
     async value(): Promise<Blob> {
         return await this.raw.blob();
@@ -446,7 +477,11 @@ export class BlobApiResponse {
 }
 
 export class TextApiResponse {
-    constructor(public raw: Response) {}
+    raw: Response;
+
+    constructor(raw: Response) {
+        this.raw = raw;
+    }
 
     async value(): Promise<string> {
         return await this.raw.text();

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/runtime.ts
@@ -28,7 +28,11 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+    private configuration: ConfigurationParameters;
+
+    constructor(configuration: ConfigurationParameters = {}) {
+        this.configuration = configuration;
+    }
 
     set config(configuration: Configuration) {
         this.configuration = configuration;
@@ -92,8 +96,10 @@ export class BaseAPI {
 
     private static readonly jsonRegex = /^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$/i;
     private middleware: Middleware[];
+    protected configuration: Configuration;
 
-    constructor(protected configuration = DefaultConfig) {
+    constructor(configuration: Configuration = DefaultConfig) {
+        this.configuration = configuration;
         this.middleware = configuration.middleware;
     }
 
@@ -258,8 +264,10 @@ function isFormData(value: any): value is FormData {
 
 export class ResponseError extends Error {
     override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
+    response: Response;
+    constructor(response: Response, msg?: string) {
         super(msg);
+        this.response = response;
 
         // restore prototype chain
         const actualProto = new.target.prototype;
@@ -269,10 +277,17 @@ export class ResponseError extends Error {
     }
 }
 
+// `cause` is declared through an interface so that it stays compatible with lib targets
+// that already declare `Error.cause` (ES2022+) as well as the ones that do not
+export interface FetchError {
+    cause: Error;
+}
+
 export class FetchError extends Error {
     override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
+    constructor(cause: Error, msg?: string) {
         super(msg);
+        this.cause = cause;
 
         // restore prototype chain
         const actualProto = new.target.prototype;
@@ -284,8 +299,10 @@ export class FetchError extends Error {
 
 export class RequiredError extends Error {
     override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
+    field: string;
+    constructor(field: string, msg?: string) {
         super(msg);
+        this.field = field;
 
         // restore prototype chain
         const actualProto = new.target.prototype;
@@ -422,7 +439,13 @@ export interface ResponseTransformer<T> {
 }
 
 export class JSONApiResponse<T> {
-    constructor(public raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {}
+    raw: Response;
+    private transformer: ResponseTransformer<T>;
+
+    constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+        this.raw = raw;
+        this.transformer = transformer;
+    }
 
     async value(): Promise<T> {
         return this.transformer(await this.raw.json());
@@ -430,7 +453,11 @@ export class JSONApiResponse<T> {
 }
 
 export class VoidApiResponse {
-    constructor(public raw: Response) {}
+    raw: Response;
+
+    constructor(raw: Response) {
+        this.raw = raw;
+    }
 
     async value(): Promise<void> {
         return undefined;
@@ -438,7 +465,11 @@ export class VoidApiResponse {
 }
 
 export class BlobApiResponse {
-    constructor(public raw: Response) {}
+    raw: Response;
+
+    constructor(raw: Response) {
+        this.raw = raw;
+    }
 
     async value(): Promise<Blob> {
         return await this.raw.blob();
@@ -446,7 +477,11 @@ export class BlobApiResponse {
 }
 
 export class TextApiResponse {
-    constructor(public raw: Response) {}
+    raw: Response;
+
+    constructor(raw: Response) {
+        this.raw = raw;
+    }
 
     async value(): Promise<string> {
         return await this.raw.text();

--- a/samples/client/petstore/typescript-fetch/builds/with-string-enums/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-string-enums/runtime.ts
@@ -28,7 +28,11 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+    private configuration: ConfigurationParameters;
+
+    constructor(configuration: ConfigurationParameters = {}) {
+        this.configuration = configuration;
+    }
 
     set config(configuration: Configuration) {
         this.configuration = configuration;
@@ -92,8 +96,10 @@ export class BaseAPI {
 
     private static readonly jsonRegex = /^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$/i;
     private middleware: Middleware[];
+    protected configuration: Configuration;
 
-    constructor(protected configuration = DefaultConfig) {
+    constructor(configuration: Configuration = DefaultConfig) {
+        this.configuration = configuration;
         this.middleware = configuration.middleware;
     }
 
@@ -258,8 +264,10 @@ function isFormData(value: any): value is FormData {
 
 export class ResponseError extends Error {
     override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
+    response: Response;
+    constructor(response: Response, msg?: string) {
         super(msg);
+        this.response = response;
 
         // restore prototype chain
         const actualProto = new.target.prototype;
@@ -269,10 +277,17 @@ export class ResponseError extends Error {
     }
 }
 
+// `cause` is declared through an interface so that it stays compatible with lib targets
+// that already declare `Error.cause` (ES2022+) as well as the ones that do not
+export interface FetchError {
+    cause: Error;
+}
+
 export class FetchError extends Error {
     override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
+    constructor(cause: Error, msg?: string) {
         super(msg);
+        this.cause = cause;
 
         // restore prototype chain
         const actualProto = new.target.prototype;
@@ -284,8 +299,10 @@ export class FetchError extends Error {
 
 export class RequiredError extends Error {
     override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
+    field: string;
+    constructor(field: string, msg?: string) {
         super(msg);
+        this.field = field;
 
         // restore prototype chain
         const actualProto = new.target.prototype;
@@ -422,7 +439,13 @@ export interface ResponseTransformer<T> {
 }
 
 export class JSONApiResponse<T> {
-    constructor(public raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {}
+    raw: Response;
+    private transformer: ResponseTransformer<T>;
+
+    constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+        this.raw = raw;
+        this.transformer = transformer;
+    }
 
     async value(): Promise<T> {
         return this.transformer(await this.raw.json());
@@ -430,7 +453,11 @@ export class JSONApiResponse<T> {
 }
 
 export class VoidApiResponse {
-    constructor(public raw: Response) {}
+    raw: Response;
+
+    constructor(raw: Response) {
+        this.raw = raw;
+    }
 
     async value(): Promise<void> {
         return undefined;
@@ -438,7 +465,11 @@ export class VoidApiResponse {
 }
 
 export class BlobApiResponse {
-    constructor(public raw: Response) {}
+    raw: Response;
+
+    constructor(raw: Response) {
+        this.raw = raw;
+    }
 
     async value(): Promise<Blob> {
         return await this.raw.blob();
@@ -446,7 +477,11 @@ export class BlobApiResponse {
 }
 
 export class TextApiResponse {
-    constructor(public raw: Response) {}
+    raw: Response;
+
+    constructor(raw: Response) {
+        this.raw = raw;
+    }
 
     async value(): Promise<string> {
         return await this.raw.text();

--- a/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/runtime.ts
@@ -28,7 +28,11 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+    private configuration: ConfigurationParameters;
+
+    constructor(configuration: ConfigurationParameters = {}) {
+        this.configuration = configuration;
+    }
 
     set config(configuration: Configuration) {
         this.configuration = configuration;
@@ -92,8 +96,10 @@ export class BaseAPI {
 
     private static readonly jsonRegex = /^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$/i;
     private middleware: Middleware[];
+    protected configuration: Configuration;
 
-    constructor(protected configuration = DefaultConfig) {
+    constructor(configuration: Configuration = DefaultConfig) {
+        this.configuration = configuration;
         this.middleware = configuration.middleware;
     }
 
@@ -258,8 +264,10 @@ function isFormData(value: any): value is FormData {
 
 export class ResponseError extends Error {
     override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
+    response: Response;
+    constructor(response: Response, msg?: string) {
         super(msg);
+        this.response = response;
 
         // restore prototype chain
         const actualProto = new.target.prototype;
@@ -269,10 +277,17 @@ export class ResponseError extends Error {
     }
 }
 
+// `cause` is declared through an interface so that it stays compatible with lib targets
+// that already declare `Error.cause` (ES2022+) as well as the ones that do not
+export interface FetchError {
+    cause: Error;
+}
+
 export class FetchError extends Error {
     override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
+    constructor(cause: Error, msg?: string) {
         super(msg);
+        this.cause = cause;
 
         // restore prototype chain
         const actualProto = new.target.prototype;
@@ -284,8 +299,10 @@ export class FetchError extends Error {
 
 export class RequiredError extends Error {
     override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
+    field: string;
+    constructor(field: string, msg?: string) {
         super(msg);
+        this.field = field;
 
         // restore prototype chain
         const actualProto = new.target.prototype;
@@ -410,7 +427,13 @@ export interface ResponseTransformer<T> {
 }
 
 export class JSONApiResponse<T> {
-    constructor(public raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {}
+    raw: Response;
+    private transformer: ResponseTransformer<T>;
+
+    constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+        this.raw = raw;
+        this.transformer = transformer;
+    }
 
     async value(): Promise<T> {
         return this.transformer(await this.raw.json());
@@ -418,7 +441,11 @@ export class JSONApiResponse<T> {
 }
 
 export class VoidApiResponse {
-    constructor(public raw: Response) {}
+    raw: Response;
+
+    constructor(raw: Response) {
+        this.raw = raw;
+    }
 
     async value(): Promise<void> {
         return undefined;
@@ -426,7 +453,11 @@ export class VoidApiResponse {
 }
 
 export class BlobApiResponse {
-    constructor(public raw: Response) {}
+    raw: Response;
+
+    constructor(raw: Response) {
+        this.raw = raw;
+    }
 
     async value(): Promise<Blob> {
         return await this.raw.blob();
@@ -434,7 +465,11 @@ export class BlobApiResponse {
 }
 
 export class TextApiResponse {
-    constructor(public raw: Response) {}
+    raw: Response;
+
+    constructor(raw: Response) {
+        this.raw = raw;
+    }
 
     async value(): Promise<string> {
         return await this.raw.text();


### PR DESCRIPTION
The `typescript-fetch` runtime template uses TypeScript constructor parameter properties in nine places. A parameter property both declares a field and assigns it, so it is not erasable syntax — it cannot be removed by stripping types.

Two consequences for generated clients:

- Node refuses to load the generated `runtime.ts` at all under type stripping: `SyntaxError [ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX]: TypeScript parameter property is not supported in strip-only mode`. Since Node 24 this is the default loader for `.ts` files, so a generated client cannot be run without a build step.
- `tsc --erasableSyntaxOnly` (TypeScript 5.8+) rejects every one of those sites with TS1294.

Separately, `FetchError` declares `cause`, which collides with `Error.cause` on ES2022 and later lib targets. Consumers compiling with `--noImplicitOverride` get TS4115. Adding an `override` modifier is not an option because it breaks the lib targets that predate `Error.cause` (TS4113) — including the generator's own default `es5`/`es6` output. Declaring `cause` on a merged interface instead satisfies both.

fixes #22400
fixes #14515

## Change

`runtime.mustache` only. Every parameter property becomes an explicit field declaration plus an assignment in the constructor body, and `FetchError.cause` moves to an interface declaration. Public API, field visibility and emitted JavaScript semantics are unchanged.

```typescript
export class Configuration {
    private configuration: ConfigurationParameters;

    constructor(configuration: ConfigurationParameters = {}) {
        this.configuration = configuration;
    }
}
```

## Verification

Against the regenerated samples:

- `tsc --noEmit` on `builds/es6-target`, `builds/with-npm-version`, `builds/prefix-parameter-interfaces` and `builds/without-runtime-checks` — clean.
- The same, with `--target es2022 --erasableSyntaxOnly --noImplicitOverride` — clean.
- Node 24 loads `builds/default/runtime.ts` directly, constructs `Configuration`, `BaseAPI`, `RequiredError`, `FetchError`, `ResponseError` and the four `ApiResponse` classes, and reads back their fields. The same script against the previous output fails with `SyntaxError: TypeScript parameter property is not supported in strip-only mode`.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/typescript-fetch*.yaml || exit
  ```
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members

cc @TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02) @davidgamero (2022/03) @mkusaka (2022/04) @joscha (2024/10) @dennisameling (2026/02)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emit erasable TypeScript in the `typescript-fetch` runtime and fix `FetchError.cause` compatibility. Generated clients now run with Node 24’s strip-only loader and compile with `tsc --erasableSyntaxOnly`.

- **Bug Fixes**
  - Replaced constructor parameter properties with explicit fields and assignments; behavior and visibility unchanged.
  - Declared `FetchError.cause` on a merged interface to avoid `TS4115`/`TS4113` across lib targets.
  - Regenerated samples to use the updated runtime.

<sup>Written for commit b2bd76d6125df964f8e23935792ce46cede802ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24575?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

