### PR TITLE
[Java] Fix generated build.gradle incompatible with Gradle 9

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/build.gradle.mustache
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
 
     publishing {
         publications {
@@ -92,7 +94,7 @@ if(hasProperty('target') && target == 'android') {
     }
 
     task execute(type:JavaExec) {
-       main = System.getProperty('mainClass')
+       mainClass = System.getProperty('mainClass')
        classpath = sourceSets.main.runtimeClasspath
     }
 

--- a/modules/openapi-generator/src/main/resources/Java/libraries/apache-httpclient/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/apache-httpclient/build.gradle.mustache
@@ -78,14 +78,16 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
+    java {
     {{^useJackson3}}
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     {{/useJackson3}}
     {{#useJackson3}}
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     {{/useJackson3}}
+    }
 
     publishing {
         publications {
@@ -98,7 +100,7 @@ if(hasProperty('target') && target == 'android') {
     }
 
     task execute(type:JavaExec) {
-       main = System.getProperty('mainClass')
+       mainClass = System.getProperty('mainClass')
        classpath = sourceSets.main.runtimeClasspath
     }
 

--- a/modules/openapi-generator/src/main/resources/Java/libraries/feign/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/feign/build.gradle.mustache
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
 
     publishing {
         publications {
@@ -91,7 +93,7 @@ if(hasProperty('target') && target == 'android') {
     }
 
     task execute(type:JavaExec) {
-       main = System.getProperty('mainClass')
+       mainClass = System.getProperty('mainClass')
        classpath = sourceSets.main.runtimeClasspath
     }
 }

--- a/modules/openapi-generator/src/main/resources/Java/libraries/google-api-client/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/google-api-client/build.gradle.mustache
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
 
     publishing {
         publications {
@@ -91,7 +93,7 @@ if(hasProperty('target') && target == 'android') {
     }
 
     task execute(type:JavaExec) {
-       main = System.getProperty('mainClass')
+       mainClass = System.getProperty('mainClass')
        classpath = sourceSets.main.runtimeClasspath
     }
 }

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/build.gradle.mustache
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
 
     apply plugin: 'java'
     apply plugin: 'maven-publish'
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
 
     publishing {
         publications {
@@ -92,7 +94,7 @@ if(hasProperty('target') && target == 'android') {
     }
 
     task execute(type:JavaExec) {
-       main = System.getProperty('mainClass')
+       mainClass = System.getProperty('mainClass')
        classpath = sourceSets.main.runtimeClasspath
     }
 }

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/build.gradle.mustache
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
 
     apply plugin: 'java'
     apply plugin: 'maven-publish'
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    java {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
 
     publishing {
         publications {
@@ -92,7 +94,7 @@ if(hasProperty('target') && target == 'android') {
     }
 
     task execute(type:JavaExec) {
-       main = System.getProperty('mainClass')
+       mainClass = System.getProperty('mainClass')
        classpath = sourceSets.main.runtimeClasspath
     }
 }

--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/build.gradle.mustache
@@ -21,14 +21,16 @@ repositories {
 apply plugin: 'java'
 apply plugin: 'maven-publish'
 
+java {
 {{^useJackson3}}
-sourceCompatibility = JavaVersion.VERSION_11
-targetCompatibility = JavaVersion.VERSION_11
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
 {{/useJackson3}}
 {{#useJackson3}}
-sourceCompatibility = JavaVersion.VERSION_17
-targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 {{/useJackson3}}
+}
 
 // Some text from the schema is copy pasted into the source files as UTF-8
 // but the default still seems to be to use platform encoding
@@ -51,7 +53,7 @@ publishing {
 }
 
 task execute(type:JavaExec) {
-   main = System.getProperty('mainClass')
+   mainClass = System.getProperty('mainClass')
    classpath = sourceSets.main.runtimeClasspath
 }
 

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/build.gradle.mustache
@@ -87,8 +87,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
 
     publishing {
         publications {
@@ -100,7 +102,7 @@ if(hasProperty('target') && target == 'android') {
     }
 
     task execute(type:JavaExec) {
-       main = System.getProperty('mainClass')
+       mainClass = System.getProperty('mainClass')
        classpath = sourceSets.main.runtimeClasspath
     }
 }

--- a/modules/openapi-generator/src/main/resources/Java/libraries/rest-assured/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/rest-assured/build.gradle.mustache
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
 
     publishing {
         publications {
@@ -91,7 +93,7 @@ if(hasProperty('target') && target == 'android') {
     }
 
     task execute(type:JavaExec) {
-       main = System.getProperty('mainClass')
+       mainClass = System.getProperty('mainClass')
        classpath = sourceSets.main.runtimeClasspath
     }
 }

--- a/modules/openapi-generator/src/main/resources/Java/libraries/restclient/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/restclient/build.gradle.mustache
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    java {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
 
     publishing {
         publications {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/build.gradle.mustache
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
 
     publishing {
         publications {
@@ -91,7 +93,7 @@ if(hasProperty('target') && target == 'android') {
     }
 
     task execute(type:JavaExec) {
-       main = System.getProperty('mainClass')
+       mainClass = System.getProperty('mainClass')
        classpath = sourceSets.main.runtimeClasspath
     }
 }

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/build.gradle.mustache
@@ -84,14 +84,16 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
+    java {
     {{#useJakartaEe}}
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     {{/useJakartaEe}}
     {{^useJakartaEe}}
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     {{/useJakartaEe}}
+    }
 
     publishing {
         publications {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/build.gradle.mustache
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
 
     publishing {
         publications {
@@ -91,7 +93,7 @@ if(hasProperty('target') && target == 'android') {
     }
 
     task execute(type:JavaExec) {
-       main = System.getProperty('mainClass')
+       mainClass = System.getProperty('mainClass')
        classpath = sourceSets.main.runtimeClasspath
     }
 }

--- a/modules/openapi-generator/src/main/resources/Java/libraries/vertx/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/vertx/build.gradle.mustache
@@ -11,8 +11,10 @@ repositories {
 apply plugin: 'java'
 apply plugin: 'maven-publish'
 
-sourceCompatibility = {{#useVertx5}}JavaVersion.VERSION_11{{/useVertx5}}{{^useVertx5}}JavaVersion.VERSION_1_8{{/useVertx5}}
-targetCompatibility = {{#useVertx5}}JavaVersion.VERSION_11{{/useVertx5}}{{^useVertx5}}JavaVersion.VERSION_1_8{{/useVertx5}}
+java {
+    sourceCompatibility = {{#useVertx5}}JavaVersion.VERSION_11{{/useVertx5}}{{^useVertx5}}JavaVersion.VERSION_1_8{{/useVertx5}}
+    targetCompatibility = {{#useVertx5}}JavaVersion.VERSION_11{{/useVertx5}}{{^useVertx5}}JavaVersion.VERSION_1_8{{/useVertx5}}
+}
 
 publishing {
     publications {
@@ -24,7 +26,7 @@ publishing {
 }
 
 task execute(type:JavaExec) {
-   main = System.getProperty('mainClass')
+   mainClass = System.getProperty('mainClass')
    classpath = sourceSets.main.runtimeClasspath
 }
 

--- a/modules/openapi-generator/src/main/resources/Java/libraries/webclient/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/webclient/build.gradle.mustache
@@ -84,14 +84,16 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
+    java {
     {{#java17}}
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     {{/java17}}
     {{^java17}}
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     {{/java17}}
+    }
 
     publishing {
         publications {

--- a/samples/client/echo_api/java/apache-httpclient/build.gradle
+++ b/samples/client/echo_api/java/apache-httpclient/build.gradle
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
 
     publishing {
         publications {
@@ -92,7 +94,7 @@ if(hasProperty('target') && target == 'android') {
     }
 
     task execute(type:JavaExec) {
-       main = System.getProperty('mainClass')
+       mainClass = System.getProperty('mainClass')
        classpath = sourceSets.main.runtimeClasspath
     }
 

--- a/samples/client/echo_api/java/feign-gson/build.gradle
+++ b/samples/client/echo_api/java/feign-gson/build.gradle
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
 
     publishing {
         publications {
@@ -91,7 +93,7 @@ if(hasProperty('target') && target == 'android') {
     }
 
     task execute(type:JavaExec) {
-       main = System.getProperty('mainClass')
+       mainClass = System.getProperty('mainClass')
        classpath = sourceSets.main.runtimeClasspath
     }
 }

--- a/samples/client/echo_api/java/native/build.gradle
+++ b/samples/client/echo_api/java/native/build.gradle
@@ -21,8 +21,10 @@ repositories {
 apply plugin: 'java'
 apply plugin: 'maven-publish'
 
-sourceCompatibility = JavaVersion.VERSION_11
-targetCompatibility = JavaVersion.VERSION_11
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}
 
 // Some text from the schema is copy pasted into the source files as UTF-8
 // but the default still seems to be to use platform encoding
@@ -45,7 +47,7 @@ publishing {
 }
 
 task execute(type:JavaExec) {
-   main = System.getProperty('mainClass')
+   mainClass = System.getProperty('mainClass')
    classpath = sourceSets.main.runtimeClasspath
 }
 

--- a/samples/client/echo_api/java/okhttp-gson-user-defined-templates/build.gradle
+++ b/samples/client/echo_api/java/okhttp-gson-user-defined-templates/build.gradle
@@ -83,8 +83,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
 
     publishing {
         publications {
@@ -96,7 +98,7 @@ if(hasProperty('target') && target == 'android') {
     }
 
     task execute(type:JavaExec) {
-       main = System.getProperty('mainClass')
+       mainClass = System.getProperty('mainClass')
        classpath = sourceSets.main.runtimeClasspath
     }
 }

--- a/samples/client/echo_api/java/okhttp-gson/build.gradle
+++ b/samples/client/echo_api/java/okhttp-gson/build.gradle
@@ -83,8 +83,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
 
     publishing {
         publications {
@@ -96,7 +98,7 @@ if(hasProperty('target') && target == 'android') {
     }
 
     task execute(type:JavaExec) {
-       main = System.getProperty('mainClass')
+       mainClass = System.getProperty('mainClass')
        classpath = sourceSets.main.runtimeClasspath
     }
 }

--- a/samples/client/echo_api/java/restclient/build.gradle
+++ b/samples/client/echo_api/java/restclient/build.gradle
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    java {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
 
     publishing {
         publications {

--- a/samples/client/echo_api/java/resteasy/build.gradle
+++ b/samples/client/echo_api/java/resteasy/build.gradle
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
 
     publishing {
         publications {
@@ -91,7 +93,7 @@ if(hasProperty('target') && target == 'android') {
     }
 
     task execute(type:JavaExec) {
-       main = System.getProperty('mainClass')
+       mainClass = System.getProperty('mainClass')
        classpath = sourceSets.main.runtimeClasspath
     }
 }

--- a/samples/client/echo_api/java/resttemplate/build.gradle
+++ b/samples/client/echo_api/java/resttemplate/build.gradle
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
 
     publishing {
         publications {

--- a/samples/client/others/java/jersey2-oneOf-Mixed/build.gradle
+++ b/samples/client/others/java/jersey2-oneOf-Mixed/build.gradle
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
 
     apply plugin: 'java'
     apply plugin: 'maven-publish'
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
 
     publishing {
         publications {
@@ -92,7 +94,7 @@ if(hasProperty('target') && target == 'android') {
     }
 
     task execute(type:JavaExec) {
-       main = System.getProperty('mainClass')
+       mainClass = System.getProperty('mainClass')
        classpath = sourceSets.main.runtimeClasspath
     }
 }

--- a/samples/client/others/java/jersey2-oneOf-duplicates/build.gradle
+++ b/samples/client/others/java/jersey2-oneOf-duplicates/build.gradle
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
 
     apply plugin: 'java'
     apply plugin: 'maven-publish'
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
 
     publishing {
         publications {
@@ -92,7 +94,7 @@ if(hasProperty('target') && target == 'android') {
     }
 
     task execute(type:JavaExec) {
-       main = System.getProperty('mainClass')
+       mainClass = System.getProperty('mainClass')
        classpath = sourceSets.main.runtimeClasspath
     }
 }

--- a/samples/client/others/java/okhttp-gson-oneOf-array/build.gradle
+++ b/samples/client/others/java/okhttp-gson-oneOf-array/build.gradle
@@ -83,8 +83,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
 
     publishing {
         publications {
@@ -96,7 +98,7 @@ if(hasProperty('target') && target == 'android') {
     }
 
     task execute(type:JavaExec) {
-       main = System.getProperty('mainClass')
+       mainClass = System.getProperty('mainClass')
        classpath = sourceSets.main.runtimeClasspath
     }
 }

--- a/samples/client/others/java/okhttp-gson-oneOf/build.gradle
+++ b/samples/client/others/java/okhttp-gson-oneOf/build.gradle
@@ -83,8 +83,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
 
     publishing {
         publications {
@@ -96,7 +98,7 @@ if(hasProperty('target') && target == 'android') {
     }
 
     task execute(type:JavaExec) {
-       main = System.getProperty('mainClass')
+       mainClass = System.getProperty('mainClass')
        classpath = sourceSets.main.runtimeClasspath
     }
 }

--- a/samples/client/others/java/okhttp-gson-streaming/build.gradle
+++ b/samples/client/others/java/okhttp-gson-streaming/build.gradle
@@ -83,8 +83,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
 
     publishing {
         publications {
@@ -96,7 +98,7 @@ if(hasProperty('target') && target == 'android') {
     }
 
     task execute(type:JavaExec) {
-       main = System.getProperty('mainClass')
+       mainClass = System.getProperty('mainClass')
        classpath = sourceSets.main.runtimeClasspath
     }
 }

--- a/samples/client/others/java/restclient-enum-in-multipart/build.gradle
+++ b/samples/client/others/java/restclient-enum-in-multipart/build.gradle
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    java {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
 
     publishing {
         publications {

--- a/samples/client/others/java/restclient-sealedInterface/build.gradle
+++ b/samples/client/others/java/restclient-sealedInterface/build.gradle
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    java {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
 
     publishing {
         publications {

--- a/samples/client/others/java/restclient-useAbstractionForFiles/build.gradle
+++ b/samples/client/others/java/restclient-useAbstractionForFiles/build.gradle
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    java {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
 
     publishing {
         publications {

--- a/samples/client/others/java/resttemplate-list-schema-validation/build.gradle
+++ b/samples/client/others/java/resttemplate-list-schema-validation/build.gradle
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
 
     publishing {
         publications {

--- a/samples/client/others/java/resttemplate-useAbstractionForFiles/build.gradle
+++ b/samples/client/others/java/resttemplate-useAbstractionForFiles/build.gradle
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
 
     publishing {
         publications {

--- a/samples/client/others/java/webclient-sealedInterface/build.gradle
+++ b/samples/client/others/java/webclient-sealedInterface/build.gradle
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    java {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
 
     publishing {
         publications {

--- a/samples/client/others/java/webclient-sealedInterface_3_1/build.gradle
+++ b/samples/client/others/java/webclient-sealedInterface_3_1/build.gradle
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    java {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
 
     publishing {
         publications {

--- a/samples/client/others/java/webclient-useAbstractionForFiles/build.gradle
+++ b/samples/client/others/java/webclient-useAbstractionForFiles/build.gradle
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
 
     publishing {
         publications {

--- a/samples/client/petstore/java/apache-httpclient-jackson3/build.gradle
+++ b/samples/client/petstore/java/apache-httpclient-jackson3/build.gradle
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    java {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
 
     publishing {
         publications {
@@ -92,7 +94,7 @@ if(hasProperty('target') && target == 'android') {
     }
 
     task execute(type:JavaExec) {
-       main = System.getProperty('mainClass')
+       mainClass = System.getProperty('mainClass')
        classpath = sourceSets.main.runtimeClasspath
     }
 

--- a/samples/client/petstore/java/apache-httpclient/build.gradle
+++ b/samples/client/petstore/java/apache-httpclient/build.gradle
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
 
     publishing {
         publications {
@@ -92,7 +94,7 @@ if(hasProperty('target') && target == 'android') {
     }
 
     task execute(type:JavaExec) {
-       main = System.getProperty('mainClass')
+       mainClass = System.getProperty('mainClass')
        classpath = sourceSets.main.runtimeClasspath
     }
 

--- a/samples/client/petstore/java/feign-hc5/build.gradle
+++ b/samples/client/petstore/java/feign-hc5/build.gradle
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
 
     publishing {
         publications {
@@ -91,7 +93,7 @@ if(hasProperty('target') && target == 'android') {
     }
 
     task execute(type:JavaExec) {
-       main = System.getProperty('mainClass')
+       mainClass = System.getProperty('mainClass')
        classpath = sourceSets.main.runtimeClasspath
     }
 }

--- a/samples/client/petstore/java/feign-no-nullable/build.gradle
+++ b/samples/client/petstore/java/feign-no-nullable/build.gradle
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
 
     publishing {
         publications {
@@ -91,7 +93,7 @@ if(hasProperty('target') && target == 'android') {
     }
 
     task execute(type:JavaExec) {
-       main = System.getProperty('mainClass')
+       mainClass = System.getProperty('mainClass')
        classpath = sourceSets.main.runtimeClasspath
     }
 }

--- a/samples/client/petstore/java/feign/build.gradle
+++ b/samples/client/petstore/java/feign/build.gradle
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
 
     publishing {
         publications {
@@ -91,7 +93,7 @@ if(hasProperty('target') && target == 'android') {
     }
 
     task execute(type:JavaExec) {
-       main = System.getProperty('mainClass')
+       mainClass = System.getProperty('mainClass')
        classpath = sourceSets.main.runtimeClasspath
     }
 }

--- a/samples/client/petstore/java/google-api-client/build.gradle
+++ b/samples/client/petstore/java/google-api-client/build.gradle
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
 
     publishing {
         publications {
@@ -91,7 +93,7 @@ if(hasProperty('target') && target == 'android') {
     }
 
     task execute(type:JavaExec) {
-       main = System.getProperty('mainClass')
+       mainClass = System.getProperty('mainClass')
        classpath = sourceSets.main.runtimeClasspath
     }
 }

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/build.gradle
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/build.gradle
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
 
     apply plugin: 'java'
     apply plugin: 'maven-publish'
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
 
     publishing {
         publications {
@@ -92,7 +94,7 @@ if(hasProperty('target') && target == 'android') {
     }
 
     task execute(type:JavaExec) {
-       main = System.getProperty('mainClass')
+       mainClass = System.getProperty('mainClass')
        classpath = sourceSets.main.runtimeClasspath
     }
 }

--- a/samples/client/petstore/java/jersey2-java8/build.gradle
+++ b/samples/client/petstore/java/jersey2-java8/build.gradle
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
 
     apply plugin: 'java'
     apply plugin: 'maven-publish'
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
 
     publishing {
         publications {
@@ -92,7 +94,7 @@ if(hasProperty('target') && target == 'android') {
     }
 
     task execute(type:JavaExec) {
-       main = System.getProperty('mainClass')
+       mainClass = System.getProperty('mainClass')
        classpath = sourceSets.main.runtimeClasspath
     }
 }

--- a/samples/client/petstore/java/jersey3-jackson3/build.gradle
+++ b/samples/client/petstore/java/jersey3-jackson3/build.gradle
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
 
     apply plugin: 'java'
     apply plugin: 'maven-publish'
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    java {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
 
     publishing {
         publications {
@@ -92,7 +94,7 @@ if(hasProperty('target') && target == 'android') {
     }
 
     task execute(type:JavaExec) {
-       main = System.getProperty('mainClass')
+       mainClass = System.getProperty('mainClass')
        classpath = sourceSets.main.runtimeClasspath
     }
 }

--- a/samples/client/petstore/java/jersey3-oneOf/build.gradle
+++ b/samples/client/petstore/java/jersey3-oneOf/build.gradle
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
 
     apply plugin: 'java'
     apply plugin: 'maven-publish'
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    java {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
 
     publishing {
         publications {
@@ -92,7 +94,7 @@ if(hasProperty('target') && target == 'android') {
     }
 
     task execute(type:JavaExec) {
-       main = System.getProperty('mainClass')
+       mainClass = System.getProperty('mainClass')
        classpath = sourceSets.main.runtimeClasspath
     }
 }

--- a/samples/client/petstore/java/jersey3/build.gradle
+++ b/samples/client/petstore/java/jersey3/build.gradle
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
 
     apply plugin: 'java'
     apply plugin: 'maven-publish'
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    java {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
 
     publishing {
         publications {
@@ -92,7 +94,7 @@ if(hasProperty('target') && target == 'android') {
     }
 
     task execute(type:JavaExec) {
-       main = System.getProperty('mainClass')
+       mainClass = System.getProperty('mainClass')
        classpath = sourceSets.main.runtimeClasspath
     }
 }

--- a/samples/client/petstore/java/native-async/build.gradle
+++ b/samples/client/petstore/java/native-async/build.gradle
@@ -21,8 +21,10 @@ repositories {
 apply plugin: 'java'
 apply plugin: 'maven-publish'
 
-sourceCompatibility = JavaVersion.VERSION_11
-targetCompatibility = JavaVersion.VERSION_11
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}
 
 // Some text from the schema is copy pasted into the source files as UTF-8
 // but the default still seems to be to use platform encoding
@@ -45,7 +47,7 @@ publishing {
 }
 
 task execute(type:JavaExec) {
-   main = System.getProperty('mainClass')
+   mainClass = System.getProperty('mainClass')
    classpath = sourceSets.main.runtimeClasspath
 }
 

--- a/samples/client/petstore/java/native-jackson3-jspecify/build.gradle
+++ b/samples/client/petstore/java/native-jackson3-jspecify/build.gradle
@@ -21,8 +21,10 @@ repositories {
 apply plugin: 'java'
 apply plugin: 'maven-publish'
 
-sourceCompatibility = JavaVersion.VERSION_17
-targetCompatibility = JavaVersion.VERSION_17
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
 
 // Some text from the schema is copy pasted into the source files as UTF-8
 // but the default still seems to be to use platform encoding
@@ -45,7 +47,7 @@ publishing {
 }
 
 task execute(type:JavaExec) {
-   main = System.getProperty('mainClass')
+   mainClass = System.getProperty('mainClass')
    classpath = sourceSets.main.runtimeClasspath
 }
 

--- a/samples/client/petstore/java/native-jackson3/build.gradle
+++ b/samples/client/petstore/java/native-jackson3/build.gradle
@@ -21,8 +21,10 @@ repositories {
 apply plugin: 'java'
 apply plugin: 'maven-publish'
 
-sourceCompatibility = JavaVersion.VERSION_17
-targetCompatibility = JavaVersion.VERSION_17
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
 
 // Some text from the schema is copy pasted into the source files as UTF-8
 // but the default still seems to be to use platform encoding
@@ -45,7 +47,7 @@ publishing {
 }
 
 task execute(type:JavaExec) {
-   main = System.getProperty('mainClass')
+   mainClass = System.getProperty('mainClass')
    classpath = sourceSets.main.runtimeClasspath
 }
 

--- a/samples/client/petstore/java/native-jakarta/build.gradle
+++ b/samples/client/petstore/java/native-jakarta/build.gradle
@@ -21,8 +21,10 @@ repositories {
 apply plugin: 'java'
 apply plugin: 'maven-publish'
 
-sourceCompatibility = JavaVersion.VERSION_11
-targetCompatibility = JavaVersion.VERSION_11
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}
 
 // Some text from the schema is copy pasted into the source files as UTF-8
 // but the default still seems to be to use platform encoding
@@ -45,7 +47,7 @@ publishing {
 }
 
 task execute(type:JavaExec) {
-   main = System.getProperty('mainClass')
+   mainClass = System.getProperty('mainClass')
    classpath = sourceSets.main.runtimeClasspath
 }
 

--- a/samples/client/petstore/java/native-useGzipFeature/build.gradle
+++ b/samples/client/petstore/java/native-useGzipFeature/build.gradle
@@ -21,8 +21,10 @@ repositories {
 apply plugin: 'java'
 apply plugin: 'maven-publish'
 
-sourceCompatibility = JavaVersion.VERSION_11
-targetCompatibility = JavaVersion.VERSION_11
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}
 
 // Some text from the schema is copy pasted into the source files as UTF-8
 // but the default still seems to be to use platform encoding
@@ -45,7 +47,7 @@ publishing {
 }
 
 task execute(type:JavaExec) {
-   main = System.getProperty('mainClass')
+   mainClass = System.getProperty('mainClass')
    classpath = sourceSets.main.runtimeClasspath
 }
 

--- a/samples/client/petstore/java/native/build.gradle
+++ b/samples/client/petstore/java/native/build.gradle
@@ -21,8 +21,10 @@ repositories {
 apply plugin: 'java'
 apply plugin: 'maven-publish'
 
-sourceCompatibility = JavaVersion.VERSION_11
-targetCompatibility = JavaVersion.VERSION_11
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}
 
 // Some text from the schema is copy pasted into the source files as UTF-8
 // but the default still seems to be to use platform encoding
@@ -45,7 +47,7 @@ publishing {
 }
 
 task execute(type:JavaExec) {
-   main = System.getProperty('mainClass')
+   mainClass = System.getProperty('mainClass')
    classpath = sourceSets.main.runtimeClasspath
 }
 

--- a/samples/client/petstore/java/okhttp-gson-3.1-duplicated-operationid/build.gradle
+++ b/samples/client/petstore/java/okhttp-gson-3.1-duplicated-operationid/build.gradle
@@ -83,8 +83,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
 
     publishing {
         publications {
@@ -96,7 +98,7 @@ if(hasProperty('target') && target == 'android') {
     }
 
     task execute(type:JavaExec) {
-       main = System.getProperty('mainClass')
+       mainClass = System.getProperty('mainClass')
        classpath = sourceSets.main.runtimeClasspath
     }
 }

--- a/samples/client/petstore/java/okhttp-gson-3.1/build.gradle
+++ b/samples/client/petstore/java/okhttp-gson-3.1/build.gradle
@@ -83,8 +83,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
 
     publishing {
         publications {
@@ -96,7 +98,7 @@ if(hasProperty('target') && target == 'android') {
     }
 
     task execute(type:JavaExec) {
-       main = System.getProperty('mainClass')
+       mainClass = System.getProperty('mainClass')
        classpath = sourceSets.main.runtimeClasspath
     }
 }

--- a/samples/client/petstore/java/okhttp-gson-awsv4signature/build.gradle
+++ b/samples/client/petstore/java/okhttp-gson-awsv4signature/build.gradle
@@ -83,8 +83,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
 
     publishing {
         publications {
@@ -96,7 +98,7 @@ if(hasProperty('target') && target == 'android') {
     }
 
     task execute(type:JavaExec) {
-       main = System.getProperty('mainClass')
+       mainClass = System.getProperty('mainClass')
        classpath = sourceSets.main.runtimeClasspath
     }
 }

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/build.gradle
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/build.gradle
@@ -83,8 +83,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
 
     publishing {
         publications {
@@ -96,7 +98,7 @@ if(hasProperty('target') && target == 'android') {
     }
 
     task execute(type:JavaExec) {
-       main = System.getProperty('mainClass')
+       mainClass = System.getProperty('mainClass')
        classpath = sourceSets.main.runtimeClasspath
     }
 }

--- a/samples/client/petstore/java/okhttp-gson-group-parameter/build.gradle
+++ b/samples/client/petstore/java/okhttp-gson-group-parameter/build.gradle
@@ -83,8 +83,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
 
     publishing {
         publications {
@@ -96,7 +98,7 @@ if(hasProperty('target') && target == 'android') {
     }
 
     task execute(type:JavaExec) {
-       main = System.getProperty('mainClass')
+       mainClass = System.getProperty('mainClass')
        classpath = sourceSets.main.runtimeClasspath
     }
 }

--- a/samples/client/petstore/java/okhttp-gson-nullable-required/build.gradle
+++ b/samples/client/petstore/java/okhttp-gson-nullable-required/build.gradle
@@ -83,8 +83,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
 
     publishing {
         publications {
@@ -96,7 +98,7 @@ if(hasProperty('target') && target == 'android') {
     }
 
     task execute(type:JavaExec) {
-       main = System.getProperty('mainClass')
+       mainClass = System.getProperty('mainClass')
        classpath = sourceSets.main.runtimeClasspath
     }
 }

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/build.gradle
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/build.gradle
@@ -83,8 +83,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
 
     publishing {
         publications {
@@ -96,7 +98,7 @@ if(hasProperty('target') && target == 'android') {
     }
 
     task execute(type:JavaExec) {
-       main = System.getProperty('mainClass')
+       mainClass = System.getProperty('mainClass')
        classpath = sourceSets.main.runtimeClasspath
     }
 }

--- a/samples/client/petstore/java/okhttp-gson-swagger1/build.gradle
+++ b/samples/client/petstore/java/okhttp-gson-swagger1/build.gradle
@@ -83,8 +83,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
 
     publishing {
         publications {
@@ -96,7 +98,7 @@ if(hasProperty('target') && target == 'android') {
     }
 
     task execute(type:JavaExec) {
-       main = System.getProperty('mainClass')
+       mainClass = System.getProperty('mainClass')
        classpath = sourceSets.main.runtimeClasspath
     }
 }

--- a/samples/client/petstore/java/okhttp-gson-swagger2/build.gradle
+++ b/samples/client/petstore/java/okhttp-gson-swagger2/build.gradle
@@ -83,8 +83,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
 
     publishing {
         publications {
@@ -96,7 +98,7 @@ if(hasProperty('target') && target == 'android') {
     }
 
     task execute(type:JavaExec) {
-       main = System.getProperty('mainClass')
+       mainClass = System.getProperty('mainClass')
        classpath = sourceSets.main.runtimeClasspath
     }
 }

--- a/samples/client/petstore/java/okhttp-gson/build.gradle
+++ b/samples/client/petstore/java/okhttp-gson/build.gradle
@@ -83,8 +83,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
 
     publishing {
         publications {
@@ -96,7 +98,7 @@ if(hasProperty('target') && target == 'android') {
     }
 
     task execute(type:JavaExec) {
-       main = System.getProperty('mainClass')
+       mainClass = System.getProperty('mainClass')
        classpath = sourceSets.main.runtimeClasspath
     }
 }

--- a/samples/client/petstore/java/rest-assured-jackson/build.gradle
+++ b/samples/client/petstore/java/rest-assured-jackson/build.gradle
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
 
     publishing {
         publications {
@@ -91,7 +93,7 @@ if(hasProperty('target') && target == 'android') {
     }
 
     task execute(type:JavaExec) {
-       main = System.getProperty('mainClass')
+       mainClass = System.getProperty('mainClass')
        classpath = sourceSets.main.runtimeClasspath
     }
 }

--- a/samples/client/petstore/java/rest-assured/build.gradle
+++ b/samples/client/petstore/java/rest-assured/build.gradle
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
 
     publishing {
         publications {
@@ -91,7 +93,7 @@ if(hasProperty('target') && target == 'android') {
     }
 
     task execute(type:JavaExec) {
-       main = System.getProperty('mainClass')
+       mainClass = System.getProperty('mainClass')
        classpath = sourceSets.main.runtimeClasspath
     }
 }

--- a/samples/client/petstore/java/restclient-nullable-arrays/build.gradle
+++ b/samples/client/petstore/java/restclient-nullable-arrays/build.gradle
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    java {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
 
     publishing {
         publications {

--- a/samples/client/petstore/java/restclient-springBoot4-jackson2/build.gradle
+++ b/samples/client/petstore/java/restclient-springBoot4-jackson2/build.gradle
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    java {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
 
     publishing {
         publications {

--- a/samples/client/petstore/java/restclient-springBoot4-jackson3-jspecify/build.gradle
+++ b/samples/client/petstore/java/restclient-springBoot4-jackson3-jspecify/build.gradle
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    java {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
 
     publishing {
         publications {

--- a/samples/client/petstore/java/restclient-springBoot4-jackson3/build.gradle
+++ b/samples/client/petstore/java/restclient-springBoot4-jackson3/build.gradle
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    java {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
 
     publishing {
         publications {

--- a/samples/client/petstore/java/restclient-swagger2/build.gradle
+++ b/samples/client/petstore/java/restclient-swagger2/build.gradle
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    java {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
 
     publishing {
         publications {

--- a/samples/client/petstore/java/restclient-useSingleRequestParameter-static/build.gradle
+++ b/samples/client/petstore/java/restclient-useSingleRequestParameter-static/build.gradle
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    java {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
 
     publishing {
         publications {

--- a/samples/client/petstore/java/restclient-useSingleRequestParameter/build.gradle
+++ b/samples/client/petstore/java/restclient-useSingleRequestParameter/build.gradle
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    java {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
 
     publishing {
         publications {

--- a/samples/client/petstore/java/restclient/build.gradle
+++ b/samples/client/petstore/java/restclient/build.gradle
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    java {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
 
     publishing {
         publications {

--- a/samples/client/petstore/java/resteasy/build.gradle
+++ b/samples/client/petstore/java/resteasy/build.gradle
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
 
     publishing {
         publications {
@@ -91,7 +93,7 @@ if(hasProperty('target') && target == 'android') {
     }
 
     task execute(type:JavaExec) {
-       main = System.getProperty('mainClass')
+       mainClass = System.getProperty('mainClass')
        classpath = sourceSets.main.runtimeClasspath
     }
 }

--- a/samples/client/petstore/java/resttemplate-jakarta/build.gradle
+++ b/samples/client/petstore/java/resttemplate-jakarta/build.gradle
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    java {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
 
     publishing {
         publications {

--- a/samples/client/petstore/java/resttemplate-springBoot4-jackson2/build.gradle
+++ b/samples/client/petstore/java/resttemplate-springBoot4-jackson2/build.gradle
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    java {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
 
     publishing {
         publications {

--- a/samples/client/petstore/java/resttemplate-springBoot4-jackson3-jspecify/build.gradle
+++ b/samples/client/petstore/java/resttemplate-springBoot4-jackson3-jspecify/build.gradle
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    java {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
 
     publishing {
         publications {

--- a/samples/client/petstore/java/resttemplate-springBoot4-jackson3/build.gradle
+++ b/samples/client/petstore/java/resttemplate-springBoot4-jackson3/build.gradle
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    java {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
 
     publishing {
         publications {

--- a/samples/client/petstore/java/resttemplate-swagger1/build.gradle
+++ b/samples/client/petstore/java/resttemplate-swagger1/build.gradle
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
 
     publishing {
         publications {

--- a/samples/client/petstore/java/resttemplate-swagger2/build.gradle
+++ b/samples/client/petstore/java/resttemplate-swagger2/build.gradle
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
 
     publishing {
         publications {

--- a/samples/client/petstore/java/resttemplate-withXml/build.gradle
+++ b/samples/client/petstore/java/resttemplate-withXml/build.gradle
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
 
     publishing {
         publications {

--- a/samples/client/petstore/java/resttemplate/build.gradle
+++ b/samples/client/petstore/java/resttemplate/build.gradle
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
 
     publishing {
         publications {

--- a/samples/client/petstore/java/retrofit2-play26/build.gradle
+++ b/samples/client/petstore/java/retrofit2-play26/build.gradle
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
 
     publishing {
         publications {
@@ -91,7 +93,7 @@ if(hasProperty('target') && target == 'android') {
     }
 
     task execute(type:JavaExec) {
-       main = System.getProperty('mainClass')
+       mainClass = System.getProperty('mainClass')
        classpath = sourceSets.main.runtimeClasspath
     }
 }

--- a/samples/client/petstore/java/retrofit2/build.gradle
+++ b/samples/client/petstore/java/retrofit2/build.gradle
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
 
     publishing {
         publications {
@@ -91,7 +93,7 @@ if(hasProperty('target') && target == 'android') {
     }
 
     task execute(type:JavaExec) {
-       main = System.getProperty('mainClass')
+       mainClass = System.getProperty('mainClass')
        classpath = sourceSets.main.runtimeClasspath
     }
 }

--- a/samples/client/petstore/java/retrofit2rx2/build.gradle
+++ b/samples/client/petstore/java/retrofit2rx2/build.gradle
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
 
     publishing {
         publications {
@@ -91,7 +93,7 @@ if(hasProperty('target') && target == 'android') {
     }
 
     task execute(type:JavaExec) {
-       main = System.getProperty('mainClass')
+       mainClass = System.getProperty('mainClass')
        classpath = sourceSets.main.runtimeClasspath
     }
 }

--- a/samples/client/petstore/java/retrofit2rx3/build.gradle
+++ b/samples/client/petstore/java/retrofit2rx3/build.gradle
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
 
     publishing {
         publications {
@@ -91,7 +93,7 @@ if(hasProperty('target') && target == 'android') {
     }
 
     task execute(type:JavaExec) {
-       main = System.getProperty('mainClass')
+       mainClass = System.getProperty('mainClass')
        classpath = sourceSets.main.runtimeClasspath
     }
 }

--- a/samples/client/petstore/java/vertx-no-nullable/build.gradle
+++ b/samples/client/petstore/java/vertx-no-nullable/build.gradle
@@ -11,8 +11,10 @@ repositories {
 apply plugin: 'java'
 apply plugin: 'maven-publish'
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
 
 publishing {
     publications {
@@ -24,7 +26,7 @@ publishing {
 }
 
 task execute(type:JavaExec) {
-   main = System.getProperty('mainClass')
+   mainClass = System.getProperty('mainClass')
    classpath = sourceSets.main.runtimeClasspath
 }
 

--- a/samples/client/petstore/java/vertx-supportVertxFuture/build.gradle
+++ b/samples/client/petstore/java/vertx-supportVertxFuture/build.gradle
@@ -11,8 +11,10 @@ repositories {
 apply plugin: 'java'
 apply plugin: 'maven-publish'
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
 
 publishing {
     publications {
@@ -24,7 +26,7 @@ publishing {
 }
 
 task execute(type:JavaExec) {
-   main = System.getProperty('mainClass')
+   mainClass = System.getProperty('mainClass')
    classpath = sourceSets.main.runtimeClasspath
 }
 

--- a/samples/client/petstore/java/vertx/build.gradle
+++ b/samples/client/petstore/java/vertx/build.gradle
@@ -11,8 +11,10 @@ repositories {
 apply plugin: 'java'
 apply plugin: 'maven-publish'
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
 
 publishing {
     publications {
@@ -24,7 +26,7 @@ publishing {
 }
 
 task execute(type:JavaExec) {
-   main = System.getProperty('mainClass')
+   mainClass = System.getProperty('mainClass')
    classpath = sourceSets.main.runtimeClasspath
 }
 

--- a/samples/client/petstore/java/vertx5-supportVertxFuture/build.gradle
+++ b/samples/client/petstore/java/vertx5-supportVertxFuture/build.gradle
@@ -11,8 +11,10 @@ repositories {
 apply plugin: 'java'
 apply plugin: 'maven-publish'
 
-sourceCompatibility = JavaVersion.VERSION_11
-targetCompatibility = JavaVersion.VERSION_11
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}
 
 publishing {
     publications {
@@ -24,7 +26,7 @@ publishing {
 }
 
 task execute(type:JavaExec) {
-   main = System.getProperty('mainClass')
+   mainClass = System.getProperty('mainClass')
    classpath = sourceSets.main.runtimeClasspath
 }
 

--- a/samples/client/petstore/java/vertx5/build.gradle
+++ b/samples/client/petstore/java/vertx5/build.gradle
@@ -11,8 +11,10 @@ repositories {
 apply plugin: 'java'
 apply plugin: 'maven-publish'
 
-sourceCompatibility = JavaVersion.VERSION_11
-targetCompatibility = JavaVersion.VERSION_11
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}
 
 publishing {
     publications {
@@ -24,7 +26,7 @@ publishing {
 }
 
 task execute(type:JavaExec) {
-   main = System.getProperty('mainClass')
+   mainClass = System.getProperty('mainClass')
    classpath = sourceSets.main.runtimeClasspath
 }
 

--- a/samples/client/petstore/java/webclient-jakarta/build.gradle
+++ b/samples/client/petstore/java/webclient-jakarta/build.gradle
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    java {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
 
     publishing {
         publications {

--- a/samples/client/petstore/java/webclient-nullable-arrays/build.gradle
+++ b/samples/client/petstore/java/webclient-nullable-arrays/build.gradle
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
 
     publishing {
         publications {

--- a/samples/client/petstore/java/webclient-springBoot4-jackson3-jspecify/build.gradle
+++ b/samples/client/petstore/java/webclient-springBoot4-jackson3-jspecify/build.gradle
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    java {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
 
     publishing {
         publications {

--- a/samples/client/petstore/java/webclient-springBoot4-jackson3/build.gradle
+++ b/samples/client/petstore/java/webclient-springBoot4-jackson3/build.gradle
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    java {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
 
     publishing {
         publications {

--- a/samples/client/petstore/java/webclient-swagger2/build.gradle
+++ b/samples/client/petstore/java/webclient-swagger2/build.gradle
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
 
     publishing {
         publications {

--- a/samples/client/petstore/java/webclient-useSingleRequestParameter/build.gradle
+++ b/samples/client/petstore/java/webclient-useSingleRequestParameter/build.gradle
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
 
     publishing {
         publications {

--- a/samples/client/petstore/java/webclient/build.gradle
+++ b/samples/client/petstore/java/webclient/build.gradle
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
 
     publishing {
         publications {

--- a/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/build.gradle
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/build.gradle
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
 
     apply plugin: 'java'
     apply plugin: 'maven-publish'
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
 
     publishing {
         publications {
@@ -92,7 +94,7 @@ if(hasProperty('target') && target == 'android') {
     }
 
     task execute(type:JavaExec) {
-       main = System.getProperty('mainClass')
+       mainClass = System.getProperty('mainClass')
        classpath = sourceSets.main.runtimeClasspath
     }
 }

--- a/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/build.gradle
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/build.gradle
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
 
     apply plugin: 'java'
     apply plugin: 'maven-publish'
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
 
     publishing {
         publications {
@@ -92,7 +94,7 @@ if(hasProperty('target') && target == 'android') {
     }
 
     task execute(type:JavaExec) {
-       main = System.getProperty('mainClass')
+       mainClass = System.getProperty('mainClass')
        classpath = sourceSets.main.runtimeClasspath
     }
 }

--- a/samples/openapi3/client/petstore/java/jersey2-java8-swagger1/build.gradle
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-swagger1/build.gradle
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
 
     apply plugin: 'java'
     apply plugin: 'maven-publish'
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
 
     publishing {
         publications {
@@ -92,7 +94,7 @@ if(hasProperty('target') && target == 'android') {
     }
 
     task execute(type:JavaExec) {
-       main = System.getProperty('mainClass')
+       mainClass = System.getProperty('mainClass')
        classpath = sourceSets.main.runtimeClasspath
     }
 }

--- a/samples/openapi3/client/petstore/java/jersey2-java8-swagger2/build.gradle
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-swagger2/build.gradle
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
 
     apply plugin: 'java'
     apply plugin: 'maven-publish'
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
 
     publishing {
         publications {
@@ -92,7 +94,7 @@ if(hasProperty('target') && target == 'android') {
     }
 
     task execute(type:JavaExec) {
-       main = System.getProperty('mainClass')
+       mainClass = System.getProperty('mainClass')
        classpath = sourceSets.main.runtimeClasspath
     }
 }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/build.gradle
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/build.gradle
@@ -78,8 +78,10 @@ if(hasProperty('target') && target == 'android') {
 
     apply plugin: 'java'
     apply plugin: 'maven-publish'
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
 
     publishing {
         publications {
@@ -92,7 +94,7 @@ if(hasProperty('target') && target == 'android') {
     }
 
     task execute(type:JavaExec) {
-       main = System.getProperty('mainClass')
+       mainClass = System.getProperty('mainClass')
        classpath = sourceSets.main.runtimeClasspath
     }
 }


### PR DESCRIPTION
## Description

Gradle 9 removed the implicit `Project.sourceCompatibility` / `targetCompatibility` convenience properties (previously provided via Groovy convention mapping) as well as `JavaExec.main`. The Java client `build.gradle.mustache` templates still used both directly, so **every generated Gradle project failed to even configure** under Gradle 9:

```
FAILURE: Build failed with an exception.

* Where:
Build file '.../build.gradle' line: 81

* What went wrong:
A problem occurred evaluating root project 'client'.
> Could not set unknown property 'sourceCompatibility' for root project 'client' of type org.gradle.api.Project.
```

This matches the reproduction and suggested fix in #22084, where @wing328 asked for a PR implementing exactly this template update.

### Fix

- Wrapped `sourceCompatibility` / `targetCompatibility` in a `java { }` extension block (valid on Gradle 4+ through 9) instead of assigning them as top-level project properties, across all Java client libraries: default, `apache-httpclient`, `feign`, `google-api-client`, `jersey2`, `jersey3`, `native`, `okhttp-gson`, `rest-assured`, `resteasy`, `retrofit2`, `vertx`.
- While verifying a full Gradle 9 build of each library, found a second, closely related Gradle 9 removal in the same templates: the `execute` task's `main = System.getProperty('mainClass')` (`JavaExec.main` was removed in Gradle 9, replaced by `mainClass`). Renamed it to `mainClass` in the same set of libraries (`webclient`, `resttemplate`, and `restclient` already used `mainClass` and were unaffected).

### Verification done

- Rebuilt `openapi-generator-cli` from source and generated a sample client for every affected library (`resttemplate`, `webclient`, `okhttp-gson`, `jersey3`, `native`, `feign`, `retrofit2`, `apache-httpclient`, `rest-assured`, `google-api-client`, `resteasy`, `jersey2`, `restclient`, `vertx`), including the `useJackson3`/`java17`/`useJakartaEe`/`useVertx5` conditional branches.
- Reproduced the exact reported failure against a real **Gradle 9.0.0** distribution on the unfixed template (`Could not set unknown property 'sourceCompatibility'`), then confirmed `compileJava` now succeeds with the fix on 11/13 libraries out of the box. The remaining 2 (`resteasy`, `vertx`) fail only on an unrelated, pre-existing dependency resolution problem (a pinned `jackson_version` that doesn't correspond to a published artifact) — unrelated to this fix and reproducible identically before/after this change.
- `./mvnw -pl modules/openapi-generator -am test -Dtest=JavaClientCodegenTest -Dsurefire.failIfNoSpecifiedTests=false` → 265 tests, 0 failures/errors.
- Regenerated all 88 affected sample configs via `./bin/generate-samples.sh` and confirmed the resulting `samples/**/build.gradle` diffs contain exactly this change (no unrelated drift).

Fixes #22084

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make generated Java clients compatible with Gradle 9 by moving Java version settings into the `java {}` block and replacing `JavaExec.main` with `mainClass`. Projects now configure and build on Gradle 9 without errors (fixes #22084).

- **Bug Fixes**
  - Wrapped `sourceCompatibility`/`targetCompatibility` in a `java {}` extension across all Java client templates (works on Gradle 4–9).
  - Renamed `JavaExec.main` to `mainClass` in `execute` tasks where needed; templates already using `mainClass` were unchanged.

<sup>Written for commit 981a41ec08eacb9c7c6294e4462fbe7ec2efe04c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24649?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

