### PR TITLE
[Java] fix restclient with useJackson3 omitting default HttpMessageConverters (#24587)

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/restclient/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/restclient/ApiClient.mustache
@@ -279,7 +279,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
         Consumer<HttpMessageConverters.ClientBuilder> messageConverters = builder -> {
             builder.registerDefaults().withJsonConverter(new JacksonJsonHttpMessageConverter(mapper));
             {{#withXml}}
-            builder.addCustomConverter(new JacksonXmlHttpMessageConverter(xmlMapper));
+            builder.withXmlConverter(new JacksonXmlHttpMessageConverter(xmlMapper));
             {{/withXml}}
         };
 

--- a/modules/openapi-generator/src/main/resources/Java/libraries/restclient/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/restclient/ApiClient.mustache
@@ -277,6 +277,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
 
         {{#useJackson3}}
         Consumer<HttpMessageConverters.ClientBuilder> messageConverters = builder -> {
+            builder.registerDefaults();
             builder.addCustomConverter(new JacksonJsonHttpMessageConverter(mapper));
             {{#withXml}}
             builder.addCustomConverter(new JacksonXmlHttpMessageConverter(xmlMapper));

--- a/modules/openapi-generator/src/main/resources/Java/libraries/restclient/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/restclient/ApiClient.mustache
@@ -277,8 +277,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
 
         {{#useJackson3}}
         Consumer<HttpMessageConverters.ClientBuilder> messageConverters = builder -> {
-            builder.registerDefaults();
-            builder.addCustomConverter(new JacksonJsonHttpMessageConverter(mapper));
+            builder.registerDefaults().withJsonConverter(new JacksonJsonHttpMessageConverter(mapper));
             {{#withXml}}
             builder.addCustomConverter(new JacksonXmlHttpMessageConverter(xmlMapper));
             {{/withXml}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/restclient/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/restclient/build.gradle.mustache
@@ -118,7 +118,7 @@ ext {
     jakarta_annotation_version = "2.1.1"
     {{/useSpringBoot4}}
     {{#useSpringBoot4}}
-    spring_web_version = "7.0.5"
+    spring_web_version = "7.0.8"
     jakarta_annotation_version = "3.0.0"
     {{/useSpringBoot4}}
     bean_validation_version = "3.1.1"

--- a/modules/openapi-generator/src/main/resources/Java/libraries/restclient/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/restclient/pom.mustache
@@ -355,7 +355,7 @@
         {{/performBeanValidation}}
         {{/useSpringBoot4}}
         {{#useSpringBoot4}}
-        <spring-web-version>7.0.5</spring-web-version>
+        <spring-web-version>7.0.8</spring-web-version>
         {{#useJackson3}}
         <jackson-version>3.1.5</jackson-version>
         {{/useJackson3}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/build.gradle.mustache
@@ -126,7 +126,7 @@ ext {
     jackson_databind_nullable_version = "0.2.11"
     {{/openApiNullable}}
     {{#useSpringBoot4}}
-    spring_web_version = "7.0.5"
+    spring_web_version = "7.0.8"
     jakarta_annotation_version = "3.0.0"
     bean_validation_version = "3.1.1"
     {{/useSpringBoot4}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/pom.mustache
@@ -379,7 +379,7 @@
         {{/swagger2AnnotationLibrary}}
 
         {{#useSpringBoot4}}
-        <spring-web-version>7.0.5</spring-web-version>
+        <spring-web-version>7.0.8</spring-web-version>
         {{#useJackson3}}
         <jackson-version>3.1.5</jackson-version>
         {{/useJackson3}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -3703,8 +3703,8 @@ public class JavaClientCodegenTest {
     }
 
     @Test(description = "Regression test for issue #24587: restclient with useJackson3=true must call"
-            + " builder.registerDefaults() inside configureMessageConverters so default Spring converters"
-            + " (ByteArray, String, Resource) are not omitted.")
+            + " builder.registerDefaults().withJsonConverter(...) inside configureMessageConverters so default Spring converters"
+            + " (ByteArray, String, Resource) are registered with Jackson as the JSON converter.")
     public void testRestClientJackson3RegistersDefaults_issue_24587() {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()
@@ -3725,8 +3725,7 @@ public class JavaClientCodegenTest {
         assertFileContains(
                 output.resolve("src/main/java/xyz/abcdef/ApiClient.java"),
                 "Consumer<HttpMessageConverters.ClientBuilder> messageConverters = builder -> {",
-                "builder.registerDefaults();",
-                "builder.addCustomConverter(new JacksonJsonHttpMessageConverter(mapper));"
+                "builder.registerDefaults().withJsonConverter(new JacksonJsonHttpMessageConverter(mapper));"
         );
     }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -3702,6 +3702,34 @@ public class JavaClientCodegenTest {
         }
     }
 
+    @Test(description = "Regression test for issue #24587: restclient with useJackson3=true must call"
+            + " builder.registerDefaults() inside configureMessageConverters so default Spring converters"
+            + " (ByteArray, String, Resource) are not omitted.")
+    public void testRestClientJackson3RegistersDefaults_issue_24587() {
+        final Path output = newTempFolder();
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName(JAVA_GENERATOR)
+                .setLibrary(JavaClientCodegen.RESTCLIENT)
+                .setAdditionalProperties(Map.of(
+                        CodegenConstants.API_PACKAGE, "xyz.abcdef.api",
+                        JavaClientCodegen.USE_JACKSON_3, true,
+                        JavaClientCodegen.USE_SPRING_BOOT4, true,
+                        JavaClientCodegen.OPENAPI_NULLABLE, false
+                ))
+                .setInputSpec("src/test/resources/3_1/java/petstore.yaml")
+                .setOutputDir(output.toString().replace("\\", "/"));
+
+        List<File> files = new DefaultGenerator().opts(configurator.toClientOptInput()).generate();
+
+        validateJavaSourceFiles(files);
+        assertFileContains(
+                output.resolve("src/main/java/xyz/abcdef/ApiClient.java"),
+                "Consumer<HttpMessageConverters.ClientBuilder> messageConverters = builder -> {",
+                "builder.registerDefaults();",
+                "builder.addCustomConverter(new JacksonJsonHttpMessageConverter(mapper));"
+        );
+    }
+
 
     @Test
     public void testRestClientWithUseSingleRequestParameter_issue_19406() {

--- a/samples/client/petstore/java/restclient-springBoot4-jackson2/build.gradle
+++ b/samples/client/petstore/java/restclient-springBoot4-jackson2/build.gradle
@@ -100,7 +100,7 @@ ext {
     jackson_version = "2.21.5"
     jackson_annotations_version = "2.21"
     jackson_databind_nullable_version = "0.2.11"
-    spring_web_version = "7.0.5"
+    spring_web_version = "7.0.8"
     jakarta_annotation_version = "3.0.0"
     bean_validation_version = "3.1.1"
     jodatime_version = "2.14.0"

--- a/samples/client/petstore/java/restclient-springBoot4-jackson2/pom.xml
+++ b/samples/client/petstore/java/restclient-springBoot4-jackson2/pom.xml
@@ -263,7 +263,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <spring-web-version>7.0.5</spring-web-version>
+        <spring-web-version>7.0.8</spring-web-version>
         <jackson-version>2.21.5</jackson-version>
         <jakarta-annotation-version>3.0.0</jakarta-annotation-version>
 

--- a/samples/client/petstore/java/restclient-springBoot4-jackson3-jspecify/build.gradle
+++ b/samples/client/petstore/java/restclient-springBoot4-jackson3-jspecify/build.gradle
@@ -99,7 +99,7 @@ if(hasProperty('target') && target == 'android') {
 ext {
     jackson_version = "3.1.5"
     jackson_annotations_version = "2.21"
-    spring_web_version = "7.0.5"
+    spring_web_version = "7.0.8"
     jakarta_annotation_version = "3.0.0"
     bean_validation_version = "3.1.1"
     jodatime_version = "2.14.0"

--- a/samples/client/petstore/java/restclient-springBoot4-jackson3-jspecify/pom.xml
+++ b/samples/client/petstore/java/restclient-springBoot4-jackson3-jspecify/pom.xml
@@ -253,7 +253,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <spring-web-version>7.0.5</spring-web-version>
+        <spring-web-version>7.0.8</spring-web-version>
         <jackson-version>3.1.5</jackson-version>
         <jakarta-annotation-version>3.0.0</jakarta-annotation-version>
 

--- a/samples/client/petstore/java/restclient-springBoot4-jackson3-jspecify/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/restclient-springBoot4-jackson3-jspecify/src/main/java/org/openapitools/client/ApiClient.java
@@ -158,8 +158,7 @@ public class ApiClient extends JavaTimeFormatter {
     public static RestClient.Builder buildRestClientBuilder(JsonMapper mapper) {
 
         Consumer<HttpMessageConverters.ClientBuilder> messageConverters = builder -> {
-            builder.registerDefaults();
-            builder.addCustomConverter(new JacksonJsonHttpMessageConverter(mapper));
+            builder.registerDefaults().withJsonConverter(new JacksonJsonHttpMessageConverter(mapper));
         };
 
         return RestClient.builder().configureMessageConverters(messageConverters);

--- a/samples/client/petstore/java/restclient-springBoot4-jackson3-jspecify/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/restclient-springBoot4-jackson3-jspecify/src/main/java/org/openapitools/client/ApiClient.java
@@ -158,6 +158,7 @@ public class ApiClient extends JavaTimeFormatter {
     public static RestClient.Builder buildRestClientBuilder(JsonMapper mapper) {
 
         Consumer<HttpMessageConverters.ClientBuilder> messageConverters = builder -> {
+            builder.registerDefaults();
             builder.addCustomConverter(new JacksonJsonHttpMessageConverter(mapper));
         };
 

--- a/samples/client/petstore/java/restclient-springBoot4-jackson3/build.gradle
+++ b/samples/client/petstore/java/restclient-springBoot4-jackson3/build.gradle
@@ -99,7 +99,7 @@ if(hasProperty('target') && target == 'android') {
 ext {
     jackson_version = "3.1.5"
     jackson_annotations_version = "2.21"
-    spring_web_version = "7.0.5"
+    spring_web_version = "7.0.8"
     jakarta_annotation_version = "3.0.0"
     bean_validation_version = "3.1.1"
     jodatime_version = "2.14.0"

--- a/samples/client/petstore/java/restclient-springBoot4-jackson3/pom.xml
+++ b/samples/client/petstore/java/restclient-springBoot4-jackson3/pom.xml
@@ -253,7 +253,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <spring-web-version>7.0.5</spring-web-version>
+        <spring-web-version>7.0.8</spring-web-version>
         <jackson-version>3.1.5</jackson-version>
         <jakarta-annotation-version>3.0.0</jakarta-annotation-version>
 

--- a/samples/client/petstore/java/restclient-springBoot4-jackson3/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/restclient-springBoot4-jackson3/src/main/java/org/openapitools/client/ApiClient.java
@@ -160,6 +160,7 @@ public class ApiClient extends JavaTimeFormatter {
     public static RestClient.Builder buildRestClientBuilder(JsonMapper mapper) {
 
         Consumer<HttpMessageConverters.ClientBuilder> messageConverters = builder -> {
+            builder.registerDefaults();
             builder.addCustomConverter(new JacksonJsonHttpMessageConverter(mapper));
         };
 

--- a/samples/client/petstore/java/restclient-springBoot4-jackson3/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/restclient-springBoot4-jackson3/src/main/java/org/openapitools/client/ApiClient.java
@@ -160,8 +160,7 @@ public class ApiClient extends JavaTimeFormatter {
     public static RestClient.Builder buildRestClientBuilder(JsonMapper mapper) {
 
         Consumer<HttpMessageConverters.ClientBuilder> messageConverters = builder -> {
-            builder.registerDefaults();
-            builder.addCustomConverter(new JacksonJsonHttpMessageConverter(mapper));
+            builder.registerDefaults().withJsonConverter(new JacksonJsonHttpMessageConverter(mapper));
         };
 
         return RestClient.builder().configureMessageConverters(messageConverters);

--- a/samples/client/petstore/java/resttemplate-springBoot4-jackson2/build.gradle
+++ b/samples/client/petstore/java/resttemplate-springBoot4-jackson2/build.gradle
@@ -100,7 +100,7 @@ ext {
     jackson_version = "2.21.5"
     jackson_annotations_version = "2.21"
     jackson_databind_nullable_version = "0.2.11"
-    spring_web_version = "7.0.5"
+    spring_web_version = "7.0.8"
     jakarta_annotation_version = "3.0.0"
     bean_validation_version = "3.1.1"
     jodatime_version = "2.9.9"

--- a/samples/client/petstore/java/resttemplate-springBoot4-jackson2/pom.xml
+++ b/samples/client/petstore/java/resttemplate-springBoot4-jackson2/pom.xml
@@ -279,7 +279,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <spring-web-version>7.0.5</spring-web-version>
+        <spring-web-version>7.0.8</spring-web-version>
         <jackson-version>2.21.5</jackson-version>
         <jakarta-annotation-version>3.0.0</jakarta-annotation-version>
 

--- a/samples/client/petstore/java/resttemplate-springBoot4-jackson3-jspecify/build.gradle
+++ b/samples/client/petstore/java/resttemplate-springBoot4-jackson3-jspecify/build.gradle
@@ -99,7 +99,7 @@ if(hasProperty('target') && target == 'android') {
 ext {
     jackson_version = "3.1.5"
     jackson_annotations_version = "2.21"
-    spring_web_version = "7.0.5"
+    spring_web_version = "7.0.8"
     jakarta_annotation_version = "3.0.0"
     bean_validation_version = "3.1.1"
     jodatime_version = "2.9.9"

--- a/samples/client/petstore/java/resttemplate-springBoot4-jackson3-jspecify/pom.xml
+++ b/samples/client/petstore/java/resttemplate-springBoot4-jackson3-jspecify/pom.xml
@@ -266,7 +266,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <spring-web-version>7.0.5</spring-web-version>
+        <spring-web-version>7.0.8</spring-web-version>
         <jackson-version>3.1.5</jackson-version>
         <jakarta-annotation-version>3.0.0</jakarta-annotation-version>
 

--- a/samples/client/petstore/java/resttemplate-springBoot4-jackson3/build.gradle
+++ b/samples/client/petstore/java/resttemplate-springBoot4-jackson3/build.gradle
@@ -99,7 +99,7 @@ if(hasProperty('target') && target == 'android') {
 ext {
     jackson_version = "3.1.5"
     jackson_annotations_version = "2.21"
-    spring_web_version = "7.0.5"
+    spring_web_version = "7.0.8"
     jakarta_annotation_version = "3.0.0"
     bean_validation_version = "3.1.1"
     jodatime_version = "2.9.9"

--- a/samples/client/petstore/java/resttemplate-springBoot4-jackson3/pom.xml
+++ b/samples/client/petstore/java/resttemplate-springBoot4-jackson3/pom.xml
@@ -269,7 +269,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <spring-web-version>7.0.5</spring-web-version>
+        <spring-web-version>7.0.8</spring-web-version>
         <jackson-version>3.1.5</jackson-version>
         <jakarta-annotation-version>3.0.0</jakarta-annotation-version>
 


### PR DESCRIPTION
### PR checklist
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title cleanly describes the fix/feature.
- [x] Code compiles cleanly by running `mvn clean install -DskipTests`.
- [x] Added unit tests for the fix/feature.
- [x] Regenerated sample code via `./bin/generate-samples.sh ./bin/configs/java*`.

### Description of the Change
When generating the `restclient` library with `useJackson3=true`, `ApiClient.mustache` configures `JacksonJsonHttpMessageConverter` on `HttpMessageConverters.ClientBuilder`. I believe `builder.registerDefaults()` was accidentally omitted here. Without calling `registerDefaults()`, standard Spring converters (such as `ByteArrayHttpMessageConverter`, `StringHttpMessageConverter`, and `ResourceHttpMessageConverter`) are not registered on the built client.

Adding `builder.registerDefaults()` inside `messageConverters` ensures Spring's default converters remain registered alongside Jackson.

Fixes #24587

cc @bbdouglas @s2308 @javier20 @wing328 @jpfinne

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing Spring default HttpMessageConverters in `restclient` when `useJackson3=true` by using `builder.registerDefaults().withJsonConverter(...)`, and switches XML to `withXmlConverter(...)` to prevent duplicates. Restores ByteArray/String/Resource support and avoids duplicate converters. Fixes #24587.

- **Bug Fixes**
  - Update `ApiClient.mustache` to call `builder.registerDefaults().withJsonConverter(new JacksonJsonHttpMessageConverter(mapper))` and `withXmlConverter(new JacksonXmlHttpMessageConverter(xmlMapper))`; add a regression test; regenerate samples.
  - Bump `spring-web` to `7.0.8` across `restclient`/`resttemplate` templates and all Spring Boot 4 samples.

<sup>Written for commit f8a8b8715a11ac20b5902365e868a8367d6c5a30. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24640?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

