### PR TITLE
Stable hash for determining if input specification changed

### DIFF
--- a/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
+++ b/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
@@ -17,11 +17,16 @@
 
 package org.openapitools.codegen.plugin;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.hash.Hashing;
 import com.google.common.io.Files;
 import io.swagger.parser.OpenAPIParser;
 import io.swagger.v3.core.util.Json;
+import io.swagger.v3.core.util.Json31;
 import io.swagger.v3.core.util.Yaml;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.SpecVersion;
 import io.swagger.v3.parser.OpenAPIResolver;
 import io.swagger.v3.parser.OpenAPIV3Parser;
 import io.swagger.v3.parser.core.models.AuthorizationValue;
@@ -1155,10 +1160,16 @@ public class CodeGenMojo extends AbstractMojo {
         final URL remoteUrl = inputSpecRemoteUrl();
         final List<AuthorizationValue> authorizationValues = AuthParser.parse(this.auth);
 
-        return Hashing.sha256().hashBytes(
-                new OpenAPIParser().readLocation(remoteUrl == null ? inputSpec : remoteUrl.toString(), authorizationValues, parseOptions)
-                        .getOpenAPI().toString().getBytes(StandardCharsets.UTF_8)
-        ).toString();
+        final OpenAPI spec = new OpenAPIParser()
+                .readLocation(remoteUrl == null ? inputSpec : remoteUrl.toString(), authorizationValues, parseOptions)
+                .getOpenAPI();
+        final ObjectMapper mapper = spec.getSpecVersion() == SpecVersion.V30 ? Json.mapper() : Json31.mapper();
+
+        try {
+            return Hashing.sha256().hashBytes(mapper.writeValueAsBytes(spec)).toString();
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**

--- a/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
+++ b/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
@@ -1163,6 +1163,12 @@ public class CodeGenMojo extends AbstractMojo {
         final OpenAPI spec = new OpenAPIParser()
                 .readLocation(remoteUrl == null ? inputSpec : remoteUrl.toString(), authorizationValues, parseOptions)
                 .getOpenAPI();
+
+        // If the specification is not parsable, a unique string is returned so the subsequent steps are not skipped.
+        // It is up to them to parse it again and deal with the error.
+        if (spec == null)
+            return "INVALID-HASH-" + System.currentTimeMillis();
+
         final ObjectMapper mapper = spec.getSpecVersion() == SpecVersion.V30 ? Json.mapper() : Json31.mapper();
 
         try {

--- a/samples/client/petstore/java/resttemplate-springBoot4-jackson3/pom.xml
+++ b/samples/client/petstore/java/resttemplate-springBoot4-jackson3/pom.xml
@@ -269,7 +269,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <spring-web-version>7.0.8</spring-web-version>
+        <spring-web-version>7.0.5</spring-web-version>
         <jackson-version>3.1.5</jackson-version>
         <jakarta-annotation-version>3.0.0</jakarta-annotation-version>
 


### PR DESCRIPTION
Fixes #24644

For the Maven plugin to reliably detect if the input specification has changed, the fully parsed specification is written to a buffer (as JSON) and the hash is computed from the result. 

Before, the hash was computed by calling `toString()` on the parsed specification, which is not stable for all possible elements of a specification. In particular, binary data provides as an example for a property of type string / format byte was not stable.

(I'm not sure why one of the pom.xml files. See the second changed file in this PR. It's a side-effect of running `generate-samples.sh`.)

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes input spec change detection in the Maven plugin by hashing the JSON-serialized OpenAPI model instead of `toString()`. Unparsable specs now yield a unique hash to avoid skipping generation steps.

- **Bug Fixes**
  - Compute SHA-256 from Jackson-serialized OpenAPI (v3.0 uses `Json.mapper()`, v3.1 uses `Json31.mapper()`).
  - Return a unique "INVALID-HASH-..." when parsing fails to ensure downstream steps still run.

- **Dependencies**
  - Sample `resttemplate-springBoot4-jackson3`: set `spring-web-version` to `7.0.5`.

<sup>Written for commit a1e0eacdc75ec9e72a429c3b62804fa6779f03dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24645?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

