### PR TITLE
[Go]: Avoid name collisions of case-sensitive properties

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
@@ -755,6 +755,16 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
                 || (property.isAnyType && !property.isModel)) {
             property.vendorExtensions.put("x-golang-is-container", true);
         }
+        for(CodegenProperty cp: model.allVars) {
+            if (cp.baseName.equals(property.baseName)) {
+                return;
+            }
+            if (cp.name.equals(property.name)) {
+                property.name = "P_" + property.baseName;
+                property.setHasSanitizedName(true);
+                return;
+            }
+        }
     }
 
     @Override

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/GoModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/GoModelTest.java
@@ -276,6 +276,38 @@ public class GoModelTest {
         Assert.assertEquals(codegen.getTypeDeclaration(model3), "File");
     }
 
+    @Test(description = "convert a model with case-sensitive properties")
+    public void caseSensitivePropsTest() {
+        final Schema model = new Schema()
+                .description("a sample model")
+                .addProperty("name", new StringSchema())
+                .addProperty("Name", new StringSchema())
+                .addProperty("FirstName", new StringSchema())
+                .addProperty("first_name", new StringSchema());
+        final DefaultCodegen codegen = new GoClientCodegen();
+        OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("sample", model);
+        codegen.setOpenAPI(openAPI);
+        final CodegenModel cm = codegen.fromModel("sample", model);
+
+        Assert.assertEquals(cm.vars.size(), 4);
+
+        final CodegenProperty property1 = cm.vars.get(0);
+        Assert.assertEquals(property1.baseName, "name");
+        Assert.assertEquals(property1.name, "Name");
+
+        final CodegenProperty property2 = cm.vars.get(1);
+        Assert.assertEquals(property2.baseName, "Name");
+        Assert.assertEquals(property2.name, "P_Name");
+
+        final CodegenProperty property3 = cm.vars.get(2);
+        Assert.assertEquals(property3.baseName, "FirstName");
+        Assert.assertEquals(property3.name, "FirstName");
+
+        final CodegenProperty property4 = cm.vars.get(3);
+        Assert.assertEquals(property4.baseName, "first_name");
+        Assert.assertEquals(property4.name, "P_first_name");
+    }
+
     @DataProvider(name = "modelNames")
     public static Object[][] primeNumbers() {
         return new Object[][]{


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
This PR changes the Go generator to avoid possible name collisions due to case-sensitive object property names. The input spec may specify two properties named `Foo` and `foo`, and the generated Go code would (before this PR) include two fields named `Foo` in the same struct.

This may be applicable to other languages as well.

Golang committee: @antihax  @grokify @kemokemo @jirikuncar  @ph4r5h4d @lwj5

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples _(there were no modifications to sample outputs)_
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Go code generation to prevent struct field collisions when properties differ only by case. Conflicting fields now get a stable `P_` prefix so the generated code compiles and remains unambiguous.

- **Bug Fixes**
  - Detect collisions on Go field names and rename duplicates to `P_<baseName>`.
  - Mark renamed fields as sanitized to reflect the change.
  - Added a unit test covering `name`, `Name`, `FirstName`, `first_name` -> `Name`, `P_Name`, `FirstName`, `P_first_name`.

- **Migration**
  - If your schema defines case-sensitive duplicates, the generated Go field names may change to `P_<baseName>`. Update any references accordingly.

<sup>Written for commit b12664928b60940fa46f833402378dd9b87164ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24624?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

