### PR TITLE
Update undici to 7.29.0

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript/package.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/package.mustache
@@ -44,7 +44,7 @@
       {{#fetch-api}}
         {{#platforms}}
           {{#node}}
-    "undici": "^7.28.0",
+    "undici": "^7.29.0",
           {{/node}}
           {{#browser}}
     "whatwg-fetch": "^3.0.0",

--- a/samples/client/echo_api/typescript/build/package.json
+++ b/samples/client/echo_api/typescript/build/package.json
@@ -32,7 +32,7 @@
     "prepare": "npm run build"
   },
   "dependencies": {
-    "undici": "^7.28.0",
+    "undici": "^7.29.0",
     "@types/node": "^20.17.10",
     "form-data": "^4.0.4",
     "es6-promise": "^4.2.4"

--- a/samples/client/others/typescript/encode-decode/build/package.json
+++ b/samples/client/others/typescript/encode-decode/build/package.json
@@ -32,7 +32,7 @@
     "prepare": "npm run build"
   },
   "dependencies": {
-    "undici": "^7.28.0",
+    "undici": "^7.29.0",
     "@types/node": "^20.17.10",
     "form-data": "^4.0.4",
     "es6-promise": "^4.2.4"

--- a/samples/openapi3/client/petstore/typescript/builds/default/package.json
+++ b/samples/openapi3/client/petstore/typescript/builds/default/package.json
@@ -32,7 +32,7 @@
     "prepare": "npm run build"
   },
   "dependencies": {
-    "undici": "^7.28.0",
+    "undici": "^7.29.0",
     "@types/node": "^20.17.10",
     "form-data": "^4.0.4",
     "es6-promise": "^4.2.4"

--- a/samples/openapi3/client/petstore/typescript/builds/explode-query/package.json
+++ b/samples/openapi3/client/petstore/typescript/builds/explode-query/package.json
@@ -32,7 +32,7 @@
     "prepare": "npm run build"
   },
   "dependencies": {
-    "undici": "^7.28.0",
+    "undici": "^7.29.0",
     "@types/node": "^20.17.10",
     "form-data": "^4.0.4",
     "es6-promise": "^4.2.4"

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/package.json
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/package.json
@@ -32,7 +32,7 @@
     "prepare": "npm run build"
   },
   "dependencies": {
-    "undici": "^7.28.0",
+    "undici": "^7.29.0",
     "@types/node": "^20.17.10",
     "form-data": "^4.0.4",
     "inversify": "^6.0.1",

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/package.json
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/package.json
@@ -32,7 +32,7 @@
     "prepare": "npm run build"
   },
   "dependencies": {
-    "undici": "^7.28.0",
+    "undici": "^7.29.0",
     "@types/node": "^20.17.10",
     "form-data": "^4.0.4",
     "es6-promise": "^4.2.4"


### PR DESCRIPTION
for https://github.com/OpenAPITools/openapi-generator/pull/24594

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `undici` to ^7.29.0 for TypeScript Node clients using the fetch API to pick up the latest fixes and keep generated packages consistent.

- **Dependencies**
  - Updated `modules/openapi-generator/src/main/resources/typescript/package.mustache` to use `undici` ^7.29.0 for Node targets.
  - Updated sample TypeScript client `package.json` files to `undici` ^7.29.0.

<sup>Written for commit e4b8fe0710e9590936332f16f465402ab5db6df8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24611?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

