### PR TITLE
[Java] [okhttp-gson] Add `anyOf` Discriminator Support

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/anyof_model.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/anyof_model.mustache
@@ -107,6 +107,30 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
                     Object deserialized = null;
                     JsonElement jsonElement = elementAdapter.read(in);
 
+                    {{#useOneOfDiscriminatorLookup}}
+                    {{#discriminator}}
+                    JsonObject jsonObject = jsonElement.getAsJsonObject();
+
+                    // use discriminator value for faster anyOf lookup
+                    {{classname}} new{{classname}} = new {{classname}}();
+                    if (jsonObject.get("{{{propertyBaseName}}}") == null) {
+                        log.log(Level.WARNING, "Failed to lookup discriminator value for {{classname}} as `{{{propertyBaseName}}}` was not found in the payload or the payload is empty.");
+                    } else  {
+                        // look up the discriminator value in the field `{{{propertyBaseName}}}`
+                        switch (jsonObject.get("{{{propertyBaseName}}}").getAsString()) {
+                        {{#mappedModels}}
+                            case "{{{mappingName}}}":
+                                deserialized = adapter{{modelName}}.fromJsonTree(jsonObject);
+                                new{{classname}}.setActualInstance(deserialized);
+                                return new{{classname}};
+                        {{/mappedModels}}
+                            default:
+                                log.log(Level.WARNING, String.format(java.util.Locale.ROOT, "Failed to lookup discriminator value `%s` for {{classname}}. Possible values:{{#mappedModels}} {{{mappingName}}}{{/mappedModels}}", jsonObject.get("{{{propertyBaseName}}}").getAsString()));
+                        }
+                    }
+
+                    {{/discriminator}}
+                    {{/useOneOfDiscriminatorLookup}}
                     ArrayList<String> errorMessages = new ArrayList<>();
                     TypeAdapter actualAdapter = elementAdapter;
 

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/anyof_model.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/anyof_model.mustache
@@ -109,23 +109,26 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
 
                     {{#useOneOfDiscriminatorLookup}}
                     {{#discriminator}}
-                    JsonObject jsonObject = jsonElement.getAsJsonObject();
+                    // non-object payloads can still match a non-object anyOf schema below
+                    if (jsonElement.isJsonObject()) {
+                        JsonObject jsonObject = jsonElement.getAsJsonObject();
 
-                    // use discriminator value for faster anyOf lookup
-                    {{classname}} new{{classname}} = new {{classname}}();
-                    if (jsonObject.get("{{{propertyBaseName}}}") == null) {
-                        log.log(Level.WARNING, "Failed to lookup discriminator value for {{classname}} as `{{{propertyBaseName}}}` was not found in the payload or the payload is empty.");
-                    } else  {
-                        // look up the discriminator value in the field `{{{propertyBaseName}}}`
-                        switch (jsonObject.get("{{{propertyBaseName}}}").getAsString()) {
-                        {{#mappedModels}}
-                            case "{{{mappingName}}}":
-                                deserialized = adapter{{modelName}}.fromJsonTree(jsonObject);
-                                new{{classname}}.setActualInstance(deserialized);
-                                return new{{classname}};
-                        {{/mappedModels}}
-                            default:
-                                log.log(Level.WARNING, String.format(java.util.Locale.ROOT, "Failed to lookup discriminator value `%s` for {{classname}}. Possible values:{{#mappedModels}} {{{mappingName}}}{{/mappedModels}}", jsonObject.get("{{{propertyBaseName}}}").getAsString()));
+                        // use discriminator value for faster anyOf lookup
+                        {{classname}} new{{classname}} = new {{classname}}();
+                        if (jsonObject.get("{{{propertyBaseName}}}") == null) {
+                            log.log(Level.WARNING, "Failed to lookup discriminator value for {{classname}} as `{{{propertyBaseName}}}` was not found in the payload or the payload is empty.");
+                        } else  {
+                            // look up the discriminator value in the field `{{{propertyBaseName}}}`
+                            switch (jsonObject.get("{{{propertyBaseName}}}").getAsString()) {
+                            {{#mappedModels}}
+                                case "{{{mappingName}}}":
+                                    deserialized = adapter{{modelName}}.fromJsonTree(jsonObject);
+                                    new{{classname}}.setActualInstance(deserialized);
+                                    return new{{classname}};
+                            {{/mappedModels}}
+                                default:
+                                    log.log(Level.WARNING, String.format(java.util.Locale.ROOT, "Failed to lookup discriminator value `%s` for {{classname}}. Possible values:{{#mappedModels}} {{{mappingName}}}{{/mappedModels}}", jsonObject.get("{{{propertyBaseName}}}").getAsString()));
+                            }
                         }
                     }
 

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/anyof_model.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/anyof_model.mustache
@@ -112,14 +112,15 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
                     // non-object payloads can still match a non-object anyOf schema below
                     if (jsonElement.isJsonObject()) {
                         JsonObject jsonObject = jsonElement.getAsJsonObject();
+                        JsonElement discriminatorElement = jsonObject.get("{{{propertyBaseName}}}");
 
                         // use discriminator value for faster anyOf lookup
                         {{classname}} new{{classname}} = new {{classname}}();
-                        if (jsonObject.get("{{{propertyBaseName}}}") == null) {
-                            log.log(Level.WARNING, "Failed to lookup discriminator value for {{classname}} as `{{{propertyBaseName}}}` was not found in the payload or the payload is empty.");
+                        if (discriminatorElement == null || !discriminatorElement.isJsonPrimitive()) {
+                            log.log(Level.WARNING, "Failed to lookup discriminator value for {{classname}} as `{{{propertyBaseName}}}` is missing or is not a primitive type in the payload.");
                         } else  {
                             // look up the discriminator value in the field `{{{propertyBaseName}}}`
-                            switch (jsonObject.get("{{{propertyBaseName}}}").getAsString()) {
+                            switch (discriminatorElement.getAsString()) {
                             {{#mappedModels}}
                                 case "{{{mappingName}}}":
                                     deserialized = adapter{{modelName}}.fromJsonTree(jsonObject);
@@ -127,7 +128,7 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
                                     return new{{classname}};
                             {{/mappedModels}}
                                 default:
-                                    log.log(Level.WARNING, String.format(java.util.Locale.ROOT, "Failed to lookup discriminator value `%s` for {{classname}}. Possible values:{{#mappedModels}} {{{mappingName}}}{{/mappedModels}}", jsonObject.get("{{{propertyBaseName}}}").getAsString()));
+                                    log.log(Level.WARNING, String.format(java.util.Locale.ROOT, "Failed to lookup discriminator value `%s` for {{classname}}. Possible values:{{#mappedModels}} {{{mappingName}}}{{/mappedModels}}", discriminatorElement.getAsString()));
                             }
                         }
                     }

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/MammalAnyof.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/MammalAnyof.java
@@ -110,6 +110,32 @@ public class MammalAnyof extends AbstractOpenApiSchema {
                     Object deserialized = null;
                     JsonElement jsonElement = elementAdapter.read(in);
 
+                    JsonObject jsonObject = jsonElement.getAsJsonObject();
+
+                    // use discriminator value for faster anyOf lookup
+                    MammalAnyof newMammalAnyof = new MammalAnyof();
+                    if (jsonObject.get("className") == null) {
+                        log.log(Level.WARNING, "Failed to lookup discriminator value for MammalAnyof as `className` was not found in the payload or the payload is empty.");
+                    } else  {
+                        // look up the discriminator value in the field `className`
+                        switch (jsonObject.get("className").getAsString()) {
+                            case "Pig":
+                                deserialized = adapterPig.fromJsonTree(jsonObject);
+                                newMammalAnyof.setActualInstance(deserialized);
+                                return newMammalAnyof;
+                            case "whale":
+                                deserialized = adapterWhale.fromJsonTree(jsonObject);
+                                newMammalAnyof.setActualInstance(deserialized);
+                                return newMammalAnyof;
+                            case "zebra":
+                                deserialized = adapterZebra.fromJsonTree(jsonObject);
+                                newMammalAnyof.setActualInstance(deserialized);
+                                return newMammalAnyof;
+                            default:
+                                log.log(Level.WARNING, String.format(java.util.Locale.ROOT, "Failed to lookup discriminator value `%s` for MammalAnyof. Possible values: Pig whale zebra", jsonObject.get("className").getAsString()));
+                        }
+                    }
+
                     ArrayList<String> errorMessages = new ArrayList<>();
                     TypeAdapter actualAdapter = elementAdapter;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/MammalAnyof.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/MammalAnyof.java
@@ -110,29 +110,33 @@ public class MammalAnyof extends AbstractOpenApiSchema {
                     Object deserialized = null;
                     JsonElement jsonElement = elementAdapter.read(in);
 
-                    JsonObject jsonObject = jsonElement.getAsJsonObject();
+                    // non-object payloads can still match a non-object anyOf schema below
+                    if (jsonElement.isJsonObject()) {
+                        JsonObject jsonObject = jsonElement.getAsJsonObject();
+                        JsonElement discriminatorElement = jsonObject.get("className");
 
-                    // use discriminator value for faster anyOf lookup
-                    MammalAnyof newMammalAnyof = new MammalAnyof();
-                    if (jsonObject.get("className") == null) {
-                        log.log(Level.WARNING, "Failed to lookup discriminator value for MammalAnyof as `className` was not found in the payload or the payload is empty.");
-                    } else  {
-                        // look up the discriminator value in the field `className`
-                        switch (jsonObject.get("className").getAsString()) {
-                            case "Pig":
-                                deserialized = adapterPig.fromJsonTree(jsonObject);
-                                newMammalAnyof.setActualInstance(deserialized);
-                                return newMammalAnyof;
-                            case "whale":
-                                deserialized = adapterWhale.fromJsonTree(jsonObject);
-                                newMammalAnyof.setActualInstance(deserialized);
-                                return newMammalAnyof;
-                            case "zebra":
-                                deserialized = adapterZebra.fromJsonTree(jsonObject);
-                                newMammalAnyof.setActualInstance(deserialized);
-                                return newMammalAnyof;
-                            default:
-                                log.log(Level.WARNING, String.format(java.util.Locale.ROOT, "Failed to lookup discriminator value `%s` for MammalAnyof. Possible values: Pig whale zebra", jsonObject.get("className").getAsString()));
+                        // use discriminator value for faster anyOf lookup
+                        MammalAnyof newMammalAnyof = new MammalAnyof();
+                        if (discriminatorElement == null || !discriminatorElement.isJsonPrimitive()) {
+                            log.log(Level.WARNING, "Failed to lookup discriminator value for MammalAnyof as `className` is missing or is not a primitive type in the payload.");
+                        } else  {
+                            // look up the discriminator value in the field `className`
+                            switch (discriminatorElement.getAsString()) {
+                                case "Pig":
+                                    deserialized = adapterPig.fromJsonTree(jsonObject);
+                                    newMammalAnyof.setActualInstance(deserialized);
+                                    return newMammalAnyof;
+                                case "whale":
+                                    deserialized = adapterWhale.fromJsonTree(jsonObject);
+                                    newMammalAnyof.setActualInstance(deserialized);
+                                    return newMammalAnyof;
+                                case "zebra":
+                                    deserialized = adapterZebra.fromJsonTree(jsonObject);
+                                    newMammalAnyof.setActualInstance(deserialized);
+                                    return newMammalAnyof;
+                                default:
+                                    log.log(Level.WARNING, String.format(java.util.Locale.ROOT, "Failed to lookup discriminator value `%s` for MammalAnyof. Possible values: Pig whale zebra", discriminatorElement.getAsString()));
+                            }
                         }
                     }
 

--- a/samples/client/petstore/java/okhttp-gson/src/test/java/org/openapitools/client/JSONTest.java
+++ b/samples/client/petstore/java/okhttp-gson/src/test/java/org/openapitools/client/JSONTest.java
@@ -500,6 +500,59 @@ public class JSONTest {
     }
 
     /**
+     * Validate an anyOf schema can be deserialized into the expected class.
+     * The anyOf schema has a discriminator.
+     */
+    @Test
+    public void testAnyOfSchemaWithDiscriminator() throws Exception {
+        {
+            // Zebra is listed after Whale in anyOf, and a zebra payload also satisfies Whale
+            // (className is Whale's only required field), so without the discriminator lookup
+            // this deserializes as Whale.
+            String str = "{ \"className\": \"zebra\", \"type\": \"plains\" }";
+
+            MammalAnyof o = json.getGson().fromJson(str, MammalAnyof.class);
+            assertTrue(o.getActualInstance() instanceof Zebra);
+            Zebra inst = (Zebra) o.getActualInstance();
+            assertEquals(inst.getClassName(), "zebra");
+            assertEquals(inst.toJson(), "{\"type\":\"plains\",\"className\":\"zebra\"}");
+            assertEquals(o.toJson(), "{\"type\":\"plains\",\"className\":\"zebra\"}");
+        }
+        {
+            String str = "{ \"className\": \"whale\", \"hasBaleen\": false, \"hasTeeth\": false }";
+
+            MammalAnyof o = json.getGson().fromJson(str, MammalAnyof.class);
+            assertTrue(o.getActualInstance() instanceof Whale);
+            Whale inst = (Whale) o.getActualInstance();
+            assertEquals(inst.getClassName(), "whale");
+            assertEquals(inst.getHasBaleen(), false);
+            assertEquals(inst.getHasTeeth(), false);
+            assertEquals(inst.toJson(), "{\"hasBaleen\":false,\"hasTeeth\":false,\"className\":\"whale\"}");
+            assertEquals(json.getGson().toJson(o), "{\"hasBaleen\":false,\"hasTeeth\":false,\"className\":\"whale\"}");
+            assertEquals(o.toJson(), "{\"hasBaleen\":false,\"hasTeeth\":false,\"className\":\"whale\"}");
+        }
+        {
+            // an unmapped discriminator value falls back to matching the anyOf schemas in order
+            String str = "{ \"className\": \"dolphin\", \"hasBaleen\": true }";
+
+            MammalAnyof o = json.getGson().fromJson(str, MammalAnyof.class);
+            assertTrue(o.getActualInstance() instanceof Whale);
+            Whale inst = (Whale) o.getActualInstance();
+            assertEquals(inst.getClassName(), "dolphin");
+            assertEquals(inst.getHasBaleen(), true);
+        }
+        {
+            // Try to deserialize empty object. This should fail 'anyOf' because none will match
+            // whale, zebra or Pig.
+            String str = "{ }";
+            Exception exception = assertThrows(com.google.gson.JsonSyntaxException.class, () -> {
+                json.getGson().fromJson(str, MammalAnyof.class);
+            });
+            assertTrue(exception.getMessage().contains("java.io.IOException: Failed deserialization for MammalAnyof"));
+        }
+    }
+
+    /**
      * Test JSON validation method
      */
     @Test


### PR DESCRIPTION
Adds support for discriminators for `anyOf` models in the Java okhttp-gson library. This functionality is copied over from the `oneOf` model to match it, and is also gated behind the `useOneOfDiscriminatorLookup` flag. I kept it behind the flag since it seemed reasonable to assume users would want to toggle discriminator lookup for both oneOf+anyOf at once, tho the flag is now slightly inappropriately named. Lmk if we need to make a change regarding that, that flag is used across a few generators.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10) @martin-mfg (2023/08) @KannaKim (2026/07)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds discriminator-based deserialization for `anyOf` models in the Java `okhttp-gson` generator, matching `oneOf`. It now performs fast discriminator lookup when present and safely skips it for non-object payloads, with clearer warnings for missing or non-primitive discriminator values.

- **New Features**
  - Added discriminator lookup in `anyOf` adapters with early switch and fallback to schema-order matching.
  - Guarded lookup to only run for object payloads; improved logs for missing/non-primitive discriminator values.
  - Updated petstore samples (`MammalAnyof`) and tests for mapped values, unmapped fallback, and empty payload failure.

- **Migration**
  - No migration required. Enable `useOneOfDiscriminatorLookup` to apply to both `oneOf` and `anyOf`.

<sup>Written for commit ebcd0a521d77bdb690f701507e25c52bf3eec470. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24632?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

