### PR TITLE
refactor: add utility methods for allOf, oneOf and anyOf CodegenModel checks

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
@@ -32,6 +32,8 @@ import java.util.*;
 import java.util.regex.Matcher;
 
 import static org.openapitools.codegen.utils.CamelizeOption.LOWERCASE_FIRST_LETTER;
+import static org.openapitools.codegen.utils.ModelUtils.hasAnyOf;
+import static org.openapitools.codegen.utils.ModelUtils.hasOneOf;
 import static org.openapitools.codegen.utils.StringUtils.camelize;
 import static org.openapitools.codegen.utils.StringUtils.underscore;
 
@@ -866,13 +868,13 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
             }
 
             // if oneOf contains "null" type
-            if (model.oneOf != null && !model.oneOf.isEmpty() && model.oneOf.contains("nil")) {
+            if (hasOneOf(model) && model.oneOf.contains("nil")) {
                 model.isNullable = true;
                 model.oneOf.remove("nil");
             }
 
             // if anyOf contains "null" type
-            if (model.anyOf != null && !model.anyOf.isEmpty() && model.anyOf.contains("nil")) {
+            if (hasAnyOf(model) && model.anyOf.contains("nil")) {
                 model.isNullable = true;
                 model.anyOf.remove("nil");
             }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
@@ -46,6 +46,7 @@ import java.util.stream.Collectors;
 
 import static org.openapitools.codegen.CodegenConstants.*;
 import static org.openapitools.codegen.utils.EnumUtils.getEnumVars;
+import static org.openapitools.codegen.utils.ModelUtils.*;
 import static org.openapitools.codegen.utils.StringUtils.*;
 
 
@@ -1059,7 +1060,7 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
             }
 
             List<CodegenProperty> codegenProperties = null;
-            if (!model.oneOf.isEmpty()) { // oneOfValidationError
+            if (hasOneOf(model)) {
                 codegenProperties = model.getComposedSchemas().getOneOf();
                 moduleImports.add("typing", "Any");
                 moduleImports.add("typing", "List");
@@ -1067,7 +1068,7 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
                 moduleImports.add(PYDANTIC, "StrictStr");
                 moduleImports.add(PYDANTIC, "ValidationError");
                 moduleImports.add(PYDANTIC, "field_validator");
-            } else if (!model.anyOf.isEmpty()) { // anyOF
+            } else if (hasAnyOf(model)) {
                 codegenProperties = model.getComposedSchemas().getAnyOf();
                 moduleImports.add(PYDANTIC, "Field");
                 moduleImports.add(PYDANTIC, "StrictStr");
@@ -1083,7 +1084,7 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
                 }
             }
 
-            if (!model.allOf.isEmpty()) { // allOf
+            if (hasAllOf(model)) {
                 for (CodegenProperty cp : model.allVars) {
                     if (!cp.isPrimitiveType || cp.isModel) {
                         if (cp.isArray || cp.isMap) { // if array or map
@@ -1121,9 +1122,9 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
                 cp.vendorExtensions.put(X_PY_TYPING, typing);
 
                 // setup x-py-name for each oneOf/anyOf schema
-                if (!model.oneOf.isEmpty()) { // oneOf
+                if (hasOneOf(model)) {
                     cp.vendorExtensions.put(X_PY_NAME, String.format(Locale.ROOT, "oneof_schema_%d_validator", property_count++));
-                } else if (!model.anyOf.isEmpty()) { // anyOf
+                } else if (hasAnyOf(model)) {
                     cp.vendorExtensions.put(X_PY_NAME, String.format(Locale.ROOT, "anyof_schema_%d_validator", property_count++));
                 }
             }
@@ -1301,9 +1302,9 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
         }
 
         List<CodegenProperty> codegenProperties = null;
-        if (cm.oneOf != null && !cm.oneOf.isEmpty()) { // oneOf
+        if (hasOneOf(cm)) {
             codegenProperties = cm.getComposedSchemas().getOneOf();
-        } else if (cm.anyOf != null && !cm.anyOf.isEmpty()) { // anyOF
+        } else if (hasAnyOf(cm)) {
             codegenProperties = cm.getComposedSchemas().getAnyOf();
         } else { // typical model
             codegenProperties = cm.vars;
@@ -1352,9 +1353,9 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
         }
 
         List<CodegenProperty> codegenProperties = null;
-        if (cm.oneOf != null && !cm.oneOf.isEmpty()) { // oneOfValidationError
+        if (hasOneOf(cm)) {
             codegenProperties = cm.getComposedSchemas().getOneOf();
-        } else if (cm.anyOf != null && !cm.anyOf.isEmpty()) { // anyOF
+        } else if (hasAnyOf(cm)) {
             codegenProperties = cm.getComposedSchemas().getAnyOf();
         } else { // typical model
             codegenProperties = cm.vars;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonPydanticV1Codegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonPydanticV1Codegen.java
@@ -42,6 +42,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static org.openapitools.codegen.CodegenConstants.*;
+import static org.openapitools.codegen.utils.ModelUtils.*;
 import static org.openapitools.codegen.utils.StringUtils.*;
 
 public abstract class AbstractPythonPydanticV1Codegen extends DefaultCodegen implements CodegenConfig {
@@ -850,7 +851,7 @@ public abstract class AbstractPythonPydanticV1Codegen extends DefaultCodegen imp
             }
 
             List<CodegenProperty> codegenProperties = null;
-            if (!model.oneOf.isEmpty()) { // oneOfValidationError
+            if (hasOneOf(model)) {
                 codegenProperties = model.getComposedSchemas().getOneOf();
                 typingImports.add("Any");
                 typingImports.add("List");
@@ -858,7 +859,7 @@ public abstract class AbstractPythonPydanticV1Codegen extends DefaultCodegen imp
                 pydanticImports.add("StrictStr");
                 pydanticImports.add("ValidationError");
                 pydanticImports.add("validator");
-            } else if (!model.anyOf.isEmpty()) { // anyOF
+            } else if (hasAnyOf(model)) {
                 codegenProperties = model.getComposedSchemas().getAnyOf();
                 pydanticImports.add("Field");
                 pydanticImports.add("StrictStr");
@@ -873,7 +874,7 @@ public abstract class AbstractPythonPydanticV1Codegen extends DefaultCodegen imp
                 }
             }
 
-            if (!model.allOf.isEmpty()) { // allOf
+            if (hasAllOf(model)) {
                 for (CodegenProperty cp : model.allVars) {
                     if (!cp.isPrimitiveType || cp.isModel) {
                         if (cp.isArray || cp.isMap) { // if array or map
@@ -961,9 +962,9 @@ public abstract class AbstractPythonPydanticV1Codegen extends DefaultCodegen imp
                 cp.vendorExtensions.put(X_PY_TYPING, typing + " = " + fieldCustomization);
 
                 // setup x-py-name for each oneOf/anyOf schema
-                if (!model.oneOf.isEmpty()) { // oneOf
+                if (hasOneOf(model)) {
                     cp.vendorExtensions.put(X_PY_NAME, String.format(Locale.ROOT, "oneof_schema_%d_validator", property_count++));
-                } else if (!model.anyOf.isEmpty()) { // anyOf
+                } else if (hasAnyOf(model)) {
                     cp.vendorExtensions.put(X_PY_NAME, String.format(Locale.ROOT, "anyof_schema_%d_validator", property_count++));
                 }
             }
@@ -1663,9 +1664,9 @@ public abstract class AbstractPythonPydanticV1Codegen extends DefaultCodegen imp
         }
 
         List<CodegenProperty> codegenProperties = null;
-        if (cm.oneOf != null && !cm.oneOf.isEmpty()) { // oneOf
+        if (hasOneOf(cm)) {
             codegenProperties = cm.getComposedSchemas().getOneOf();
-        } else if (cm.anyOf != null && !cm.anyOf.isEmpty()) { // anyOF
+        } else if (hasAnyOf(cm)) {
             codegenProperties = cm.getComposedSchemas().getAnyOf();
         } else { // typical model
             codegenProperties = cm.vars;
@@ -1714,9 +1715,9 @@ public abstract class AbstractPythonPydanticV1Codegen extends DefaultCodegen imp
         }
 
         List<CodegenProperty> codegenProperties = null;
-        if (cm.oneOf != null && !cm.oneOf.isEmpty()) { // oneOfValidationError
+        if (hasOneOf(cm)) {
             codegenProperties = cm.getComposedSchemas().getOneOf();
-        } else if (cm.anyOf != null && !cm.anyOf.isEmpty()) { // anyOF
+        } else if (hasAnyOf(cm)) {
             codegenProperties = cm.getComposedSchemas().getAnyOf();
         } else { // typical model
             codegenProperties = cm.vars;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractRustCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractRustCodegen.java
@@ -15,6 +15,8 @@ import java.math.BigInteger;
 import java.util.*;
 import java.util.function.Function;
 
+import static org.openapitools.codegen.utils.ModelUtils.hasAnyOf;
+import static org.openapitools.codegen.utils.ModelUtils.hasOneOf;
 import static org.openapitools.codegen.utils.StringUtils.*;
 
 public abstract class AbstractRustCodegen extends DefaultCodegen implements CodegenConfig {
@@ -292,7 +294,7 @@ public abstract class AbstractRustCodegen extends DefaultCodegen implements Code
             } else {
                 mdl.arrayModelType = toModelName(mdl.arrayModelType);
             }
-        } else if ((!mdl.anyOf.isEmpty()) || (!mdl.oneOf.isEmpty())) {
+        } else if ((hasAnyOf(mdl)) || (hasOneOf(mdl))) {
             mdl.dataType = getSchemaType(model);
         }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpClientCodegen.java
@@ -41,6 +41,8 @@ import java.util.stream.Collectors;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.openapitools.codegen.CodegenConstants.X_CSHARP_VALUE_TYPE;
 import static org.openapitools.codegen.utils.CamelizeOption.LOWERCASE_FIRST_LETTER;
+import static org.openapitools.codegen.utils.ModelUtils.hasAnyOf;
+import static org.openapitools.codegen.utils.ModelUtils.hasOneOf;
 import static org.openapitools.codegen.utils.StringUtils.camelize;
 import static org.openapitools.codegen.utils.StringUtils.underscore;
 
@@ -1688,12 +1690,12 @@ public class CSharpClientCodegen extends AbstractCSharpCodegen {
         for (ModelMap mo : objs.getModels()) {
             CodegenModel cm = mo.getModel();
 
-            if (cm.oneOf != null && !cm.oneOf.isEmpty() && cm.oneOf.remove("Null")) {
+            if (hasOneOf(cm) && cm.oneOf.remove("Null")) {
                 // if oneOf contains "null" type
                 cm.isNullable = true;
             }
 
-            if (cm.anyOf != null && !cm.anyOf.isEmpty() && cm.anyOf.remove("Null")) {
+            if (hasAnyOf(cm) && cm.anyOf.remove("Null")) {
                 // if anyOf contains "null" type
                 cm.isNullable = true;
             }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpReducedClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpReducedClientCodegen.java
@@ -39,6 +39,8 @@ import java.util.stream.Collectors;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.openapitools.codegen.CodegenConstants.X_CSHARP_VALUE_TYPE;
 import static org.openapitools.codegen.utils.CamelizeOption.LOWERCASE_FIRST_LETTER;
+import static org.openapitools.codegen.utils.ModelUtils.hasAnyOf;
+import static org.openapitools.codegen.utils.ModelUtils.hasOneOf;
 import static org.openapitools.codegen.utils.StringUtils.camelize;
 import static org.openapitools.codegen.utils.StringUtils.underscore;
 
@@ -1081,13 +1083,13 @@ public class CSharpReducedClientCodegen extends AbstractCSharpCodegen {
         for (ModelMap mo : objs.getModels()) {
             CodegenModel cm = mo.getModel();
 
-            if (cm.oneOf != null && !cm.oneOf.isEmpty() && cm.oneOf.contains("ModelNull")) {
+            if (hasOneOf(cm) && cm.oneOf.contains("ModelNull")) {
                 // if oneOf contains "null" type
                 cm.isNullable = true;
                 cm.oneOf.remove("ModelNull");
             }
 
-            if (cm.anyOf != null && !cm.anyOf.isEmpty() && cm.anyOf.contains("ModelNull")) {
+            if (hasAnyOf(cm) && cm.anyOf.contains("ModelNull")) {
                 // if anyOf contains "null" type
                 cm.isNullable = true;
                 cm.anyOf.remove("ModelNull");

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientCodegen.java
@@ -44,6 +44,8 @@ import static org.openapitools.codegen.CodegenConstants.*;
 import static org.openapitools.codegen.utils.CamelizeOption.LOWERCASE_FIRST_LETTER;
 import static org.openapitools.codegen.utils.EnumUtils.getEnumValues;
 import static org.openapitools.codegen.utils.EnumUtils.getEnumVars;
+import static org.openapitools.codegen.utils.ModelUtils.hasAnyOf;
+import static org.openapitools.codegen.utils.ModelUtils.hasOneOf;
 import static org.openapitools.codegen.utils.StringUtils.camelize;
 
 /**
@@ -543,7 +545,7 @@ public class GoClientCodegen extends AbstractGoCodegen {
             boolean addedFmtImport = false;
 
             // oneOf
-            if (model.oneOf != null && !model.oneOf.isEmpty()) {
+            if (hasOneOf(model)) {
                 imports.add(createMapping("import", "fmt"));
                 addedFmtImport = true;
 
@@ -554,7 +556,7 @@ public class GoClientCodegen extends AbstractGoCodegen {
             }
 
             // anyOf
-            if (model.anyOf != null && !model.anyOf.isEmpty()) {
+            if (hasAnyOf(model)) {
                 imports.add(createMapping("import", "fmt"));
                 addedFmtImport = true;
             }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
@@ -50,6 +50,8 @@ import static com.google.common.base.CaseFormat.UPPER_UNDERSCORE;
 import static java.util.Collections.sort;
 import static org.openapitools.codegen.CodegenConstants.*;
 import static org.openapitools.codegen.utils.CamelizeOption.LOWERCASE_FIRST_LETTER;
+import static org.openapitools.codegen.utils.ModelUtils.hasAnyOf;
+import static org.openapitools.codegen.utils.ModelUtils.hasOneOf;
 import static org.openapitools.codegen.utils.StringUtils.camelize;
 
 /**
@@ -1269,13 +1271,13 @@ public class JavaClientCodegen extends AbstractJavaCodegen
 
             cm.getVendorExtensions().putIfAbsent(X_IMPLEMENTS, new ArrayList<String>());
             if (isLibrary(JERSEY2) || isLibrary(JERSEY3) || isLibrary(NATIVE) || isLibrary(OKHTTP_GSON)) {
-                if (cm.oneOf != null && !cm.oneOf.isEmpty() && cm.oneOf.contains("ModelNull")) {
+                if (hasOneOf(cm) && cm.oneOf.contains("ModelNull")) {
                     // if oneOf contains "null" type
                     cm.isNullable = true;
                     cm.oneOf.remove("ModelNull");
                 }
 
-                if (cm.anyOf != null && !cm.anyOf.isEmpty() && cm.anyOf.contains("ModelNull")) {
+                if (hasAnyOf(cm) && cm.anyOf.contains("ModelNull")) {
                     // if anyOf contains "null" type
                     cm.isNullable = true;
                     cm.anyOf.remove("ModelNull");

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinServerCodegen.java
@@ -58,6 +58,8 @@ import org.slf4j.LoggerFactory;
 import static org.openapitools.codegen.languages.KotlinServerCodegen.Constants.USE_TAGS;
 import static org.openapitools.codegen.utils.EnumUtils.getEnumValues;
 import static org.openapitools.codegen.utils.EnumUtils.hasEnumValues;
+import static org.openapitools.codegen.utils.ModelUtils.hasAnyOf;
+import static org.openapitools.codegen.utils.ModelUtils.hasOneOf;
 
 /**
  * <p>Mustache templates are located in
@@ -522,8 +524,7 @@ public class KotlinServerCodegen extends AbstractKotlinCodegen implements BeanVa
                         // For allOf pattern: if parent has properties, mark child's inherited properties
                         // Skip this for oneOf/anyOf patterns where parent properties are merged from children
                         boolean parentIsOneOfOrAnyOf = parentModel != null
-                                && ((parentModel.oneOf != null && !parentModel.oneOf.isEmpty())
-                                || (parentModel.anyOf != null && !parentModel.anyOf.isEmpty()));
+                                && (hasOneOf(parentModel) || (hasAnyOf(parentModel)));
 
                         if (parentModel != null && parentModel.getHasVars() && !parentIsOneOfOrAnyOf) {
                             Set<String> parentPropNames = new HashSet<>();
@@ -572,8 +573,7 @@ public class KotlinServerCodegen extends AbstractKotlinCodegen implements BeanVa
                 CodegenModel owner = allModelsMap.get(ownerName);
                 if (owner != null && owner.getDiscriminator() != null) {
                     String discriminatorPropBaseName = owner.getDiscriminator().getPropertyBaseName();
-                    boolean isOneOfOrAnyOfPattern = (owner.oneOf != null && !owner.oneOf.isEmpty())
-                            || (owner.anyOf != null && !owner.anyOf.isEmpty());
+                    boolean isOneOfOrAnyOfPattern = hasOneOf(owner) || hasAnyOf(owner);
 
                     // hasParentProperties controls whether the sealed class has properties in its constructor
                     // This should be false for oneOf/anyOf patterns (parent is a type union, no direct properties)

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/OCamlClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/OCamlClientCodegen.java
@@ -43,6 +43,8 @@ import java.util.stream.Collectors;
 import static org.apache.commons.lang3.StringUtils.capitalize;
 import static org.openapitools.codegen.CodegenConstants.ENUM_NAME;
 import static org.openapitools.codegen.CodegenConstants.ENUM_VALUES;
+import static org.openapitools.codegen.utils.ModelUtils.hasAnyOf;
+import static org.openapitools.codegen.utils.ModelUtils.hasOneOf;
 import static org.openapitools.codegen.utils.StringUtils.escape;
 import static org.openapitools.codegen.utils.StringUtils.underscore;
 
@@ -221,11 +223,11 @@ public class OCamlClientCodegen extends DefaultCodegen implements CodegenConfig 
                     enrichPropertiesWithEnumDefaultValues(cm.getParentVars());
                 }
 
-                if (!cm.oneOf.isEmpty()) {
+                if (hasOneOf(cm)) {
                     // Add a boolean if it is a `oneOf`, because Mustache does not let us check if a list is non-empty
                     cm.getVendorExtensions().put("x-ocaml-isOneOf", true);
                 }
-                if (!cm.anyOf.isEmpty()) {
+                if (hasAnyOf(cm)) {
                     // Add a boolean if it is a `anyOf`, because Mustache does not let us check if a list is non-empty
                     cm.getVendorExtensions().put("x-ocaml-isAnyOf", true);
                 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PlantumlDocumentationCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PlantumlDocumentationCodegen.java
@@ -20,12 +20,15 @@ import org.openapitools.codegen.*;
 import org.openapitools.codegen.meta.GeneratorMetadata;
 import org.openapitools.codegen.meta.Stability;
 import org.openapitools.codegen.model.ModelMap;
+import org.openapitools.codegen.utils.ModelUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.util.*;
 import java.util.stream.Collectors;
+
+import static org.openapitools.codegen.utils.ModelUtils.hasAllOf;
 
 /**
  * <p>Mustache templates are located in {@code src/main/resources/plantuml/}.
@@ -79,7 +82,7 @@ public class PlantumlDocumentationCodegen extends DefaultCodegen implements Code
                 .collect(Collectors.toList());
 
         List<CodegenModel> subtypeCodegenModelList = codegenModelList.stream()
-                .filter(codegenModel -> !codegenModel.allOf.isEmpty())
+                .filter(ModelUtils::hasAllOf)
                 .collect(Collectors.toList());
 
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PowerShellClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PowerShellClientCodegen.java
@@ -38,8 +38,9 @@ import java.io.File;
 import java.util.*;
 
 import static java.util.UUID.randomUUID;
-import static org.openapitools.codegen.CodegenConstants.ENUM_VALUES;
 import static org.openapitools.codegen.utils.EnumUtils.getEnumValues;
+import static org.openapitools.codegen.utils.ModelUtils.hasAnyOf;
+import static org.openapitools.codegen.utils.ModelUtils.hasOneOf;
 import static org.openapitools.codegen.utils.StringUtils.camelize;
 
 /**
@@ -1060,11 +1061,11 @@ public class PowerShellClientCodegen extends DefaultCodegen implements CodegenCo
                 if (modelMaps.containsKey(op.returnType) && modelMaps.get(op.returnType) != null) {
                     CodegenModel cm = modelMaps.get(op.returnType);
 
-                    if (cm.oneOf != null && !cm.oneOf.isEmpty()) {
+                    if (hasOneOf(cm)) {
                         op.vendorExtensions.put("x-ps-return-type-one-of", true);
                     }
 
-                    if (cm.anyOf != null && !cm.anyOf.isEmpty()) {
+                    if (hasAnyOf(cm)) {
                         op.vendorExtensions.put("x-ps-return-type-any-of", true);
                     }
                 } else {
@@ -1101,13 +1102,13 @@ public class PowerShellClientCodegen extends DefaultCodegen implements CodegenCo
             }
 
             // if oneOf contains "null" type
-            if (model.oneOf != null && !model.oneOf.isEmpty() && model.oneOf.contains("ModelNull")) {
+            if (hasOneOf(model) && model.oneOf.contains("ModelNull")) {
                 model.isNullable = true;
                 model.oneOf.remove("ModelNull");
             }
 
             // if anyOf contains "null" type
-            if (model.anyOf != null && !model.anyOf.isEmpty() && model.anyOf.contains("ModelNull")) {
+            if (hasAnyOf(model) && model.anyOf.contains("ModelNull")) {
                 model.isNullable = true;
                 model.anyOf.remove("ModelNull");
             }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ProtobufSchemaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ProtobufSchemaCodegen.java
@@ -50,6 +50,7 @@ import com.google.common.base.CaseFormat;
 
 import static org.openapitools.codegen.CodegenConstants.*;
 import static org.openapitools.codegen.utils.EnumUtils.*;
+import static org.openapitools.codegen.utils.ModelUtils.*;
 import static org.openapitools.codegen.utils.StringUtils.*;
 
 /**
@@ -740,9 +741,9 @@ public class ProtobufSchemaCodegen extends DefaultCodegen implements CodegenConf
                 }
             }
 
-            if(cm.oneOf != null && !cm.oneOf.isEmpty()){
+            if(hasOneOf(cm)){
                 cm.vars = processOneOfAnyOfItems(cm.getComposedSchemas().getOneOf());
-            } else if (cm.anyOf != null && !cm.anyOf.isEmpty()) {
+            } else if (hasAnyOf(cm)) {
                 cm.vars = processOneOfAnyOfItems(cm.getComposedSchemas().getAnyOf());
             }
             int index = 1;
@@ -1059,7 +1060,7 @@ public class ProtobufSchemaCodegen extends DefaultCodegen implements CodegenConf
         // Phase 1: Bottom-up property propagation
         // Each child copies its properties to all ancestors in the chain
         for (CodegenModel model : allModels.values()) {
-            if (!model.allOf.isEmpty() && model.getParentModel() != null) {
+            if (hasAllOf(model) && model.getParentModel() != null) {
                 // Walk up the entire parent chain
                 CodegenModel currentAncestor = model.getParentModel();
                 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientCodegen.java
@@ -43,6 +43,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
+import static org.openapitools.codegen.utils.ModelUtils.hasAnyOf;
+import static org.openapitools.codegen.utils.ModelUtils.hasOneOf;
 import static org.openapitools.codegen.utils.StringUtils.camelize;
 import static org.openapitools.codegen.utils.StringUtils.underscore;
 
@@ -668,7 +670,7 @@ public class PythonClientCodegen extends AbstractPythonCodegen implements Codege
         for (ModelsMap modelsMap : objs.values()) {
             for (ModelMap modelMap : modelsMap.getModels()) {
                 CodegenModel model = modelMap.getModel();
-                if (model == null || !model.oneOf.isEmpty() || !model.anyOf.isEmpty()) {
+                if (model == null || hasOneOf(model) || hasAnyOf(model)) {
                     continue;
                 }
                 List<CodegenProperty> generatedProperties = generatedProperties(model);
@@ -993,7 +995,7 @@ public class PythonClientCodegen extends AbstractPythonCodegen implements Codege
     @Override
     public void postProcessModelProperty(CodegenModel model, CodegenProperty property) {
         super.postProcessModelProperty(model, property);
-        if (!model.oneOf.isEmpty() || !model.anyOf.isEmpty()) {
+        if (hasOneOf(model) || hasAnyOf(model)) {
             return;
         }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -2345,6 +2345,21 @@ public class ModelUtils {
     }
 
     /**
+     * Returns true if the model contains allOf and may or may not have
+     * properties/oneOf/anyOf defined.
+     *
+     * @param model the model
+     * @return true if allOf is not empty
+     */
+    public static boolean hasAllOf(CodegenModel model) {
+        if (model != null && model.allOf != null && !model.allOf.isEmpty()) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
      * Returns true if the schema contains allOf and properties,
      * and no oneOf/anyOf defined.
      *
@@ -2383,10 +2398,25 @@ public class ModelUtils {
      * properties/allOf/anyOf defined.
      *
      * @param schema the schema
-     * @return true if allOf is not empty
+     * @return true if oneOf is not empty
      */
     public static boolean hasOneOf(Schema schema) {
         if (schema != null && schema.getOneOf() != null && !schema.getOneOf().isEmpty()) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Returns true if the model contains oneOf and may or may not have
+     * properties/allOf/anyOf defined.
+     *
+     * @param model the model
+     * @return true if oneOf is not empty
+     */
+    public static boolean hasOneOf(CodegenModel model) {
+        if (model != null && model.oneOf != null && !model.oneOf.isEmpty()) {
             return true;
         }
 
@@ -2423,6 +2453,21 @@ public class ModelUtils {
      */
     public static boolean hasAnyOf(Schema schema) {
         if (schema != null && schema.getAnyOf() != null && !schema.getAnyOf().isEmpty()) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Returns true if the model contains anyOf and may or may not have
+     * properties/allOf/oneOf defined.
+     *
+     * @param model the model
+     * @return true if anyOf is not empty
+     */
+    public static boolean hasAnyOf(CodegenModel model) {
+        if (model != null && model.anyOf != null && !model.anyOf.isEmpty()) {
             return true;
         }
 
@@ -2617,7 +2662,7 @@ public class ModelUtils {
         schema = ModelUtils.getReferencedSchema(openAPI, schema);
 
         // allOf/anyOf/oneOf
-        if (ModelUtils.hasAllOf(schema) || ModelUtils.hasOneOf(schema) || ModelUtils.hasAnyOf(schema)) {
+        if (hasAllOf(schema) || hasOneOf(schema) || hasAnyOf(schema)) {
             return false;
         }
 


### PR DESCRIPTION
Similar to the changes done in https://github.com/OpenAPITools/openapi-generator/pull/23608 where the available util methods for `Schema` was used further. This PR introduces and uses the same structure but for `CodegenModel` and handling the presence of oneOf/anyOf/allOf.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `ModelUtils` helpers to check `allOf`/`oneOf`/`anyOf` on `CodegenModel`, and refactors generators to use them. This unifies composed schema checks and reduces null/empty guard code without changing behavior.

- **Refactors**
  - Added `ModelUtils.hasAllOf(CodegenModel)`, `ModelUtils.hasOneOf(CodegenModel)`, `ModelUtils.hasAnyOf(CodegenModel)`.
  - Replaced manual checks across generators: Go (`AbstractGoCodegen`, `GoClientCodegen`), Python (`AbstractPythonCodegen`, `AbstractPythonPydanticV1Codegen`, `PythonClientCodegen`), Rust, C# (`CSharpClientCodegen`, `CSharpReducedClientCodegen`), Java (`JavaClientCodegen`), Kotlin (`KotlinServerCodegen`), OCaml, PowerShell, Protobuf, and PlantUML.
  - Cleaned up spots where nullability, imports, and validators depend on `oneOf`/`anyOf` presence. No functional changes intended.

<sup>Written for commit e73096d764831b82ebc51a9d1c68db8853baef08. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24608?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

