### PR TITLE
fix(normalizer): restore behavior of clearing a oneOf if the schema content cannot currently be used by the generator

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
@@ -43,6 +43,7 @@ import java.util.stream.Collectors;
 import static org.openapitools.codegen.CodegenConstants.*;
 import static org.openapitools.codegen.utils.EnumUtils.ANY_OF;
 import static org.openapitools.codegen.utils.EnumUtils.ONE_OF;
+import static org.openapitools.codegen.utils.ModelUtils.isOneOfOfConsts;
 import static org.openapitools.codegen.utils.ModelUtils.simplifyOneOfAnyOfWithOnlyOneNonNullSubSchema;
 import static org.openapitools.codegen.utils.StringUtils.getUniqueString;
 
@@ -1705,18 +1706,24 @@ public class OpenAPINormalizer {
             }
 
             schema = simplifyOneOfAnyOfWithOnlyOneNonNullSubSchema(openAPI, schema, oneOfSchemas);
-            if (ModelUtils.isIntegerSchema(schema) || ModelUtils.isNumberSchema(schema) || ModelUtils.isStringSchema(schema)) {
-                if (schema.getSpecVersion().equals(SpecVersion.V30)) {
-                    schema.setOneOf(null);
-                } //else {
-                    // TODO convert oneOf const/deprecated to enum
-               // }
-            }
+            clearOneOf(schema);
         }
 
         return schema;
     }
 
+    /**
+     * Removes the {@code oneOf} from the schema if it is considered to not contain information that the generator can
+     * currently act upon. The schema is left untouched if all the {@code oneOf} branches contain an OAS 3.1 {@code const}.
+     * This since that structure can potentially be used for enum interpretation.
+     */
+    private void clearOneOf(Schema schema) {
+        if (ModelUtils.isIntegerSchema(schema) || ModelUtils.isNumberSchema(schema) || ModelUtils.isStringSchema(schema)) {
+            if (!isOneOfOfConsts(schema)) {
+                schema.setOneOf(null);
+            }
+        }
+    }
 
     /**
      * Ensure inheritance is correctly defined for OneOf and Discriminators.

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -2802,6 +2802,19 @@ public class ModelUtils {
         return schemaMap.values().stream().anyMatch(ModelUtils::isEnumSchema);
     }
 
+    /**
+     * Whether all branches in the oneOf contains a {@code const}. Returns false for OAS 3.0 since that does not support
+     * {@code const}.
+     * @param schema The Schema
+     * @return true if all {@code oneOf} branches contains a {@code const}.
+     */
+    public static boolean isOneOfOfConsts(Schema<?> schema) {
+        if (hasOneOf(schema) && !schema.getSpecVersion().equals(SpecVersion.V30)) {
+            return schema.getOneOf().stream().allMatch(oneOf -> oneOf.getConst() != null);
+        }
+        return false;
+    }
+
     @FunctionalInterface
     private interface OpenAPISchemaVisitor {
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/OpenAPINormalizerTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/OpenAPINormalizerTest.java
@@ -34,6 +34,8 @@ import static org.testng.Assert.*;
 
 public class OpenAPINormalizerTest {
 
+    private static final String SIMPLIFY_ONE_OF_ANY_OF = "SIMPLIFY_ONEOF_ANYOF";
+    private static final String SIMPLIFY_ONEOF_ANYOF_ENUM = "SIMPLIFY_ONEOF_ANYOF_ENUM";
     private static final String REF_AS_PARENT_IN_ALLOF = "REF_AS_PARENT_IN_ALLOF";
     private static final String X_PARENT = "x-parent";
     private static final String X_INTERNAL = "x-internal";
@@ -201,7 +203,7 @@ public class OpenAPINormalizerTest {
 
         // Test with rule enabled (default)
         Map<String, String> options = new HashMap<>();
-        options.put("SIMPLIFY_ONEOF_ANYOF_ENUM", "true");
+        options.put(SIMPLIFY_ONEOF_ANYOF_ENUM, "true");
         OpenAPINormalizer normalizer = new OpenAPINormalizer(openAPI, options);
         normalizer.normalize();
 
@@ -239,7 +241,7 @@ public class OpenAPINormalizerTest {
         // Test with rule disabled
         OpenAPI openAPI2 = TestUtils.parseSpec("src/test/resources/3_0/simplifyOneOfWithEnums_test.yaml");
         Map<String, String> options2 = new HashMap<>();
-        options2.put("SIMPLIFY_ONEOF_ANYOF_ENUM", "false");
+        options2.put(SIMPLIFY_ONEOF_ANYOF_ENUM, "false");
         OpenAPINormalizer normalizer2 = new OpenAPINormalizer(openAPI2, options2);
         normalizer2.normalize();
 
@@ -303,7 +305,7 @@ public class OpenAPINormalizerTest {
         assertEquals(schema19.getAnyOf().size(), 1);
 
         Map<String, String> options = new HashMap<>();
-        options.put("SIMPLIFY_ONEOF_ANYOF", "true");
+        options.put(SIMPLIFY_ONE_OF_ANY_OF, "true");
         OpenAPINormalizer openAPINormalizer = new OpenAPINormalizer(openAPI, options);
         openAPINormalizer.normalize();
 
@@ -361,7 +363,7 @@ public class OpenAPINormalizerTest {
         assertEquals(((Schema) oneOfWithSingleRef.getProperties().get("number")).getOneOf().size(), 1);
 
         Map<String, String> options = new HashMap<>();
-        options.put("SIMPLIFY_ONEOF_ANYOF", "true");
+        options.put(SIMPLIFY_ONE_OF_ANY_OF, "true");
         OpenAPINormalizer openAPINormalizer = new OpenAPINormalizer(openAPI, options);
         openAPINormalizer.normalize();
 
@@ -502,7 +504,7 @@ public class OpenAPINormalizerTest {
         assertNull(schema.getNullable());
 
         Map<String, String> options = new HashMap<>();
-        options.put("SIMPLIFY_ONEOF_ANYOF", "true");
+        options.put(SIMPLIFY_ONE_OF_ANY_OF, "true");
         OpenAPINormalizer openAPINormalizer = new OpenAPINormalizer(openAPI, options);
         openAPINormalizer.normalize();
 
@@ -1530,7 +1532,7 @@ public class OpenAPINormalizerTest {
 
         // start the normalization
         Map<String, String> options = new HashMap<>();
-        options.put("SIMPLIFY_ONEOF_ANYOF", "true");
+        options.put(SIMPLIFY_ONE_OF_ANY_OF, "true");
         OpenAPINormalizer openAPINormalizer = new OpenAPINormalizer(openAPI, options);
         openAPINormalizer.normalize();
 
@@ -1605,6 +1607,40 @@ public class OpenAPINormalizerTest {
     }
 
     @Test
+    public void testOneOfWithStringsWithDifferentPatternsAreCollapsedWithSimplifyOneOfAnyOf() {
+        OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_1/simplifyOneOfAnyOf_test.yaml");
+
+        Schema stringPatternsWithOneOf = openAPI.getComponents().getSchemas().get("StringPatternsWithOneOf");
+        assertEquals(stringPatternsWithOneOf.getOneOf().size(), 2);
+
+        // start the normalization
+        Map<String, String> options = new HashMap<>();
+        options.put(SIMPLIFY_ONE_OF_ANY_OF, "true");
+        OpenAPINormalizer openAPINormalizer = new OpenAPINormalizer(openAPI, options);
+        openAPINormalizer.normalize();
+
+        Schema normalizedStringPatternsWithOneOf = openAPI.getComponents().getSchemas().get("StringPatternsWithOneOf");
+        assertNull(normalizedStringPatternsWithOneOf.getOneOf());
+    }
+
+    @Test
+    public void testOneOfWithConstsIsUntouchedBySimplifyOneOfAnyOf() {
+        OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_1/simplifyOneOfAnyOf_test.yaml");
+
+        Schema integerWithOneOfConsts = openAPI.getComponents().getSchemas().get("TypeIntegerWithOneOf");
+        assertEquals(integerWithOneOfConsts.getOneOf().size(), 3);
+
+        // start the normalization
+        Map<String, String> options = new HashMap<>();
+        options.put(SIMPLIFY_ONEOF_ANYOF_ENUM, "false");
+        OpenAPINormalizer openAPINormalizer = new OpenAPINormalizer(openAPI, options);
+        openAPINormalizer.normalize();
+
+        Schema normalizedIntegerWithOneOfConsts = openAPI.getComponents().getSchemas().get("TypeIntegerWithOneOf");
+        assertEquals(normalizedIntegerWithOneOfConsts.getOneOf().size(), 3);
+    }
+
+    @Test
     public void testOpenAPINormalizerSimplifyOneOfWithSingleRef31Spec() {
         OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_1/simplifyOneOfAnyOf_test.yaml");
 
@@ -1612,7 +1648,7 @@ public class OpenAPINormalizerTest {
         assertEquals(((Schema) oneOfWithSingleRef.getProperties().get("number")).getOneOf().size(), 1);
 
         Map<String, String> options = new HashMap<>();
-        options.put("SIMPLIFY_ONEOF_ANYOF", "true");
+        options.put(SIMPLIFY_ONE_OF_ANY_OF, "true");
         OpenAPINormalizer openAPINormalizer = new OpenAPINormalizer(openAPI, options);
         openAPINormalizer.normalize();
 

--- a/modules/openapi-generator/src/test/resources/3_1/simplifyOneOfAnyOf_test.yaml
+++ b/modules/openapi-generator/src/test/resources/3_1/simplifyOneOfAnyOf_test.yaml
@@ -151,3 +151,12 @@ components:
       oneOf:
         - $ref: '#/components/schemas/Parent'
         - type: "null"
+    StringPatternsWithOneOf:
+      type: string
+      oneOf:
+        - type: string
+          description: Numeric identifier
+          pattern: '^\d{1,35}$'
+        - type: string
+          description: UUID identifier
+          pattern: '^[0-9a-f-]{36}$'

--- a/samples/client/petstore/csharp/generichost/latest/AnnotatedEnum/api/openapi.yaml
+++ b/samples/client/petstore/csharp/generichost/latest/AnnotatedEnum/api/openapi.yaml
@@ -131,6 +131,8 @@ components:
       allOf:
       - $ref: "#/components/schemas/Parent"
       nullable: true
+    StringPatternsWithOneOf:
+      type: string
     ParentWithPluralOneOfProperty_number:
       oneOf:
       - $ref: "#/components/schemas/Number"


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Restores behavior of clearing a `oneOf` when running normalization `normalizeOneOf` as part of the `SIMPLIFY_ONEOF_ANYOF` rule. 

The only case that currently is kept is when the `oneOf` only has `const` branches. Note that this case is not really relevant as of current, with the introduction of const parsing with https://github.com/OpenAPITools/openapi-generator/pull/23869 (being part of rule `SIMPLIFY_ONEOF_ANYOF_ENUM`), which is processed before `SIMPLIFY_ONEOF_ANYOF`.

Would be good to get feedback from the original author, since it could be that https://github.com/OpenAPITools/openapi-generator/issues/22571 looks to forward meta annotations from a `oneOf` that is not tied to `const`.

Fixes https://github.com/OpenAPITools/openapi-generator/issues/24574

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the normalizer to clear `oneOf` under `SIMPLIFY_ONEOF_ANYOF` when the generator can’t use its content, keeping it only when all branches are OAS 3.1 `const` for potential enum handling. Fixes #24574.

- **Bug Fixes**
  - Added `clearOneOf()` in `OpenAPINormalizer` to drop `oneOf` on integer/number/string schemas unless `ModelUtils.isOneOfOfConsts()` is true.
  - Implemented `ModelUtils.isOneOfOfConsts()` (OAS 3.1 only; all branches must have `const`).
  - Expanded tests: collapse differing string patterns (`StringPatternsWithOneOf`); preserve const-only `oneOf` when `SIMPLIFY_ONEOF_ANYOF_ENUM` is disabled; extracted option keys to constants.
  - Updated C# sample OpenAPI to include `StringPatternsWithOneOf`.

<sup>Written for commit 565c78b32e51eed9566e92fe4b4703e6b9653f38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24585?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

