### PR TITLE
Fix anyOf serialization in dart-dio

### DIFF
--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/built_value/class_serializer.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/built_value/class_serializer.mustache
@@ -77,12 +77,12 @@ class _${{classname}}Serializer implements PrimitiveSerializer<{{classname}}> {
     final anyOf = object.anyOf;
     {{#vendorExtensions.x-self-and-ancestor-only-props}}
     final result = _serializeProperties(serializers, object, specifiedType: specifiedType).toList();
-    final serialized = serializers.serialize(anyOf, specifiedType: FullType(AnyOf, anyOf.valueTypes.map((type) => FullType(type)).toList()));
+    final serialized = serializers.serialize(anyOf, specifiedType: FullType(AnyOf, anyOf.types.map((type) => FullType(type)).toList()));
     result.addAll((serialized is Map ? serialized.entries.map((e) => <dynamic>[e.key, e.value]).expand<dynamic>((e) => e) : serialized) as Iterable<Object?>);
     return result;
     {{/vendorExtensions.x-self-and-ancestor-only-props}}
     {{^vendorExtensions.x-self-and-ancestor-only-props}}
-    return serializers.serialize(anyOf, specifiedType: FullType(AnyOf, anyOf.valueTypes.map((type) => FullType(type)).toList()))!;
+    return serializers.serialize(anyOf, specifiedType: FullType(AnyOf, anyOf.types.map((type) => FullType(type)).toList()))!;
     {{/vendorExtensions.x-self-and-ancestor-only-props}}
     {{/-first}}
     {{/anyOf}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/dart/dio/DartDioClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/dart/dio/DartDioClientCodegenTest.java
@@ -215,6 +215,39 @@ public class DartDioClientCodegenTest {
                 "if (valueDes == null) continue;");
     }
 
+    /**
+     * Regression test for dart-dio built_value anyOf serialization.
+     *
+     * The one_of AnyOf implementation stores selected values by the index of
+     * the matching declared schema. Before the fix, generated serializers built
+     * the FullType parameters from anyOf.valueTypes, which only contains the
+     * selected value's type. A value stored at index 1 therefore tried to read
+     * specifiedType.parameters[1] from a one-element parameter list and threw a
+     * RangeError during serialization.
+     */
+    @Test
+    public void testAnyOfSerializationUsesDeclaredTypeIndexes() throws IOException {
+        File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("dart-dio")
+                .setInputSpec("src/test/resources/3_0/dart-dio/built_value_anyof_primitive.yaml")
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+        ClientOptInput opts = configurator.toClientOptInput();
+        Generator generator = new DefaultGenerator().opts(opts);
+        List<File> files = generator.generate();
+        files.forEach(File::deleteOnExit);
+
+        Path fieldValue = output.toPath().resolve("lib/src/model/field_value.dart");
+
+        TestUtils.assertFileContains(fieldValue,
+                "FullType(AnyOf, anyOf.types.map((type) => FullType(type)).toList())");
+        TestUtils.assertFileNotContains(fieldValue,
+                "FullType(AnyOf, anyOf.valueTypes.map((type) => FullType(type)).toList())");
+    }
+
     @Test
     public void verifyDartDioGeneratorRuns() throws IOException {
         File output = Files.createTempDirectory("test").toFile();

--- a/modules/openapi-generator/src/test/resources/3_0/dart-dio/built_value_anyof_primitive.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/dart-dio/built_value_anyof_primitive.yaml
@@ -1,0 +1,22 @@
+openapi: "3.0.0"
+info:
+  title: Built-value anyOf primitive serialization test
+  version: "1.0.0"
+paths:
+  /field-value:
+    get:
+      operationId: getFieldValue
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FieldValue"
+components:
+  schemas:
+    FieldValue:
+      anyOf:
+        - type: integer
+        - type: string
+          format: uuid

--- a/samples/openapi3/client/petstore/dart-dio/oneof/lib/src/model/apple.dart
+++ b/samples/openapi3/client/petstore/dart-dio/oneof/lib/src/model/apple.dart
@@ -107,3 +107,4 @@ class _$AppleSerializer implements PrimitiveSerializer<Apple> {
   }
 }
 
+

--- a/samples/openapi3/client/petstore/dart-dio/oneof/lib/src/model/banana.dart
+++ b/samples/openapi3/client/petstore/dart-dio/oneof/lib/src/model/banana.dart
@@ -107,3 +107,4 @@ class _$BananaSerializer implements PrimitiveSerializer<Banana> {
   }
 }
 
+

--- a/samples/openapi3/client/petstore/dart-dio/oneof/lib/src/model/fruit.dart
+++ b/samples/openapi3/client/petstore/dart-dio/oneof/lib/src/model/fruit.dart
@@ -124,3 +124,4 @@ class _$FruitSerializer implements PrimitiveSerializer<Fruit> {
   }
 }
 
+

--- a/samples/openapi3/client/petstore/dart-dio/oneof/lib/src/model/orange.dart
+++ b/samples/openapi3/client/petstore/dart-dio/oneof/lib/src/model/orange.dart
@@ -107,3 +107,4 @@ class _$OrangeSerializer implements PrimitiveSerializer<Orange> {
   }
 }
 
+

--- a/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/lib/src/model/addressable.dart
+++ b/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/lib/src/model/addressable.dart
@@ -74,6 +74,7 @@ class _$AddressableSerializer implements PrimitiveSerializer<Addressable> {
   }
 }
 
+
 /// a concrete implementation of [Addressable], since [Addressable] is not instantiable
 @BuiltValue(instantiable: true)
 abstract class $Addressable implements Addressable, Built<$Addressable, $AddressableBuilder> {

--- a/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/lib/src/model/animal.dart
+++ b/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/lib/src/model/animal.dart
@@ -71,3 +71,4 @@ class _$AnimalSerializer implements PrimitiveSerializer<Animal> {
   }
 }
 
+

--- a/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/lib/src/model/apple.dart
+++ b/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/lib/src/model/apple.dart
@@ -104,3 +104,4 @@ class _$AppleSerializer implements PrimitiveSerializer<Apple> {
   }
 }
 
+

--- a/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/lib/src/model/banana.dart
+++ b/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/lib/src/model/banana.dart
@@ -104,3 +104,4 @@ class _$BananaSerializer implements PrimitiveSerializer<Banana> {
   }
 }
 
+

--- a/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/lib/src/model/bar.dart
+++ b/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/lib/src/model/bar.dart
@@ -224,3 +224,4 @@ class _$BarSerializer implements PrimitiveSerializer<Bar> {
   }
 }
 
+

--- a/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/lib/src/model/bar_create.dart
+++ b/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/lib/src/model/bar_create.dart
@@ -224,3 +224,4 @@ class _$BarCreateSerializer implements PrimitiveSerializer<BarCreate> {
   }
 }
 
+

--- a/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/lib/src/model/bar_ref.dart
+++ b/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/lib/src/model/bar_ref.dart
@@ -198,3 +198,4 @@ class _$BarRefSerializer implements PrimitiveSerializer<BarRef> {
   }
 }
 
+

--- a/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/lib/src/model/bar_ref_or_value.dart
+++ b/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/lib/src/model/bar_ref_or_value.dart
@@ -133,3 +133,4 @@ class _$BarRefOrValueSerializer implements PrimitiveSerializer<BarRefOrValue> {
   }
 }
 
+

--- a/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/lib/src/model/cat.dart
+++ b/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/lib/src/model/cat.dart
@@ -107,3 +107,4 @@ class _$CatSerializer implements PrimitiveSerializer<Cat> {
   }
 }
 
+

--- a/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/lib/src/model/dog.dart
+++ b/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/lib/src/model/dog.dart
@@ -107,3 +107,4 @@ class _$DogSerializer implements PrimitiveSerializer<Dog> {
   }
 }
 
+

--- a/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/lib/src/model/entity.dart
+++ b/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/lib/src/model/entity.dart
@@ -190,6 +190,7 @@ class _$EntitySerializer implements PrimitiveSerializer<Entity> {
   }
 }
 
+
 /// a concrete implementation of [Entity], since [Entity] is not instantiable
 @BuiltValue(instantiable: true)
 abstract class $Entity implements Entity, Built<$Entity, $EntityBuilder> {

--- a/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/lib/src/model/entity_ref.dart
+++ b/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/lib/src/model/entity_ref.dart
@@ -162,6 +162,7 @@ class _$EntityRefSerializer implements PrimitiveSerializer<EntityRef> {
   }
 }
 
+
 /// a concrete implementation of [EntityRef], since [EntityRef] is not instantiable
 @BuiltValue(instantiable: true)
 abstract class $EntityRef implements EntityRef, Built<$EntityRef, $EntityRefBuilder> {

--- a/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/lib/src/model/extensible.dart
+++ b/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/lib/src/model/extensible.dart
@@ -84,6 +84,7 @@ class _$ExtensibleSerializer implements PrimitiveSerializer<Extensible> {
   }
 }
 
+
 /// a concrete implementation of [Extensible], since [Extensible] is not instantiable
 @BuiltValue(instantiable: true)
 abstract class $Extensible implements Extensible, Built<$Extensible, $ExtensibleBuilder> {

--- a/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/lib/src/model/foo.dart
+++ b/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/lib/src/model/foo.dart
@@ -204,3 +204,4 @@ class _$FooSerializer implements PrimitiveSerializer<Foo> {
   }
 }
 
+

--- a/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/lib/src/model/foo_ref.dart
+++ b/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/lib/src/model/foo_ref.dart
@@ -217,3 +217,4 @@ class _$FooRefSerializer implements PrimitiveSerializer<FooRef> {
   }
 }
 
+

--- a/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/lib/src/model/foo_ref_or_value.dart
+++ b/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/lib/src/model/foo_ref_or_value.dart
@@ -132,3 +132,4 @@ class _$FooRefOrValueSerializer implements PrimitiveSerializer<FooRefOrValue> {
   }
 }
 
+

--- a/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/lib/src/model/fruit.dart
+++ b/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/lib/src/model/fruit.dart
@@ -164,3 +164,4 @@ class _$FruitSerializer implements PrimitiveSerializer<Fruit> {
   }
 }
 
+

--- a/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/lib/src/model/pasta.dart
+++ b/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/lib/src/model/pasta.dart
@@ -185,3 +185,4 @@ class _$PastaSerializer implements PrimitiveSerializer<Pasta> {
   }
 }
 
+

--- a/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/lib/src/model/pizza.dart
+++ b/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/lib/src/model/pizza.dart
@@ -135,6 +135,7 @@ class _$PizzaSerializer implements PrimitiveSerializer<Pizza> {
   }
 }
 
+
 /// a concrete implementation of [Pizza], since [Pizza] is not instantiable
 @BuiltValue(instantiable: true)
 abstract class $Pizza implements Pizza, Built<$Pizza, $PizzaBuilder> {

--- a/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/lib/src/model/pizza_speziale.dart
+++ b/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/lib/src/model/pizza_speziale.dart
@@ -201,3 +201,4 @@ class _$PizzaSpezialeSerializer implements PrimitiveSerializer<PizzaSpeziale> {
   }
 }
 
+

--- a/samples/openapi3/client/petstore/dart-dio/oneof_primitive/lib/src/model/child.dart
+++ b/samples/openapi3/client/petstore/dart-dio/oneof_primitive/lib/src/model/child.dart
@@ -107,3 +107,4 @@ class _$ChildSerializer implements PrimitiveSerializer<Child> {
   }
 }
 
+

--- a/samples/openapi3/client/petstore/dart-dio/oneof_primitive/lib/src/model/example.dart
+++ b/samples/openapi3/client/petstore/dart-dio/oneof_primitive/lib/src/model/example.dart
@@ -70,3 +70,4 @@ class _$ExampleSerializer implements PrimitiveSerializer<Example> {
   }
 }
 
+

--- a/samples/openapi3/client/petstore/dart-dio/petstore-timemachine/lib/src/model/api_response.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore-timemachine/lib/src/model/api_response.dart
@@ -145,3 +145,4 @@ class _$ApiResponseSerializer implements PrimitiveSerializer<ApiResponse> {
   }
 }
 
+

--- a/samples/openapi3/client/petstore/dart-dio/petstore-timemachine/lib/src/model/category.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore-timemachine/lib/src/model/category.dart
@@ -126,3 +126,4 @@ class _$CategorySerializer implements PrimitiveSerializer<Category> {
   }
 }
 
+

--- a/samples/openapi3/client/petstore/dart-dio/petstore-timemachine/lib/src/model/order.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore-timemachine/lib/src/model/order.dart
@@ -207,6 +207,7 @@ class _$OrderSerializer implements PrimitiveSerializer<Order> {
   }
 }
 
+
 /// Order Status
 class OrderStatusEnum extends EnumClass {
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore-timemachine/lib/src/model/pet.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore-timemachine/lib/src/model/pet.dart
@@ -202,6 +202,7 @@ class _$PetSerializer implements PrimitiveSerializer<Pet> {
   }
 }
 
+
 /// pet status in the store
 class PetStatusEnum extends EnumClass {
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore-timemachine/lib/src/model/tag.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore-timemachine/lib/src/model/tag.dart
@@ -126,3 +126,4 @@ class _$TagSerializer implements PrimitiveSerializer<Tag> {
   }
 }
 
+

--- a/samples/openapi3/client/petstore/dart-dio/petstore-timemachine/lib/src/model/user.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore-timemachine/lib/src/model/user.dart
@@ -241,3 +241,4 @@ class _$UserSerializer implements PrimitiveSerializer<User> {
   }
 }
 
+

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/additional_properties_class.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/additional_properties_class.dart
@@ -146,3 +146,4 @@ class _$AdditionalPropertiesClassSerializer implements PrimitiveSerializer<Addit
   }
 }
 
+

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/all_of_with_single_ref.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/all_of_with_single_ref.dart
@@ -128,3 +128,4 @@ class _$AllOfWithSingleRefSerializer implements PrimitiveSerializer<AllOfWithSin
   }
 }
 
+

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/animal.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/animal.dart
@@ -118,6 +118,7 @@ class _$AnimalSerializer implements PrimitiveSerializer<Animal> {
   }
 }
 
+
 /// a concrete implementation of [Animal], since [Animal] is not instantiable
 @BuiltValue(instantiable: true)
 abstract class $Animal implements Animal, Built<$Animal, $AnimalBuilder> {

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/api_response.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/api_response.dart
@@ -145,3 +145,4 @@ class _$ApiResponseSerializer implements PrimitiveSerializer<ApiResponse> {
   }
 }
 
+

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/array_of_array_of_number_only.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/array_of_array_of_number_only.dart
@@ -108,3 +108,4 @@ class _$ArrayOfArrayOfNumberOnlySerializer implements PrimitiveSerializer<ArrayO
   }
 }
 
+

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/array_of_number_only.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/array_of_number_only.dart
@@ -108,3 +108,4 @@ class _$ArrayOfNumberOnlySerializer implements PrimitiveSerializer<ArrayOfNumber
   }
 }
 
+

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/array_test.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/array_test.dart
@@ -147,3 +147,4 @@ class _$ArrayTestSerializer implements PrimitiveSerializer<ArrayTest> {
   }
 }
 
+

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/capitalization.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/capitalization.dart
@@ -203,3 +203,4 @@ class _$CapitalizationSerializer implements PrimitiveSerializer<Capitalization> 
   }
 }
 
+

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/cat.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/cat.dart
@@ -138,3 +138,4 @@ class _$CatSerializer implements PrimitiveSerializer<Cat> {
   }
 }
 
+

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/category.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/category.dart
@@ -124,3 +124,4 @@ class _$CategorySerializer implements PrimitiveSerializer<Category> {
   }
 }
 
+

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/child_with_nullable.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/child_with_nullable.dart
@@ -140,3 +140,4 @@ class _$ChildWithNullableSerializer implements PrimitiveSerializer<ChildWithNull
   }
 }
 
+

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/class_model.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/class_model.dart
@@ -107,3 +107,4 @@ class _$ClassModelSerializer implements PrimitiveSerializer<ClassModel> {
   }
 }
 
+

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/deprecated_object.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/deprecated_object.dart
@@ -108,3 +108,4 @@ class _$DeprecatedObjectSerializer implements PrimitiveSerializer<DeprecatedObje
   }
 }
 
+

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/dog.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/dog.dart
@@ -138,3 +138,4 @@ class _$DogSerializer implements PrimitiveSerializer<Dog> {
   }
 }
 
+

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/enum_arrays.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/enum_arrays.dart
@@ -129,6 +129,7 @@ class _$EnumArraysSerializer implements PrimitiveSerializer<EnumArrays> {
   }
 }
 
+
 class EnumArraysJustSymbolEnum extends EnumClass {
 
   @BuiltValueEnumConst(wireName: r'>=')

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/enum_test.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/enum_test.dart
@@ -250,6 +250,7 @@ class _$EnumTestSerializer implements PrimitiveSerializer<EnumTest> {
   }
 }
 
+
 class EnumTestEnumStringEnum extends EnumClass {
 
   @BuiltValueEnumConst(wireName: r'UPPER')

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/fake_big_decimal_map200_response.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/fake_big_decimal_map200_response.dart
@@ -127,3 +127,4 @@ class _$FakeBigDecimalMap200ResponseSerializer implements PrimitiveSerializer<Fa
   }
 }
 
+

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/file_schema_test_class.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/file_schema_test_class.dart
@@ -128,3 +128,4 @@ class _$FileSchemaTestClassSerializer implements PrimitiveSerializer<FileSchemaT
   }
 }
 
+

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/foo.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/foo.dart
@@ -108,3 +108,4 @@ class _$FooSerializer implements PrimitiveSerializer<Foo> {
   }
 }
 
+

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/foo_get_default_response.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/foo_get_default_response.dart
@@ -108,3 +108,4 @@ class _$FooGetDefaultResponseSerializer implements PrimitiveSerializer<FooGetDef
   }
 }
 
+

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/format_test.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/format_test.dart
@@ -384,3 +384,4 @@ class _$FormatTestSerializer implements PrimitiveSerializer<FormatTest> {
   }
 }
 
+

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/has_only_read_only.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/has_only_read_only.dart
@@ -126,3 +126,4 @@ class _$HasOnlyReadOnlySerializer implements PrimitiveSerializer<HasOnlyReadOnly
   }
 }
 
+

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/health_check_result.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/health_check_result.dart
@@ -107,3 +107,4 @@ class _$HealthCheckResultSerializer implements PrimitiveSerializer<HealthCheckRe
   }
 }
 
+

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/map_test.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/map_test.dart
@@ -166,6 +166,7 @@ class _$MapTestSerializer implements PrimitiveSerializer<MapTest> {
   }
 }
 
+
 class MapTestMapOfEnumStringEnum extends EnumClass {
 
   @BuiltValueEnumConst(wireName: r'UPPER')

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/mixed_properties_and_additional_properties_class.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/mixed_properties_and_additional_properties_class.dart
@@ -147,3 +147,4 @@ class _$MixedPropertiesAndAdditionalPropertiesClassSerializer implements Primiti
   }
 }
 
+

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/model200_response.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/model200_response.dart
@@ -126,3 +126,4 @@ class _$Model200ResponseSerializer implements PrimitiveSerializer<Model200Respon
   }
 }
 
+

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/model_client.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/model_client.dart
@@ -107,3 +107,4 @@ class _$ModelClientSerializer implements PrimitiveSerializer<ModelClient> {
   }
 }
 
+

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/model_file.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/model_file.dart
@@ -108,3 +108,4 @@ class _$ModelFileSerializer implements PrimitiveSerializer<ModelFile> {
   }
 }
 
+

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/model_list.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/model_list.dart
@@ -107,3 +107,4 @@ class _$ModelListSerializer implements PrimitiveSerializer<ModelList> {
   }
 }
 
+

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/model_return.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/model_return.dart
@@ -107,3 +107,4 @@ class _$ModelReturnSerializer implements PrimitiveSerializer<ModelReturn> {
   }
 }
 
+

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/name.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/name.dart
@@ -161,3 +161,4 @@ class _$NameSerializer implements PrimitiveSerializer<Name> {
   }
 }
 
+

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/nullable_class.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/nullable_class.dart
@@ -319,3 +319,4 @@ class _$NullableClassSerializer implements PrimitiveSerializer<NullableClass> {
   }
 }
 
+

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/number_only.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/number_only.dart
@@ -107,3 +107,4 @@ class _$NumberOnlySerializer implements PrimitiveSerializer<NumberOnly> {
   }
 }
 
+

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/object_that_references_objects_with_duplicate_inline_enums.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/object_that_references_objects_with_duplicate_inline_enums.dart
@@ -128,3 +128,4 @@ class _$ObjectThatReferencesObjectsWithDuplicateInlineEnumsSerializer implements
   }
 }
 
+

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/object_with_deprecated_fields.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/object_with_deprecated_fields.dart
@@ -169,3 +169,4 @@ class _$ObjectWithDeprecatedFieldsSerializer implements PrimitiveSerializer<Obje
   }
 }
 
+

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/object_with_duplicate_inline_enum.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/object_with_duplicate_inline_enum.dart
@@ -110,6 +110,7 @@ class _$ObjectWithDuplicateInlineEnumSerializer implements PrimitiveSerializer<O
   }
 }
 
+
 class ObjectWithDuplicateInlineEnumAttributeEnum extends EnumClass {
 
   @BuiltValueEnumConst(wireName: r'value_one')

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/object_with_enum.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/object_with_enum.dart
@@ -110,3 +110,4 @@ class _$ObjectWithEnumSerializer implements PrimitiveSerializer<ObjectWithEnum> 
   }
 }
 
+

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/object_with_inline_enum.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/object_with_inline_enum.dart
@@ -110,6 +110,7 @@ class _$ObjectWithInlineEnumSerializer implements PrimitiveSerializer<ObjectWith
   }
 }
 
+
 class ObjectWithInlineEnumAttributeEnum extends EnumClass {
 
   @BuiltValueEnumConst(wireName: r'value_one')

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/object_with_inline_enum_default_value.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/object_with_inline_enum_default_value.dart
@@ -111,6 +111,7 @@ class _$ObjectWithInlineEnumDefaultValueSerializer implements PrimitiveSerialize
   }
 }
 
+
 /// Object one attribute enum with default value
 class ObjectWithInlineEnumDefaultValueAttributeEnum extends EnumClass {
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/order.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/order.dart
@@ -206,6 +206,7 @@ class _$OrderSerializer implements PrimitiveSerializer<Order> {
   }
 }
 
+
 /// Order Status
 class OrderStatusEnum extends EnumClass {
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/outer_composite.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/outer_composite.dart
@@ -145,3 +145,4 @@ class _$OuterCompositeSerializer implements PrimitiveSerializer<OuterComposite> 
   }
 }
 
+

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/outer_object_with_enum_property.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/outer_object_with_enum_property.dart
@@ -106,3 +106,4 @@ class _$OuterObjectWithEnumPropertySerializer implements PrimitiveSerializer<Out
   }
 }
 
+

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/parent_with_nullable.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/parent_with_nullable.dart
@@ -107,6 +107,7 @@ class _$ParentWithNullableSerializer implements PrimitiveSerializer<ParentWithNu
   }
 }
 
+
 /// a concrete implementation of [ParentWithNullable], since [ParentWithNullable] is not instantiable
 @BuiltValue(instantiable: true)
 abstract class $ParentWithNullable implements ParentWithNullable, Built<$ParentWithNullable, $ParentWithNullableBuilder> {

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/pet.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/pet.dart
@@ -201,6 +201,7 @@ class _$PetSerializer implements PrimitiveSerializer<Pet> {
   }
 }
 
+
 /// pet status in the store
 class PetStatusEnum extends EnumClass {
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/read_only_first.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/read_only_first.dart
@@ -126,3 +126,4 @@ class _$ReadOnlyFirstSerializer implements PrimitiveSerializer<ReadOnlyFirst> {
   }
 }
 
+

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/special_model_name.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/special_model_name.dart
@@ -107,3 +107,4 @@ class _$SpecialModelNameSerializer implements PrimitiveSerializer<SpecialModelNa
   }
 }
 
+

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/tag.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/tag.dart
@@ -126,3 +126,4 @@ class _$TagSerializer implements PrimitiveSerializer<Tag> {
   }
 }
 
+

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/test_inline_freeform_additional_properties_request.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/test_inline_freeform_additional_properties_request.dart
@@ -109,3 +109,4 @@ class _$TestInlineFreeformAdditionalPropertiesRequestSerializer implements Primi
   }
 }
 
+

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/user.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/user.dart
@@ -241,3 +241,4 @@ class _$UserSerializer implements PrimitiveSerializer<User> {
   }
 }
 
+


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Fixes #24603 

@jaumard @amondnet @sbu-WBT @kuhnroyal @agilob @ahmednfwela

Regenerating the samples introduced these blanklines. When I did not do that, the checks would fail. Not sure whether this is acceptable.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes anyOf serialization in `dart-dio` built_value by using declared types to build `FullType` parameters. Prevents RangeError when the selected variant is not the first.

- **Bug Fixes**
  - Use `anyOf.types` instead of `anyOf.valueTypes` in `class_serializer.mustache` when building `FullType(AnyOf, ...)`.
  - Add a regression test and a small `anyOf` primitive schema; regenerate `dart-dio` samples.

<sup>Written for commit 22f3fec9853583e1d089f5c12868808008255edb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24605?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

