### PR TITLE
[Java] fix Jackson 3 createDefaultMapper(null) losing the default date format (restclient, webclient)

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/restclient/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/restclient/ApiClient.mustache
@@ -206,6 +206,9 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
 
     {{#useJackson3}}
     public static JsonMapper createDefaultMapper(@Nullable DateFormat dateFormat) {
+        if (null == dateFormat) {
+            dateFormat = createDefaultDateFormat();
+        }
         return JsonMapper.builder()
             .defaultDateFormat(dateFormat)
             {{#failOnUnknownProperties}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/webclient/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/webclient/ApiClient.mustache
@@ -183,6 +183,9 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
 
     {{#useJackson3}}
     public static JsonMapper createDefaultMapper(@Nullable DateFormat dateFormat) {
+        if (null == dateFormat) {
+            dateFormat = createDefaultDateFormat();
+        }
         return JsonMapper.builder()
             .defaultDateFormat(dateFormat)
             {{#failOnUnknownProperties}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -3671,6 +3671,37 @@ public class JavaClientCodegenTest {
         );
     }
 
+    @Test(description = "Regression test for issue #24588: with useJackson3=true the generated"
+            + " createDefaultMapper must fall back to createDefaultDateFormat() when called with"
+            + " null, like the Jackson 2 branch does. Otherwise date-time fields serialize as"
+            + " epoch numbers instead of RFC 3339.")
+    public void testJackson3DefaultMapperFallsBackToDefaultDateFormat_issue_24588() {
+        for (String library : new String[]{JavaClientCodegen.RESTCLIENT, JavaClientCodegen.WEBCLIENT}) {
+            final Path output = newTempFolder();
+            final CodegenConfigurator configurator = new CodegenConfigurator()
+                    .setGeneratorName(JAVA_GENERATOR)
+                    .setLibrary(library)
+                    .setAdditionalProperties(Map.of(
+                            CodegenConstants.API_PACKAGE, "xyz.abcdef.api",
+                            JavaClientCodegen.USE_JACKSON_3, true,
+                            JavaClientCodegen.USE_SPRING_BOOT4, true,
+                            JavaClientCodegen.OPENAPI_NULLABLE, false
+                    ))
+                    .setInputSpec("src/test/resources/3_1/java/petstore.yaml")
+                    .setOutputDir(output.toString().replace("\\", "/"));
+
+            List<File> files = new DefaultGenerator().opts(configurator.toClientOptInput()).generate();
+
+            validateJavaSourceFiles(files);
+            assertFileContains(
+                    output.resolve("src/main/java/xyz/abcdef/ApiClient.java"),
+                    "public static JsonMapper createDefaultMapper(@Nullable DateFormat dateFormat) {",
+                    "if (null == dateFormat) {",
+                    "dateFormat = createDefaultDateFormat();"
+            );
+        }
+    }
+
 
     @Test
     public void testRestClientWithUseSingleRequestParameter_issue_19406() {

--- a/samples/client/petstore/java/restclient-springBoot4-jackson3-jspecify/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/restclient-springBoot4-jackson3-jspecify/src/main/java/org/openapitools/client/ApiClient.java
@@ -134,6 +134,9 @@ public class ApiClient extends JavaTimeFormatter {
     }
 
     public static JsonMapper createDefaultMapper(@Nullable DateFormat dateFormat) {
+        if (null == dateFormat) {
+            dateFormat = createDefaultDateFormat();
+        }
         return JsonMapper.builder()
             .defaultDateFormat(dateFormat)
             .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)

--- a/samples/client/petstore/java/restclient-springBoot4-jackson3/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/restclient-springBoot4-jackson3/src/main/java/org/openapitools/client/ApiClient.java
@@ -135,6 +135,9 @@ public class ApiClient extends JavaTimeFormatter {
     }
 
     public static JsonMapper createDefaultMapper(@Nullable DateFormat dateFormat) {
+        if (null == dateFormat) {
+            dateFormat = createDefaultDateFormat();
+        }
         return JsonMapper.builder()
             .defaultDateFormat(dateFormat)
             .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)

--- a/samples/client/petstore/java/webclient-springBoot4-jackson3-jspecify/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/webclient-springBoot4-jackson3-jspecify/src/main/java/org/openapitools/client/ApiClient.java
@@ -148,6 +148,9 @@ public class ApiClient extends JavaTimeFormatter {
     }
 
     public static JsonMapper createDefaultMapper(@Nullable DateFormat dateFormat) {
+        if (null == dateFormat) {
+            dateFormat = createDefaultDateFormat();
+        }
         return JsonMapper.builder()
             .defaultDateFormat(dateFormat)
             .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)

--- a/samples/client/petstore/java/webclient-springBoot4-jackson3/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/webclient-springBoot4-jackson3/src/main/java/org/openapitools/client/ApiClient.java
@@ -149,6 +149,9 @@ public class ApiClient extends JavaTimeFormatter {
     }
 
     public static JsonMapper createDefaultMapper(@Nullable DateFormat dateFormat) {
+        if (null == dateFormat) {
+            dateFormat = createDefaultDateFormat();
+        }
         return JsonMapper.builder()
             .defaultDateFormat(dateFormat)
             .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)


### PR DESCRIPTION
Fixes #24588

With `useJackson3=true`, the Jackson 3 branch of `createDefaultMapper` passes a null `DateFormat` straight into `JsonMapper.builder().defaultDateFormat(dateFormat)`. The Jackson 2 branch of the same template falls back to `createDefaultDateFormat()` when the argument is null. The generator's own entry points (`buildRestClientBuilder()`, `buildRestClient()`) call `createDefaultMapper(null)`, so nothing clears `WRITE_DATES_AS_TIMESTAMPS` and `date-time` fields serialize as epoch numbers instead of RFC 3339.

Verified against Jackson 3.1.5 with an exact copy of the generated method:

```
createDefaultMapper(null), master : {"clientId":"client-1","issuedAt":1785605400.000000000}
createDefaultMapper(null), fixed  : {"clientId":"client-1","issuedAt":"2026-08-01T17:30:00Z"}
```

The fix adds the same null fallback the Jackson 2 branch already has. The webclient template has the identical bug (same `createDefaultMapper(null)` call sites, same missing fallback), so it gets the same 3 lines.

Not touched: #24587 (missing message converters) is a separate bug in the same file and will get its own PR.

Changes:
- `Java/libraries/restclient/ApiClient.mustache`, `Java/libraries/webclient/ApiClient.mustache`: null fallback in the Jackson 3 `createDefaultMapper`
- Regression test `JavaClientCodegenTest#testJackson3DefaultMapperFallsBackToDefaultDateFormat_issue_24588` (both libraries)
- Regenerated the 4 affected sample configs (java-restclient/webclient-springBoot4-jackson3, plus jspecify variants), 3 lines each, no other drift

Tested: JavaClientCodegenTest 273/273 green.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ```
  Commit all changed files.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

Java technical committee: @bbdouglas @sreeshas @jfiala @lukoyanov @cbornet @jeff9finger @karismann @Zomzog @lwlee2608 @martin-mfg @KannaKim

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect date-time serialization when `useJackson3=true` by making `createDefaultMapper(null)` fall back to the default date format in Java `restclient` and `webclient`. Date-times now serialize as RFC 3339 strings instead of epoch numbers. Fixes #24588.

- **Bug Fixes**
  - In the Jackson 3 branch of `createDefaultMapper`, use `createDefaultDateFormat()` when `dateFormat` is null (parity with Jackson 2).
  - Added regression test: `JavaClientCodegenTest#testJackson3DefaultMapperFallsBackToDefaultDateFormat_issue_24588`.
  - Regenerated affected samples (restclient/webclient Spring Boot 4 + Jackson 3, including jspecify).

<sup>Written for commit da0732bbc9e9d0095bcea9239eb707015eb3f1fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24625?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

