### PR TITLE
[core] keep property type when an allOf part redefines it without a type

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -3664,101 +3664,14 @@ public class DefaultCodegen implements CodegenConfig {
     private void putProperty(Map<String, Schema> targetProperties, String name, Schema incoming) {
         Schema existing = targetProperties.get(name);
         if (existing != null && incoming != null
-                && !ModelUtils.isAnyType(existing) && isConstraintOnlySchema(incoming)) {
+                && !ModelUtils.isAnyType(existing)
+                && ModelUtils.isMetadataOnlySchema(incoming) && incoming.getEnum() == null) {
             Schema merged = ModelUtils.cloneSchema(existing, specVersionGreaterThanOrEqualTo310(openAPI));
-            if (incoming.getNullable() != null) {
-                merged.setNullable(incoming.getNullable());
-            }
-            if (incoming.getDescription() != null) {
-                merged.setDescription(incoming.getDescription());
-            }
-            if (incoming.getDeprecated() != null) {
-                merged.setDeprecated(incoming.getDeprecated());
-            }
-            if (incoming.getReadOnly() != null) {
-                merged.setReadOnly(incoming.getReadOnly());
-            }
-            if (incoming.getWriteOnly() != null) {
-                merged.setWriteOnly(incoming.getWriteOnly());
-            }
-            if (incoming.getTitle() != null) {
-                merged.setTitle(incoming.getTitle());
-            }
-            if (incoming.getFormat() != null) {
-                merged.setFormat(incoming.getFormat());
-            }
-            if (incoming.getDefault() != null) {
-                merged.setDefault(incoming.getDefault());
-            }
-            if (incoming.getExample() != null) {
-                merged.setExample(incoming.getExample());
-            }
-            if (incoming.getPattern() != null) {
-                merged.setPattern(incoming.getPattern());
-            }
-            if (incoming.getMaxLength() != null) {
-                merged.setMaxLength(incoming.getMaxLength());
-            }
-            if (incoming.getMinLength() != null) {
-                merged.setMinLength(incoming.getMinLength());
-            }
-            if (incoming.getMaximum() != null) {
-                merged.setMaximum(incoming.getMaximum());
-            }
-            if (incoming.getMinimum() != null) {
-                merged.setMinimum(incoming.getMinimum());
-            }
-            if (incoming.getExclusiveMaximum() != null) {
-                merged.setExclusiveMaximum(incoming.getExclusiveMaximum());
-            }
-            if (incoming.getExclusiveMinimum() != null) {
-                merged.setExclusiveMinimum(incoming.getExclusiveMinimum());
-            }
-            if (incoming.getExclusiveMaximumValue() != null) {
-                merged.setExclusiveMaximumValue(incoming.getExclusiveMaximumValue());
-            }
-            if (incoming.getExclusiveMinimumValue() != null) {
-                merged.setExclusiveMinimumValue(incoming.getExclusiveMinimumValue());
-            }
-            if (incoming.getMultipleOf() != null) {
-                merged.setMultipleOf(incoming.getMultipleOf());
-            }
-            if (incoming.getMaxItems() != null) {
-                merged.setMaxItems(incoming.getMaxItems());
-            }
-            if (incoming.getMinItems() != null) {
-                merged.setMinItems(incoming.getMinItems());
-            }
-            if (incoming.getUniqueItems() != null) {
-                merged.setUniqueItems(incoming.getUniqueItems());
-            }
-            if (incoming.getMaxProperties() != null) {
-                merged.setMaxProperties(incoming.getMaxProperties());
-            }
-            if (incoming.getMinProperties() != null) {
-                merged.setMinProperties(incoming.getMinProperties());
-            }
-            if (incoming.getExtensions() != null) {
-                incoming.getExtensions().forEach((k, v) -> merged.addExtension(String.valueOf(k), v));
-            }
+            ModelUtils.copyConstraints(incoming, merged);
             targetProperties.put(name, merged);
         } else {
             targetProperties.put(name, incoming);
         }
-    }
-
-    /**
-     * True when the schema defines no type of its own: no type, no $ref, no items,
-     * no properties, no composition and no enum.
-     */
-    private static boolean isConstraintOnlySchema(Schema schema) {
-        return ModelUtils.isAnyType(schema)
-                && schema.getItems() == null
-                && schema.getProperties() == null
-                && schema.getAllOf() == null
-                && schema.getOneOf() == null
-                && schema.getAnyOf() == null
-                && schema.getEnum() == null;
     }
 
     /**

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -2941,7 +2941,7 @@ public class DefaultCodegen implements CodegenConfig {
             Schema existingType = existingProperties.get("type");
             Schema newType = newProperties.get("type");
             newProperties.forEach((key, value) ->
-                    existingProperties.put(key, ModelUtils.cloneSchema(value, specVersionGreaterThanOrEqualTo310(openAPI)))
+                    putProperty(existingProperties, key, ModelUtils.cloneSchema(value, specVersionGreaterThanOrEqualTo310(openAPI)))
             );
             if (null != existingType && null != newType && null != newType.getEnum() && !newType.getEnum().isEmpty()) {
                 for (Object e : newType.getEnum()) {
@@ -3608,7 +3608,7 @@ public class DefaultCodegen implements CodegenConfig {
         if (ModelUtils.isComposedSchema(schema)) {
             // fix issue #16797 and #15796, constructor fail by missing parent required params
             if (ModelUtils.hasProperties(schema)) {
-                properties.putAll(schema.getProperties());
+                putProperties(properties, schema.getProperties());
             }
 
             if (schema.getAllOf() != null) {
@@ -3642,11 +3642,65 @@ public class DefaultCodegen implements CodegenConfig {
             return;
         }
         if (schema.getProperties() != null) {
-            properties.putAll(schema.getProperties());
+            putProperties(properties, schema.getProperties());
         }
         if (schema.getRequired() != null) {
             required.addAll(schema.getRequired());
         }
+    }
+
+    /**
+     * Adds each property to the target map. When a property of the same name is already present
+     * with type information and the incoming schema carries no type of its own (for example an
+     * allOf part that only sets 'nullable: true' on an inherited property), the incoming
+     * constraints are applied on top of the existing schema instead of replacing it, so the
+     * type is not lost. See issue #4128.
+     */
+    private void putProperties(Map<String, Schema> targetProperties, Map<String, Schema> newProperties) {
+        newProperties.forEach((name, incoming) -> putProperty(targetProperties, name, incoming));
+    }
+
+    private void putProperty(Map<String, Schema> targetProperties, String name, Schema incoming) {
+        Schema existing = targetProperties.get(name);
+        if (existing != null && incoming != null
+                && !ModelUtils.isAnyType(existing) && isConstraintOnlySchema(incoming)) {
+            Schema merged = ModelUtils.cloneSchema(existing, specVersionGreaterThanOrEqualTo310(openAPI));
+            if (incoming.getNullable() != null) {
+                merged.setNullable(incoming.getNullable());
+            }
+            if (incoming.getDescription() != null) {
+                merged.setDescription(incoming.getDescription());
+            }
+            if (incoming.getDeprecated() != null) {
+                merged.setDeprecated(incoming.getDeprecated());
+            }
+            if (incoming.getReadOnly() != null) {
+                merged.setReadOnly(incoming.getReadOnly());
+            }
+            if (incoming.getWriteOnly() != null) {
+                merged.setWriteOnly(incoming.getWriteOnly());
+            }
+            if (incoming.getExtensions() != null) {
+                incoming.getExtensions().forEach((k, v) -> merged.addExtension(String.valueOf(k), v));
+            }
+            targetProperties.put(name, merged);
+        } else {
+            targetProperties.put(name, incoming);
+        }
+    }
+
+    /**
+     * True when the schema defines no type of its own: no type, no $ref, no items,
+     * no properties, no composition and no enum.
+     */
+    private static boolean isConstraintOnlySchema(Schema schema) {
+        return ModelUtils.isAnyType(schema)
+                && schema.getItems() == null
+                && schema.getProperties() == null
+                && schema.getAllOf() == null
+                && schema.getOneOf() == null
+                && schema.getAnyOf() == null
+                && schema.getEnum() == null;
     }
 
     /**

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -3665,7 +3665,8 @@ public class DefaultCodegen implements CodegenConfig {
         Schema existing = targetProperties.get(name);
         if (existing != null && incoming != null
                 && !ModelUtils.isAnyType(existing)
-                && ModelUtils.isMetadataOnlySchema(incoming) && incoming.getEnum() == null) {
+                && ModelUtils.isMetadataOnlySchema(incoming)
+                && incoming.getEnum() == null && incoming.getConst() == null && incoming.getNot() == null) {
             Schema merged = ModelUtils.cloneSchema(existing, specVersionGreaterThanOrEqualTo310(openAPI));
             ModelUtils.copyConstraints(incoming, merged);
             targetProperties.put(name, merged);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -3653,8 +3653,9 @@ public class DefaultCodegen implements CodegenConfig {
      * Adds each property to the target map. When a property of the same name is already present
      * with type information and the incoming schema carries no type of its own (for example an
      * allOf part that only sets 'nullable: true' on an inherited property), the incoming
-     * constraints are applied on top of the existing schema instead of replacing it, so the
-     * type is not lost. See issue #4128.
+     * constraints (nullable, description, validation keywords, format, default, extensions)
+     * are applied on top of the existing schema instead of replacing it, so the type is not
+     * lost. See issue #4128.
      */
     private void putProperties(Map<String, Schema> targetProperties, Map<String, Schema> newProperties) {
         newProperties.forEach((name, incoming) -> putProperty(targetProperties, name, incoming));
@@ -3679,6 +3680,63 @@ public class DefaultCodegen implements CodegenConfig {
             }
             if (incoming.getWriteOnly() != null) {
                 merged.setWriteOnly(incoming.getWriteOnly());
+            }
+            if (incoming.getTitle() != null) {
+                merged.setTitle(incoming.getTitle());
+            }
+            if (incoming.getFormat() != null) {
+                merged.setFormat(incoming.getFormat());
+            }
+            if (incoming.getDefault() != null) {
+                merged.setDefault(incoming.getDefault());
+            }
+            if (incoming.getExample() != null) {
+                merged.setExample(incoming.getExample());
+            }
+            if (incoming.getPattern() != null) {
+                merged.setPattern(incoming.getPattern());
+            }
+            if (incoming.getMaxLength() != null) {
+                merged.setMaxLength(incoming.getMaxLength());
+            }
+            if (incoming.getMinLength() != null) {
+                merged.setMinLength(incoming.getMinLength());
+            }
+            if (incoming.getMaximum() != null) {
+                merged.setMaximum(incoming.getMaximum());
+            }
+            if (incoming.getMinimum() != null) {
+                merged.setMinimum(incoming.getMinimum());
+            }
+            if (incoming.getExclusiveMaximum() != null) {
+                merged.setExclusiveMaximum(incoming.getExclusiveMaximum());
+            }
+            if (incoming.getExclusiveMinimum() != null) {
+                merged.setExclusiveMinimum(incoming.getExclusiveMinimum());
+            }
+            if (incoming.getExclusiveMaximumValue() != null) {
+                merged.setExclusiveMaximumValue(incoming.getExclusiveMaximumValue());
+            }
+            if (incoming.getExclusiveMinimumValue() != null) {
+                merged.setExclusiveMinimumValue(incoming.getExclusiveMinimumValue());
+            }
+            if (incoming.getMultipleOf() != null) {
+                merged.setMultipleOf(incoming.getMultipleOf());
+            }
+            if (incoming.getMaxItems() != null) {
+                merged.setMaxItems(incoming.getMaxItems());
+            }
+            if (incoming.getMinItems() != null) {
+                merged.setMinItems(incoming.getMinItems());
+            }
+            if (incoming.getUniqueItems() != null) {
+                merged.setUniqueItems(incoming.getUniqueItems());
+            }
+            if (incoming.getMaxProperties() != null) {
+                merged.setMaxProperties(incoming.getMaxProperties());
+            }
+            if (incoming.getMinProperties() != null) {
+                merged.setMinProperties(incoming.getMinProperties());
             }
             if (incoming.getExtensions() != null) {
                 incoming.getExtensions().forEach((k, v) -> merged.addExtension(String.valueOf(k), v));

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -2816,7 +2816,14 @@ public class ModelUtils {
      * @param to   schema to copy to
      */
     public static void copyConstraints(Schema from, Schema to) {
+        Map<String, Object> targetExtensions = to.getExtensions() == null ? null : new HashMap<>(to.getExtensions());
         copyMetadata(from, to);
+        // merge extensions per key instead of replacing, the source wins on conflicts
+        if (targetExtensions != null && from.getExtensions() != null) {
+            Map<String, Object> mergedExtensions = new HashMap<>(targetExtensions);
+            mergedExtensions.putAll(from.getExtensions());
+            to.setExtensions(mergedExtensions);
+        }
         if (from.getFormat() != null) {
             to.setFormat(from.getFormat());
         }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -2808,6 +2808,48 @@ public class ModelUtils {
     }
 
     /**
+     * Copies metadata plus the validation and format keywords that copyMetadata does not cover.
+     * Used when an allOf part only constrains an inherited property (see issue #4128), so no
+     * declared keyword is lost while the type is kept.
+     *
+     * @param from schema to copy from
+     * @param to   schema to copy to
+     */
+    public static void copyConstraints(Schema from, Schema to) {
+        copyMetadata(from, to);
+        if (from.getFormat() != null) {
+            to.setFormat(from.getFormat());
+        }
+        if (from.getPattern() != null) {
+            to.setPattern(from.getPattern());
+        }
+        if (from.getExclusiveMaximum() != null) {
+            to.setExclusiveMaximum(from.getExclusiveMaximum());
+        }
+        if (from.getExclusiveMinimum() != null) {
+            to.setExclusiveMinimum(from.getExclusiveMinimum());
+        }
+        if (from.getExclusiveMaximumValue() != null) {
+            to.setExclusiveMaximumValue(from.getExclusiveMaximumValue());
+        }
+        if (from.getExclusiveMinimumValue() != null) {
+            to.setExclusiveMinimumValue(from.getExclusiveMinimumValue());
+        }
+        if (from.getMultipleOf() != null) {
+            to.setMultipleOf(from.getMultipleOf());
+        }
+        if (from.getUniqueItems() != null) {
+            to.setUniqueItems(from.getUniqueItems());
+        }
+        if (from.getMaxProperties() != null) {
+            to.setMaxProperties(from.getMaxProperties());
+        }
+        if (from.getMinProperties() != null) {
+            to.setMinProperties(from.getMinProperties());
+        }
+    }
+
+    /**
      * Returns true if a schema is only metadata and not an actual type.
      * For example, a schema that only has a `description` without any `properties` or `$ref` defined.
      *

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -1329,6 +1329,7 @@ public class DefaultCodegenTest {
                 .filter(v -> "addressId".equals(v.baseName)).findFirst().orElseThrow();
         assertEquals("String", addressId.dataType);
         assertTrue(addressId.isNullable);
+        assertEquals(Integer.valueOf(36), addressId.maxLength);
     }
 
     @Test

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -1315,6 +1315,23 @@ public class DefaultCodegenTest {
     }
 
     @Test
+    public void testAllOfNullableWithoutTypeKeepsType() {
+        // issue #4128: an allOf part that only sets 'nullable: true' on a property
+        // defined in another part must not erase the property type
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/allOf-nullable-typeless-override.yaml");
+        DefaultCodegen codegen = new DefaultCodegen();
+        codegen.setOpenAPI(openAPI);
+
+        Schema schema = openAPI.getComponents().getSchemas().get("UpdateFirm");
+        CodegenModel model = codegen.fromModel("UpdateFirm", schema);
+
+        CodegenProperty addressId = model.vars.stream()
+                .filter(v -> "addressId".equals(v.baseName)).findFirst().orElseThrow();
+        assertEquals("String", addressId.dataType);
+        assertTrue(addressId.isNullable);
+    }
+
+    @Test
     public void testAllOfSingleAndDoubleRefWithOwnPropsNoDiscriminator() {
         final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/allOf_composition.yaml");
         final DefaultCodegen codegen = new CodegenWithMultipleInheritance();

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -1330,6 +1330,9 @@ public class DefaultCodegenTest {
         assertEquals("String", addressId.dataType);
         assertTrue(addressId.isNullable);
         assertEquals(Integer.valueOf(36), addressId.maxLength);
+        // extensions from both parts survive the merge
+        assertEquals("keep", addressId.vendorExtensions.get("x-base-marker"));
+        assertEquals("added", addressId.vendorExtensions.get("x-overlay-marker"));
     }
 
     @Test

--- a/modules/openapi-generator/src/test/resources/3_0/allOf-nullable-typeless-override.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/allOf-nullable-typeless-override.yaml
@@ -36,3 +36,4 @@ components:
               nullable: true
             addressId:
               nullable: true
+              maxLength: 36

--- a/modules/openapi-generator/src/test/resources/3_0/allOf-nullable-typeless-override.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/allOf-nullable-typeless-override.yaml
@@ -27,6 +27,7 @@ components:
       properties:
         addressId:
           type: string
+          x-base-marker: keep
     UpdateFirm:
       allOf:
         - $ref: "#/components/schemas/FirmProperties"
@@ -37,3 +38,4 @@ components:
             addressId:
               nullable: true
               maxLength: 36
+              x-overlay-marker: added

--- a/modules/openapi-generator/src/test/resources/3_0/allOf-nullable-typeless-override.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/allOf-nullable-typeless-override.yaml
@@ -1,0 +1,38 @@
+openapi: 3.0.3
+info:
+  title: allOf nullable without type
+  version: 1.0.0
+paths:
+  /firm/{firmId}:
+    patch:
+      operationId: updateFirm
+      parameters:
+        - in: path
+          name: firmId
+          required: true
+          schema:
+            type: integer
+            format: int64
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateFirm"
+      responses:
+        "204":
+          description: Updated
+components:
+  schemas:
+    FirmProperties:
+      properties:
+        addressId:
+          type: string
+    UpdateFirm:
+      allOf:
+        - $ref: "#/components/schemas/FirmProperties"
+        - properties:
+            firmName:
+              type: string
+              nullable: true
+            addressId:
+              nullable: true


### PR DESCRIPTION
Relates to #4128, fixes its OpenAPI 3.x case.

An allOf part that only constrains an inherited property:

```yaml
UpdateFirm:
  allOf:
    - $ref: "#/components/schemas/FirmProperties"   # addressId: string
    - properties:
        addressId:
          nullable: true
```

replaced the typed schema wholesale, so the field degraded to Object (`JsonNullable<Object>` with openApiNullable).

Fix: if the incoming property schema has no type of its own (no type, $ref, items, properties, composition, enum) and the existing one is typed, merge the constraints onto a clone of the existing schema instead of replacing it. Both merge points in DefaultCodegen.

Intentional overrides unchanged: a part that repeats a type still replaces. allOfDuplicatedProperties passes.

Swagger 2.0 input (the original report) still degrades: the 2.0 to 3.0 converter injects `type: object` before the generator runs. Parser issue, not fixable here.

Tested: new DefaultCodegenTest case, full module test suite green, all 700+ sample configs regenerated across every generator family, zero output changes.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ```
  (All sample configs regenerated, zero changes. No generator options or docs changed, so export_docs_generators was not needed.)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request. (Core change, not language specific.)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep property types when an `allOf` part redefines a property without a type by merging constraints and extensions instead of replacing the schema. Fixes #4128 for OpenAPI 3.x.

- **Bug Fixes**
  - Merge “metadata-only” `allOf` property overrides into the existing typed schema in `DefaultCodegen`, preserving type while copying validation, format, metadata, and extensions.
  - Applies only when the incoming property has no own type, `$ref`, `items`, `properties`, composition, `enum`, `const`, or `not`; explicit type repeats still replace.
  - Added `ModelUtils.copyConstraints` (built on `copyMetadata`) and used `ModelUtils.isMetadataOnlySchema`; extensions are merged per key (overlay wins); property merges now go through `putProperties`/`putProperty`.
  - Added test `testAllOfNullableWithoutTypeKeepsType` with an OAS 3.0 fixture; vendor extensions from both parts are kept; no sample outputs changed. Swagger 2.0 still degrades due to the converter injecting `type: object`.

<sup>Written for commit 49352ca65439a46cce0d14128e3f8c16834c819f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24586?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

