### PR TITLE
[swift6] Emit enum description for query parameters

### DIFF
--- a/modules/openapi-generator/src/main/resources/swift6/api.mustache
+++ b/modules/openapi-generator/src/main/resources/swift6/api.mustache
@@ -34,6 +34,9 @@ extension {{projectName}}API {
         {{^enumUnknownDefaultCase}}
         {{#allowableValues}}
         {{#enumVars}}
+        {{#enumDescription}}
+        /** {{.}} */
+        {{/enumDescription}}
         case {{name}} = {{{value}}}
         {{/enumVars}}
         {{/allowableValues}}

--- a/modules/openapi-generator/src/main/resources/swift6/modelEnum.mustache
+++ b/modules/openapi-generator/src/main/resources/swift6/modelEnum.mustache
@@ -3,7 +3,7 @@
 {{#allowableValues}}
 {{#enumVars}}
     {{#enumDescription}}
-    /// {{enumDescription}}
+    /** {{.}} */
     {{/enumDescription}}
     case {{{name}}} = {{{value}}}
 {{/enumVars}}

--- a/modules/openapi-generator/src/main/resources/swift6/modelInlineEnumDeclaration.mustache
+++ b/modules/openapi-generator/src/main/resources/swift6/modelInlineEnumDeclaration.mustache
@@ -2,7 +2,7 @@
         {{#allowableValues}}
         {{#enumVars}}
         {{#enumDescription}}
-        /// {{enumDescription}}
+        /** {{.}} */
         {{/enumDescription}}
         case {{{name}}} = {{{value}}}
         {{/enumVars}}

--- a/modules/openapi-generator/src/test/resources/2_0/swift/petstore-with-fake-endpoints-models-for-testing.yaml
+++ b/modules/openapi-generator/src/test/resources/2_0/swift/petstore-with-fake-endpoints-models-for-testing.yaml
@@ -98,6 +98,10 @@ paths:
               - available
               - pending
               - sold
+            x-enum-descriptions:
+              - Label for available status
+              - Other label for pending status
+              - Another label for sold status
             default: available
           collectionFormat: csv
       responses:

--- a/samples/client/petstore/swift6/alamofireLibrary/Sources/PetstoreClient/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift6/alamofireLibrary/Sources/PetstoreClient/APIs/PetAPI.swift
@@ -115,8 +115,11 @@ open class PetAPI {
      * enum for parameter status
      */
     public enum Status_findPetsByStatus: String, Sendable, CaseIterable {
+        /** Label for available status */
         case available = "available"
+        /** Other label for pending status */
         case pending = "pending"
+        /** Another label for sold status */
         case sold = "sold"
     }
 

--- a/samples/client/petstore/swift6/alamofireLibrary/Sources/PetstoreClient/Models/EnumTest.swift
+++ b/samples/client/petstore/swift6/alamofireLibrary/Sources/PetstoreClient/Models/EnumTest.swift
@@ -24,9 +24,9 @@ public struct EnumTest: Sendable, Codable, Hashable {
         case number1 = -1
     }
     public enum EnumNumber: Double, Sendable, Codable, CaseIterable {
-        /// Description for 1.1
+        /** Description for 1.1 */
         case _11 = 1.1
-        /// Description for -1.2
+        /** Description for -1.2 */
         case number12 = -1.2
     }
     public var enumString: EnumString?

--- a/samples/client/petstore/swift6/alamofireLibrary/Sources/PetstoreClient/Models/OuterEnum.swift
+++ b/samples/client/petstore/swift6/alamofireLibrary/Sources/PetstoreClient/Models/OuterEnum.swift
@@ -8,10 +8,10 @@
 import Foundation
 
 public enum OuterEnum: String, Sendable, Codable, CaseIterable {
-    /// Description for placed
+    /** Description for placed */
     case placed = "placed"
-    /// Description for approved
+    /** Description for approved */
     case approved = "approved"
-    /// Description for delivered
+    /** Description for delivered */
     case delivered = "delivered"
 }

--- a/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/APIs/PetAPI.swift
@@ -323,8 +323,11 @@ open class PetAPI {
      * enum for parameter status
      */
     public enum Status_findPetsByStatus: String, Sendable, CaseIterable {
+        /** Label for available status */
         case available = "available"
+        /** Other label for pending status */
         case pending = "pending"
+        /** Another label for sold status */
         case sold = "sold"
     }
 

--- a/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/Models/EnumTest.swift
+++ b/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/Models/EnumTest.swift
@@ -24,9 +24,9 @@ public struct EnumTest: Sendable, Codable, Hashable {
         case number1 = -1
     }
     public enum EnumNumber: Double, Sendable, Codable, CaseIterable {
-        /// Description for 1.1
+        /** Description for 1.1 */
         case _11 = 1.1
-        /// Description for -1.2
+        /** Description for -1.2 */
         case number12 = -1.2
     }
     public var enumString: EnumString?

--- a/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/Models/OuterEnum.swift
+++ b/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/Models/OuterEnum.swift
@@ -8,10 +8,10 @@
 import Foundation
 
 public enum OuterEnum: String, Sendable, Codable, CaseIterable {
-    /// Description for placed
+    /** Description for placed */
     case placed = "placed"
-    /// Description for approved
+    /** Description for approved */
     case approved = "approved"
-    /// Description for delivered
+    /** Description for delivered */
     case delivered = "delivered"
 }

--- a/samples/client/petstore/swift6/asyncAwaitLibrary/Sources/PetstoreClient/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift6/asyncAwaitLibrary/Sources/PetstoreClient/APIs/PetAPI.swift
@@ -99,8 +99,11 @@ open class PetAPI {
      * enum for parameter status
      */
     public enum Status_findPetsByStatus: String, Sendable, CaseIterable {
+        /** Label for available status */
         case available = "available"
+        /** Other label for pending status */
         case pending = "pending"
+        /** Another label for sold status */
         case sold = "sold"
     }
 

--- a/samples/client/petstore/swift6/asyncAwaitLibrary/Sources/PetstoreClient/Models/EnumTest.swift
+++ b/samples/client/petstore/swift6/asyncAwaitLibrary/Sources/PetstoreClient/Models/EnumTest.swift
@@ -24,9 +24,9 @@ public struct EnumTest: Sendable, Codable, Hashable {
         case number1 = -1
     }
     public enum EnumNumber: Double, Sendable, Codable, CaseIterable {
-        /// Description for 1.1
+        /** Description for 1.1 */
         case _11 = 1.1
-        /// Description for -1.2
+        /** Description for -1.2 */
         case number12 = -1.2
     }
     public var enumString: EnumString?

--- a/samples/client/petstore/swift6/asyncAwaitLibrary/Sources/PetstoreClient/Models/OuterEnum.swift
+++ b/samples/client/petstore/swift6/asyncAwaitLibrary/Sources/PetstoreClient/Models/OuterEnum.swift
@@ -8,10 +8,10 @@
 import Foundation
 
 public enum OuterEnum: String, Sendable, Codable, CaseIterable {
-    /// Description for placed
+    /** Description for placed */
     case placed = "placed"
-    /// Description for approved
+    /** Description for approved */
     case approved = "approved"
-    /// Description for delivered
+    /** Description for delivered */
     case delivered = "delivered"
 }

--- a/samples/client/petstore/swift6/combineDeferredLibrary/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift6/combineDeferredLibrary/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
@@ -136,8 +136,11 @@ open class PetAPI {
      * enum for parameter status
      */
     public enum Status_findPetsByStatus: String, Sendable, CaseIterable {
+        /** Label for available status */
         case available = "available"
+        /** Other label for pending status */
         case pending = "pending"
+        /** Another label for sold status */
         case sold = "sold"
     }
 

--- a/samples/client/petstore/swift6/combineDeferredLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
+++ b/samples/client/petstore/swift6/combineDeferredLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
@@ -24,9 +24,9 @@ public struct EnumTest: Sendable, Codable, Hashable {
         case number1 = -1
     }
     public enum EnumNumber: Double, Sendable, Codable, CaseIterable {
-        /// Description for 1.1
+        /** Description for 1.1 */
         case _11 = 1.1
-        /// Description for -1.2
+        /** Description for -1.2 */
         case number12 = -1.2
     }
     public var enumString: EnumString?

--- a/samples/client/petstore/swift6/combineDeferredLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterEnum.swift
+++ b/samples/client/petstore/swift6/combineDeferredLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterEnum.swift
@@ -8,10 +8,10 @@
 import Foundation
 
 public enum OuterEnum: String, Sendable, Codable, CaseIterable {
-    /// Description for placed
+    /** Description for placed */
     case placed = "placed"
-    /// Description for approved
+    /** Description for approved */
     case approved = "approved"
-    /// Description for delivered
+    /** Description for delivered */
     case delivered = "delivered"
 }

--- a/samples/client/petstore/swift6/combineLibrary/Sources/CombineLibrary/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift6/combineLibrary/Sources/CombineLibrary/APIs/PetAPI.swift
@@ -132,8 +132,11 @@ open class PetAPI {
      * enum for parameter status
      */
     public enum Status_findPetsByStatus: String, Sendable, CaseIterable {
+        /** Label for available status */
         case available = "available"
+        /** Other label for pending status */
         case pending = "pending"
+        /** Another label for sold status */
         case sold = "sold"
     }
 

--- a/samples/client/petstore/swift6/combineLibrary/Sources/CombineLibrary/Models/EnumTest.swift
+++ b/samples/client/petstore/swift6/combineLibrary/Sources/CombineLibrary/Models/EnumTest.swift
@@ -24,9 +24,9 @@ public struct EnumTest: Sendable, Codable, Hashable {
         case number1 = -1
     }
     public enum EnumNumber: Double, Sendable, Codable, CaseIterable {
-        /// Description for 1.1
+        /** Description for 1.1 */
         case _11 = 1.1
-        /// Description for -1.2
+        /** Description for -1.2 */
         case number12 = -1.2
     }
     public var enumString: EnumString?

--- a/samples/client/petstore/swift6/combineLibrary/Sources/CombineLibrary/Models/OuterEnum.swift
+++ b/samples/client/petstore/swift6/combineLibrary/Sources/CombineLibrary/Models/OuterEnum.swift
@@ -8,10 +8,10 @@
 import Foundation
 
 public enum OuterEnum: String, Sendable, Codable, CaseIterable {
-    /// Description for placed
+    /** Description for placed */
     case placed = "placed"
-    /// Description for approved
+    /** Description for approved */
     case approved = "approved"
-    /// Description for delivered
+    /** Description for delivered */
     case delivered = "delivered"
 }

--- a/samples/client/petstore/swift6/objcCompatible/Sources/PetstoreClient/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift6/objcCompatible/Sources/PetstoreClient/APIs/PetAPI.swift
@@ -115,8 +115,11 @@ import Foundation
      * enum for parameter status
      */
     public enum Status_findPetsByStatus: String, Sendable, CaseIterable {
+        /** Label for available status */
         case available = "available"
+        /** Other label for pending status */
         case pending = "pending"
+        /** Another label for sold status */
         case sold = "sold"
     }
 

--- a/samples/client/petstore/swift6/objcCompatible/Sources/PetstoreClient/Models/EnumTest.swift
+++ b/samples/client/petstore/swift6/objcCompatible/Sources/PetstoreClient/Models/EnumTest.swift
@@ -24,9 +24,9 @@ import Foundation
         case number1 = -1
     }
     public enum EnumNumber: Double, Sendable, Codable, CaseIterable {
-        /// Description for 1.1
+        /** Description for 1.1 */
         case _11 = 1.1
-        /// Description for -1.2
+        /** Description for -1.2 */
         case number12 = -1.2
     }
     public var enumString: EnumString?

--- a/samples/client/petstore/swift6/objcCompatible/Sources/PetstoreClient/Models/OuterEnum.swift
+++ b/samples/client/petstore/swift6/objcCompatible/Sources/PetstoreClient/Models/OuterEnum.swift
@@ -8,10 +8,10 @@
 import Foundation
 
 public enum OuterEnum: String, Sendable, Codable, CaseIterable {
-    /// Description for placed
+    /** Description for placed */
     case placed = "placed"
-    /// Description for approved
+    /** Description for approved */
     case approved = "approved"
-    /// Description for delivered
+    /** Description for delivered */
     case delivered = "delivered"
 }

--- a/samples/client/petstore/swift6/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift6/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
@@ -120,8 +120,11 @@ open class PetAPI {
      * enum for parameter status
      */
     public enum Status_findPetsByStatus: String, Sendable, CaseIterable {
+        /** Label for available status */
         case available = "available"
+        /** Other label for pending status */
         case pending = "pending"
+        /** Another label for sold status */
         case sold = "sold"
     }
 

--- a/samples/client/petstore/swift6/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
+++ b/samples/client/petstore/swift6/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
@@ -24,9 +24,9 @@ public struct EnumTest: Sendable, Codable, Hashable {
         case number1 = -1
     }
     public enum EnumNumber: Double, Sendable, Codable, CaseIterable {
-        /// Description for 1.1
+        /** Description for 1.1 */
         case _11 = 1.1
-        /// Description for -1.2
+        /** Description for -1.2 */
         case number12 = -1.2
     }
     public var enumString: EnumString?

--- a/samples/client/petstore/swift6/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterEnum.swift
+++ b/samples/client/petstore/swift6/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterEnum.swift
@@ -8,10 +8,10 @@
 import Foundation
 
 public enum OuterEnum: String, Sendable, Codable, CaseIterable {
-    /// Description for placed
+    /** Description for placed */
     case placed = "placed"
-    /// Description for approved
+    /** Description for approved */
     case approved = "approved"
-    /// Description for delivered
+    /** Description for delivered */
     case delivered = "delivered"
 }

--- a/samples/client/petstore/swift6/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
+++ b/samples/client/petstore/swift6/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
@@ -27,9 +27,9 @@ internal struct EnumTest: Sendable, Codable {
         case unknownDefaultOpenApi = 11184809
     }
     internal enum EnumNumber: Double, Sendable, Codable, CaseIterable, CaseIterableDefaultsLast {
-        /// Description for 1.1
+        /** Description for 1.1 */
         case _11 = 1.1
-        /// Description for -1.2
+        /** Description for -1.2 */
         case number12 = -1.2
         case unknownDefaultOpenApi = 11184809
     }

--- a/samples/client/petstore/swift6/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterEnum.swift
+++ b/samples/client/petstore/swift6/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterEnum.swift
@@ -8,11 +8,11 @@
 import Foundation
 
 internal enum OuterEnum: String, Sendable, Codable, CaseIterable, CaseIterableDefaultsLast {
-    /// Description for placed
+    /** Description for placed */
     case placed = "placed"
-    /// Description for approved
+    /** Description for approved */
     case approved = "approved"
-    /// Description for delivered
+    /** Description for delivered */
     case delivered = "delivered"
     case unknownDefaultOpenApi = "unknown_default_open_api"
 }

--- a/samples/client/petstore/swift6/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift6/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
@@ -128,8 +128,11 @@ open class PetAPI {
      * enum for parameter status
      */
     public enum Status_findPetsByStatus: String, Sendable, CaseIterable {
+        /** Label for available status */
         case available = "available"
+        /** Other label for pending status */
         case pending = "pending"
+        /** Another label for sold status */
         case sold = "sold"
     }
 

--- a/samples/client/petstore/swift6/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
+++ b/samples/client/petstore/swift6/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
@@ -24,9 +24,9 @@ public struct EnumTest: Sendable, Codable, Hashable {
         case number1 = -1
     }
     public enum EnumNumber: Double, Sendable, Codable, CaseIterable {
-        /// Description for 1.1
+        /** Description for 1.1 */
         case _11 = 1.1
-        /// Description for -1.2
+        /** Description for -1.2 */
         case number12 = -1.2
     }
     public var enumString: EnumString?

--- a/samples/client/petstore/swift6/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterEnum.swift
+++ b/samples/client/petstore/swift6/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterEnum.swift
@@ -8,10 +8,10 @@
 import Foundation
 
 public enum OuterEnum: String, Sendable, Codable, CaseIterable {
-    /// Description for placed
+    /** Description for placed */
     case placed = "placed"
-    /// Description for approved
+    /** Description for approved */
     case approved = "approved"
-    /// Description for delivered
+    /** Description for delivered */
     case delivered = "delivered"
 }

--- a/samples/client/petstore/swift6/urlsessionLibrary/Sources/PetstoreClient/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift6/urlsessionLibrary/Sources/PetstoreClient/APIs/PetAPI.swift
@@ -118,8 +118,11 @@ open class PetAPI {
      * enum for parameter status
      */
     public enum Status_findPetsByStatus: String, Sendable, CaseIterable {
+        /** Label for available status */
         case available = "available"
+        /** Other label for pending status */
         case pending = "pending"
+        /** Another label for sold status */
         case sold = "sold"
     }
 

--- a/samples/client/petstore/swift6/urlsessionLibrary/Sources/PetstoreClient/Models/EnumTest.swift
+++ b/samples/client/petstore/swift6/urlsessionLibrary/Sources/PetstoreClient/Models/EnumTest.swift
@@ -29,9 +29,9 @@ public final class EnumTest: @unchecked Sendable, Codable, Hashable {
         case number1 = -1
     }
     public enum EnumNumber: Double, Sendable, Codable, CaseIterable {
-        /// Description for 1.1
+        /** Description for 1.1 */
         case _11 = 1.1
-        /// Description for -1.2
+        /** Description for -1.2 */
         case number12 = -1.2
     }
     public private(set) var enumString: EnumString?

--- a/samples/client/petstore/swift6/urlsessionLibrary/Sources/PetstoreClient/Models/OuterEnum.swift
+++ b/samples/client/petstore/swift6/urlsessionLibrary/Sources/PetstoreClient/Models/OuterEnum.swift
@@ -13,11 +13,11 @@ public typealias OuterEnum = PetstoreClientAPI.OuterEnum
 extension PetstoreClientAPI {
 
 public enum OuterEnum: String, Sendable, Codable, CaseIterable {
-    /// Description for placed
+    /** Description for placed */
     case placed = "placed"
-    /// Description for approved
+    /** Description for approved */
     case approved = "approved"
-    /// Description for delivered
+    /** Description for delivered */
     case delivered = "delivered"
 }
 }


### PR DESCRIPTION
This adds the enum description in one more missing place, as well as changes the other enum descriptions to use multiline comment syntax instead of single lines.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
@jgavris (2017/07) @ehyche (2017/08) @Edubits (2017/09) @jaz-ah (2017/09) @4brunu (2019/11) @dydus0x14 (2023/06)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds enum descriptions to Swift 6 query parameter enums and switches enum case docs to block comments for consistency. This improves the generated client docs across APIs and models.

- **New Features**
  - Emit `x-enum-descriptions` for query parameter enums in `api.mustache`.
  - Standardize enum case comments to `/** ... */` in `modelEnum.mustache` and `modelInlineEnumDeclaration.mustache`.
  - Updated test fixture and regenerated Swift 6 samples to reflect the new comments and query param enum descriptions.

<sup>Written for commit 1ca6f90a86a56915b4202b15ba26bb6cf3c6d0e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24639?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

