### PR TITLE
fix(typescript-fetch): correct ToJSON/ToJSONTyped type signatures

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelEnum.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelEnum.mustache
@@ -23,6 +23,6 @@ export function {{classname}}ToJSON(value?: {{classname}} | null): any {
     return {{classname}}ToJSONTyped(value, false);
 }
 
-export function {{classname}}ToJSONTyped(value?: {{classname}} | null, ignoreDiscriminator: boolean): any {
+export function {{classname}}ToJSONTyped(value?: {{classname}} | null, ignoreDiscriminator: boolean = false): any {
     return value as {{classname}};
 }

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelEnum.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelEnum.mustache
@@ -24,5 +24,5 @@ export function {{classname}}ToJSON(value?: {{classname}} | null): any {
 }
 
 export function {{classname}}ToJSONTyped(value?: {{classname}} | null, ignoreDiscriminator: boolean = false): any {
-    return value as {{classname}};
+    return value as any;
 }

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelEnum.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelEnum.mustache
@@ -20,9 +20,9 @@ export function {{classname}}FromJSONTyped(json: any, ignoreDiscriminator: boole
 }
 
 export function {{classname}}ToJSON(value?: {{classname}} | null): any {
-    return value as any;
+    return {{classname}}ToJSONTyped(value, false);
 }
 
-export function {{classname}}ToJSONTyped(value: any, ignoreDiscriminator: boolean): {{classname}} {
+export function {{classname}}ToJSONTyped(value?: {{classname}} | null, ignoreDiscriminator: boolean): any {
     return value as {{classname}};
 }

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
@@ -141,8 +141,8 @@ export function {{classname}}FromJSONTyped(json: any, ignoreDiscriminator: boole
     {{/hasVars}}
 }
 
-export function {{classname}}ToJSON(json: any): {{classname}} {
-    return {{classname}}ToJSONTyped(json, false);
+export function {{classname}}ToJSON(value?: {{classname}} | null): any {
+    return {{classname}}ToJSONTyped(value, false);
 }
 
 export function {{classname}}ToJSONTyped(value?: {{#hasReadOnly}}Omit<{{classname}}, {{#readOnlyVars}}'{{name}}'{{^-last}}|{{/-last}}{{/readOnlyVars}}>{{/hasReadOnly}}{{^hasReadOnly}}{{classname}}{{/hasReadOnly}} | null, ignoreDiscriminator: boolean = false): any {

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelOneOf.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelOneOf.mustache
@@ -147,8 +147,8 @@ export function {{classname}}FromJSONTyped(json: any, ignoreDiscriminator: boole
 {{/discriminator}}
 }
 
-export function {{classname}}ToJSON(json: any): any {
-    return {{classname}}ToJSONTyped(json, false);
+export function {{classname}}ToJSON(value?: {{classname}} | null): any {
+    return {{classname}}ToJSONTyped(value, false);
 }
 
 export function {{classname}}ToJSONTyped(value?: {{classname}} | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/others/typescript-fetch/additional-properties-in-multipart-issue/models/StructuredType.ts
+++ b/samples/client/others/typescript-fetch/additional-properties-in-multipart-issue/models/StructuredType.ts
@@ -46,8 +46,8 @@ export function StructuredTypeFromJSONTyped(json: any, ignoreDiscriminator: bool
     };
 }
 
-export function StructuredTypeToJSON(json: any): StructuredType {
-    return StructuredTypeToJSONTyped(json, false);
+export function StructuredTypeToJSON(value?: StructuredType | null): any {
+    return StructuredTypeToJSONTyped(value, false);
 }
 
 export function StructuredTypeToJSONTyped(value?: StructuredType | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/others/typescript-fetch/infinite-recursion-issue/models/ExtendDto.ts
+++ b/samples/client/others/typescript-fetch/infinite-recursion-issue/models/ExtendDto.ts
@@ -63,8 +63,8 @@ export function ExtendDtoFromJSONTyped(json: any, ignoreDiscriminator: boolean):
     };
 }
 
-export function ExtendDtoToJSON(json: any): ExtendDto {
-    return ExtendDtoToJSONTyped(json, false);
+export function ExtendDtoToJSON(value?: ExtendDto | null): any {
+    return ExtendDtoToJSONTyped(value, false);
 }
 
 export function ExtendDtoToJSONTyped(value?: ExtendDto | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/others/typescript-fetch/infinite-recursion-issue/models/TestBaseDto.ts
+++ b/samples/client/others/typescript-fetch/infinite-recursion-issue/models/TestBaseDto.ts
@@ -71,8 +71,8 @@ export function TestBaseDtoFromJSONTyped(json: any, ignoreDiscriminator: boolean
     };
 }
 
-export function TestBaseDtoToJSON(json: any): TestBaseDto {
-    return TestBaseDtoToJSONTyped(json, false);
+export function TestBaseDtoToJSON(value?: TestBaseDto | null): any {
+    return TestBaseDtoToJSONTyped(value, false);
 }
 
 export function TestBaseDtoToJSONTyped(value?: TestBaseDto | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/others/typescript-fetch/infinite-recursion-issue/models/TestObjectType.ts
+++ b/samples/client/others/typescript-fetch/infinite-recursion-issue/models/TestObjectType.ts
@@ -45,10 +45,10 @@ export function TestObjectTypeFromJSONTyped(json: any, ignoreDiscriminator: bool
 }
 
 export function TestObjectTypeToJSON(value?: TestObjectType | null): any {
-    return value as any;
+    return TestObjectTypeToJSONTyped(value, false);
 }
 
-export function TestObjectTypeToJSONTyped(value: any, ignoreDiscriminator: boolean): TestObjectType {
+export function TestObjectTypeToJSONTyped(value?: TestObjectType | null, ignoreDiscriminator: boolean): any {
     return value as TestObjectType;
 }
 

--- a/samples/client/others/typescript-fetch/infinite-recursion-issue/models/TestObjectType.ts
+++ b/samples/client/others/typescript-fetch/infinite-recursion-issue/models/TestObjectType.ts
@@ -49,6 +49,6 @@ export function TestObjectTypeToJSON(value?: TestObjectType | null): any {
 }
 
 export function TestObjectTypeToJSONTyped(value?: TestObjectType | null, ignoreDiscriminator: boolean = false): any {
-    return value as TestObjectType;
+    return value as any;
 }
 

--- a/samples/client/others/typescript-fetch/infinite-recursion-issue/models/TestObjectType.ts
+++ b/samples/client/others/typescript-fetch/infinite-recursion-issue/models/TestObjectType.ts
@@ -48,7 +48,7 @@ export function TestObjectTypeToJSON(value?: TestObjectType | null): any {
     return TestObjectTypeToJSONTyped(value, false);
 }
 
-export function TestObjectTypeToJSONTyped(value?: TestObjectType | null, ignoreDiscriminator: boolean): any {
+export function TestObjectTypeToJSONTyped(value?: TestObjectType | null, ignoreDiscriminator: boolean = false): any {
     return value as TestObjectType;
 }
 

--- a/samples/client/others/typescript-fetch/self-import-issue/models/AbstractUserDto.ts
+++ b/samples/client/others/typescript-fetch/self-import-issue/models/AbstractUserDto.ts
@@ -75,8 +75,8 @@ export function AbstractUserDtoFromJSONTyped(json: any, ignoreDiscriminator: boo
     };
 }
 
-export function AbstractUserDtoToJSON(json: any): AbstractUserDto {
-    return AbstractUserDtoToJSONTyped(json, false);
+export function AbstractUserDtoToJSON(value?: AbstractUserDto | null): any {
+    return AbstractUserDtoToJSONTyped(value, false);
 }
 
 export function AbstractUserDtoToJSONTyped(value?: AbstractUserDto | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/others/typescript-fetch/self-import-issue/models/BranchDto.ts
+++ b/samples/client/others/typescript-fetch/self-import-issue/models/BranchDto.ts
@@ -46,8 +46,8 @@ export function BranchDtoFromJSONTyped(json: any, ignoreDiscriminator: boolean):
     };
 }
 
-export function BranchDtoToJSON(json: any): BranchDto {
-    return BranchDtoToJSONTyped(json, false);
+export function BranchDtoToJSON(value?: BranchDto | null): any {
+    return BranchDtoToJSONTyped(value, false);
 }
 
 export function BranchDtoToJSONTyped(value?: BranchDto | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/others/typescript-fetch/self-import-issue/models/InternalAuthenticatedUserDto.ts
+++ b/samples/client/others/typescript-fetch/self-import-issue/models/InternalAuthenticatedUserDto.ts
@@ -51,8 +51,8 @@ export function InternalAuthenticatedUserDtoFromJSONTyped(json: any, ignoreDiscr
     return json;
 }
 
-export function InternalAuthenticatedUserDtoToJSON(json: any): InternalAuthenticatedUserDto {
-    return InternalAuthenticatedUserDtoToJSONTyped(json, false);
+export function InternalAuthenticatedUserDtoToJSON(value?: InternalAuthenticatedUserDto | null): any {
+    return InternalAuthenticatedUserDtoToJSONTyped(value, false);
 }
 
 export function InternalAuthenticatedUserDtoToJSONTyped(value?: InternalAuthenticatedUserDto | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/others/typescript-fetch/self-import-issue/models/RemoteAuthenticatedUserDto.ts
+++ b/samples/client/others/typescript-fetch/self-import-issue/models/RemoteAuthenticatedUserDto.ts
@@ -51,8 +51,8 @@ export function RemoteAuthenticatedUserDtoFromJSONTyped(json: any, ignoreDiscrim
     return json;
 }
 
-export function RemoteAuthenticatedUserDtoToJSON(json: any): RemoteAuthenticatedUserDto {
-    return RemoteAuthenticatedUserDtoToJSONTyped(json, false);
+export function RemoteAuthenticatedUserDtoToJSON(value?: RemoteAuthenticatedUserDto | null): any {
+    return RemoteAuthenticatedUserDtoToJSONTyped(value, false);
 }
 
 export function RemoteAuthenticatedUserDtoToJSONTyped(value?: RemoteAuthenticatedUserDto | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/allOf-nullable/models/Club.ts
+++ b/samples/client/petstore/typescript-fetch/builds/allOf-nullable/models/Club.ts
@@ -54,8 +54,8 @@ export function ClubFromJSONTyped(json: any, ignoreDiscriminator: boolean): Club
     };
 }
 
-export function ClubToJSON(json: any): Club {
-    return ClubToJSONTyped(json, false);
+export function ClubToJSON(value?: Club | null): any {
+    return ClubToJSONTyped(value, false);
 }
 
 export function ClubToJSONTyped(value?: Club | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/allOf-nullable/models/Owner.ts
+++ b/samples/client/petstore/typescript-fetch/builds/allOf-nullable/models/Owner.ts
@@ -46,8 +46,8 @@ export function OwnerFromJSONTyped(json: any, ignoreDiscriminator: boolean): Own
     };
 }
 
-export function OwnerToJSON(json: any): Owner {
-    return OwnerToJSONTyped(json, false);
+export function OwnerToJSON(value?: Owner | null): any {
+    return OwnerToJSONTyped(value, false);
 }
 
 export function OwnerToJSONTyped(value?: Owner | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/allOf-readonly/models/Club.ts
+++ b/samples/client/petstore/typescript-fetch/builds/allOf-readonly/models/Club.ts
@@ -54,8 +54,8 @@ export function ClubFromJSONTyped(json: any, ignoreDiscriminator: boolean): Club
     };
 }
 
-export function ClubToJSON(json: any): Club {
-    return ClubToJSONTyped(json, false);
+export function ClubToJSON(value?: Club | null): any {
+    return ClubToJSONTyped(value, false);
 }
 
 export function ClubToJSONTyped(value?: Omit<Club, 'owner'> | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/allOf-readonly/models/Owner.ts
+++ b/samples/client/petstore/typescript-fetch/builds/allOf-readonly/models/Owner.ts
@@ -46,8 +46,8 @@ export function OwnerFromJSONTyped(json: any, ignoreDiscriminator: boolean): Own
     };
 }
 
-export function OwnerToJSON(json: any): Owner {
-    return OwnerToJSONTyped(json, false);
+export function OwnerToJSON(value?: Owner | null): any {
+    return OwnerToJSONTyped(value, false);
 }
 
 export function OwnerToJSONTyped(value?: Owner | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/AdditionalPropertiesClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/AdditionalPropertiesClass.ts
@@ -51,8 +51,8 @@ export function AdditionalPropertiesClassFromJSONTyped(json: any, ignoreDiscrimi
     };
 }
 
-export function AdditionalPropertiesClassToJSON(json: any): AdditionalPropertiesClass {
-    return AdditionalPropertiesClassToJSONTyped(json, false);
+export function AdditionalPropertiesClassToJSON(value?: AdditionalPropertiesClass | null): any {
+    return AdditionalPropertiesClassToJSONTyped(value, false);
 }
 
 export function AdditionalPropertiesClassToJSONTyped(value?: AdditionalPropertiesClass | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/AllOfWithSingleRef.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/AllOfWithSingleRef.ts
@@ -61,8 +61,8 @@ export function AllOfWithSingleRefFromJSONTyped(json: any, ignoreDiscriminator: 
     };
 }
 
-export function AllOfWithSingleRefToJSON(json: any): AllOfWithSingleRef {
-    return AllOfWithSingleRefToJSONTyped(json, false);
+export function AllOfWithSingleRefToJSON(value?: AllOfWithSingleRef | null): any {
+    return AllOfWithSingleRefToJSONTyped(value, false);
 }
 
 export function AllOfWithSingleRefToJSONTyped(value?: AllOfWithSingleRef | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Animal.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Animal.ts
@@ -63,8 +63,8 @@ export function AnimalFromJSONTyped(json: any, ignoreDiscriminator: boolean): An
     };
 }
 
-export function AnimalToJSON(json: any): Animal {
-    return AnimalToJSONTyped(json, false);
+export function AnimalToJSON(value?: Animal | null): any {
+    return AnimalToJSONTyped(value, false);
 }
 
 export function AnimalToJSONTyped(value?: Animal | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ArrayOfArrayOfNumberOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ArrayOfArrayOfNumberOnly.ts
@@ -46,8 +46,8 @@ export function ArrayOfArrayOfNumberOnlyFromJSONTyped(json: any, ignoreDiscrimin
     };
 }
 
-export function ArrayOfArrayOfNumberOnlyToJSON(json: any): ArrayOfArrayOfNumberOnly {
-    return ArrayOfArrayOfNumberOnlyToJSONTyped(json, false);
+export function ArrayOfArrayOfNumberOnlyToJSON(value?: ArrayOfArrayOfNumberOnly | null): any {
+    return ArrayOfArrayOfNumberOnlyToJSONTyped(value, false);
 }
 
 export function ArrayOfArrayOfNumberOnlyToJSONTyped(value?: ArrayOfArrayOfNumberOnly | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ArrayOfNumberOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ArrayOfNumberOnly.ts
@@ -46,8 +46,8 @@ export function ArrayOfNumberOnlyFromJSONTyped(json: any, ignoreDiscriminator: b
     };
 }
 
-export function ArrayOfNumberOnlyToJSON(json: any): ArrayOfNumberOnly {
-    return ArrayOfNumberOnlyToJSONTyped(json, false);
+export function ArrayOfNumberOnlyToJSON(value?: ArrayOfNumberOnly | null): any {
+    return ArrayOfNumberOnlyToJSONTyped(value, false);
 }
 
 export function ArrayOfNumberOnlyToJSONTyped(value?: ArrayOfNumberOnly | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ArrayTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ArrayTest.ts
@@ -64,8 +64,8 @@ export function ArrayTestFromJSONTyped(json: any, ignoreDiscriminator: boolean):
     };
 }
 
-export function ArrayTestToJSON(json: any): ArrayTest {
-    return ArrayTestToJSONTyped(json, false);
+export function ArrayTestToJSON(value?: ArrayTest | null): any {
+    return ArrayTestToJSONTyped(value, false);
 }
 
 export function ArrayTestToJSONTyped(value?: ArrayTest | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Capitalization.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Capitalization.ts
@@ -72,8 +72,8 @@ export function CapitalizationFromJSONTyped(json: any, ignoreDiscriminator: bool
     };
 }
 
-export function CapitalizationToJSON(json: any): Capitalization {
-    return CapitalizationToJSONTyped(json, false);
+export function CapitalizationToJSON(value?: Capitalization | null): any {
+    return CapitalizationToJSONTyped(value, false);
 }
 
 export function CapitalizationToJSONTyped(value?: Capitalization | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Cat.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Cat.ts
@@ -54,8 +54,8 @@ export function CatFromJSONTyped(json: any, ignoreDiscriminator: boolean): Cat {
     };
 }
 
-export function CatToJSON(json: any): Cat {
-    return CatToJSONTyped(json, false);
+export function CatToJSON(value?: Cat | null): any {
+    return CatToJSONTyped(value, false);
 }
 
 export function CatToJSONTyped(value?: Cat | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Category.ts
@@ -52,8 +52,8 @@ export function CategoryFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
     };
 }
 
-export function CategoryToJSON(json: any): Category {
-    return CategoryToJSONTyped(json, false);
+export function CategoryToJSON(value?: Category | null): any {
+    return CategoryToJSONTyped(value, false);
 }
 
 export function CategoryToJSONTyped(value?: Category | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ChildWithNullable.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ChildWithNullable.ts
@@ -56,8 +56,8 @@ export function ChildWithNullableFromJSONTyped(json: any, ignoreDiscriminator: b
     };
 }
 
-export function ChildWithNullableToJSON(json: any): ChildWithNullable {
-    return ChildWithNullableToJSONTyped(json, false);
+export function ChildWithNullableToJSON(value?: ChildWithNullable | null): any {
+    return ChildWithNullableToJSONTyped(value, false);
 }
 
 export function ChildWithNullableToJSONTyped(value?: ChildWithNullable | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ClassModel.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ClassModel.ts
@@ -46,8 +46,8 @@ export function ClassModelFromJSONTyped(json: any, ignoreDiscriminator: boolean)
     };
 }
 
-export function ClassModelToJSON(json: any): ClassModel {
-    return ClassModelToJSONTyped(json, false);
+export function ClassModelToJSON(value?: ClassModel | null): any {
+    return ClassModelToJSONTyped(value, false);
 }
 
 export function ClassModelToJSONTyped(value?: ClassModel | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Client.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Client.ts
@@ -46,8 +46,8 @@ export function ClientFromJSONTyped(json: any, ignoreDiscriminator: boolean): Cl
     };
 }
 
-export function ClientToJSON(json: any): Client {
-    return ClientToJSONTyped(json, false);
+export function ClientToJSON(value?: Client | null): any {
+    return ClientToJSONTyped(value, false);
 }
 
 export function ClientToJSONTyped(value?: Client | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/DeprecatedObject.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/DeprecatedObject.ts
@@ -46,8 +46,8 @@ export function DeprecatedObjectFromJSONTyped(json: any, ignoreDiscriminator: bo
     };
 }
 
-export function DeprecatedObjectToJSON(json: any): DeprecatedObject {
-    return DeprecatedObjectToJSONTyped(json, false);
+export function DeprecatedObjectToJSON(value?: DeprecatedObject | null): any {
+    return DeprecatedObjectToJSONTyped(value, false);
 }
 
 export function DeprecatedObjectToJSONTyped(value?: DeprecatedObject | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Dog.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Dog.ts
@@ -54,8 +54,8 @@ export function DogFromJSONTyped(json: any, ignoreDiscriminator: boolean): Dog {
     };
 }
 
-export function DogToJSON(json: any): Dog {
-    return DogToJSONTyped(json, false);
+export function DogToJSON(value?: Dog | null): any {
+    return DogToJSONTyped(value, false);
 }
 
 export function DogToJSONTyped(value?: Dog | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumArrays.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumArrays.ts
@@ -71,8 +71,8 @@ export function EnumArraysFromJSONTyped(json: any, ignoreDiscriminator: boolean)
     };
 }
 
-export function EnumArraysToJSON(json: any): EnumArrays {
-    return EnumArraysToJSONTyped(json, false);
+export function EnumArraysToJSON(value?: EnumArrays | null): any {
+    return EnumArraysToJSONTyped(value, false);
 }
 
 export function EnumArraysToJSONTyped(value?: EnumArrays | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumClass.ts
@@ -48,7 +48,7 @@ export function EnumClassToJSON(value?: EnumClass | null): any {
     return EnumClassToJSONTyped(value, false);
 }
 
-export function EnumClassToJSONTyped(value?: EnumClass | null, ignoreDiscriminator: boolean): any {
+export function EnumClassToJSONTyped(value?: EnumClass | null, ignoreDiscriminator: boolean = false): any {
     return value as EnumClass;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumClass.ts
@@ -49,6 +49,6 @@ export function EnumClassToJSON(value?: EnumClass | null): any {
 }
 
 export function EnumClassToJSONTyped(value?: EnumClass | null, ignoreDiscriminator: boolean = false): any {
-    return value as EnumClass;
+    return value as any;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumClass.ts
@@ -45,10 +45,10 @@ export function EnumClassFromJSONTyped(json: any, ignoreDiscriminator: boolean):
 }
 
 export function EnumClassToJSON(value?: EnumClass | null): any {
-    return value as any;
+    return EnumClassToJSONTyped(value, false);
 }
 
-export function EnumClassToJSONTyped(value: any, ignoreDiscriminator: boolean): EnumClass {
+export function EnumClassToJSONTyped(value?: EnumClass | null, ignoreDiscriminator: boolean): any {
     return value as EnumClass;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumTest.ts
@@ -151,8 +151,8 @@ export function EnumTestFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
     };
 }
 
-export function EnumTestToJSON(json: any): EnumTest {
-    return EnumTestToJSONTyped(json, false);
+export function EnumTestToJSON(value?: EnumTest | null): any {
+    return EnumTestToJSONTyped(value, false);
 }
 
 export function EnumTestToJSONTyped(value?: EnumTest | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FakeBigDecimalMap200Response.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FakeBigDecimalMap200Response.ts
@@ -51,8 +51,8 @@ export function FakeBigDecimalMap200ResponseFromJSONTyped(json: any, ignoreDiscr
     };
 }
 
-export function FakeBigDecimalMap200ResponseToJSON(json: any): FakeBigDecimalMap200Response {
-    return FakeBigDecimalMap200ResponseToJSONTyped(json, false);
+export function FakeBigDecimalMap200ResponseToJSON(value?: FakeBigDecimalMap200Response | null): any {
+    return FakeBigDecimalMap200ResponseToJSONTyped(value, false);
 }
 
 export function FakeBigDecimalMap200ResponseToJSONTyped(value?: FakeBigDecimalMap200Response | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FileSchemaTestClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FileSchemaTestClass.ts
@@ -51,8 +51,8 @@ export function FileSchemaTestClassFromJSONTyped(json: any, ignoreDiscriminator:
     };
 }
 
-export function FileSchemaTestClassToJSON(json: any): FileSchemaTestClass {
-    return FileSchemaTestClassToJSONTyped(json, false);
+export function FileSchemaTestClassToJSON(value?: FileSchemaTestClass | null): any {
+    return FileSchemaTestClassToJSONTyped(value, false);
 }
 
 export function FileSchemaTestClassToJSONTyped(value?: FileSchemaTestClass | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Foo.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Foo.ts
@@ -46,8 +46,8 @@ export function FooFromJSONTyped(json: any, ignoreDiscriminator: boolean): Foo {
     };
 }
 
-export function FooToJSON(json: any): Foo {
-    return FooToJSONTyped(json, false);
+export function FooToJSON(value?: Foo | null): any {
+    return FooToJSONTyped(value, false);
 }
 
 export function FooToJSONTyped(value?: Foo | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FooGetDefaultResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FooGetDefaultResponse.ts
@@ -54,8 +54,8 @@ export function FooGetDefaultResponseFromJSONTyped(json: any, ignoreDiscriminato
     };
 }
 
-export function FooGetDefaultResponseToJSON(json: any): FooGetDefaultResponse {
-    return FooGetDefaultResponseToJSONTyped(json, false);
+export function FooGetDefaultResponseToJSON(value?: FooGetDefaultResponse | null): any {
+    return FooGetDefaultResponseToJSONTyped(value, false);
 }
 
 export function FooGetDefaultResponseToJSONTyped(value?: FooGetDefaultResponse | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FormatTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FormatTest.ts
@@ -125,8 +125,8 @@ export function FormatTestFromJSONTyped(json: any, ignoreDiscriminator: boolean)
     };
 }
 
-export function FormatTestToJSON(json: any): FormatTest {
-    return FormatTestToJSONTyped(json, false);
+export function FormatTestToJSON(value?: FormatTest | null): any {
+    return FormatTestToJSONTyped(value, false);
 }
 
 export function FormatTestToJSONTyped(value?: FormatTest | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/HasOnlyReadOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/HasOnlyReadOnly.ts
@@ -51,8 +51,8 @@ export function HasOnlyReadOnlyFromJSONTyped(json: any, ignoreDiscriminator: boo
     };
 }
 
-export function HasOnlyReadOnlyToJSON(json: any): HasOnlyReadOnly {
-    return HasOnlyReadOnlyToJSONTyped(json, false);
+export function HasOnlyReadOnlyToJSON(value?: HasOnlyReadOnly | null): any {
+    return HasOnlyReadOnlyToJSONTyped(value, false);
 }
 
 export function HasOnlyReadOnlyToJSONTyped(value?: Omit<HasOnlyReadOnly, 'bar'|'foo'> | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/HealthCheckResult.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/HealthCheckResult.ts
@@ -46,8 +46,8 @@ export function HealthCheckResultFromJSONTyped(json: any, ignoreDiscriminator: b
     };
 }
 
-export function HealthCheckResultToJSON(json: any): HealthCheckResult {
-    return HealthCheckResultToJSONTyped(json, false);
+export function HealthCheckResultToJSON(value?: HealthCheckResult | null): any {
+    return HealthCheckResultToJSONTyped(value, false);
 }
 
 export function HealthCheckResultToJSONTyped(value?: HealthCheckResult | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/List.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/List.ts
@@ -46,8 +46,8 @@ export function ListFromJSONTyped(json: any, ignoreDiscriminator: boolean): List
     };
 }
 
-export function ListToJSON(json: any): List {
-    return ListToJSONTyped(json, false);
+export function ListToJSON(value?: List | null): any {
+    return ListToJSONTyped(value, false);
 }
 
 export function ListToJSONTyped(value?: List | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/MapTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/MapTest.ts
@@ -72,8 +72,8 @@ export function MapTestFromJSONTyped(json: any, ignoreDiscriminator: boolean): M
     };
 }
 
-export function MapTestToJSON(json: any): MapTest {
-    return MapTestToJSONTyped(json, false);
+export function MapTestToJSON(value?: MapTest | null): any {
+    return MapTestToJSONTyped(value, false);
 }
 
 export function MapTestToJSONTyped(value?: MapTest | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/MixedPropertiesAndAdditionalPropertiesClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/MixedPropertiesAndAdditionalPropertiesClass.ts
@@ -64,8 +64,8 @@ export function MixedPropertiesAndAdditionalPropertiesClassFromJSONTyped(json: a
     };
 }
 
-export function MixedPropertiesAndAdditionalPropertiesClassToJSON(json: any): MixedPropertiesAndAdditionalPropertiesClass {
-    return MixedPropertiesAndAdditionalPropertiesClassToJSONTyped(json, false);
+export function MixedPropertiesAndAdditionalPropertiesClassToJSON(value?: MixedPropertiesAndAdditionalPropertiesClass | null): any {
+    return MixedPropertiesAndAdditionalPropertiesClassToJSONTyped(value, false);
 }
 
 export function MixedPropertiesAndAdditionalPropertiesClassToJSONTyped(value?: MixedPropertiesAndAdditionalPropertiesClass | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Model200Response.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Model200Response.ts
@@ -51,8 +51,8 @@ export function Model200ResponseFromJSONTyped(json: any, ignoreDiscriminator: bo
     };
 }
 
-export function Model200ResponseToJSON(json: any): Model200Response {
-    return Model200ResponseToJSONTyped(json, false);
+export function Model200ResponseToJSON(value?: Model200Response | null): any {
+    return Model200ResponseToJSONTyped(value, false);
 }
 
 export function Model200ResponseToJSONTyped(value?: Model200Response | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ModelApiResponse.ts
@@ -56,8 +56,8 @@ export function ModelApiResponseFromJSONTyped(json: any, ignoreDiscriminator: bo
     };
 }
 
-export function ModelApiResponseToJSON(json: any): ModelApiResponse {
-    return ModelApiResponseToJSONTyped(json, false);
+export function ModelApiResponseToJSON(value?: ModelApiResponse | null): any {
+    return ModelApiResponseToJSONTyped(value, false);
 }
 
 export function ModelApiResponseToJSONTyped(value?: ModelApiResponse | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ModelFile.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ModelFile.ts
@@ -46,8 +46,8 @@ export function ModelFileFromJSONTyped(json: any, ignoreDiscriminator: boolean):
     };
 }
 
-export function ModelFileToJSON(json: any): ModelFile {
-    return ModelFileToJSONTyped(json, false);
+export function ModelFileToJSON(value?: ModelFile | null): any {
+    return ModelFileToJSONTyped(value, false);
 }
 
 export function ModelFileToJSONTyped(value?: ModelFile | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Name.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Name.ts
@@ -62,8 +62,8 @@ export function NameFromJSONTyped(json: any, ignoreDiscriminator: boolean): Name
     };
 }
 
-export function NameToJSON(json: any): Name {
-    return NameToJSONTyped(json, false);
+export function NameToJSON(value?: Name | null): any {
+    return NameToJSONTyped(value, false);
 }
 
 export function NameToJSONTyped(value?: Omit<Name, 'snakeCase'|'_123number'> | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/NullableClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/NullableClass.ts
@@ -103,8 +103,8 @@ export function NullableClassFromJSONTyped(json: any, ignoreDiscriminator: boole
     };
 }
 
-export function NullableClassToJSON(json: any): NullableClass {
-    return NullableClassToJSONTyped(json, false);
+export function NullableClassToJSON(value?: NullableClass | null): any {
+    return NullableClassToJSONTyped(value, false);
 }
 
 export function NullableClassToJSONTyped(value?: NullableClass | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/NumberOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/NumberOnly.ts
@@ -46,8 +46,8 @@ export function NumberOnlyFromJSONTyped(json: any, ignoreDiscriminator: boolean)
     };
 }
 
-export function NumberOnlyToJSON(json: any): NumberOnly {
-    return NumberOnlyToJSONTyped(json, false);
+export function NumberOnlyToJSON(value?: NumberOnly | null): any {
+    return NumberOnlyToJSONTyped(value, false);
 }
 
 export function NumberOnlyToJSONTyped(value?: NumberOnly | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ObjectWithDeprecatedFields.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ObjectWithDeprecatedFields.ts
@@ -72,8 +72,8 @@ export function ObjectWithDeprecatedFieldsFromJSONTyped(json: any, ignoreDiscrim
     };
 }
 
-export function ObjectWithDeprecatedFieldsToJSON(json: any): ObjectWithDeprecatedFields {
-    return ObjectWithDeprecatedFieldsToJSONTyped(json, false);
+export function ObjectWithDeprecatedFieldsToJSON(value?: ObjectWithDeprecatedFields | null): any {
+    return ObjectWithDeprecatedFieldsToJSONTyped(value, false);
 }
 
 export function ObjectWithDeprecatedFieldsToJSONTyped(value?: ObjectWithDeprecatedFields | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Order.ts
@@ -83,8 +83,8 @@ export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Ord
     };
 }
 
-export function OrderToJSON(json: any): Order {
-    return OrderToJSONTyped(json, false);
+export function OrderToJSON(value?: Order | null): any {
+    return OrderToJSONTyped(value, false);
 }
 
 export function OrderToJSONTyped(value?: Order | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterComposite.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterComposite.ts
@@ -56,8 +56,8 @@ export function OuterCompositeFromJSONTyped(json: any, ignoreDiscriminator: bool
     };
 }
 
-export function OuterCompositeToJSON(json: any): OuterComposite {
-    return OuterCompositeToJSONTyped(json, false);
+export function OuterCompositeToJSON(value?: OuterComposite | null): any {
+    return OuterCompositeToJSONTyped(value, false);
 }
 
 export function OuterCompositeToJSONTyped(value?: OuterComposite | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnum.ts
@@ -45,10 +45,10 @@ export function OuterEnumFromJSONTyped(json: any, ignoreDiscriminator: boolean):
 }
 
 export function OuterEnumToJSON(value?: OuterEnum | null): any {
-    return value as any;
+    return OuterEnumToJSONTyped(value, false);
 }
 
-export function OuterEnumToJSONTyped(value: any, ignoreDiscriminator: boolean): OuterEnum {
+export function OuterEnumToJSONTyped(value?: OuterEnum | null, ignoreDiscriminator: boolean): any {
     return value as OuterEnum;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnum.ts
@@ -49,6 +49,6 @@ export function OuterEnumToJSON(value?: OuterEnum | null): any {
 }
 
 export function OuterEnumToJSONTyped(value?: OuterEnum | null, ignoreDiscriminator: boolean = false): any {
-    return value as OuterEnum;
+    return value as any;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnum.ts
@@ -48,7 +48,7 @@ export function OuterEnumToJSON(value?: OuterEnum | null): any {
     return OuterEnumToJSONTyped(value, false);
 }
 
-export function OuterEnumToJSONTyped(value?: OuterEnum | null, ignoreDiscriminator: boolean): any {
+export function OuterEnumToJSONTyped(value?: OuterEnum | null, ignoreDiscriminator: boolean = false): any {
     return value as OuterEnum;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumDefaultValue.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumDefaultValue.ts
@@ -45,10 +45,10 @@ export function OuterEnumDefaultValueFromJSONTyped(json: any, ignoreDiscriminato
 }
 
 export function OuterEnumDefaultValueToJSON(value?: OuterEnumDefaultValue | null): any {
-    return value as any;
+    return OuterEnumDefaultValueToJSONTyped(value, false);
 }
 
-export function OuterEnumDefaultValueToJSONTyped(value: any, ignoreDiscriminator: boolean): OuterEnumDefaultValue {
+export function OuterEnumDefaultValueToJSONTyped(value?: OuterEnumDefaultValue | null, ignoreDiscriminator: boolean): any {
     return value as OuterEnumDefaultValue;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumDefaultValue.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumDefaultValue.ts
@@ -48,7 +48,7 @@ export function OuterEnumDefaultValueToJSON(value?: OuterEnumDefaultValue | null
     return OuterEnumDefaultValueToJSONTyped(value, false);
 }
 
-export function OuterEnumDefaultValueToJSONTyped(value?: OuterEnumDefaultValue | null, ignoreDiscriminator: boolean): any {
+export function OuterEnumDefaultValueToJSONTyped(value?: OuterEnumDefaultValue | null, ignoreDiscriminator: boolean = false): any {
     return value as OuterEnumDefaultValue;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumDefaultValue.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumDefaultValue.ts
@@ -49,6 +49,6 @@ export function OuterEnumDefaultValueToJSON(value?: OuterEnumDefaultValue | null
 }
 
 export function OuterEnumDefaultValueToJSONTyped(value?: OuterEnumDefaultValue | null, ignoreDiscriminator: boolean = false): any {
-    return value as OuterEnumDefaultValue;
+    return value as any;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumInteger.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumInteger.ts
@@ -48,7 +48,7 @@ export function OuterEnumIntegerToJSON(value?: OuterEnumInteger | null): any {
     return OuterEnumIntegerToJSONTyped(value, false);
 }
 
-export function OuterEnumIntegerToJSONTyped(value?: OuterEnumInteger | null, ignoreDiscriminator: boolean): any {
+export function OuterEnumIntegerToJSONTyped(value?: OuterEnumInteger | null, ignoreDiscriminator: boolean = false): any {
     return value as OuterEnumInteger;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumInteger.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumInteger.ts
@@ -45,10 +45,10 @@ export function OuterEnumIntegerFromJSONTyped(json: any, ignoreDiscriminator: bo
 }
 
 export function OuterEnumIntegerToJSON(value?: OuterEnumInteger | null): any {
-    return value as any;
+    return OuterEnumIntegerToJSONTyped(value, false);
 }
 
-export function OuterEnumIntegerToJSONTyped(value: any, ignoreDiscriminator: boolean): OuterEnumInteger {
+export function OuterEnumIntegerToJSONTyped(value?: OuterEnumInteger | null, ignoreDiscriminator: boolean): any {
     return value as OuterEnumInteger;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumInteger.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumInteger.ts
@@ -49,6 +49,6 @@ export function OuterEnumIntegerToJSON(value?: OuterEnumInteger | null): any {
 }
 
 export function OuterEnumIntegerToJSONTyped(value?: OuterEnumInteger | null, ignoreDiscriminator: boolean = false): any {
-    return value as OuterEnumInteger;
+    return value as any;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumIntegerDefaultValue.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumIntegerDefaultValue.ts
@@ -45,10 +45,10 @@ export function OuterEnumIntegerDefaultValueFromJSONTyped(json: any, ignoreDiscr
 }
 
 export function OuterEnumIntegerDefaultValueToJSON(value?: OuterEnumIntegerDefaultValue | null): any {
-    return value as any;
+    return OuterEnumIntegerDefaultValueToJSONTyped(value, false);
 }
 
-export function OuterEnumIntegerDefaultValueToJSONTyped(value: any, ignoreDiscriminator: boolean): OuterEnumIntegerDefaultValue {
+export function OuterEnumIntegerDefaultValueToJSONTyped(value?: OuterEnumIntegerDefaultValue | null, ignoreDiscriminator: boolean): any {
     return value as OuterEnumIntegerDefaultValue;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumIntegerDefaultValue.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumIntegerDefaultValue.ts
@@ -49,6 +49,6 @@ export function OuterEnumIntegerDefaultValueToJSON(value?: OuterEnumIntegerDefau
 }
 
 export function OuterEnumIntegerDefaultValueToJSONTyped(value?: OuterEnumIntegerDefaultValue | null, ignoreDiscriminator: boolean = false): any {
-    return value as OuterEnumIntegerDefaultValue;
+    return value as any;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumIntegerDefaultValue.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumIntegerDefaultValue.ts
@@ -48,7 +48,7 @@ export function OuterEnumIntegerDefaultValueToJSON(value?: OuterEnumIntegerDefau
     return OuterEnumIntegerDefaultValueToJSONTyped(value, false);
 }
 
-export function OuterEnumIntegerDefaultValueToJSONTyped(value?: OuterEnumIntegerDefaultValue | null, ignoreDiscriminator: boolean): any {
+export function OuterEnumIntegerDefaultValueToJSONTyped(value?: OuterEnumIntegerDefaultValue | null, ignoreDiscriminator: boolean = false): any {
     return value as OuterEnumIntegerDefaultValue;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterObjectWithEnumProperty.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterObjectWithEnumProperty.ts
@@ -57,8 +57,8 @@ export function OuterObjectWithEnumPropertyFromJSONTyped(json: any, ignoreDiscri
     };
 }
 
-export function OuterObjectWithEnumPropertyToJSON(json: any): OuterObjectWithEnumProperty {
-    return OuterObjectWithEnumPropertyToJSONTyped(json, false);
+export function OuterObjectWithEnumPropertyToJSON(value?: OuterObjectWithEnumProperty | null): any {
+    return OuterObjectWithEnumPropertyToJSONTyped(value, false);
 }
 
 export function OuterObjectWithEnumPropertyToJSONTyped(value?: OuterObjectWithEnumProperty | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ParentWithNullable.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ParentWithNullable.ts
@@ -68,8 +68,8 @@ export function ParentWithNullableFromJSONTyped(json: any, ignoreDiscriminator: 
     };
 }
 
-export function ParentWithNullableToJSON(json: any): ParentWithNullable {
-    return ParentWithNullableToJSONTyped(json, false);
+export function ParentWithNullableToJSON(value?: ParentWithNullable | null): any {
+    return ParentWithNullableToJSONTyped(value, false);
 }
 
 export function ParentWithNullableToJSONTyped(value?: ParentWithNullable | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Pet.ts
@@ -100,8 +100,8 @@ export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
     };
 }
 
-export function PetToJSON(json: any): Pet {
-    return PetToJSONTyped(json, false);
+export function PetToJSON(value?: Pet | null): any {
+    return PetToJSONTyped(value, false);
 }
 
 export function PetToJSONTyped(value?: Pet | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ReadOnlyFirst.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ReadOnlyFirst.ts
@@ -51,8 +51,8 @@ export function ReadOnlyFirstFromJSONTyped(json: any, ignoreDiscriminator: boole
     };
 }
 
-export function ReadOnlyFirstToJSON(json: any): ReadOnlyFirst {
-    return ReadOnlyFirstToJSONTyped(json, false);
+export function ReadOnlyFirstToJSON(value?: ReadOnlyFirst | null): any {
+    return ReadOnlyFirstToJSONTyped(value, false);
 }
 
 export function ReadOnlyFirstToJSONTyped(value?: Omit<ReadOnlyFirst, 'bar'> | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Return.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Return.ts
@@ -46,8 +46,8 @@ export function ReturnFromJSONTyped(json: any, ignoreDiscriminator: boolean): Re
     };
 }
 
-export function ReturnToJSON(json: any): Return {
-    return ReturnToJSONTyped(json, false);
+export function ReturnToJSON(value?: Return | null): any {
+    return ReturnToJSONTyped(value, false);
 }
 
 export function ReturnToJSONTyped(value?: Return | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/SingleRefType.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/SingleRefType.ts
@@ -47,7 +47,7 @@ export function SingleRefTypeToJSON(value?: SingleRefType | null): any {
     return SingleRefTypeToJSONTyped(value, false);
 }
 
-export function SingleRefTypeToJSONTyped(value?: SingleRefType | null, ignoreDiscriminator: boolean): any {
+export function SingleRefTypeToJSONTyped(value?: SingleRefType | null, ignoreDiscriminator: boolean = false): any {
     return value as SingleRefType;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/SingleRefType.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/SingleRefType.ts
@@ -48,6 +48,6 @@ export function SingleRefTypeToJSON(value?: SingleRefType | null): any {
 }
 
 export function SingleRefTypeToJSONTyped(value?: SingleRefType | null, ignoreDiscriminator: boolean = false): any {
-    return value as SingleRefType;
+    return value as any;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/SingleRefType.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/SingleRefType.ts
@@ -44,10 +44,10 @@ export function SingleRefTypeFromJSONTyped(json: any, ignoreDiscriminator: boole
 }
 
 export function SingleRefTypeToJSON(value?: SingleRefType | null): any {
-    return value as any;
+    return SingleRefTypeToJSONTyped(value, false);
 }
 
-export function SingleRefTypeToJSONTyped(value: any, ignoreDiscriminator: boolean): SingleRefType {
+export function SingleRefTypeToJSONTyped(value?: SingleRefType | null, ignoreDiscriminator: boolean): any {
     return value as SingleRefType;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/SpecialModelName.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/SpecialModelName.ts
@@ -46,8 +46,8 @@ export function SpecialModelNameFromJSONTyped(json: any, ignoreDiscriminator: bo
     };
 }
 
-export function SpecialModelNameToJSON(json: any): SpecialModelName {
-    return SpecialModelNameToJSONTyped(json, false);
+export function SpecialModelNameToJSON(value?: SpecialModelName | null): any {
+    return SpecialModelNameToJSONTyped(value, false);
 }
 
 export function SpecialModelNameToJSONTyped(value?: SpecialModelName | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Tag.ts
@@ -51,8 +51,8 @@ export function TagFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tag {
     };
 }
 
-export function TagToJSON(json: any): Tag {
-    return TagToJSONTyped(json, false);
+export function TagToJSON(value?: Tag | null): any {
+    return TagToJSONTyped(value, false);
 }
 
 export function TagToJSONTyped(value?: Tag | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/TestInlineFreeformAdditionalPropertiesRequest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/TestInlineFreeformAdditionalPropertiesRequest.ts
@@ -48,8 +48,8 @@ export function TestInlineFreeformAdditionalPropertiesRequestFromJSONTyped(json:
     };
 }
 
-export function TestInlineFreeformAdditionalPropertiesRequestToJSON(json: any): TestInlineFreeformAdditionalPropertiesRequest {
-    return TestInlineFreeformAdditionalPropertiesRequestToJSONTyped(json, false);
+export function TestInlineFreeformAdditionalPropertiesRequestToJSON(value?: TestInlineFreeformAdditionalPropertiesRequest | null): any {
+    return TestInlineFreeformAdditionalPropertiesRequestToJSONTyped(value, false);
 }
 
 export function TestInlineFreeformAdditionalPropertiesRequestToJSONTyped(value?: TestInlineFreeformAdditionalPropertiesRequest | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/User.ts
@@ -81,8 +81,8 @@ export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User
     };
 }
 
-export function UserToJSON(json: any): User {
-    return UserToJSONTyped(json, false);
+export function UserToJSON(value?: User | null): any {
+    return UserToJSONTyped(value, false);
 }
 
 export function UserToJSONTyped(value?: User | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/default/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/models/Category.ts
@@ -51,8 +51,8 @@ export function CategoryFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
     };
 }
 
-export function CategoryToJSON(json: any): Category {
-    return CategoryToJSONTyped(json, false);
+export function CategoryToJSON(value?: Category | null): any {
+    return CategoryToJSONTyped(value, false);
 }
 
 export function CategoryToJSONTyped(value?: Category | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/default/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/models/ModelApiResponse.ts
@@ -56,8 +56,8 @@ export function ModelApiResponseFromJSONTyped(json: any, ignoreDiscriminator: bo
     };
 }
 
-export function ModelApiResponseToJSON(json: any): ModelApiResponse {
-    return ModelApiResponseToJSONTyped(json, false);
+export function ModelApiResponseToJSON(value?: ModelApiResponse | null): any {
+    return ModelApiResponseToJSONTyped(value, false);
 }
 
 export function ModelApiResponseToJSONTyped(value?: ModelApiResponse | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/default/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/models/Order.ts
@@ -83,8 +83,8 @@ export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Ord
     };
 }
 
-export function OrderToJSON(json: any): Order {
-    return OrderToJSONTyped(json, false);
+export function OrderToJSON(value?: Order | null): any {
+    return OrderToJSONTyped(value, false);
 }
 
 export function OrderToJSONTyped(value?: Order | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/default/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/models/Pet.ts
@@ -100,8 +100,8 @@ export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
     };
 }
 
-export function PetToJSON(json: any): Pet {
-    return PetToJSONTyped(json, false);
+export function PetToJSON(value?: Pet | null): any {
+    return PetToJSONTyped(value, false);
 }
 
 export function PetToJSONTyped(value?: Pet | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/default/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/models/Tag.ts
@@ -51,8 +51,8 @@ export function TagFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tag {
     };
 }
 
-export function TagToJSON(json: any): Tag {
-    return TagToJSONTyped(json, false);
+export function TagToJSON(value?: Tag | null): any {
+    return TagToJSONTyped(value, false);
 }
 
 export function TagToJSONTyped(value?: Tag | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/default/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/models/User.ts
@@ -81,8 +81,8 @@ export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User
     };
 }
 
-export function UserToJSON(json: any): User {
-    return UserToJSONTyped(json, false);
+export function UserToJSON(value?: User | null): any {
+    return UserToJSONTyped(value, false);
 }
 
 export function UserToJSONTyped(value?: User | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/enum/models/EnumPatternObject.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/models/EnumPatternObject.ts
@@ -78,8 +78,8 @@ export function EnumPatternObjectFromJSONTyped(json: any, ignoreDiscriminator: b
     };
 }
 
-export function EnumPatternObjectToJSON(json: any): EnumPatternObject {
-    return EnumPatternObjectToJSONTyped(json, false);
+export function EnumPatternObjectToJSON(value?: EnumPatternObject | null): any {
+    return EnumPatternObjectToJSONTyped(value, false);
 }
 
 export function EnumPatternObjectToJSONTyped(value?: EnumPatternObject | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/enum/models/FakeEnumRequestGetInline200Response.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/models/FakeEnumRequestGetInline200Response.ts
@@ -103,8 +103,8 @@ export function FakeEnumRequestGetInline200ResponseFromJSONTyped(json: any, igno
     };
 }
 
-export function FakeEnumRequestGetInline200ResponseToJSON(json: any): FakeEnumRequestGetInline200Response {
-    return FakeEnumRequestGetInline200ResponseToJSONTyped(json, false);
+export function FakeEnumRequestGetInline200ResponseToJSON(value?: FakeEnumRequestGetInline200Response | null): any {
+    return FakeEnumRequestGetInline200ResponseToJSONTyped(value, false);
 }
 
 export function FakeEnumRequestGetInline200ResponseToJSONTyped(value?: FakeEnumRequestGetInline200Response | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/enum/models/NumberEnum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/models/NumberEnum.ts
@@ -48,7 +48,7 @@ export function NumberEnumToJSON(value?: NumberEnum | null): any {
     return NumberEnumToJSONTyped(value, false);
 }
 
-export function NumberEnumToJSONTyped(value?: NumberEnum | null, ignoreDiscriminator: boolean): any {
+export function NumberEnumToJSONTyped(value?: NumberEnum | null, ignoreDiscriminator: boolean = false): any {
     return value as NumberEnum;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/enum/models/NumberEnum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/models/NumberEnum.ts
@@ -45,10 +45,10 @@ export function NumberEnumFromJSONTyped(json: any, ignoreDiscriminator: boolean)
 }
 
 export function NumberEnumToJSON(value?: NumberEnum | null): any {
-    return value as any;
+    return NumberEnumToJSONTyped(value, false);
 }
 
-export function NumberEnumToJSONTyped(value: any, ignoreDiscriminator: boolean): NumberEnum {
+export function NumberEnumToJSONTyped(value?: NumberEnum | null, ignoreDiscriminator: boolean): any {
     return value as NumberEnum;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/enum/models/NumberEnum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/models/NumberEnum.ts
@@ -49,6 +49,6 @@ export function NumberEnumToJSON(value?: NumberEnum | null): any {
 }
 
 export function NumberEnumToJSONTyped(value?: NumberEnum | null, ignoreDiscriminator: boolean = false): any {
-    return value as NumberEnum;
+    return value as any;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/enum/models/StringEnum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/models/StringEnum.ts
@@ -45,10 +45,10 @@ export function StringEnumFromJSONTyped(json: any, ignoreDiscriminator: boolean)
 }
 
 export function StringEnumToJSON(value?: StringEnum | null): any {
-    return value as any;
+    return StringEnumToJSONTyped(value, false);
 }
 
-export function StringEnumToJSONTyped(value: any, ignoreDiscriminator: boolean): StringEnum {
+export function StringEnumToJSONTyped(value?: StringEnum | null, ignoreDiscriminator: boolean): any {
     return value as StringEnum;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/enum/models/StringEnum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/models/StringEnum.ts
@@ -48,7 +48,7 @@ export function StringEnumToJSON(value?: StringEnum | null): any {
     return StringEnumToJSONTyped(value, false);
 }
 
-export function StringEnumToJSONTyped(value?: StringEnum | null, ignoreDiscriminator: boolean): any {
+export function StringEnumToJSONTyped(value?: StringEnum | null, ignoreDiscriminator: boolean = false): any {
     return value as StringEnum;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/enum/models/StringEnum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/models/StringEnum.ts
@@ -49,6 +49,6 @@ export function StringEnumToJSON(value?: StringEnum | null): any {
 }
 
 export function StringEnumToJSONTyped(value?: StringEnum | null, ignoreDiscriminator: boolean = false): any {
-    return value as StringEnum;
+    return value as any;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Category.ts
@@ -51,8 +51,8 @@ export function CategoryFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
     };
 }
 
-export function CategoryToJSON(json: any): Category {
-    return CategoryToJSONTyped(json, false);
+export function CategoryToJSON(value?: Category | null): any {
+    return CategoryToJSONTyped(value, false);
 }
 
 export function CategoryToJSONTyped(value?: Category | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/ModelApiResponse.ts
@@ -56,8 +56,8 @@ export function ModelApiResponseFromJSONTyped(json: any, ignoreDiscriminator: bo
     };
 }
 
-export function ModelApiResponseToJSON(json: any): ModelApiResponse {
-    return ModelApiResponseToJSONTyped(json, false);
+export function ModelApiResponseToJSON(value?: ModelApiResponse | null): any {
+    return ModelApiResponseToJSONTyped(value, false);
 }
 
 export function ModelApiResponseToJSONTyped(value?: ModelApiResponse | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Order.ts
@@ -83,8 +83,8 @@ export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Ord
     };
 }
 
-export function OrderToJSON(json: any): Order {
-    return OrderToJSONTyped(json, false);
+export function OrderToJSON(value?: Order | null): any {
+    return OrderToJSONTyped(value, false);
 }
 
 export function OrderToJSONTyped(value?: Order | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Pet.ts
@@ -100,8 +100,8 @@ export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
     };
 }
 
-export function PetToJSON(json: any): Pet {
-    return PetToJSONTyped(json, false);
+export function PetToJSON(value?: Pet | null): any {
+    return PetToJSONTyped(value, false);
 }
 
 export function PetToJSONTyped(value?: Pet | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Tag.ts
@@ -51,8 +51,8 @@ export function TagFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tag {
     };
 }
 
-export function TagToJSON(json: any): Tag {
-    return TagToJSONTyped(json, false);
+export function TagToJSON(value?: Tag | null): any {
+    return TagToJSONTyped(value, false);
 }
 
 export function TagToJSONTyped(value?: Tag | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/User.ts
@@ -81,8 +81,8 @@ export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User
     };
 }
 
-export function UserToJSON(json: any): User {
-    return UserToJSONTyped(json, false);
+export function UserToJSON(value?: User | null): any {
+    return UserToJSONTyped(value, false);
 }
 
 export function UserToJSONTyped(value?: User | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/additional-properties-class.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/additional-properties-class.ts
@@ -51,8 +51,8 @@ export function AdditionalPropertiesClassFromJSONTyped(json: any, ignoreDiscrimi
     };
 }
 
-export function AdditionalPropertiesClassToJSON(json: any): AdditionalPropertiesClass {
-    return AdditionalPropertiesClassToJSONTyped(json, false);
+export function AdditionalPropertiesClassToJSON(value?: AdditionalPropertiesClass | null): any {
+    return AdditionalPropertiesClassToJSONTyped(value, false);
 }
 
 export function AdditionalPropertiesClassToJSONTyped(value?: AdditionalPropertiesClass | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/all-of-with-single-ref.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/all-of-with-single-ref.ts
@@ -61,8 +61,8 @@ export function AllOfWithSingleRefFromJSONTyped(json: any, ignoreDiscriminator: 
     };
 }
 
-export function AllOfWithSingleRefToJSON(json: any): AllOfWithSingleRef {
-    return AllOfWithSingleRefToJSONTyped(json, false);
+export function AllOfWithSingleRefToJSON(value?: AllOfWithSingleRef | null): any {
+    return AllOfWithSingleRefToJSONTyped(value, false);
 }
 
 export function AllOfWithSingleRefToJSONTyped(value?: AllOfWithSingleRef | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/animal.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/animal.ts
@@ -63,8 +63,8 @@ export function AnimalFromJSONTyped(json: any, ignoreDiscriminator: boolean): An
     };
 }
 
-export function AnimalToJSON(json: any): Animal {
-    return AnimalToJSONTyped(json, false);
+export function AnimalToJSON(value?: Animal | null): any {
+    return AnimalToJSONTyped(value, false);
 }
 
 export function AnimalToJSONTyped(value?: Animal | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/array-of-array-of-number-only.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/array-of-array-of-number-only.ts
@@ -46,8 +46,8 @@ export function ArrayOfArrayOfNumberOnlyFromJSONTyped(json: any, ignoreDiscrimin
     };
 }
 
-export function ArrayOfArrayOfNumberOnlyToJSON(json: any): ArrayOfArrayOfNumberOnly {
-    return ArrayOfArrayOfNumberOnlyToJSONTyped(json, false);
+export function ArrayOfArrayOfNumberOnlyToJSON(value?: ArrayOfArrayOfNumberOnly | null): any {
+    return ArrayOfArrayOfNumberOnlyToJSONTyped(value, false);
 }
 
 export function ArrayOfArrayOfNumberOnlyToJSONTyped(value?: ArrayOfArrayOfNumberOnly | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/array-of-number-only.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/array-of-number-only.ts
@@ -46,8 +46,8 @@ export function ArrayOfNumberOnlyFromJSONTyped(json: any, ignoreDiscriminator: b
     };
 }
 
-export function ArrayOfNumberOnlyToJSON(json: any): ArrayOfNumberOnly {
-    return ArrayOfNumberOnlyToJSONTyped(json, false);
+export function ArrayOfNumberOnlyToJSON(value?: ArrayOfNumberOnly | null): any {
+    return ArrayOfNumberOnlyToJSONTyped(value, false);
 }
 
 export function ArrayOfNumberOnlyToJSONTyped(value?: ArrayOfNumberOnly | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/array-test.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/array-test.ts
@@ -64,8 +64,8 @@ export function ArrayTestFromJSONTyped(json: any, ignoreDiscriminator: boolean):
     };
 }
 
-export function ArrayTestToJSON(json: any): ArrayTest {
-    return ArrayTestToJSONTyped(json, false);
+export function ArrayTestToJSON(value?: ArrayTest | null): any {
+    return ArrayTestToJSONTyped(value, false);
 }
 
 export function ArrayTestToJSONTyped(value?: ArrayTest | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/capitalization.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/capitalization.ts
@@ -72,8 +72,8 @@ export function CapitalizationFromJSONTyped(json: any, ignoreDiscriminator: bool
     };
 }
 
-export function CapitalizationToJSON(json: any): Capitalization {
-    return CapitalizationToJSONTyped(json, false);
+export function CapitalizationToJSON(value?: Capitalization | null): any {
+    return CapitalizationToJSONTyped(value, false);
 }
 
 export function CapitalizationToJSONTyped(value?: Capitalization | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/cat.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/cat.ts
@@ -54,8 +54,8 @@ export function CatFromJSONTyped(json: any, ignoreDiscriminator: boolean): Cat {
     };
 }
 
-export function CatToJSON(json: any): Cat {
-    return CatToJSONTyped(json, false);
+export function CatToJSON(value?: Cat | null): any {
+    return CatToJSONTyped(value, false);
 }
 
 export function CatToJSONTyped(value?: Cat | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/category.ts
@@ -52,8 +52,8 @@ export function CategoryFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
     };
 }
 
-export function CategoryToJSON(json: any): Category {
-    return CategoryToJSONTyped(json, false);
+export function CategoryToJSON(value?: Category | null): any {
+    return CategoryToJSONTyped(value, false);
 }
 
 export function CategoryToJSONTyped(value?: Category | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/child-with-nullable.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/child-with-nullable.ts
@@ -56,8 +56,8 @@ export function ChildWithNullableFromJSONTyped(json: any, ignoreDiscriminator: b
     };
 }
 
-export function ChildWithNullableToJSON(json: any): ChildWithNullable {
-    return ChildWithNullableToJSONTyped(json, false);
+export function ChildWithNullableToJSON(value?: ChildWithNullable | null): any {
+    return ChildWithNullableToJSONTyped(value, false);
 }
 
 export function ChildWithNullableToJSONTyped(value?: ChildWithNullable | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/class-model.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/class-model.ts
@@ -46,8 +46,8 @@ export function ClassModelFromJSONTyped(json: any, ignoreDiscriminator: boolean)
     };
 }
 
-export function ClassModelToJSON(json: any): ClassModel {
-    return ClassModelToJSONTyped(json, false);
+export function ClassModelToJSON(value?: ClassModel | null): any {
+    return ClassModelToJSONTyped(value, false);
 }
 
 export function ClassModelToJSONTyped(value?: ClassModel | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/client.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/client.ts
@@ -46,8 +46,8 @@ export function ClientFromJSONTyped(json: any, ignoreDiscriminator: boolean): Cl
     };
 }
 
-export function ClientToJSON(json: any): Client {
-    return ClientToJSONTyped(json, false);
+export function ClientToJSON(value?: Client | null): any {
+    return ClientToJSONTyped(value, false);
 }
 
 export function ClientToJSONTyped(value?: Client | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/deprecated-object.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/deprecated-object.ts
@@ -46,8 +46,8 @@ export function DeprecatedObjectFromJSONTyped(json: any, ignoreDiscriminator: bo
     };
 }
 
-export function DeprecatedObjectToJSON(json: any): DeprecatedObject {
-    return DeprecatedObjectToJSONTyped(json, false);
+export function DeprecatedObjectToJSON(value?: DeprecatedObject | null): any {
+    return DeprecatedObjectToJSONTyped(value, false);
 }
 
 export function DeprecatedObjectToJSONTyped(value?: DeprecatedObject | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/dog.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/dog.ts
@@ -54,8 +54,8 @@ export function DogFromJSONTyped(json: any, ignoreDiscriminator: boolean): Dog {
     };
 }
 
-export function DogToJSON(json: any): Dog {
-    return DogToJSONTyped(json, false);
+export function DogToJSON(value?: Dog | null): any {
+    return DogToJSONTyped(value, false);
 }
 
 export function DogToJSONTyped(value?: Dog | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/enum-arrays.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/enum-arrays.ts
@@ -71,8 +71,8 @@ export function EnumArraysFromJSONTyped(json: any, ignoreDiscriminator: boolean)
     };
 }
 
-export function EnumArraysToJSON(json: any): EnumArrays {
-    return EnumArraysToJSONTyped(json, false);
+export function EnumArraysToJSON(value?: EnumArrays | null): any {
+    return EnumArraysToJSONTyped(value, false);
 }
 
 export function EnumArraysToJSONTyped(value?: EnumArrays | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/enum-class.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/enum-class.ts
@@ -48,7 +48,7 @@ export function EnumClassToJSON(value?: EnumClass | null): any {
     return EnumClassToJSONTyped(value, false);
 }
 
-export function EnumClassToJSONTyped(value?: EnumClass | null, ignoreDiscriminator: boolean): any {
+export function EnumClassToJSONTyped(value?: EnumClass | null, ignoreDiscriminator: boolean = false): any {
     return value as EnumClass;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/enum-class.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/enum-class.ts
@@ -49,6 +49,6 @@ export function EnumClassToJSON(value?: EnumClass | null): any {
 }
 
 export function EnumClassToJSONTyped(value?: EnumClass | null, ignoreDiscriminator: boolean = false): any {
-    return value as EnumClass;
+    return value as any;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/enum-class.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/enum-class.ts
@@ -45,10 +45,10 @@ export function EnumClassFromJSONTyped(json: any, ignoreDiscriminator: boolean):
 }
 
 export function EnumClassToJSON(value?: EnumClass | null): any {
-    return value as any;
+    return EnumClassToJSONTyped(value, false);
 }
 
-export function EnumClassToJSONTyped(value: any, ignoreDiscriminator: boolean): EnumClass {
+export function EnumClassToJSONTyped(value?: EnumClass | null, ignoreDiscriminator: boolean): any {
     return value as EnumClass;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/enum-test.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/enum-test.ts
@@ -151,8 +151,8 @@ export function EnumTestFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
     };
 }
 
-export function EnumTestToJSON(json: any): EnumTest {
-    return EnumTestToJSONTyped(json, false);
+export function EnumTestToJSON(value?: EnumTest | null): any {
+    return EnumTestToJSONTyped(value, false);
 }
 
 export function EnumTestToJSONTyped(value?: EnumTest | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/fake-big-decimal-map200-response.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/fake-big-decimal-map200-response.ts
@@ -51,8 +51,8 @@ export function FakeBigDecimalMap200ResponseFromJSONTyped(json: any, ignoreDiscr
     };
 }
 
-export function FakeBigDecimalMap200ResponseToJSON(json: any): FakeBigDecimalMap200Response {
-    return FakeBigDecimalMap200ResponseToJSONTyped(json, false);
+export function FakeBigDecimalMap200ResponseToJSON(value?: FakeBigDecimalMap200Response | null): any {
+    return FakeBigDecimalMap200ResponseToJSONTyped(value, false);
 }
 
 export function FakeBigDecimalMap200ResponseToJSONTyped(value?: FakeBigDecimalMap200Response | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/file-schema-test-class.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/file-schema-test-class.ts
@@ -51,8 +51,8 @@ export function FileSchemaTestClassFromJSONTyped(json: any, ignoreDiscriminator:
     };
 }
 
-export function FileSchemaTestClassToJSON(json: any): FileSchemaTestClass {
-    return FileSchemaTestClassToJSONTyped(json, false);
+export function FileSchemaTestClassToJSON(value?: FileSchemaTestClass | null): any {
+    return FileSchemaTestClassToJSONTyped(value, false);
 }
 
 export function FileSchemaTestClassToJSONTyped(value?: FileSchemaTestClass | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/foo-get-default-response.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/foo-get-default-response.ts
@@ -54,8 +54,8 @@ export function FooGetDefaultResponseFromJSONTyped(json: any, ignoreDiscriminato
     };
 }
 
-export function FooGetDefaultResponseToJSON(json: any): FooGetDefaultResponse {
-    return FooGetDefaultResponseToJSONTyped(json, false);
+export function FooGetDefaultResponseToJSON(value?: FooGetDefaultResponse | null): any {
+    return FooGetDefaultResponseToJSONTyped(value, false);
 }
 
 export function FooGetDefaultResponseToJSONTyped(value?: FooGetDefaultResponse | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/foo.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/foo.ts
@@ -46,8 +46,8 @@ export function FooFromJSONTyped(json: any, ignoreDiscriminator: boolean): Foo {
     };
 }
 
-export function FooToJSON(json: any): Foo {
-    return FooToJSONTyped(json, false);
+export function FooToJSON(value?: Foo | null): any {
+    return FooToJSONTyped(value, false);
 }
 
 export function FooToJSONTyped(value?: Foo | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/format-test.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/format-test.ts
@@ -125,8 +125,8 @@ export function FormatTestFromJSONTyped(json: any, ignoreDiscriminator: boolean)
     };
 }
 
-export function FormatTestToJSON(json: any): FormatTest {
-    return FormatTestToJSONTyped(json, false);
+export function FormatTestToJSON(value?: FormatTest | null): any {
+    return FormatTestToJSONTyped(value, false);
 }
 
 export function FormatTestToJSONTyped(value?: FormatTest | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/has-only-read-only.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/has-only-read-only.ts
@@ -51,8 +51,8 @@ export function HasOnlyReadOnlyFromJSONTyped(json: any, ignoreDiscriminator: boo
     };
 }
 
-export function HasOnlyReadOnlyToJSON(json: any): HasOnlyReadOnly {
-    return HasOnlyReadOnlyToJSONTyped(json, false);
+export function HasOnlyReadOnlyToJSON(value?: HasOnlyReadOnly | null): any {
+    return HasOnlyReadOnlyToJSONTyped(value, false);
 }
 
 export function HasOnlyReadOnlyToJSONTyped(value?: Omit<HasOnlyReadOnly, 'bar'|'foo'> | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/health-check-result.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/health-check-result.ts
@@ -46,8 +46,8 @@ export function HealthCheckResultFromJSONTyped(json: any, ignoreDiscriminator: b
     };
 }
 
-export function HealthCheckResultToJSON(json: any): HealthCheckResult {
-    return HealthCheckResultToJSONTyped(json, false);
+export function HealthCheckResultToJSON(value?: HealthCheckResult | null): any {
+    return HealthCheckResultToJSONTyped(value, false);
 }
 
 export function HealthCheckResultToJSONTyped(value?: HealthCheckResult | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/list.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/list.ts
@@ -46,8 +46,8 @@ export function ListFromJSONTyped(json: any, ignoreDiscriminator: boolean): List
     };
 }
 
-export function ListToJSON(json: any): List {
-    return ListToJSONTyped(json, false);
+export function ListToJSON(value?: List | null): any {
+    return ListToJSONTyped(value, false);
 }
 
 export function ListToJSONTyped(value?: List | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/map-test.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/map-test.ts
@@ -72,8 +72,8 @@ export function MapTestFromJSONTyped(json: any, ignoreDiscriminator: boolean): M
     };
 }
 
-export function MapTestToJSON(json: any): MapTest {
-    return MapTestToJSONTyped(json, false);
+export function MapTestToJSON(value?: MapTest | null): any {
+    return MapTestToJSONTyped(value, false);
 }
 
 export function MapTestToJSONTyped(value?: MapTest | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/mixed-properties-and-additional-properties-class.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/mixed-properties-and-additional-properties-class.ts
@@ -64,8 +64,8 @@ export function MixedPropertiesAndAdditionalPropertiesClassFromJSONTyped(json: a
     };
 }
 
-export function MixedPropertiesAndAdditionalPropertiesClassToJSON(json: any): MixedPropertiesAndAdditionalPropertiesClass {
-    return MixedPropertiesAndAdditionalPropertiesClassToJSONTyped(json, false);
+export function MixedPropertiesAndAdditionalPropertiesClassToJSON(value?: MixedPropertiesAndAdditionalPropertiesClass | null): any {
+    return MixedPropertiesAndAdditionalPropertiesClassToJSONTyped(value, false);
 }
 
 export function MixedPropertiesAndAdditionalPropertiesClassToJSONTyped(value?: MixedPropertiesAndAdditionalPropertiesClass | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/model-api-response.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/model-api-response.ts
@@ -56,8 +56,8 @@ export function ModelApiResponseFromJSONTyped(json: any, ignoreDiscriminator: bo
     };
 }
 
-export function ModelApiResponseToJSON(json: any): ModelApiResponse {
-    return ModelApiResponseToJSONTyped(json, false);
+export function ModelApiResponseToJSON(value?: ModelApiResponse | null): any {
+    return ModelApiResponseToJSONTyped(value, false);
 }
 
 export function ModelApiResponseToJSONTyped(value?: ModelApiResponse | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/model-file.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/model-file.ts
@@ -46,8 +46,8 @@ export function ModelFileFromJSONTyped(json: any, ignoreDiscriminator: boolean):
     };
 }
 
-export function ModelFileToJSON(json: any): ModelFile {
-    return ModelFileToJSONTyped(json, false);
+export function ModelFileToJSON(value?: ModelFile | null): any {
+    return ModelFileToJSONTyped(value, false);
 }
 
 export function ModelFileToJSONTyped(value?: ModelFile | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/model200-response.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/model200-response.ts
@@ -51,8 +51,8 @@ export function Model200ResponseFromJSONTyped(json: any, ignoreDiscriminator: bo
     };
 }
 
-export function Model200ResponseToJSON(json: any): Model200Response {
-    return Model200ResponseToJSONTyped(json, false);
+export function Model200ResponseToJSON(value?: Model200Response | null): any {
+    return Model200ResponseToJSONTyped(value, false);
 }
 
 export function Model200ResponseToJSONTyped(value?: Model200Response | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/name.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/name.ts
@@ -62,8 +62,8 @@ export function NameFromJSONTyped(json: any, ignoreDiscriminator: boolean): Name
     };
 }
 
-export function NameToJSON(json: any): Name {
-    return NameToJSONTyped(json, false);
+export function NameToJSON(value?: Name | null): any {
+    return NameToJSONTyped(value, false);
 }
 
 export function NameToJSONTyped(value?: Omit<Name, 'snakeCase'|'_123number'> | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/nullable-class.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/nullable-class.ts
@@ -103,8 +103,8 @@ export function NullableClassFromJSONTyped(json: any, ignoreDiscriminator: boole
     };
 }
 
-export function NullableClassToJSON(json: any): NullableClass {
-    return NullableClassToJSONTyped(json, false);
+export function NullableClassToJSON(value?: NullableClass | null): any {
+    return NullableClassToJSONTyped(value, false);
 }
 
 export function NullableClassToJSONTyped(value?: NullableClass | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/number-only.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/number-only.ts
@@ -46,8 +46,8 @@ export function NumberOnlyFromJSONTyped(json: any, ignoreDiscriminator: boolean)
     };
 }
 
-export function NumberOnlyToJSON(json: any): NumberOnly {
-    return NumberOnlyToJSONTyped(json, false);
+export function NumberOnlyToJSON(value?: NumberOnly | null): any {
+    return NumberOnlyToJSONTyped(value, false);
 }
 
 export function NumberOnlyToJSONTyped(value?: NumberOnly | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/object-with-deprecated-fields.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/object-with-deprecated-fields.ts
@@ -72,8 +72,8 @@ export function ObjectWithDeprecatedFieldsFromJSONTyped(json: any, ignoreDiscrim
     };
 }
 
-export function ObjectWithDeprecatedFieldsToJSON(json: any): ObjectWithDeprecatedFields {
-    return ObjectWithDeprecatedFieldsToJSONTyped(json, false);
+export function ObjectWithDeprecatedFieldsToJSON(value?: ObjectWithDeprecatedFields | null): any {
+    return ObjectWithDeprecatedFieldsToJSONTyped(value, false);
 }
 
 export function ObjectWithDeprecatedFieldsToJSONTyped(value?: ObjectWithDeprecatedFields | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/order.ts
@@ -83,8 +83,8 @@ export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Ord
     };
 }
 
-export function OrderToJSON(json: any): Order {
-    return OrderToJSONTyped(json, false);
+export function OrderToJSON(value?: Order | null): any {
+    return OrderToJSONTyped(value, false);
 }
 
 export function OrderToJSONTyped(value?: Order | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/outer-composite.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/outer-composite.ts
@@ -56,8 +56,8 @@ export function OuterCompositeFromJSONTyped(json: any, ignoreDiscriminator: bool
     };
 }
 
-export function OuterCompositeToJSON(json: any): OuterComposite {
-    return OuterCompositeToJSONTyped(json, false);
+export function OuterCompositeToJSON(value?: OuterComposite | null): any {
+    return OuterCompositeToJSONTyped(value, false);
 }
 
 export function OuterCompositeToJSONTyped(value?: OuterComposite | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/outer-enum-default-value.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/outer-enum-default-value.ts
@@ -45,10 +45,10 @@ export function OuterEnumDefaultValueFromJSONTyped(json: any, ignoreDiscriminato
 }
 
 export function OuterEnumDefaultValueToJSON(value?: OuterEnumDefaultValue | null): any {
-    return value as any;
+    return OuterEnumDefaultValueToJSONTyped(value, false);
 }
 
-export function OuterEnumDefaultValueToJSONTyped(value: any, ignoreDiscriminator: boolean): OuterEnumDefaultValue {
+export function OuterEnumDefaultValueToJSONTyped(value?: OuterEnumDefaultValue | null, ignoreDiscriminator: boolean): any {
     return value as OuterEnumDefaultValue;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/outer-enum-default-value.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/outer-enum-default-value.ts
@@ -48,7 +48,7 @@ export function OuterEnumDefaultValueToJSON(value?: OuterEnumDefaultValue | null
     return OuterEnumDefaultValueToJSONTyped(value, false);
 }
 
-export function OuterEnumDefaultValueToJSONTyped(value?: OuterEnumDefaultValue | null, ignoreDiscriminator: boolean): any {
+export function OuterEnumDefaultValueToJSONTyped(value?: OuterEnumDefaultValue | null, ignoreDiscriminator: boolean = false): any {
     return value as OuterEnumDefaultValue;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/outer-enum-default-value.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/outer-enum-default-value.ts
@@ -49,6 +49,6 @@ export function OuterEnumDefaultValueToJSON(value?: OuterEnumDefaultValue | null
 }
 
 export function OuterEnumDefaultValueToJSONTyped(value?: OuterEnumDefaultValue | null, ignoreDiscriminator: boolean = false): any {
-    return value as OuterEnumDefaultValue;
+    return value as any;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/outer-enum-integer-default-value.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/outer-enum-integer-default-value.ts
@@ -45,10 +45,10 @@ export function OuterEnumIntegerDefaultValueFromJSONTyped(json: any, ignoreDiscr
 }
 
 export function OuterEnumIntegerDefaultValueToJSON(value?: OuterEnumIntegerDefaultValue | null): any {
-    return value as any;
+    return OuterEnumIntegerDefaultValueToJSONTyped(value, false);
 }
 
-export function OuterEnumIntegerDefaultValueToJSONTyped(value: any, ignoreDiscriminator: boolean): OuterEnumIntegerDefaultValue {
+export function OuterEnumIntegerDefaultValueToJSONTyped(value?: OuterEnumIntegerDefaultValue | null, ignoreDiscriminator: boolean): any {
     return value as OuterEnumIntegerDefaultValue;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/outer-enum-integer-default-value.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/outer-enum-integer-default-value.ts
@@ -49,6 +49,6 @@ export function OuterEnumIntegerDefaultValueToJSON(value?: OuterEnumIntegerDefau
 }
 
 export function OuterEnumIntegerDefaultValueToJSONTyped(value?: OuterEnumIntegerDefaultValue | null, ignoreDiscriminator: boolean = false): any {
-    return value as OuterEnumIntegerDefaultValue;
+    return value as any;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/outer-enum-integer-default-value.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/outer-enum-integer-default-value.ts
@@ -48,7 +48,7 @@ export function OuterEnumIntegerDefaultValueToJSON(value?: OuterEnumIntegerDefau
     return OuterEnumIntegerDefaultValueToJSONTyped(value, false);
 }
 
-export function OuterEnumIntegerDefaultValueToJSONTyped(value?: OuterEnumIntegerDefaultValue | null, ignoreDiscriminator: boolean): any {
+export function OuterEnumIntegerDefaultValueToJSONTyped(value?: OuterEnumIntegerDefaultValue | null, ignoreDiscriminator: boolean = false): any {
     return value as OuterEnumIntegerDefaultValue;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/outer-enum-integer.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/outer-enum-integer.ts
@@ -48,7 +48,7 @@ export function OuterEnumIntegerToJSON(value?: OuterEnumInteger | null): any {
     return OuterEnumIntegerToJSONTyped(value, false);
 }
 
-export function OuterEnumIntegerToJSONTyped(value?: OuterEnumInteger | null, ignoreDiscriminator: boolean): any {
+export function OuterEnumIntegerToJSONTyped(value?: OuterEnumInteger | null, ignoreDiscriminator: boolean = false): any {
     return value as OuterEnumInteger;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/outer-enum-integer.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/outer-enum-integer.ts
@@ -45,10 +45,10 @@ export function OuterEnumIntegerFromJSONTyped(json: any, ignoreDiscriminator: bo
 }
 
 export function OuterEnumIntegerToJSON(value?: OuterEnumInteger | null): any {
-    return value as any;
+    return OuterEnumIntegerToJSONTyped(value, false);
 }
 
-export function OuterEnumIntegerToJSONTyped(value: any, ignoreDiscriminator: boolean): OuterEnumInteger {
+export function OuterEnumIntegerToJSONTyped(value?: OuterEnumInteger | null, ignoreDiscriminator: boolean): any {
     return value as OuterEnumInteger;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/outer-enum-integer.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/outer-enum-integer.ts
@@ -49,6 +49,6 @@ export function OuterEnumIntegerToJSON(value?: OuterEnumInteger | null): any {
 }
 
 export function OuterEnumIntegerToJSONTyped(value?: OuterEnumInteger | null, ignoreDiscriminator: boolean = false): any {
-    return value as OuterEnumInteger;
+    return value as any;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/outer-enum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/outer-enum.ts
@@ -45,10 +45,10 @@ export function OuterEnumFromJSONTyped(json: any, ignoreDiscriminator: boolean):
 }
 
 export function OuterEnumToJSON(value?: OuterEnum | null): any {
-    return value as any;
+    return OuterEnumToJSONTyped(value, false);
 }
 
-export function OuterEnumToJSONTyped(value: any, ignoreDiscriminator: boolean): OuterEnum {
+export function OuterEnumToJSONTyped(value?: OuterEnum | null, ignoreDiscriminator: boolean): any {
     return value as OuterEnum;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/outer-enum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/outer-enum.ts
@@ -49,6 +49,6 @@ export function OuterEnumToJSON(value?: OuterEnum | null): any {
 }
 
 export function OuterEnumToJSONTyped(value?: OuterEnum | null, ignoreDiscriminator: boolean = false): any {
-    return value as OuterEnum;
+    return value as any;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/outer-enum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/outer-enum.ts
@@ -48,7 +48,7 @@ export function OuterEnumToJSON(value?: OuterEnum | null): any {
     return OuterEnumToJSONTyped(value, false);
 }
 
-export function OuterEnumToJSONTyped(value?: OuterEnum | null, ignoreDiscriminator: boolean): any {
+export function OuterEnumToJSONTyped(value?: OuterEnum | null, ignoreDiscriminator: boolean = false): any {
     return value as OuterEnum;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/outer-object-with-enum-property.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/outer-object-with-enum-property.ts
@@ -57,8 +57,8 @@ export function OuterObjectWithEnumPropertyFromJSONTyped(json: any, ignoreDiscri
     };
 }
 
-export function OuterObjectWithEnumPropertyToJSON(json: any): OuterObjectWithEnumProperty {
-    return OuterObjectWithEnumPropertyToJSONTyped(json, false);
+export function OuterObjectWithEnumPropertyToJSON(value?: OuterObjectWithEnumProperty | null): any {
+    return OuterObjectWithEnumPropertyToJSONTyped(value, false);
 }
 
 export function OuterObjectWithEnumPropertyToJSONTyped(value?: OuterObjectWithEnumProperty | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/parent-with-nullable.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/parent-with-nullable.ts
@@ -68,8 +68,8 @@ export function ParentWithNullableFromJSONTyped(json: any, ignoreDiscriminator: 
     };
 }
 
-export function ParentWithNullableToJSON(json: any): ParentWithNullable {
-    return ParentWithNullableToJSONTyped(json, false);
+export function ParentWithNullableToJSON(value?: ParentWithNullable | null): any {
+    return ParentWithNullableToJSONTyped(value, false);
 }
 
 export function ParentWithNullableToJSONTyped(value?: ParentWithNullable | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/pet.ts
@@ -100,8 +100,8 @@ export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
     };
 }
 
-export function PetToJSON(json: any): Pet {
-    return PetToJSONTyped(json, false);
+export function PetToJSON(value?: Pet | null): any {
+    return PetToJSONTyped(value, false);
 }
 
 export function PetToJSONTyped(value?: Pet | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/read-only-first.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/read-only-first.ts
@@ -51,8 +51,8 @@ export function ReadOnlyFirstFromJSONTyped(json: any, ignoreDiscriminator: boole
     };
 }
 
-export function ReadOnlyFirstToJSON(json: any): ReadOnlyFirst {
-    return ReadOnlyFirstToJSONTyped(json, false);
+export function ReadOnlyFirstToJSON(value?: ReadOnlyFirst | null): any {
+    return ReadOnlyFirstToJSONTyped(value, false);
 }
 
 export function ReadOnlyFirstToJSONTyped(value?: Omit<ReadOnlyFirst, 'bar'> | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/return.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/return.ts
@@ -46,8 +46,8 @@ export function ReturnFromJSONTyped(json: any, ignoreDiscriminator: boolean): Re
     };
 }
 
-export function ReturnToJSON(json: any): Return {
-    return ReturnToJSONTyped(json, false);
+export function ReturnToJSON(value?: Return | null): any {
+    return ReturnToJSONTyped(value, false);
 }
 
 export function ReturnToJSONTyped(value?: Return | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/single-ref-type.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/single-ref-type.ts
@@ -47,7 +47,7 @@ export function SingleRefTypeToJSON(value?: SingleRefType | null): any {
     return SingleRefTypeToJSONTyped(value, false);
 }
 
-export function SingleRefTypeToJSONTyped(value?: SingleRefType | null, ignoreDiscriminator: boolean): any {
+export function SingleRefTypeToJSONTyped(value?: SingleRefType | null, ignoreDiscriminator: boolean = false): any {
     return value as SingleRefType;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/single-ref-type.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/single-ref-type.ts
@@ -48,6 +48,6 @@ export function SingleRefTypeToJSON(value?: SingleRefType | null): any {
 }
 
 export function SingleRefTypeToJSONTyped(value?: SingleRefType | null, ignoreDiscriminator: boolean = false): any {
-    return value as SingleRefType;
+    return value as any;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/single-ref-type.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/single-ref-type.ts
@@ -44,10 +44,10 @@ export function SingleRefTypeFromJSONTyped(json: any, ignoreDiscriminator: boole
 }
 
 export function SingleRefTypeToJSON(value?: SingleRefType | null): any {
-    return value as any;
+    return SingleRefTypeToJSONTyped(value, false);
 }
 
-export function SingleRefTypeToJSONTyped(value: any, ignoreDiscriminator: boolean): SingleRefType {
+export function SingleRefTypeToJSONTyped(value?: SingleRefType | null, ignoreDiscriminator: boolean): any {
     return value as SingleRefType;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/special-model-name.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/special-model-name.ts
@@ -46,8 +46,8 @@ export function SpecialModelNameFromJSONTyped(json: any, ignoreDiscriminator: bo
     };
 }
 
-export function SpecialModelNameToJSON(json: any): SpecialModelName {
-    return SpecialModelNameToJSONTyped(json, false);
+export function SpecialModelNameToJSON(value?: SpecialModelName | null): any {
+    return SpecialModelNameToJSONTyped(value, false);
 }
 
 export function SpecialModelNameToJSONTyped(value?: SpecialModelName | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/tag.ts
@@ -51,8 +51,8 @@ export function TagFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tag {
     };
 }
 
-export function TagToJSON(json: any): Tag {
-    return TagToJSONTyped(json, false);
+export function TagToJSON(value?: Tag | null): any {
+    return TagToJSONTyped(value, false);
 }
 
 export function TagToJSONTyped(value?: Tag | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/test-inline-freeform-additional-properties-request.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/test-inline-freeform-additional-properties-request.ts
@@ -48,8 +48,8 @@ export function TestInlineFreeformAdditionalPropertiesRequestFromJSONTyped(json:
     };
 }
 
-export function TestInlineFreeformAdditionalPropertiesRequestToJSON(json: any): TestInlineFreeformAdditionalPropertiesRequest {
-    return TestInlineFreeformAdditionalPropertiesRequestToJSONTyped(json, false);
+export function TestInlineFreeformAdditionalPropertiesRequestToJSON(value?: TestInlineFreeformAdditionalPropertiesRequest | null): any {
+    return TestInlineFreeformAdditionalPropertiesRequestToJSONTyped(value, false);
 }
 
 export function TestInlineFreeformAdditionalPropertiesRequestToJSONTyped(value?: TestInlineFreeformAdditionalPropertiesRequest | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/user.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/user.ts
@@ -81,8 +81,8 @@ export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User
     };
 }
 
-export function UserToJSON(json: any): User {
-    return UserToJSONTyped(json, false);
+export function UserToJSON(value?: User | null): any {
+    return UserToJSONTyped(value, false);
 }
 
 export function UserToJSONTyped(value?: User | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Category.ts
@@ -51,8 +51,8 @@ export function CategoryFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
     };
 }
 
-export function CategoryToJSON(json: any): Category {
-    return CategoryToJSONTyped(json, false);
+export function CategoryToJSON(value?: Category | null): any {
+    return CategoryToJSONTyped(value, false);
 }
 
 export function CategoryToJSONTyped(value?: Category | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/ModelApiResponse.ts
@@ -56,8 +56,8 @@ export function ModelApiResponseFromJSONTyped(json: any, ignoreDiscriminator: bo
     };
 }
 
-export function ModelApiResponseToJSON(json: any): ModelApiResponse {
-    return ModelApiResponseToJSONTyped(json, false);
+export function ModelApiResponseToJSON(value?: ModelApiResponse | null): any {
+    return ModelApiResponseToJSONTyped(value, false);
 }
 
 export function ModelApiResponseToJSONTyped(value?: ModelApiResponse | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Order.ts
@@ -83,8 +83,8 @@ export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Ord
     };
 }
 
-export function OrderToJSON(json: any): Order {
-    return OrderToJSONTyped(json, false);
+export function OrderToJSON(value?: Order | null): any {
+    return OrderToJSONTyped(value, false);
 }
 
 export function OrderToJSONTyped(value?: Order | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Pet.ts
@@ -100,8 +100,8 @@ export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
     };
 }
 
-export function PetToJSON(json: any): Pet {
-    return PetToJSONTyped(json, false);
+export function PetToJSON(value?: Pet | null): any {
+    return PetToJSONTyped(value, false);
 }
 
 export function PetToJSONTyped(value?: Pet | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Tag.ts
@@ -51,8 +51,8 @@ export function TagFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tag {
     };
 }
 
-export function TagToJSON(json: any): Tag {
-    return TagToJSONTyped(json, false);
+export function TagToJSON(value?: Tag | null): any {
+    return TagToJSONTyped(value, false);
 }
 
 export function TagToJSONTyped(value?: Tag | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/User.ts
@@ -81,8 +81,8 @@ export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User
     };
 }
 
-export function UserToJSON(json: any): User {
-    return UserToJSONTyped(json, false);
+export function UserToJSON(value?: User | null): any {
+    return UserToJSONTyped(value, false);
 }
 
 export function UserToJSONTyped(value?: User | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/oneOf/models/DashedOptionOne.ts
+++ b/samples/client/petstore/typescript-fetch/builds/oneOf/models/DashedOptionOne.ts
@@ -65,8 +65,8 @@ export function DashedOptionOneFromJSONTyped(json: any, ignoreDiscriminator: boo
     };
 }
 
-export function DashedOptionOneToJSON(json: any): DashedOptionOne {
-    return DashedOptionOneToJSONTyped(json, false);
+export function DashedOptionOneToJSON(value?: DashedOptionOne | null): any {
+    return DashedOptionOneToJSONTyped(value, false);
 }
 
 export function DashedOptionOneToJSONTyped(value?: DashedOptionOne | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/oneOf/models/DashedOptionTwo.ts
+++ b/samples/client/petstore/typescript-fetch/builds/oneOf/models/DashedOptionTwo.ts
@@ -65,8 +65,8 @@ export function DashedOptionTwoFromJSONTyped(json: any, ignoreDiscriminator: boo
     };
 }
 
-export function DashedOptionTwoToJSON(json: any): DashedOptionTwo {
-    return DashedOptionTwoToJSONTyped(json, false);
+export function DashedOptionTwoToJSON(value?: DashedOptionTwo | null): any {
+    return DashedOptionTwoToJSONTyped(value, false);
 }
 
 export function DashedOptionTwoToJSONTyped(value?: DashedOptionTwo | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/oneOf/models/NumericSingletonEnumModel.ts
+++ b/samples/client/petstore/typescript-fetch/builds/oneOf/models/NumericSingletonEnumModel.ts
@@ -59,8 +59,8 @@ export function NumericSingletonEnumModelFromJSONTyped(json: any, ignoreDiscrimi
     };
 }
 
-export function NumericSingletonEnumModelToJSON(json: any): NumericSingletonEnumModel {
-    return NumericSingletonEnumModelToJSONTyped(json, false);
+export function NumericSingletonEnumModelToJSON(value?: NumericSingletonEnumModel | null): any {
+    return NumericSingletonEnumModelToJSONTyped(value, false);
 }
 
 export function NumericSingletonEnumModelToJSONTyped(value?: NumericSingletonEnumModel | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/oneOf/models/OptionOne.ts
+++ b/samples/client/petstore/typescript-fetch/builds/oneOf/models/OptionOne.ts
@@ -59,8 +59,8 @@ export function OptionOneFromJSONTyped(json: any, ignoreDiscriminator: boolean):
     };
 }
 
-export function OptionOneToJSON(json: any): OptionOne {
-    return OptionOneToJSONTyped(json, false);
+export function OptionOneToJSON(value?: OptionOne | null): any {
+    return OptionOneToJSONTyped(value, false);
 }
 
 export function OptionOneToJSONTyped(value?: OptionOne | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/oneOf/models/OptionTwo.ts
+++ b/samples/client/petstore/typescript-fetch/builds/oneOf/models/OptionTwo.ts
@@ -59,8 +59,8 @@ export function OptionTwoFromJSONTyped(json: any, ignoreDiscriminator: boolean):
     };
 }
 
-export function OptionTwoToJSON(json: any): OptionTwo {
-    return OptionTwoToJSONTyped(json, false);
+export function OptionTwoToJSON(value?: OptionTwo | null): any {
+    return OptionTwoToJSONTyped(value, false);
 }
 
 export function OptionTwoToJSONTyped(value?: OptionTwo | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/oneOf/models/SnakeOptionOne.ts
+++ b/samples/client/petstore/typescript-fetch/builds/oneOf/models/SnakeOptionOne.ts
@@ -65,8 +65,8 @@ export function SnakeOptionOneFromJSONTyped(json: any, ignoreDiscriminator: bool
     };
 }
 
-export function SnakeOptionOneToJSON(json: any): SnakeOptionOne {
-    return SnakeOptionOneToJSONTyped(json, false);
+export function SnakeOptionOneToJSON(value?: SnakeOptionOne | null): any {
+    return SnakeOptionOneToJSONTyped(value, false);
 }
 
 export function SnakeOptionOneToJSONTyped(value?: SnakeOptionOne | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/oneOf/models/SnakeOptionTwo.ts
+++ b/samples/client/petstore/typescript-fetch/builds/oneOf/models/SnakeOptionTwo.ts
@@ -65,8 +65,8 @@ export function SnakeOptionTwoFromJSONTyped(json: any, ignoreDiscriminator: bool
     };
 }
 
-export function SnakeOptionTwoToJSON(json: any): SnakeOptionTwo {
-    return SnakeOptionTwoToJSONTyped(json, false);
+export function SnakeOptionTwoToJSON(value?: SnakeOptionTwo | null): any {
+    return SnakeOptionTwoToJSONTyped(value, false);
 }
 
 export function SnakeOptionTwoToJSONTyped(value?: SnakeOptionTwo | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/oneOf/models/TestA.ts
+++ b/samples/client/petstore/typescript-fetch/builds/oneOf/models/TestA.ts
@@ -47,8 +47,8 @@ export function TestAFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tes
     };
 }
 
-export function TestAToJSON(json: any): TestA {
-    return TestAToJSONTyped(json, false);
+export function TestAToJSON(value?: TestA | null): any {
+    return TestAToJSONTyped(value, false);
 }
 
 export function TestAToJSONTyped(value?: TestA | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/oneOf/models/TestArrayResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/oneOf/models/TestArrayResponse.ts
@@ -63,8 +63,8 @@ export function TestArrayResponseFromJSONTyped(json: any, ignoreDiscriminator: b
     return {} as any;
 }
 
-export function TestArrayResponseToJSON(json: any): any {
-    return TestArrayResponseToJSONTyped(json, false);
+export function TestArrayResponseToJSON(value?: TestArrayResponse | null): any {
+    return TestArrayResponseToJSONTyped(value, false);
 }
 
 export function TestArrayResponseToJSONTyped(value?: TestArrayResponse | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/oneOf/models/TestB.ts
+++ b/samples/client/petstore/typescript-fetch/builds/oneOf/models/TestB.ts
@@ -47,8 +47,8 @@ export function TestBFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tes
     };
 }
 
-export function TestBToJSON(json: any): TestB {
-    return TestBToJSONTyped(json, false);
+export function TestBToJSON(value?: TestB | null): any {
+    return TestBToJSONTyped(value, false);
 }
 
 export function TestBToJSONTyped(value?: TestB | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/oneOf/models/TestDashedDiscriminatorResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/oneOf/models/TestDashedDiscriminatorResponse.ts
@@ -52,8 +52,8 @@ export function TestDashedDiscriminatorResponseFromJSONTyped(json: any, ignoreDi
     }
 }
 
-export function TestDashedDiscriminatorResponseToJSON(json: any): any {
-    return TestDashedDiscriminatorResponseToJSONTyped(json, false);
+export function TestDashedDiscriminatorResponseToJSON(value?: TestDashedDiscriminatorResponse | null): any {
+    return TestDashedDiscriminatorResponseToJSONTyped(value, false);
 }
 
 export function TestDashedDiscriminatorResponseToJSONTyped(value?: TestDashedDiscriminatorResponse | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/oneOf/models/TestDiscriminatorResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/oneOf/models/TestDiscriminatorResponse.ts
@@ -52,8 +52,8 @@ export function TestDiscriminatorResponseFromJSONTyped(json: any, ignoreDiscrimi
     }
 }
 
-export function TestDiscriminatorResponseToJSON(json: any): any {
-    return TestDiscriminatorResponseToJSONTyped(json, false);
+export function TestDiscriminatorResponseToJSON(value?: TestDiscriminatorResponse | null): any {
+    return TestDiscriminatorResponseToJSONTyped(value, false);
 }
 
 export function TestDiscriminatorResponseToJSONTyped(value?: TestDiscriminatorResponse | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/oneOf/models/TestResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/oneOf/models/TestResponse.ts
@@ -57,8 +57,8 @@ export function TestResponseFromJSONTyped(json: any, ignoreDiscriminator: boolea
     return {} as any;
 }
 
-export function TestResponseToJSON(json: any): any {
-    return TestResponseToJSONTyped(json, false);
+export function TestResponseToJSON(value?: TestResponse | null): any {
+    return TestResponseToJSONTyped(value, false);
 }
 
 export function TestResponseToJSONTyped(value?: TestResponse | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/oneOf/models/TestSnakeCaseDiscriminatorResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/oneOf/models/TestSnakeCaseDiscriminatorResponse.ts
@@ -52,8 +52,8 @@ export function TestSnakeCaseDiscriminatorResponseFromJSONTyped(json: any, ignor
     }
 }
 
-export function TestSnakeCaseDiscriminatorResponseToJSON(json: any): any {
-    return TestSnakeCaseDiscriminatorResponseToJSONTyped(json, false);
+export function TestSnakeCaseDiscriminatorResponseToJSON(value?: TestSnakeCaseDiscriminatorResponse | null): any {
+    return TestSnakeCaseDiscriminatorResponseToJSONTyped(value, false);
 }
 
 export function TestSnakeCaseDiscriminatorResponseToJSONTyped(value?: TestSnakeCaseDiscriminatorResponse | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Category.ts
@@ -51,8 +51,8 @@ export function CategoryFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
     };
 }
 
-export function CategoryToJSON(json: any): Category {
-    return CategoryToJSONTyped(json, false);
+export function CategoryToJSON(value?: Category | null): any {
+    return CategoryToJSONTyped(value, false);
 }
 
 export function CategoryToJSONTyped(value?: Category | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/ModelApiResponse.ts
@@ -56,8 +56,8 @@ export function ModelApiResponseFromJSONTyped(json: any, ignoreDiscriminator: bo
     };
 }
 
-export function ModelApiResponseToJSON(json: any): ModelApiResponse {
-    return ModelApiResponseToJSONTyped(json, false);
+export function ModelApiResponseToJSON(value?: ModelApiResponse | null): any {
+    return ModelApiResponseToJSONTyped(value, false);
 }
 
 export function ModelApiResponseToJSONTyped(value?: ModelApiResponse | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Order.ts
@@ -83,8 +83,8 @@ export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Ord
     };
 }
 
-export function OrderToJSON(json: any): Order {
-    return OrderToJSONTyped(json, false);
+export function OrderToJSON(value?: Order | null): any {
+    return OrderToJSONTyped(value, false);
 }
 
 export function OrderToJSONTyped(value?: Order | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Pet.ts
@@ -100,8 +100,8 @@ export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
     };
 }
 
-export function PetToJSON(json: any): Pet {
-    return PetToJSONTyped(json, false);
+export function PetToJSON(value?: Pet | null): any {
+    return PetToJSONTyped(value, false);
 }
 
 export function PetToJSONTyped(value?: Pet | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Tag.ts
@@ -51,8 +51,8 @@ export function TagFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tag {
     };
 }
 
-export function TagToJSON(json: any): Tag {
-    return TagToJSONTyped(json, false);
+export function TagToJSON(value?: Tag | null): any {
+    return TagToJSONTyped(value, false);
 }
 
 export function TagToJSONTyped(value?: Tag | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/User.ts
@@ -81,8 +81,8 @@ export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User
     };
 }
 
-export function UserToJSON(json: any): User {
-    return UserToJSONTyped(json, false);
+export function UserToJSON(value?: User | null): any {
+    return UserToJSONTyped(value, false);
 }
 
 export function UserToJSONTyped(value?: User | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/BehaviorType.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/BehaviorType.ts
@@ -49,6 +49,6 @@ export function BehaviorTypeToJSON(value?: BehaviorType | null): any {
 }
 
 export function BehaviorTypeToJSONTyped(value?: BehaviorType | null, ignoreDiscriminator: boolean = false): any {
-    return value as BehaviorType;
+    return value as any;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/BehaviorType.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/BehaviorType.ts
@@ -48,7 +48,7 @@ export function BehaviorTypeToJSON(value?: BehaviorType | null): any {
     return BehaviorTypeToJSONTyped(value, false);
 }
 
-export function BehaviorTypeToJSONTyped(value?: BehaviorType | null, ignoreDiscriminator: boolean): any {
+export function BehaviorTypeToJSONTyped(value?: BehaviorType | null, ignoreDiscriminator: boolean = false): any {
     return value as BehaviorType;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/BehaviorType.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/BehaviorType.ts
@@ -45,10 +45,10 @@ export function BehaviorTypeFromJSONTyped(json: any, ignoreDiscriminator: boolea
 }
 
 export function BehaviorTypeToJSON(value?: BehaviorType | null): any {
-    return value as any;
+    return BehaviorTypeToJSONTyped(value, false);
 }
 
-export function BehaviorTypeToJSONTyped(value: any, ignoreDiscriminator: boolean): BehaviorType {
+export function BehaviorTypeToJSONTyped(value?: BehaviorType | null, ignoreDiscriminator: boolean): any {
     return value as BehaviorType;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Category.ts
@@ -51,8 +51,8 @@ export function CategoryFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
     };
 }
 
-export function CategoryToJSON(json: any): Category {
-    return CategoryToJSONTyped(json, false);
+export function CategoryToJSON(value?: Category | null): any {
+    return CategoryToJSONTyped(value, false);
 }
 
 export function CategoryToJSONTyped(value?: Category | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/DefaultMetaOnlyResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/DefaultMetaOnlyResponse.ts
@@ -55,8 +55,8 @@ export function DefaultMetaOnlyResponseFromJSONTyped(json: any, ignoreDiscrimina
     };
 }
 
-export function DefaultMetaOnlyResponseToJSON(json: any): DefaultMetaOnlyResponse {
-    return DefaultMetaOnlyResponseToJSONTyped(json, false);
+export function DefaultMetaOnlyResponseToJSON(value?: DefaultMetaOnlyResponse | null): any {
+    return DefaultMetaOnlyResponseToJSONTyped(value, false);
 }
 
 export function DefaultMetaOnlyResponseToJSONTyped(value?: DefaultMetaOnlyResponse | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/DeploymentRequestStatus.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/DeploymentRequestStatus.ts
@@ -54,10 +54,10 @@ export function DeploymentRequestStatusFromJSONTyped(json: any, ignoreDiscrimina
 }
 
 export function DeploymentRequestStatusToJSON(value?: DeploymentRequestStatus | null): any {
-    return value as any;
+    return DeploymentRequestStatusToJSONTyped(value, false);
 }
 
-export function DeploymentRequestStatusToJSONTyped(value: any, ignoreDiscriminator: boolean): DeploymentRequestStatus {
+export function DeploymentRequestStatusToJSONTyped(value?: DeploymentRequestStatus | null, ignoreDiscriminator: boolean): any {
     return value as DeploymentRequestStatus;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/DeploymentRequestStatus.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/DeploymentRequestStatus.ts
@@ -58,6 +58,6 @@ export function DeploymentRequestStatusToJSON(value?: DeploymentRequestStatus | 
 }
 
 export function DeploymentRequestStatusToJSONTyped(value?: DeploymentRequestStatus | null, ignoreDiscriminator: boolean = false): any {
-    return value as DeploymentRequestStatus;
+    return value as any;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/DeploymentRequestStatus.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/DeploymentRequestStatus.ts
@@ -57,7 +57,7 @@ export function DeploymentRequestStatusToJSON(value?: DeploymentRequestStatus | 
     return DeploymentRequestStatusToJSONTyped(value, false);
 }
 
-export function DeploymentRequestStatusToJSONTyped(value?: DeploymentRequestStatus | null, ignoreDiscriminator: boolean): any {
+export function DeploymentRequestStatusToJSONTyped(value?: DeploymentRequestStatus | null, ignoreDiscriminator: boolean = false): any {
     return value as DeploymentRequestStatus;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ErrorCode.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ErrorCode.ts
@@ -63,7 +63,7 @@ export function ErrorCodeToJSON(value?: ErrorCode | null): any {
     return ErrorCodeToJSONTyped(value, false);
 }
 
-export function ErrorCodeToJSONTyped(value?: ErrorCode | null, ignoreDiscriminator: boolean): any {
+export function ErrorCodeToJSONTyped(value?: ErrorCode | null, ignoreDiscriminator: boolean = false): any {
     return value as ErrorCode;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ErrorCode.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ErrorCode.ts
@@ -64,6 +64,6 @@ export function ErrorCodeToJSON(value?: ErrorCode | null): any {
 }
 
 export function ErrorCodeToJSONTyped(value?: ErrorCode | null, ignoreDiscriminator: boolean = false): any {
-    return value as ErrorCode;
+    return value as any;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ErrorCode.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ErrorCode.ts
@@ -60,10 +60,10 @@ export function ErrorCodeFromJSONTyped(json: any, ignoreDiscriminator: boolean):
 }
 
 export function ErrorCodeToJSON(value?: ErrorCode | null): any {
-    return value as any;
+    return ErrorCodeToJSONTyped(value, false);
 }
 
-export function ErrorCodeToJSONTyped(value: any, ignoreDiscriminator: boolean): ErrorCode {
+export function ErrorCodeToJSONTyped(value?: ErrorCode | null, ignoreDiscriminator: boolean): any {
     return value as ErrorCode;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/FindPetsByStatusResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/FindPetsByStatusResponse.ts
@@ -67,8 +67,8 @@ export function FindPetsByStatusResponseFromJSONTyped(json: any, ignoreDiscrimin
     };
 }
 
-export function FindPetsByStatusResponseToJSON(json: any): FindPetsByStatusResponse {
-    return FindPetsByStatusResponseToJSONTyped(json, false);
+export function FindPetsByStatusResponseToJSON(value?: FindPetsByStatusResponse | null): any {
+    return FindPetsByStatusResponseToJSONTyped(value, false);
 }
 
 export function FindPetsByStatusResponseToJSONTyped(value?: FindPetsByStatusResponse | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/FindPetsByUserResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/FindPetsByUserResponse.ts
@@ -67,8 +67,8 @@ export function FindPetsByUserResponseFromJSONTyped(json: any, ignoreDiscriminat
     };
 }
 
-export function FindPetsByUserResponseToJSON(json: any): FindPetsByUserResponse {
-    return FindPetsByUserResponseToJSONTyped(json, false);
+export function FindPetsByUserResponseToJSON(value?: FindPetsByUserResponse | null): any {
+    return FindPetsByUserResponseToJSONTyped(value, false);
 }
 
 export function FindPetsByUserResponseToJSONTyped(value?: FindPetsByUserResponse | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetBehaviorPermissionsResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetBehaviorPermissionsResponse.ts
@@ -60,8 +60,8 @@ export function GetBehaviorPermissionsResponseFromJSONTyped(json: any, ignoreDis
     };
 }
 
-export function GetBehaviorPermissionsResponseToJSON(json: any): GetBehaviorPermissionsResponse {
-    return GetBehaviorPermissionsResponseToJSONTyped(json, false);
+export function GetBehaviorPermissionsResponseToJSON(value?: GetBehaviorPermissionsResponse | null): any {
+    return GetBehaviorPermissionsResponseToJSONTyped(value, false);
 }
 
 export function GetBehaviorPermissionsResponseToJSONTyped(value?: GetBehaviorPermissionsResponse | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetBehaviorTypeResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetBehaviorTypeResponse.ts
@@ -69,8 +69,8 @@ export function GetBehaviorTypeResponseFromJSONTyped(json: any, ignoreDiscrimina
     };
 }
 
-export function GetBehaviorTypeResponseToJSON(json: any): GetBehaviorTypeResponse {
-    return GetBehaviorTypeResponseToJSONTyped(json, false);
+export function GetBehaviorTypeResponseToJSON(value?: GetBehaviorTypeResponse | null): any {
+    return GetBehaviorTypeResponseToJSONTyped(value, false);
 }
 
 export function GetBehaviorTypeResponseToJSONTyped(value?: GetBehaviorTypeResponse | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetMatchingPartsResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetMatchingPartsResponse.ts
@@ -67,8 +67,8 @@ export function GetMatchingPartsResponseFromJSONTyped(json: any, ignoreDiscrimin
     };
 }
 
-export function GetMatchingPartsResponseToJSON(json: any): GetMatchingPartsResponse {
-    return GetMatchingPartsResponseToJSONTyped(json, false);
+export function GetMatchingPartsResponseToJSON(value?: GetMatchingPartsResponse | null): any {
+    return GetMatchingPartsResponseToJSONTyped(value, false);
 }
 
 export function GetMatchingPartsResponseToJSONTyped(value?: GetMatchingPartsResponse | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetPetPartTypeResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetPetPartTypeResponse.ts
@@ -69,8 +69,8 @@ export function GetPetPartTypeResponseFromJSONTyped(json: any, ignoreDiscriminat
     };
 }
 
-export function GetPetPartTypeResponseToJSON(json: any): GetPetPartTypeResponse {
-    return GetPetPartTypeResponseToJSONTyped(json, false);
+export function GetPetPartTypeResponseToJSON(value?: GetPetPartTypeResponse | null): any {
+    return GetPetPartTypeResponseToJSONTyped(value, false);
 }
 
 export function GetPetPartTypeResponseToJSONTyped(value?: GetPetPartTypeResponse | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ItemId.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ItemId.ts
@@ -53,8 +53,8 @@ export function ItemIdFromJSONTyped(json: any, ignoreDiscriminator: boolean): It
     };
 }
 
-export function ItemIdToJSON(json: any): ItemId {
-    return ItemIdToJSONTyped(json, false);
+export function ItemIdToJSON(value?: ItemId | null): any {
+    return ItemIdToJSONTyped(value, false);
 }
 
 export function ItemIdToJSONTyped(value?: ItemId | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/MatchingParts.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/MatchingParts.ts
@@ -61,8 +61,8 @@ export function MatchingPartsFromJSONTyped(json: any, ignoreDiscriminator: boole
     };
 }
 
-export function MatchingPartsToJSON(json: any): MatchingParts {
-    return MatchingPartsToJSONTyped(json, false);
+export function MatchingPartsToJSON(value?: MatchingParts | null): any {
+    return MatchingPartsToJSONTyped(value, false);
 }
 
 export function MatchingPartsToJSONTyped(value?: MatchingParts | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ModelApiResponse.ts
@@ -56,8 +56,8 @@ export function ModelApiResponseFromJSONTyped(json: any, ignoreDiscriminator: bo
     };
 }
 
-export function ModelApiResponseToJSON(json: any): ModelApiResponse {
-    return ModelApiResponseToJSONTyped(json, false);
+export function ModelApiResponseToJSON(value?: ModelApiResponse | null): any {
+    return ModelApiResponseToJSONTyped(value, false);
 }
 
 export function ModelApiResponseToJSONTyped(value?: ModelApiResponse | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ModelError.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ModelError.ts
@@ -70,8 +70,8 @@ export function ModelErrorFromJSONTyped(json: any, ignoreDiscriminator: boolean)
     };
 }
 
-export function ModelErrorToJSON(json: any): ModelError {
-    return ModelErrorToJSONTyped(json, false);
+export function ModelErrorToJSON(value?: ModelError | null): any {
+    return ModelErrorToJSONTyped(value, false);
 }
 
 export function ModelErrorToJSONTyped(value?: ModelError | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Order.ts
@@ -83,8 +83,8 @@ export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Ord
     };
 }
 
-export function OrderToJSON(json: any): Order {
-    return OrderToJSONTyped(json, false);
+export function OrderToJSON(value?: Order | null): any {
+    return OrderToJSONTyped(value, false);
 }
 
 export function OrderToJSONTyped(value?: Order | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Part.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Part.ts
@@ -53,8 +53,8 @@ export function PartFromJSONTyped(json: any, ignoreDiscriminator: boolean): Part
     };
 }
 
-export function PartToJSON(json: any): Part {
-    return PartToJSONTyped(json, false);
+export function PartToJSON(value?: Part | null): any {
+    return PartToJSONTyped(value, false);
 }
 
 export function PartToJSONTyped(value?: Part | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Pet.ts
@@ -201,8 +201,8 @@ export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
     };
 }
 
-export function PetToJSON(json: any): Pet {
-    return PetToJSONTyped(json, false);
+export function PetToJSON(value?: Pet | null): any {
+    return PetToJSONTyped(value, false);
 }
 
 export function PetToJSONTyped(value?: Pet | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/PetPartType.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/PetPartType.ts
@@ -48,7 +48,7 @@ export function PetPartTypeToJSON(value?: PetPartType | null): any {
     return PetPartTypeToJSONTyped(value, false);
 }
 
-export function PetPartTypeToJSONTyped(value?: PetPartType | null, ignoreDiscriminator: boolean): any {
+export function PetPartTypeToJSONTyped(value?: PetPartType | null, ignoreDiscriminator: boolean = false): any {
     return value as PetPartType;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/PetPartType.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/PetPartType.ts
@@ -45,10 +45,10 @@ export function PetPartTypeFromJSONTyped(json: any, ignoreDiscriminator: boolean
 }
 
 export function PetPartTypeToJSON(value?: PetPartType | null): any {
-    return value as any;
+    return PetPartTypeToJSONTyped(value, false);
 }
 
-export function PetPartTypeToJSONTyped(value: any, ignoreDiscriminator: boolean): PetPartType {
+export function PetPartTypeToJSONTyped(value?: PetPartType | null, ignoreDiscriminator: boolean): any {
     return value as PetPartType;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/PetPartType.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/PetPartType.ts
@@ -49,6 +49,6 @@ export function PetPartTypeToJSON(value?: PetPartType | null): any {
 }
 
 export function PetPartTypeToJSONTyped(value?: PetPartType | null, ignoreDiscriminator: boolean = false): any {
-    return value as PetPartType;
+    return value as any;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/PetRegionsResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/PetRegionsResponse.ts
@@ -60,8 +60,8 @@ export function PetRegionsResponseFromJSONTyped(json: any, ignoreDiscriminator: 
     };
 }
 
-export function PetRegionsResponseToJSON(json: any): PetRegionsResponse {
-    return PetRegionsResponseToJSONTyped(json, false);
+export function PetRegionsResponseToJSON(value?: PetRegionsResponse | null): any {
+    return PetRegionsResponseToJSONTyped(value, false);
 }
 
 export function PetRegionsResponseToJSONTyped(value?: PetRegionsResponse | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ResponseMeta.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ResponseMeta.ts
@@ -112,8 +112,8 @@ export function ResponseMetaFromJSONTyped(json: any, ignoreDiscriminator: boolea
     };
 }
 
-export function ResponseMetaToJSON(json: any): ResponseMeta {
-    return ResponseMetaToJSONTyped(json, false);
+export function ResponseMetaToJSON(value?: ResponseMeta | null): any {
+    return ResponseMetaToJSONTyped(value, false);
 }
 
 export function ResponseMetaToJSONTyped(value?: ResponseMeta | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Tag.ts
@@ -51,8 +51,8 @@ export function TagFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tag {
     };
 }
 
-export function TagToJSON(json: any): Tag {
-    return TagToJSONTyped(json, false);
+export function TagToJSON(value?: Tag | null): any {
+    return TagToJSONTyped(value, false);
 }
 
 export function TagToJSONTyped(value?: Tag | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/User.ts
@@ -93,8 +93,8 @@ export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User
     };
 }
 
-export function UserToJSON(json: any): User {
-    return UserToJSONTyped(json, false);
+export function UserToJSON(value?: User | null): any {
+    return UserToJSONTyped(value, false);
 }
 
 export function UserToJSONTyped(value?: User | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/WarningCode.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/WarningCode.ts
@@ -45,10 +45,10 @@ export function WarningCodeFromJSONTyped(json: any, ignoreDiscriminator: boolean
 }
 
 export function WarningCodeToJSON(value?: WarningCode | null): any {
-    return value as any;
+    return WarningCodeToJSONTyped(value, false);
 }
 
-export function WarningCodeToJSONTyped(value: any, ignoreDiscriminator: boolean): WarningCode {
+export function WarningCodeToJSONTyped(value?: WarningCode | null, ignoreDiscriminator: boolean): any {
     return value as WarningCode;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/WarningCode.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/WarningCode.ts
@@ -48,7 +48,7 @@ export function WarningCodeToJSON(value?: WarningCode | null): any {
     return WarningCodeToJSONTyped(value, false);
 }
 
-export function WarningCodeToJSONTyped(value?: WarningCode | null, ignoreDiscriminator: boolean): any {
+export function WarningCodeToJSONTyped(value?: WarningCode | null, ignoreDiscriminator: boolean = false): any {
     return value as WarningCode;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/WarningCode.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/WarningCode.ts
@@ -49,6 +49,6 @@ export function WarningCodeToJSON(value?: WarningCode | null): any {
 }
 
 export function WarningCodeToJSONTyped(value?: WarningCode | null, ignoreDiscriminator: boolean = false): any {
-    return value as WarningCode;
+    return value as any;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/AdditionalPropertiesClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/AdditionalPropertiesClass.ts
@@ -51,8 +51,8 @@ export function AdditionalPropertiesClassFromJSONTyped(json: any, ignoreDiscrimi
     };
 }
 
-export function AdditionalPropertiesClassToJSON(json: any): AdditionalPropertiesClass {
-    return AdditionalPropertiesClassToJSONTyped(json, false);
+export function AdditionalPropertiesClassToJSON(value?: AdditionalPropertiesClass | null): any {
+    return AdditionalPropertiesClassToJSONTyped(value, false);
 }
 
 export function AdditionalPropertiesClassToJSONTyped(value?: AdditionalPropertiesClass | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/AllOfWithSingleRef.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/AllOfWithSingleRef.ts
@@ -61,8 +61,8 @@ export function AllOfWithSingleRefFromJSONTyped(json: any, ignoreDiscriminator: 
     };
 }
 
-export function AllOfWithSingleRefToJSON(json: any): AllOfWithSingleRef {
-    return AllOfWithSingleRefToJSONTyped(json, false);
+export function AllOfWithSingleRefToJSON(value?: AllOfWithSingleRef | null): any {
+    return AllOfWithSingleRefToJSONTyped(value, false);
 }
 
 export function AllOfWithSingleRefToJSONTyped(value?: AllOfWithSingleRef | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Animal.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Animal.ts
@@ -63,8 +63,8 @@ export function AnimalFromJSONTyped(json: any, ignoreDiscriminator: boolean): An
     };
 }
 
-export function AnimalToJSON(json: any): Animal {
-    return AnimalToJSONTyped(json, false);
+export function AnimalToJSON(value?: Animal | null): any {
+    return AnimalToJSONTyped(value, false);
 }
 
 export function AnimalToJSONTyped(value?: Animal | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ArrayOfArrayOfNumberOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ArrayOfArrayOfNumberOnly.ts
@@ -46,8 +46,8 @@ export function ArrayOfArrayOfNumberOnlyFromJSONTyped(json: any, ignoreDiscrimin
     };
 }
 
-export function ArrayOfArrayOfNumberOnlyToJSON(json: any): ArrayOfArrayOfNumberOnly {
-    return ArrayOfArrayOfNumberOnlyToJSONTyped(json, false);
+export function ArrayOfArrayOfNumberOnlyToJSON(value?: ArrayOfArrayOfNumberOnly | null): any {
+    return ArrayOfArrayOfNumberOnlyToJSONTyped(value, false);
 }
 
 export function ArrayOfArrayOfNumberOnlyToJSONTyped(value?: ArrayOfArrayOfNumberOnly | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ArrayOfNumberOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ArrayOfNumberOnly.ts
@@ -46,8 +46,8 @@ export function ArrayOfNumberOnlyFromJSONTyped(json: any, ignoreDiscriminator: b
     };
 }
 
-export function ArrayOfNumberOnlyToJSON(json: any): ArrayOfNumberOnly {
-    return ArrayOfNumberOnlyToJSONTyped(json, false);
+export function ArrayOfNumberOnlyToJSON(value?: ArrayOfNumberOnly | null): any {
+    return ArrayOfNumberOnlyToJSONTyped(value, false);
 }
 
 export function ArrayOfNumberOnlyToJSONTyped(value?: ArrayOfNumberOnly | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ArrayTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ArrayTest.ts
@@ -64,8 +64,8 @@ export function ArrayTestFromJSONTyped(json: any, ignoreDiscriminator: boolean):
     };
 }
 
-export function ArrayTestToJSON(json: any): ArrayTest {
-    return ArrayTestToJSONTyped(json, false);
+export function ArrayTestToJSON(value?: ArrayTest | null): any {
+    return ArrayTestToJSONTyped(value, false);
 }
 
 export function ArrayTestToJSONTyped(value?: ArrayTest | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Capitalization.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Capitalization.ts
@@ -72,8 +72,8 @@ export function CapitalizationFromJSONTyped(json: any, ignoreDiscriminator: bool
     };
 }
 
-export function CapitalizationToJSON(json: any): Capitalization {
-    return CapitalizationToJSONTyped(json, false);
+export function CapitalizationToJSON(value?: Capitalization | null): any {
+    return CapitalizationToJSONTyped(value, false);
 }
 
 export function CapitalizationToJSONTyped(value?: Capitalization | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Cat.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Cat.ts
@@ -54,8 +54,8 @@ export function CatFromJSONTyped(json: any, ignoreDiscriminator: boolean): Cat {
     };
 }
 
-export function CatToJSON(json: any): Cat {
-    return CatToJSONTyped(json, false);
+export function CatToJSON(value?: Cat | null): any {
+    return CatToJSONTyped(value, false);
 }
 
 export function CatToJSONTyped(value?: Cat | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Category.ts
@@ -52,8 +52,8 @@ export function CategoryFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
     };
 }
 
-export function CategoryToJSON(json: any): Category {
-    return CategoryToJSONTyped(json, false);
+export function CategoryToJSON(value?: Category | null): any {
+    return CategoryToJSONTyped(value, false);
 }
 
 export function CategoryToJSONTyped(value?: Category | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ClassModel.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ClassModel.ts
@@ -46,8 +46,8 @@ export function ClassModelFromJSONTyped(json: any, ignoreDiscriminator: boolean)
     };
 }
 
-export function ClassModelToJSON(json: any): ClassModel {
-    return ClassModelToJSONTyped(json, false);
+export function ClassModelToJSON(value?: ClassModel | null): any {
+    return ClassModelToJSONTyped(value, false);
 }
 
 export function ClassModelToJSONTyped(value?: ClassModel | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Client.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Client.ts
@@ -46,8 +46,8 @@ export function ClientFromJSONTyped(json: any, ignoreDiscriminator: boolean): Cl
     };
 }
 
-export function ClientToJSON(json: any): Client {
-    return ClientToJSONTyped(json, false);
+export function ClientToJSON(value?: Client | null): any {
+    return ClientToJSONTyped(value, false);
 }
 
 export function ClientToJSONTyped(value?: Client | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/DeprecatedObject.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/DeprecatedObject.ts
@@ -46,8 +46,8 @@ export function DeprecatedObjectFromJSONTyped(json: any, ignoreDiscriminator: bo
     };
 }
 
-export function DeprecatedObjectToJSON(json: any): DeprecatedObject {
-    return DeprecatedObjectToJSONTyped(json, false);
+export function DeprecatedObjectToJSON(value?: DeprecatedObject | null): any {
+    return DeprecatedObjectToJSONTyped(value, false);
 }
 
 export function DeprecatedObjectToJSONTyped(value?: DeprecatedObject | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Dog.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Dog.ts
@@ -54,8 +54,8 @@ export function DogFromJSONTyped(json: any, ignoreDiscriminator: boolean): Dog {
     };
 }
 
-export function DogToJSON(json: any): Dog {
-    return DogToJSONTyped(json, false);
+export function DogToJSON(value?: Dog | null): any {
+    return DogToJSONTyped(value, false);
 }
 
 export function DogToJSONTyped(value?: Dog | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/EnumArrays.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/EnumArrays.ts
@@ -71,8 +71,8 @@ export function EnumArraysFromJSONTyped(json: any, ignoreDiscriminator: boolean)
     };
 }
 
-export function EnumArraysToJSON(json: any): EnumArrays {
-    return EnumArraysToJSONTyped(json, false);
+export function EnumArraysToJSON(value?: EnumArrays | null): any {
+    return EnumArraysToJSONTyped(value, false);
 }
 
 export function EnumArraysToJSONTyped(value?: EnumArrays | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/EnumClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/EnumClass.ts
@@ -48,7 +48,7 @@ export function EnumClassToJSON(value?: EnumClass | null): any {
     return EnumClassToJSONTyped(value, false);
 }
 
-export function EnumClassToJSONTyped(value?: EnumClass | null, ignoreDiscriminator: boolean): any {
+export function EnumClassToJSONTyped(value?: EnumClass | null, ignoreDiscriminator: boolean = false): any {
     return value as EnumClass;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/EnumClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/EnumClass.ts
@@ -49,6 +49,6 @@ export function EnumClassToJSON(value?: EnumClass | null): any {
 }
 
 export function EnumClassToJSONTyped(value?: EnumClass | null, ignoreDiscriminator: boolean = false): any {
-    return value as EnumClass;
+    return value as any;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/EnumClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/EnumClass.ts
@@ -45,10 +45,10 @@ export function EnumClassFromJSONTyped(json: any, ignoreDiscriminator: boolean):
 }
 
 export function EnumClassToJSON(value?: EnumClass | null): any {
-    return value as any;
+    return EnumClassToJSONTyped(value, false);
 }
 
-export function EnumClassToJSONTyped(value: any, ignoreDiscriminator: boolean): EnumClass {
+export function EnumClassToJSONTyped(value?: EnumClass | null, ignoreDiscriminator: boolean): any {
     return value as EnumClass;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/EnumTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/EnumTest.ts
@@ -151,8 +151,8 @@ export function EnumTestFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
     };
 }
 
-export function EnumTestToJSON(json: any): EnumTest {
-    return EnumTestToJSONTyped(json, false);
+export function EnumTestToJSON(value?: EnumTest | null): any {
+    return EnumTestToJSONTyped(value, false);
 }
 
 export function EnumTestToJSONTyped(value?: EnumTest | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/FakeBigDecimalMap200Response.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/FakeBigDecimalMap200Response.ts
@@ -51,8 +51,8 @@ export function FakeBigDecimalMap200ResponseFromJSONTyped(json: any, ignoreDiscr
     };
 }
 
-export function FakeBigDecimalMap200ResponseToJSON(json: any): FakeBigDecimalMap200Response {
-    return FakeBigDecimalMap200ResponseToJSONTyped(json, false);
+export function FakeBigDecimalMap200ResponseToJSON(value?: FakeBigDecimalMap200Response | null): any {
+    return FakeBigDecimalMap200ResponseToJSONTyped(value, false);
 }
 
 export function FakeBigDecimalMap200ResponseToJSONTyped(value?: FakeBigDecimalMap200Response | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/FileSchemaTestClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/FileSchemaTestClass.ts
@@ -51,8 +51,8 @@ export function FileSchemaTestClassFromJSONTyped(json: any, ignoreDiscriminator:
     };
 }
 
-export function FileSchemaTestClassToJSON(json: any): FileSchemaTestClass {
-    return FileSchemaTestClassToJSONTyped(json, false);
+export function FileSchemaTestClassToJSON(value?: FileSchemaTestClass | null): any {
+    return FileSchemaTestClassToJSONTyped(value, false);
 }
 
 export function FileSchemaTestClassToJSONTyped(value?: FileSchemaTestClass | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Foo.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Foo.ts
@@ -46,8 +46,8 @@ export function FooFromJSONTyped(json: any, ignoreDiscriminator: boolean): Foo {
     };
 }
 
-export function FooToJSON(json: any): Foo {
-    return FooToJSONTyped(json, false);
+export function FooToJSON(value?: Foo | null): any {
+    return FooToJSONTyped(value, false);
 }
 
 export function FooToJSONTyped(value?: Foo | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/FooGetDefaultResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/FooGetDefaultResponse.ts
@@ -54,8 +54,8 @@ export function FooGetDefaultResponseFromJSONTyped(json: any, ignoreDiscriminato
     };
 }
 
-export function FooGetDefaultResponseToJSON(json: any): FooGetDefaultResponse {
-    return FooGetDefaultResponseToJSONTyped(json, false);
+export function FooGetDefaultResponseToJSON(value?: FooGetDefaultResponse | null): any {
+    return FooGetDefaultResponseToJSONTyped(value, false);
 }
 
 export function FooGetDefaultResponseToJSONTyped(value?: FooGetDefaultResponse | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/FormatTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/FormatTest.ts
@@ -125,8 +125,8 @@ export function FormatTestFromJSONTyped(json: any, ignoreDiscriminator: boolean)
     };
 }
 
-export function FormatTestToJSON(json: any): FormatTest {
-    return FormatTestToJSONTyped(json, false);
+export function FormatTestToJSON(value?: FormatTest | null): any {
+    return FormatTestToJSONTyped(value, false);
 }
 
 export function FormatTestToJSONTyped(value?: FormatTest | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/HasOnlyReadOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/HasOnlyReadOnly.ts
@@ -51,8 +51,8 @@ export function HasOnlyReadOnlyFromJSONTyped(json: any, ignoreDiscriminator: boo
     };
 }
 
-export function HasOnlyReadOnlyToJSON(json: any): HasOnlyReadOnly {
-    return HasOnlyReadOnlyToJSONTyped(json, false);
+export function HasOnlyReadOnlyToJSON(value?: HasOnlyReadOnly | null): any {
+    return HasOnlyReadOnlyToJSONTyped(value, false);
 }
 
 export function HasOnlyReadOnlyToJSONTyped(value?: Omit<HasOnlyReadOnly, 'bar'|'foo'> | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/HealthCheckResult.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/HealthCheckResult.ts
@@ -46,8 +46,8 @@ export function HealthCheckResultFromJSONTyped(json: any, ignoreDiscriminator: b
     };
 }
 
-export function HealthCheckResultToJSON(json: any): HealthCheckResult {
-    return HealthCheckResultToJSONTyped(json, false);
+export function HealthCheckResultToJSON(value?: HealthCheckResult | null): any {
+    return HealthCheckResultToJSONTyped(value, false);
 }
 
 export function HealthCheckResultToJSONTyped(value?: HealthCheckResult | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/List.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/List.ts
@@ -46,8 +46,8 @@ export function ListFromJSONTyped(json: any, ignoreDiscriminator: boolean): List
     };
 }
 
-export function ListToJSON(json: any): List {
-    return ListToJSONTyped(json, false);
+export function ListToJSON(value?: List | null): any {
+    return ListToJSONTyped(value, false);
 }
 
 export function ListToJSONTyped(value?: List | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/MapTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/MapTest.ts
@@ -72,8 +72,8 @@ export function MapTestFromJSONTyped(json: any, ignoreDiscriminator: boolean): M
     };
 }
 
-export function MapTestToJSON(json: any): MapTest {
-    return MapTestToJSONTyped(json, false);
+export function MapTestToJSON(value?: MapTest | null): any {
+    return MapTestToJSONTyped(value, false);
 }
 
 export function MapTestToJSONTyped(value?: MapTest | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/MixedPropertiesAndAdditionalPropertiesClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/MixedPropertiesAndAdditionalPropertiesClass.ts
@@ -64,8 +64,8 @@ export function MixedPropertiesAndAdditionalPropertiesClassFromJSONTyped(json: a
     };
 }
 
-export function MixedPropertiesAndAdditionalPropertiesClassToJSON(json: any): MixedPropertiesAndAdditionalPropertiesClass {
-    return MixedPropertiesAndAdditionalPropertiesClassToJSONTyped(json, false);
+export function MixedPropertiesAndAdditionalPropertiesClassToJSON(value?: MixedPropertiesAndAdditionalPropertiesClass | null): any {
+    return MixedPropertiesAndAdditionalPropertiesClassToJSONTyped(value, false);
 }
 
 export function MixedPropertiesAndAdditionalPropertiesClassToJSONTyped(value?: MixedPropertiesAndAdditionalPropertiesClass | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Model200Response.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Model200Response.ts
@@ -51,8 +51,8 @@ export function Model200ResponseFromJSONTyped(json: any, ignoreDiscriminator: bo
     };
 }
 
-export function Model200ResponseToJSON(json: any): Model200Response {
-    return Model200ResponseToJSONTyped(json, false);
+export function Model200ResponseToJSON(value?: Model200Response | null): any {
+    return Model200ResponseToJSONTyped(value, false);
 }
 
 export function Model200ResponseToJSONTyped(value?: Model200Response | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ModelApiResponse.ts
@@ -56,8 +56,8 @@ export function ModelApiResponseFromJSONTyped(json: any, ignoreDiscriminator: bo
     };
 }
 
-export function ModelApiResponseToJSON(json: any): ModelApiResponse {
-    return ModelApiResponseToJSONTyped(json, false);
+export function ModelApiResponseToJSON(value?: ModelApiResponse | null): any {
+    return ModelApiResponseToJSONTyped(value, false);
 }
 
 export function ModelApiResponseToJSONTyped(value?: ModelApiResponse | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ModelFile.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ModelFile.ts
@@ -46,8 +46,8 @@ export function ModelFileFromJSONTyped(json: any, ignoreDiscriminator: boolean):
     };
 }
 
-export function ModelFileToJSON(json: any): ModelFile {
-    return ModelFileToJSONTyped(json, false);
+export function ModelFileToJSON(value?: ModelFile | null): any {
+    return ModelFileToJSONTyped(value, false);
 }
 
 export function ModelFileToJSONTyped(value?: ModelFile | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Name.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Name.ts
@@ -62,8 +62,8 @@ export function NameFromJSONTyped(json: any, ignoreDiscriminator: boolean): Name
     };
 }
 
-export function NameToJSON(json: any): Name {
-    return NameToJSONTyped(json, false);
+export function NameToJSON(value?: Name | null): any {
+    return NameToJSONTyped(value, false);
 }
 
 export function NameToJSONTyped(value?: Omit<Name, 'snakeCase'|'_123number'> | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/NullableClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/NullableClass.ts
@@ -103,8 +103,8 @@ export function NullableClassFromJSONTyped(json: any, ignoreDiscriminator: boole
     };
 }
 
-export function NullableClassToJSON(json: any): NullableClass {
-    return NullableClassToJSONTyped(json, false);
+export function NullableClassToJSON(value?: NullableClass | null): any {
+    return NullableClassToJSONTyped(value, false);
 }
 
 export function NullableClassToJSONTyped(value?: NullableClass | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/NumberOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/NumberOnly.ts
@@ -46,8 +46,8 @@ export function NumberOnlyFromJSONTyped(json: any, ignoreDiscriminator: boolean)
     };
 }
 
-export function NumberOnlyToJSON(json: any): NumberOnly {
-    return NumberOnlyToJSONTyped(json, false);
+export function NumberOnlyToJSON(value?: NumberOnly | null): any {
+    return NumberOnlyToJSONTyped(value, false);
 }
 
 export function NumberOnlyToJSONTyped(value?: NumberOnly | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ObjectWithDeprecatedFields.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ObjectWithDeprecatedFields.ts
@@ -72,8 +72,8 @@ export function ObjectWithDeprecatedFieldsFromJSONTyped(json: any, ignoreDiscrim
     };
 }
 
-export function ObjectWithDeprecatedFieldsToJSON(json: any): ObjectWithDeprecatedFields {
-    return ObjectWithDeprecatedFieldsToJSONTyped(json, false);
+export function ObjectWithDeprecatedFieldsToJSON(value?: ObjectWithDeprecatedFields | null): any {
+    return ObjectWithDeprecatedFieldsToJSONTyped(value, false);
 }
 
 export function ObjectWithDeprecatedFieldsToJSONTyped(value?: ObjectWithDeprecatedFields | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Order.ts
@@ -83,8 +83,8 @@ export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Ord
     };
 }
 
-export function OrderToJSON(json: any): Order {
-    return OrderToJSONTyped(json, false);
+export function OrderToJSON(value?: Order | null): any {
+    return OrderToJSONTyped(value, false);
 }
 
 export function OrderToJSONTyped(value?: Order | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterComposite.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterComposite.ts
@@ -56,8 +56,8 @@ export function OuterCompositeFromJSONTyped(json: any, ignoreDiscriminator: bool
     };
 }
 
-export function OuterCompositeToJSON(json: any): OuterComposite {
-    return OuterCompositeToJSONTyped(json, false);
+export function OuterCompositeToJSON(value?: OuterComposite | null): any {
+    return OuterCompositeToJSONTyped(value, false);
 }
 
 export function OuterCompositeToJSONTyped(value?: OuterComposite | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnum.ts
@@ -45,10 +45,10 @@ export function OuterEnumFromJSONTyped(json: any, ignoreDiscriminator: boolean):
 }
 
 export function OuterEnumToJSON(value?: OuterEnum | null): any {
-    return value as any;
+    return OuterEnumToJSONTyped(value, false);
 }
 
-export function OuterEnumToJSONTyped(value: any, ignoreDiscriminator: boolean): OuterEnum {
+export function OuterEnumToJSONTyped(value?: OuterEnum | null, ignoreDiscriminator: boolean): any {
     return value as OuterEnum;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnum.ts
@@ -49,6 +49,6 @@ export function OuterEnumToJSON(value?: OuterEnum | null): any {
 }
 
 export function OuterEnumToJSONTyped(value?: OuterEnum | null, ignoreDiscriminator: boolean = false): any {
-    return value as OuterEnum;
+    return value as any;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnum.ts
@@ -48,7 +48,7 @@ export function OuterEnumToJSON(value?: OuterEnum | null): any {
     return OuterEnumToJSONTyped(value, false);
 }
 
-export function OuterEnumToJSONTyped(value?: OuterEnum | null, ignoreDiscriminator: boolean): any {
+export function OuterEnumToJSONTyped(value?: OuterEnum | null, ignoreDiscriminator: boolean = false): any {
     return value as OuterEnum;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnumDefaultValue.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnumDefaultValue.ts
@@ -45,10 +45,10 @@ export function OuterEnumDefaultValueFromJSONTyped(json: any, ignoreDiscriminato
 }
 
 export function OuterEnumDefaultValueToJSON(value?: OuterEnumDefaultValue | null): any {
-    return value as any;
+    return OuterEnumDefaultValueToJSONTyped(value, false);
 }
 
-export function OuterEnumDefaultValueToJSONTyped(value: any, ignoreDiscriminator: boolean): OuterEnumDefaultValue {
+export function OuterEnumDefaultValueToJSONTyped(value?: OuterEnumDefaultValue | null, ignoreDiscriminator: boolean): any {
     return value as OuterEnumDefaultValue;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnumDefaultValue.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnumDefaultValue.ts
@@ -48,7 +48,7 @@ export function OuterEnumDefaultValueToJSON(value?: OuterEnumDefaultValue | null
     return OuterEnumDefaultValueToJSONTyped(value, false);
 }
 
-export function OuterEnumDefaultValueToJSONTyped(value?: OuterEnumDefaultValue | null, ignoreDiscriminator: boolean): any {
+export function OuterEnumDefaultValueToJSONTyped(value?: OuterEnumDefaultValue | null, ignoreDiscriminator: boolean = false): any {
     return value as OuterEnumDefaultValue;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnumDefaultValue.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnumDefaultValue.ts
@@ -49,6 +49,6 @@ export function OuterEnumDefaultValueToJSON(value?: OuterEnumDefaultValue | null
 }
 
 export function OuterEnumDefaultValueToJSONTyped(value?: OuterEnumDefaultValue | null, ignoreDiscriminator: boolean = false): any {
-    return value as OuterEnumDefaultValue;
+    return value as any;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnumInteger.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnumInteger.ts
@@ -48,7 +48,7 @@ export function OuterEnumIntegerToJSON(value?: OuterEnumInteger | null): any {
     return OuterEnumIntegerToJSONTyped(value, false);
 }
 
-export function OuterEnumIntegerToJSONTyped(value?: OuterEnumInteger | null, ignoreDiscriminator: boolean): any {
+export function OuterEnumIntegerToJSONTyped(value?: OuterEnumInteger | null, ignoreDiscriminator: boolean = false): any {
     return value as OuterEnumInteger;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnumInteger.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnumInteger.ts
@@ -45,10 +45,10 @@ export function OuterEnumIntegerFromJSONTyped(json: any, ignoreDiscriminator: bo
 }
 
 export function OuterEnumIntegerToJSON(value?: OuterEnumInteger | null): any {
-    return value as any;
+    return OuterEnumIntegerToJSONTyped(value, false);
 }
 
-export function OuterEnumIntegerToJSONTyped(value: any, ignoreDiscriminator: boolean): OuterEnumInteger {
+export function OuterEnumIntegerToJSONTyped(value?: OuterEnumInteger | null, ignoreDiscriminator: boolean): any {
     return value as OuterEnumInteger;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnumInteger.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnumInteger.ts
@@ -49,6 +49,6 @@ export function OuterEnumIntegerToJSON(value?: OuterEnumInteger | null): any {
 }
 
 export function OuterEnumIntegerToJSONTyped(value?: OuterEnumInteger | null, ignoreDiscriminator: boolean = false): any {
-    return value as OuterEnumInteger;
+    return value as any;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnumIntegerDefaultValue.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnumIntegerDefaultValue.ts
@@ -45,10 +45,10 @@ export function OuterEnumIntegerDefaultValueFromJSONTyped(json: any, ignoreDiscr
 }
 
 export function OuterEnumIntegerDefaultValueToJSON(value?: OuterEnumIntegerDefaultValue | null): any {
-    return value as any;
+    return OuterEnumIntegerDefaultValueToJSONTyped(value, false);
 }
 
-export function OuterEnumIntegerDefaultValueToJSONTyped(value: any, ignoreDiscriminator: boolean): OuterEnumIntegerDefaultValue {
+export function OuterEnumIntegerDefaultValueToJSONTyped(value?: OuterEnumIntegerDefaultValue | null, ignoreDiscriminator: boolean): any {
     return value as OuterEnumIntegerDefaultValue;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnumIntegerDefaultValue.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnumIntegerDefaultValue.ts
@@ -49,6 +49,6 @@ export function OuterEnumIntegerDefaultValueToJSON(value?: OuterEnumIntegerDefau
 }
 
 export function OuterEnumIntegerDefaultValueToJSONTyped(value?: OuterEnumIntegerDefaultValue | null, ignoreDiscriminator: boolean = false): any {
-    return value as OuterEnumIntegerDefaultValue;
+    return value as any;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnumIntegerDefaultValue.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnumIntegerDefaultValue.ts
@@ -48,7 +48,7 @@ export function OuterEnumIntegerDefaultValueToJSON(value?: OuterEnumIntegerDefau
     return OuterEnumIntegerDefaultValueToJSONTyped(value, false);
 }
 
-export function OuterEnumIntegerDefaultValueToJSONTyped(value?: OuterEnumIntegerDefaultValue | null, ignoreDiscriminator: boolean): any {
+export function OuterEnumIntegerDefaultValueToJSONTyped(value?: OuterEnumIntegerDefaultValue | null, ignoreDiscriminator: boolean = false): any {
     return value as OuterEnumIntegerDefaultValue;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterObjectWithEnumProperty.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterObjectWithEnumProperty.ts
@@ -57,8 +57,8 @@ export function OuterObjectWithEnumPropertyFromJSONTyped(json: any, ignoreDiscri
     };
 }
 
-export function OuterObjectWithEnumPropertyToJSON(json: any): OuterObjectWithEnumProperty {
-    return OuterObjectWithEnumPropertyToJSONTyped(json, false);
+export function OuterObjectWithEnumPropertyToJSON(value?: OuterObjectWithEnumProperty | null): any {
+    return OuterObjectWithEnumPropertyToJSONTyped(value, false);
 }
 
 export function OuterObjectWithEnumPropertyToJSONTyped(value?: OuterObjectWithEnumProperty | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Pet.ts
@@ -100,8 +100,8 @@ export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
     };
 }
 
-export function PetToJSON(json: any): Pet {
-    return PetToJSONTyped(json, false);
+export function PetToJSON(value?: Pet | null): any {
+    return PetToJSONTyped(value, false);
 }
 
 export function PetToJSONTyped(value?: Pet | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ReadOnlyFirst.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ReadOnlyFirst.ts
@@ -51,8 +51,8 @@ export function ReadOnlyFirstFromJSONTyped(json: any, ignoreDiscriminator: boole
     };
 }
 
-export function ReadOnlyFirstToJSON(json: any): ReadOnlyFirst {
-    return ReadOnlyFirstToJSONTyped(json, false);
+export function ReadOnlyFirstToJSON(value?: ReadOnlyFirst | null): any {
+    return ReadOnlyFirstToJSONTyped(value, false);
 }
 
 export function ReadOnlyFirstToJSONTyped(value?: Omit<ReadOnlyFirst, 'bar'> | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Return.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Return.ts
@@ -46,8 +46,8 @@ export function ReturnFromJSONTyped(json: any, ignoreDiscriminator: boolean): Re
     };
 }
 
-export function ReturnToJSON(json: any): Return {
-    return ReturnToJSONTyped(json, false);
+export function ReturnToJSON(value?: Return | null): any {
+    return ReturnToJSONTyped(value, false);
 }
 
 export function ReturnToJSONTyped(value?: Return | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/SingleRefType.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/SingleRefType.ts
@@ -47,7 +47,7 @@ export function SingleRefTypeToJSON(value?: SingleRefType | null): any {
     return SingleRefTypeToJSONTyped(value, false);
 }
 
-export function SingleRefTypeToJSONTyped(value?: SingleRefType | null, ignoreDiscriminator: boolean): any {
+export function SingleRefTypeToJSONTyped(value?: SingleRefType | null, ignoreDiscriminator: boolean = false): any {
     return value as SingleRefType;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/SingleRefType.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/SingleRefType.ts
@@ -48,6 +48,6 @@ export function SingleRefTypeToJSON(value?: SingleRefType | null): any {
 }
 
 export function SingleRefTypeToJSONTyped(value?: SingleRefType | null, ignoreDiscriminator: boolean = false): any {
-    return value as SingleRefType;
+    return value as any;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/SingleRefType.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/SingleRefType.ts
@@ -44,10 +44,10 @@ export function SingleRefTypeFromJSONTyped(json: any, ignoreDiscriminator: boole
 }
 
 export function SingleRefTypeToJSON(value?: SingleRefType | null): any {
-    return value as any;
+    return SingleRefTypeToJSONTyped(value, false);
 }
 
-export function SingleRefTypeToJSONTyped(value: any, ignoreDiscriminator: boolean): SingleRefType {
+export function SingleRefTypeToJSONTyped(value?: SingleRefType | null, ignoreDiscriminator: boolean): any {
     return value as SingleRefType;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/SpecialModelName.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/SpecialModelName.ts
@@ -46,8 +46,8 @@ export function SpecialModelNameFromJSONTyped(json: any, ignoreDiscriminator: bo
     };
 }
 
-export function SpecialModelNameToJSON(json: any): SpecialModelName {
-    return SpecialModelNameToJSONTyped(json, false);
+export function SpecialModelNameToJSON(value?: SpecialModelName | null): any {
+    return SpecialModelNameToJSONTyped(value, false);
 }
 
 export function SpecialModelNameToJSONTyped(value?: SpecialModelName | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Tag.ts
@@ -51,8 +51,8 @@ export function TagFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tag {
     };
 }
 
-export function TagToJSON(json: any): Tag {
-    return TagToJSONTyped(json, false);
+export function TagToJSON(value?: Tag | null): any {
+    return TagToJSONTyped(value, false);
 }
 
 export function TagToJSONTyped(value?: Tag | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/User.ts
@@ -81,8 +81,8 @@ export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User
     };
 }
 
-export function UserToJSON(json: any): User {
-    return UserToJSONTyped(json, false);
+export function UserToJSON(value?: User | null): any {
+    return UserToJSONTyped(value, false);
 }
 
 export function UserToJSONTyped(value?: User | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/Category.ts
@@ -74,8 +74,8 @@ export function CategoryFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
     };
 }
 
-export function CategoryToJSON(json: any): Category {
-    return CategoryToJSONTyped(json, false);
+export function CategoryToJSON(value?: Category | null): any {
+    return CategoryToJSONTyped(value, false);
 }
 
 export function CategoryToJSONTyped(value?: Category | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/ModelApiResponse.ts
@@ -75,8 +75,8 @@ export function ModelApiResponseFromJSONTyped(json: any, ignoreDiscriminator: bo
     };
 }
 
-export function ModelApiResponseToJSON(json: any): ModelApiResponse {
-    return ModelApiResponseToJSONTyped(json, false);
+export function ModelApiResponseToJSON(value?: ModelApiResponse | null): any {
+    return ModelApiResponseToJSONTyped(value, false);
 }
 
 export function ModelApiResponseToJSONTyped(value?: ModelApiResponse | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/Order.ts
@@ -109,8 +109,8 @@ export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Ord
     };
 }
 
-export function OrderToJSON(json: any): Order {
-    return OrderToJSONTyped(json, false);
+export function OrderToJSON(value?: Order | null): any {
+    return OrderToJSONTyped(value, false);
 }
 
 export function OrderToJSONTyped(value?: Order | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/Pet.ts
@@ -127,8 +127,8 @@ export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
     };
 }
 
-export function PetToJSON(json: any): Pet {
-    return PetToJSONTyped(json, false);
+export function PetToJSON(value?: Pet | null): any {
+    return PetToJSONTyped(value, false);
 }
 
 export function PetToJSONTyped(value?: Pet | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/Tag.ts
@@ -70,8 +70,8 @@ export function TagFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tag {
     };
 }
 
-export function TagToJSON(json: any): Tag {
-    return TagToJSONTyped(json, false);
+export function TagToJSON(value?: Tag | null): any {
+    return TagToJSONTyped(value, false);
 }
 
 export function TagToJSONTyped(value?: Tag | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/User.ts
@@ -122,8 +122,8 @@ export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User
     };
 }
 
-export function UserToJSON(json: any): User {
-    return UserToJSONTyped(json, false);
+export function UserToJSON(value?: User | null): any {
+    return UserToJSONTyped(value, false);
 }
 
 export function UserToJSONTyped(value?: User | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Category.ts
@@ -51,8 +51,8 @@ export function CategoryFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
     };
 }
 
-export function CategoryToJSON(json: any): Category {
-    return CategoryToJSONTyped(json, false);
+export function CategoryToJSON(value?: Category | null): any {
+    return CategoryToJSONTyped(value, false);
 }
 
 export function CategoryToJSONTyped(value?: Category | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/ModelApiResponse.ts
@@ -56,8 +56,8 @@ export function ModelApiResponseFromJSONTyped(json: any, ignoreDiscriminator: bo
     };
 }
 
-export function ModelApiResponseToJSON(json: any): ModelApiResponse {
-    return ModelApiResponseToJSONTyped(json, false);
+export function ModelApiResponseToJSON(value?: ModelApiResponse | null): any {
+    return ModelApiResponseToJSONTyped(value, false);
 }
 
 export function ModelApiResponseToJSONTyped(value?: ModelApiResponse | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Order.ts
@@ -83,8 +83,8 @@ export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Ord
     };
 }
 
-export function OrderToJSON(json: any): Order {
-    return OrderToJSONTyped(json, false);
+export function OrderToJSON(value?: Order | null): any {
+    return OrderToJSONTyped(value, false);
 }
 
 export function OrderToJSONTyped(value?: Order | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Pet.ts
@@ -100,8 +100,8 @@ export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
     };
 }
 
-export function PetToJSON(json: any): Pet {
-    return PetToJSONTyped(json, false);
+export function PetToJSON(value?: Pet | null): any {
+    return PetToJSONTyped(value, false);
 }
 
 export function PetToJSONTyped(value?: Pet | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Tag.ts
@@ -51,8 +51,8 @@ export function TagFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tag {
     };
 }
 
-export function TagToJSON(json: any): Tag {
-    return TagToJSONTyped(json, false);
+export function TagToJSON(value?: Tag | null): any {
+    return TagToJSONTyped(value, false);
 }
 
 export function TagToJSONTyped(value?: Tag | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/User.ts
@@ -81,8 +81,8 @@ export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User
     };
 }
 
-export function UserToJSON(json: any): User {
-    return UserToJSONTyped(json, false);
+export function UserToJSON(value?: User | null): any {
+    return UserToJSONTyped(value, false);
 }
 
 export function UserToJSONTyped(value?: User | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Category.ts
@@ -51,8 +51,8 @@ export function CategoryFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
     };
 }
 
-export function CategoryToJSON(json: any): Category {
-    return CategoryToJSONTyped(json, false);
+export function CategoryToJSON(value?: Category | null): any {
+    return CategoryToJSONTyped(value, false);
 }
 
 export function CategoryToJSONTyped(value?: Category | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/ModelApiResponse.ts
@@ -56,8 +56,8 @@ export function ModelApiResponseFromJSONTyped(json: any, ignoreDiscriminator: bo
     };
 }
 
-export function ModelApiResponseToJSON(json: any): ModelApiResponse {
-    return ModelApiResponseToJSONTyped(json, false);
+export function ModelApiResponseToJSON(value?: ModelApiResponse | null): any {
+    return ModelApiResponseToJSONTyped(value, false);
 }
 
 export function ModelApiResponseToJSONTyped(value?: ModelApiResponse | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Order.ts
@@ -83,8 +83,8 @@ export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Ord
     };
 }
 
-export function OrderToJSON(json: any): Order {
-    return OrderToJSONTyped(json, false);
+export function OrderToJSON(value?: Order | null): any {
+    return OrderToJSONTyped(value, false);
 }
 
 export function OrderToJSONTyped(value?: Order | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Pet.ts
@@ -100,8 +100,8 @@ export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
     };
 }
 
-export function PetToJSON(json: any): Pet {
-    return PetToJSONTyped(json, false);
+export function PetToJSON(value?: Pet | null): any {
+    return PetToJSONTyped(value, false);
 }
 
 export function PetToJSONTyped(value?: Pet | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Tag.ts
@@ -51,8 +51,8 @@ export function TagFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tag {
     };
 }
 
-export function TagToJSON(json: any): Tag {
-    return TagToJSONTyped(json, false);
+export function TagToJSON(value?: Tag | null): any {
+    return TagToJSONTyped(value, false);
 }
 
 export function TagToJSONTyped(value?: Tag | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/User.ts
@@ -81,8 +81,8 @@ export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User
     };
 }
 
-export function UserToJSON(json: any): User {
-    return UserToJSONTyped(json, false);
+export function UserToJSON(value?: User | null): any {
+    return UserToJSONTyped(value, false);
 }
 
 export function UserToJSONTyped(value?: User | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/EnumPatternObject.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/EnumPatternObject.ts
@@ -78,8 +78,8 @@ export function EnumPatternObjectFromJSONTyped(json: any, ignoreDiscriminator: b
     };
 }
 
-export function EnumPatternObjectToJSON(json: any): EnumPatternObject {
-    return EnumPatternObjectToJSONTyped(json, false);
+export function EnumPatternObjectToJSON(value?: EnumPatternObject | null): any {
+    return EnumPatternObjectToJSONTyped(value, false);
 }
 
 export function EnumPatternObjectToJSONTyped(value?: EnumPatternObject | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/FakeEnumRequestGetInline200Response.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/FakeEnumRequestGetInline200Response.ts
@@ -99,8 +99,8 @@ export function FakeEnumRequestGetInline200ResponseFromJSONTyped(json: any, igno
     };
 }
 
-export function FakeEnumRequestGetInline200ResponseToJSON(json: any): FakeEnumRequestGetInline200Response {
-    return FakeEnumRequestGetInline200ResponseToJSONTyped(json, false);
+export function FakeEnumRequestGetInline200ResponseToJSON(value?: FakeEnumRequestGetInline200Response | null): any {
+    return FakeEnumRequestGetInline200ResponseToJSONTyped(value, false);
 }
 
 export function FakeEnumRequestGetInline200ResponseToJSONTyped(value?: FakeEnumRequestGetInline200Response | null, ignoreDiscriminator: boolean = false): any {

--- a/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/NumberEnum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/NumberEnum.ts
@@ -48,6 +48,6 @@ export function NumberEnumToJSON(value?: NumberEnum | null): any {
 }
 
 export function NumberEnumToJSONTyped(value?: NumberEnum | null, ignoreDiscriminator: boolean = false): any {
-    return value as NumberEnum;
+    return value as any;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/NumberEnum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/NumberEnum.ts
@@ -44,10 +44,10 @@ export function NumberEnumFromJSONTyped(json: any, ignoreDiscriminator: boolean)
 }
 
 export function NumberEnumToJSON(value?: NumberEnum | null): any {
-    return value as any;
+    return NumberEnumToJSONTyped(value, false);
 }
 
-export function NumberEnumToJSONTyped(value: any, ignoreDiscriminator: boolean): NumberEnum {
+export function NumberEnumToJSONTyped(value?: NumberEnum | null, ignoreDiscriminator: boolean): any {
     return value as NumberEnum;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/NumberEnum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/NumberEnum.ts
@@ -47,7 +47,7 @@ export function NumberEnumToJSON(value?: NumberEnum | null): any {
     return NumberEnumToJSONTyped(value, false);
 }
 
-export function NumberEnumToJSONTyped(value?: NumberEnum | null, ignoreDiscriminator: boolean): any {
+export function NumberEnumToJSONTyped(value?: NumberEnum | null, ignoreDiscriminator: boolean = false): any {
     return value as NumberEnum;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/StringEnum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/StringEnum.ts
@@ -44,10 +44,10 @@ export function StringEnumFromJSONTyped(json: any, ignoreDiscriminator: boolean)
 }
 
 export function StringEnumToJSON(value?: StringEnum | null): any {
-    return value as any;
+    return StringEnumToJSONTyped(value, false);
 }
 
-export function StringEnumToJSONTyped(value: any, ignoreDiscriminator: boolean): StringEnum {
+export function StringEnumToJSONTyped(value?: StringEnum | null, ignoreDiscriminator: boolean): any {
     return value as StringEnum;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/StringEnum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/StringEnum.ts
@@ -47,7 +47,7 @@ export function StringEnumToJSON(value?: StringEnum | null): any {
     return StringEnumToJSONTyped(value, false);
 }
 
-export function StringEnumToJSONTyped(value?: StringEnum | null, ignoreDiscriminator: boolean): any {
+export function StringEnumToJSONTyped(value?: StringEnum | null, ignoreDiscriminator: boolean = false): any {
     return value as StringEnum;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/StringEnum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/StringEnum.ts
@@ -48,6 +48,6 @@ export function StringEnumToJSON(value?: StringEnum | null): any {
 }
 
 export function StringEnumToJSONTyped(value?: StringEnum | null, ignoreDiscriminator: boolean = false): any {
-    return value as StringEnum;
+    return value as any;
 }
 


### PR DESCRIPTION
Fix the incorrect parameter and return types in the generated ToJSON and ToJSONTyped functions for typescript-fetch models.

- modelGeneric/mustache, modelOneOf.mustache: Fix ToJSON signature from (json: any): Model to (value?: Model | null): any
- modelEnum.mustache: Fix ToJSONTyped signature from (value: any, ignoreDiscriminator: boolean): Enum to (value?: Enum | null, ignoreDiscriminator: boolean): any Also make ToJSON delegate to ToJSONTyped instead of a raw cast

Fixes #21005

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect ToJSON/ToJSONTyped type signatures in `typescript-fetch` to match runtime behavior and improve type safety. All ToJSON functions now accept optional model values and delegate to ToJSONTyped; enum ToJSONTyped returns any and defaults ignoreDiscriminator to false (fixes #21005).

- **Bug Fixes**
  - `modelGeneric.mustache`, `modelOneOf.mustache`: change ToJSON from (json: any): Model to (value?: Model | null): any; delegate to ToJSONTyped.
  - `modelEnum.mustache`: make ToJSON call ToJSONTyped; change ToJSONTyped to (value?: Enum | null, ignoreDiscriminator: boolean = false): any.
  - Regenerated `typescript-fetch` samples to apply the new signatures and delegation, including enum files.

<sup>Written for commit 420421aa4e4e2ca26406e8968824cee9cf17778b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24581?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

