### PR TITLE
fix(powershell): replace UrlEncode with System.Uri EscapeDataString for path parameter encoding

### DIFF
--- a/modules/openapi-generator/src/main/resources/powershell/api.mustache
+++ b/modules/openapi-generator/src/main/resources/powershell/api.mustache
@@ -90,7 +90,7 @@ function {{{vendorExtensions.x-powershell-method-name}}} {
         if (!$<paramName>) {
             throw "Error! The required parameter `<paramName>` missing when calling <operationId>."
         }
-        $LocalVarUri = $LocalVarUri.replace('{<baseName>}', [System.Web.HTTPUtility]::UrlEncode($<paramName>))
+        $LocalVarUri = $LocalVarUri.replace('{<baseName>}', [System.Uri]::EscapeDataString([string]$<paramName>))
         </pathParams>
         <={{ }}=>
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/powershell/PowerShellClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/powershell/PowerShellClientCodegenTest.java
@@ -96,4 +96,34 @@ public class PowerShellClientCodegenTest {
                 "$JsonParameters.PSobject.Properties[\"$dollarValue$\"]",
                 "-match \"$dollarValue$\"");
     }
+
+    @Test
+    public void pathParametersAreEscaped() throws IOException {
+        File output = Files.createTempDirectory("test-powershell-24602").toFile().getCanonicalFile();
+        output.deleteOnExit();
+        String outputPath = output.getAbsolutePath().replace('\\', '/');
+
+        OpenAPI openAPI = new OpenAPIParser()
+                .readLocation("src/test/resources/3_0/petstore.yaml", null, new ParseOptions())
+                .getOpenAPI();
+
+        PowerShellClientCodegen codegen = new PowerShellClientCodegen();
+        codegen.setOutputDir(output.getAbsolutePath());
+
+        ClientOptInput input = new ClientOptInput();
+        input.openAPI(openAPI);
+        input.config(codegen);
+
+        DefaultGenerator generator = new DefaultGenerator();
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODELS, "false");
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODEL_TESTS, "false");
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODEL_DOCS, "false");
+        generator.setGeneratorPropertyDefault(CodegenConstants.APIS, "true");
+        generator.setGeneratorPropertyDefault(CodegenConstants.SUPPORTING_FILES, "false");
+        generator.opts(input).generate();
+
+        java.nio.file.Path petApi = Paths.get(outputPath + "/src/PSOpenAPITools/Api/PetApi.ps1");
+
+        assertFileContains(petApi, "$LocalVarUri.replace('{petId}', [System.Uri]::EscapeDataString([string]$PetId))");
+    }
 }

--- a/samples/client/echo_api/powershell/src/PSOpenAPITools/Api/PathApi.ps1
+++ b/samples/client/echo_api/powershell/src/PSOpenAPITools/Api/PathApi.ps1
@@ -76,19 +76,19 @@ function Test-sPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRef
         if (!$PathString) {
             throw "Error! The required parameter `PathString` missing when calling tests_path_string_pathString_integer_pathInteger_enumNonrefStringPath_enumRefStringPath."
         }
-        $LocalVarUri = $LocalVarUri.replace('{path_string}', [System.Web.HTTPUtility]::UrlEncode($PathString))
+        $LocalVarUri = $LocalVarUri.replace('{path_string}', [System.Uri]::EscapeDataString([string]$PathString))
         if (!$PathInteger) {
             throw "Error! The required parameter `PathInteger` missing when calling tests_path_string_pathString_integer_pathInteger_enumNonrefStringPath_enumRefStringPath."
         }
-        $LocalVarUri = $LocalVarUri.replace('{path_integer}', [System.Web.HTTPUtility]::UrlEncode($PathInteger))
+        $LocalVarUri = $LocalVarUri.replace('{path_integer}', [System.Uri]::EscapeDataString([string]$PathInteger))
         if (!$EnumNonrefStringPath) {
             throw "Error! The required parameter `EnumNonrefStringPath` missing when calling tests_path_string_pathString_integer_pathInteger_enumNonrefStringPath_enumRefStringPath."
         }
-        $LocalVarUri = $LocalVarUri.replace('{enum_nonref_string_path}', [System.Web.HTTPUtility]::UrlEncode($EnumNonrefStringPath))
+        $LocalVarUri = $LocalVarUri.replace('{enum_nonref_string_path}', [System.Uri]::EscapeDataString([string]$EnumNonrefStringPath))
         if (!$EnumRefStringPath) {
             throw "Error! The required parameter `EnumRefStringPath` missing when calling tests_path_string_pathString_integer_pathInteger_enumNonrefStringPath_enumRefStringPath."
         }
-        $LocalVarUri = $LocalVarUri.replace('{enum_ref_string_path}', [System.Web.HTTPUtility]::UrlEncode($EnumRefStringPath))
+        $LocalVarUri = $LocalVarUri.replace('{enum_ref_string_path}', [System.Uri]::EscapeDataString([string]$EnumRefStringPath))
 
         $LocalVarResult = Invoke-ApiClient -Method 'GET' `
                                 -Uri $LocalVarUri `

--- a/samples/client/petstore/powershell/src/PSPetstore/Api/PSPetApi.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Api/PSPetApi.ps1
@@ -136,7 +136,7 @@ function Remove-Pet {
         if (!$PetId) {
             throw "Error! The required parameter `PetId` missing when calling deletePet."
         }
-        $LocalVarUri = $LocalVarUri.replace('{petId}', [System.Web.HTTPUtility]::UrlEncode($PetId))
+        $LocalVarUri = $LocalVarUri.replace('{petId}', [System.Uri]::EscapeDataString([string]$PetId))
 
         if ($ApiKey) {
             $LocalVarHeaderParameters['api_key'] = $ApiKey
@@ -403,7 +403,7 @@ function Get-PSPetById {
         if (!$PetId) {
             throw "Error! The required parameter `PetId` missing when calling getPetById."
         }
-        $LocalVarUri = $LocalVarUri.replace('{petId}', [System.Web.HTTPUtility]::UrlEncode($PetId))
+        $LocalVarUri = $LocalVarUri.replace('{petId}', [System.Uri]::EscapeDataString([string]$PetId))
 
         if ($Configuration["ApiKeyPrefix"] -and $Configuration["ApiKeyPrefix"]["api_key_name"]) {
             $apiKeyPrefix = $Configuration["ApiKeyPrefix"]["api_key_name"]
@@ -575,7 +575,7 @@ function Update-PSPetWithForm {
         if (!$PetId) {
             throw "Error! The required parameter `PetId` missing when calling updatePetWithForm."
         }
-        $LocalVarUri = $LocalVarUri.replace('{petId}', [System.Web.HTTPUtility]::UrlEncode($PetId))
+        $LocalVarUri = $LocalVarUri.replace('{petId}', [System.Uri]::EscapeDataString([string]$PetId))
 
         if ($Name) {
             $LocalVarFormParameters['name'] = $Name
@@ -672,7 +672,7 @@ function Invoke-PSUploadFile {
         if (!$PetId) {
             throw "Error! The required parameter `PetId` missing when calling uploadFile."
         }
-        $LocalVarUri = $LocalVarUri.replace('{petId}', [System.Web.HTTPUtility]::UrlEncode($PetId))
+        $LocalVarUri = $LocalVarUri.replace('{petId}', [System.Uri]::EscapeDataString([string]$PetId))
 
         if ($AdditionalMetadata) {
             $LocalVarFormParameters['additionalMetadata'] = $AdditionalMetadata
@@ -769,7 +769,7 @@ function Invoke-PSUploadFileWithRequiredFile {
         if (!$PetId) {
             throw "Error! The required parameter `PetId` missing when calling uploadFileWithRequiredFile."
         }
-        $LocalVarUri = $LocalVarUri.replace('{petId}', [System.Web.HTTPUtility]::UrlEncode($PetId))
+        $LocalVarUri = $LocalVarUri.replace('{petId}', [System.Uri]::EscapeDataString([string]$PetId))
 
         if ($AdditionalMetadata) {
             $LocalVarFormParameters['additionalMetadata'] = $AdditionalMetadata

--- a/samples/client/petstore/powershell/src/PSPetstore/Api/PSStoreApi.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Api/PSStoreApi.ps1
@@ -53,7 +53,7 @@ function Remove-PSOrder {
         if (!$OrderId) {
             throw "Error! The required parameter `OrderId` missing when calling deleteOrder."
         }
-        $LocalVarUri = $LocalVarUri.replace('{order_id}', [System.Web.HTTPUtility]::UrlEncode($OrderId))
+        $LocalVarUri = $LocalVarUri.replace('{order_id}', [System.Uri]::EscapeDataString([string]$OrderId))
 
         $LocalVarResult = Invoke-PSApiClient -Method 'DELETE' `
                                 -Uri $LocalVarUri `
@@ -211,7 +211,7 @@ function Get-PSOrderById {
         if (!$OrderId) {
             throw "Error! The required parameter `OrderId` missing when calling getOrderById."
         }
-        $LocalVarUri = $LocalVarUri.replace('{order_id}', [System.Web.HTTPUtility]::UrlEncode($OrderId))
+        $LocalVarUri = $LocalVarUri.replace('{order_id}', [System.Uri]::EscapeDataString([string]$OrderId))
 
         $LocalVarResult = Invoke-PSApiClient -Method 'GET' `
                                 -Uri $LocalVarUri `

--- a/samples/client/petstore/powershell/src/PSPetstore/Api/PSUserApi.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Api/PSUserApi.ps1
@@ -278,7 +278,7 @@ function Remove-PSUser {
         if (!$Username) {
             throw "Error! The required parameter `Username` missing when calling deleteUser."
         }
-        $LocalVarUri = $LocalVarUri.replace('{username}', [System.Web.HTTPUtility]::UrlEncode($Username))
+        $LocalVarUri = $LocalVarUri.replace('{username}', [System.Uri]::EscapeDataString([string]$Username))
 
         $LocalVarResult = Invoke-PSApiClient -Method 'DELETE' `
                                 -Uri $LocalVarUri `
@@ -363,7 +363,7 @@ function Get-PSUserByName {
         if (!$Username) {
             throw "Error! The required parameter `Username` missing when calling getUserByName."
         }
-        $LocalVarUri = $LocalVarUri.replace('{username}', [System.Web.HTTPUtility]::UrlEncode($Username))
+        $LocalVarUri = $LocalVarUri.replace('{username}', [System.Uri]::EscapeDataString([string]$Username))
 
         $LocalVarResult = Invoke-PSApiClient -Method 'GET' `
                                 -Uri $LocalVarUri `
@@ -599,7 +599,7 @@ function Update-PSUser {
         if (!$Username) {
             throw "Error! The required parameter `Username` missing when calling updateUser."
         }
-        $LocalVarUri = $LocalVarUri.replace('{username}', [System.Web.HTTPUtility]::UrlEncode($Username))
+        $LocalVarUri = $LocalVarUri.replace('{username}', [System.Uri]::EscapeDataString([string]$Username))
 
         if (!$User) {
             throw "Error! The required parameter `User` missing when calling updateUser."


### PR DESCRIPTION
Path parameters are currently encoded with `UrlEncode`, but in the documentation there is a [remark](https://learn.microsoft.com/en-us/dotnet/api/system.web.httputility.urlencode?view=net-10.0#remarks) for how it will handle spaces, and it suggests to instead use `UrlPathEncode`.

Edit: The solution has been adjusted to using `System.Uri` and `EscapeDataString` based on feedback. This since `UrlPathEncode` is designed for full path construction and not the path-by-path template building that is occurring in code.

Could be considered a breaking change if someone relies on a space being encoded as `+` rather than the usual `%20`. The current behavior comes from https://github.com/OpenAPITools/openapi-generator/pull/9688.

Fixes: https://github.com/OpenAPITools/openapi-generator/issues/24602

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrected path parameter encoding in PowerShell clients so spaces encode as %20 and “+” is no longer used. Replaced `UrlEncode` with `[System.Uri]::EscapeDataString` to follow .NET guidance (fixes #24602).

- **Bug Fixes**
  - Update PowerShell `api.mustache` to encode path params with `[System.Uri]::EscapeDataString([string]$param)`.
  - Add a test to verify escaping in generated scripts; regenerate samples.

- **Migration**
  - Spaces in path params now encode as `%20` instead of `+`. Update expectations or pin the previous generator version.

<sup>Written for commit 60588c87adbc4ccd3318b5a9a00a46ca9b162f4b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24604?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



