### PR TITLE
refactor: unify handling of content examples parsing

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
@@ -481,6 +481,7 @@ public class CodegenConstants {
     public static final String ENUM_DESCRIPTION = "enumDescription";
 
     // Vendor extensions
+    public static final String X_EXAMPLE = "x-example";
     public static final String X_INTERNAL = "x-internal";
     public static final String X_PARENT = "x-parent";
     public static final String X_COMPOSED_DATA_TYPE = "x-composed-data-type";

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -2115,8 +2115,8 @@ public class DefaultCodegen implements CodegenConfig {
         // set the example value
         // if not specified in x-example, generate a default value
         // TODO need to revise how to obtain the example value
-        if (codegenParameter.vendorExtensions != null && codegenParameter.vendorExtensions.containsKey("x-example")) {
-            codegenParameter.example = Json.pretty(codegenParameter.vendorExtensions.get("x-example"));
+        if (codegenParameter.vendorExtensions != null && codegenParameter.vendorExtensions.containsKey(X_EXAMPLE)) {
+            codegenParameter.example = Json.pretty(codegenParameter.vendorExtensions.get(X_EXAMPLE));
         } else if (codegenParameter.isBoolean) {
             codegenParameter.example = "true";
         } else if (codegenParameter.isLong) {
@@ -2201,23 +2201,11 @@ public class DefaultCodegen implements CodegenConfig {
     public void setParameterExampleValue(CodegenParameter codegenParameter, RequestBody requestBody) {
         Content content = requestBody.getContent();
 
-        if (content.size() > 1) {
-            // @see ModelUtils.getSchemaFromContent()
-            once(LOGGER).debug("Multiple MediaTypes found, using only the first one");
-        }
+        Optional<Object> contentExample = ExamplesUtils.getContentExample(content);
 
-        MediaType mediaType = content.values().iterator().next();
-        if (mediaType.getExample() != null) {
-            codegenParameter.example = mediaType.getExample().toString();
+        if (contentExample.isPresent()) {
+            codegenParameter.example = contentExample.get().toString();
             return;
-        }
-
-        if (mediaType.getExamples() != null && !mediaType.getExamples().isEmpty()) {
-            Example example = mediaType.getExamples().values().iterator().next();
-            if (example.getValue() != null) {
-                codegenParameter.example = example.getValue().toString();
-                return;
-            }
         }
 
         setParameterExampleValue(codegenParameter);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractFSharpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractFSharpCodegen.java
@@ -39,6 +39,7 @@ import java.util.*;
 
 import static org.openapitools.codegen.CodegenConstants.ENUM_VARS;
 import static org.openapitools.codegen.CodegenConstants.X_ENUM_BYTE;
+import static org.openapitools.codegen.CodegenConstants.X_EXAMPLE;
 import static org.openapitools.codegen.utils.CamelizeOption.LOWERCASE_FIRST_LETTER;
 import static org.openapitools.codegen.utils.EnumUtils.getEnumVarsAsString;
 import static org.openapitools.codegen.utils.StringUtils.camelize;
@@ -1006,8 +1007,8 @@ public abstract class AbstractFSharpCodegen extends DefaultCodegen implements Co
         // set the example value
         // if not specified in x-example, generate a default value
         // TODO need to revise how to obtain the example value
-        if (codegenParameter.vendorExtensions != null && codegenParameter.vendorExtensions.containsKey("x-example")) {
-            codegenParameter.example = Json.pretty(codegenParameter.vendorExtensions.get("x-example"));
+        if (codegenParameter.vendorExtensions != null && codegenParameter.vendorExtensions.containsKey(X_EXAMPLE)) {
+            codegenParameter.example = Json.pretty(codegenParameter.vendorExtensions.get(X_EXAMPLE));
         } else if (Boolean.TRUE.equals(codegenParameter.isBoolean)) {
             codegenParameter.example = "true";
         } else if (Boolean.TRUE.equals(codegenParameter.isLong)) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -30,7 +30,6 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.PathItem;
 import io.swagger.v3.oas.models.examples.Example;
-import io.swagger.v3.oas.models.media.Content;
 import io.swagger.v3.oas.models.media.MediaType;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.media.StringSchema;
@@ -1764,36 +1763,16 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
     public void setParameterExampleValue(CodegenParameter codegenParameter, RequestBody requestBody) {
         boolean isModel = (codegenParameter.isModel || (codegenParameter.isContainer && codegenParameter.getItems().isModel));
 
-        Content content = requestBody.getContent();
-
-        if (content.size() > 1) {
-            // @see ModelUtils.getSchemaFromContent()
-            LOGGER.debug("Multiple MediaTypes found, using only the first one");
-        }
-
-        MediaType mediaType = content.values().iterator().next();
-        if (mediaType.getExample() != null) {
-            if (isModel) {
+        MediaType mediaType = requestBody.getContent().values().iterator().next();
+        boolean hasExample = mediaType.getExample() != null || (mediaType.getExamples() != null && !mediaType.getExamples().isEmpty());
+        if (isModel) {
+            if (hasExample) {
                 once(LOGGER).warn("Ignoring complex example on request body");
-            } else {
-                codegenParameter.example = mediaType.getExample().toString();
-                return;
             }
+            setParameterExampleValue(codegenParameter);
+        } else {
+            super.setParameterExampleValue(codegenParameter, requestBody);
         }
-
-        if (mediaType.getExamples() != null && !mediaType.getExamples().isEmpty()) {
-            Example example = mediaType.getExamples().values().iterator().next();
-            if (example.getValue() != null) {
-                if (isModel) {
-                    once(LOGGER).warn("Ignoring complex example on request body");
-                } else {
-                    codegenParameter.example = example.getValue().toString();
-                    return;
-                }
-            }
-        }
-
-        setParameterExampleValue(codegenParameter);
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
@@ -1087,8 +1087,8 @@ public class RustServerCodegen extends AbstractRustCodegen implements CodegenCon
             codegenParameter.isByteArray = ModelUtils.isByteArraySchema(original_schema);
 
             // This is a model, so should only have an example if explicitly defined.
-            if (codegenParameter.vendorExtensions != null && codegenParameter.vendorExtensions.containsKey("x-example")) {
-                codegenParameter.example = Json.pretty(codegenParameter.vendorExtensions.get("x-example"));
+            if (codegenParameter.vendorExtensions != null && codegenParameter.vendorExtensions.containsKey(X_EXAMPLE)) {
+                codegenParameter.example = Json.pretty(codegenParameter.vendorExtensions.get(X_EXAMPLE));
             } else if (!codegenParameter.required) {
                 //mandatory parameter use the example in the yaml. if no example, it is also null.
                 codegenParameter.example = null;
@@ -1784,24 +1784,24 @@ public class RustServerCodegen extends AbstractRustCodegen implements CodegenCon
 
         if (param.required) {
             if (example != null) {
-                param.vendorExtensions.put("x-example", example);
+                param.vendorExtensions.put(X_EXAMPLE, example);
             } else if (param.isArray) {
                 // Use the empty list if we don't have an example
-                param.vendorExtensions.put("x-example", "&Vec::new()");
+                param.vendorExtensions.put(X_EXAMPLE, "&Vec::new()");
             } else {
                 // If we don't have an example that we can provide, we need to disable the client example, as it won't build.
-                param.vendorExtensions.put("x-example", "???");
+                param.vendorExtensions.put(X_EXAMPLE, "???");
                 op.vendorExtensions.put("x-no-client-example", Boolean.TRUE);
             }
         } else if ((param.dataFormat != null) && (("date-time".equals(param.dataFormat)) || ("date".equals(param.dataFormat)))) {
             param.vendorExtensions.put("x-format-string", "{:?}");
-            param.vendorExtensions.put("x-example", "None");
+            param.vendorExtensions.put(X_EXAMPLE, "None");
         } else {
             // Not required, so override the format string and example
             boolean itemsAreEnum = param.isArray && param.items != null && param.items.getIsEnumOrRef();
             param.vendorExtensions.put("x-format-string", (param.getIsEnumOrRef() || itemsAreEnum) ? "{}" : "{:?}");
             String exampleString = (example != null) ? "Some(" + example + ")" : "None";
-            param.vendorExtensions.put("x-example", exampleString);
+            param.vendorExtensions.put(X_EXAMPLE, exampleString);
         }
 
         // Add a vendor extension to flag if this can have validate() run on it.

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegenDeprecated.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegenDeprecated.java
@@ -48,8 +48,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import static org.openapitools.codegen.CodegenConstants.ENUM_VALUES;
 import static org.openapitools.codegen.CodegenConstants.X_ONE_OF_NAME;
+import static org.openapitools.codegen.CodegenConstants.X_EXAMPLE;
 import static org.openapitools.codegen.utils.EnumUtils.getEnumValues;
 import static org.openapitools.codegen.utils.EnumUtils.hasEnumValues;
 import static org.openapitools.codegen.utils.StringUtils.camelize;
@@ -1028,8 +1028,8 @@ public class RustServerCodegenDeprecated extends AbstractRustCodegen implements 
 
             // This is a model, so should only have an example if explicitly
             // defined.
-            if (codegenParameter.vendorExtensions != null && codegenParameter.vendorExtensions.containsKey("x-example")) {
-                codegenParameter.example = Json.pretty(codegenParameter.vendorExtensions.get("x-example"));
+            if (codegenParameter.vendorExtensions != null && codegenParameter.vendorExtensions.containsKey(X_EXAMPLE)) {
+                codegenParameter.example = Json.pretty(codegenParameter.vendorExtensions.get(X_EXAMPLE));
             } else if (!codegenParameter.required) {
                 //mandatory parameter use the example in the yaml. if no example, it is also null.
                 codegenParameter.example = null;
@@ -1583,23 +1583,23 @@ public class RustServerCodegenDeprecated extends AbstractRustCodegen implements 
 
         if (param.required) {
             if (example != null) {
-                param.vendorExtensions.put("x-example", example);
+                param.vendorExtensions.put(X_EXAMPLE, example);
             } else if (param.isArray) {
                 // Use the empty list if we don't have an example
-                param.vendorExtensions.put("x-example", "&Vec::new()");
+                param.vendorExtensions.put(X_EXAMPLE, "&Vec::new()");
             } else {
                 // If we don't have an example that we can provide, we need to disable the client example, as it won't build.
-                param.vendorExtensions.put("x-example", "???");
+                param.vendorExtensions.put(X_EXAMPLE, "???");
                 op.vendorExtensions.put("x-no-client-example", Boolean.TRUE);
             }
         } else if ((param.dataFormat != null) && (("date-time".equals(param.dataFormat)) || ("date".equals(param.dataFormat)))) {
             param.vendorExtensions.put("x-format-string", "{:?}");
-            param.vendorExtensions.put("x-example", "None");
+            param.vendorExtensions.put(X_EXAMPLE, "None");
         } else {
             // Not required, so override the format string and example
             param.vendorExtensions.put("x-format-string", "{:?}");
             String exampleString = (example != null) ? "Some(" + example + ")" : "None";
-            param.vendorExtensions.put("x-example", exampleString);
+            param.vendorExtensions.put(X_EXAMPLE, exampleString);
         }
     }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptClientCodegen.java
@@ -39,6 +39,7 @@ import org.openapitools.codegen.model.ModelMap;
 import org.openapitools.codegen.model.ModelsMap;
 import org.openapitools.codegen.model.OperationMap;
 import org.openapitools.codegen.model.OperationsMap;
+import org.openapitools.codegen.utils.ExamplesUtils;
 import org.openapitools.codegen.utils.ModelUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,6 +52,7 @@ import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static org.openapitools.codegen.CodegenConstants.X_EXAMPLE;
 import static org.openapitools.codegen.utils.CamelizeOption.LOWERCASE_FIRST_LETTER;
 import static org.openapitools.codegen.utils.OnceLogger.once;
 import static org.openapitools.codegen.utils.StringUtils.camelize;
@@ -1060,8 +1062,8 @@ public class TypeScriptClientCodegen extends AbstractTypeScriptClientCodegen imp
         }
 
         Object example = null;
-        if (codegenParameter.vendorExtensions != null && codegenParameter.vendorExtensions.containsKey("x-example")) {
-            example = codegenParameter.vendorExtensions.get("x-example");
+        if (codegenParameter.vendorExtensions != null && codegenParameter.vendorExtensions.containsKey(X_EXAMPLE)) {
+            example = codegenParameter.vendorExtensions.get(X_EXAMPLE);
         } else if (parameter.getExample() != null) {
             example = parameter.getExample();
         } else if (parameter.getExamples() != null && !parameter.getExamples().isEmpty() && parameter.getExamples().values().iterator().next().getValue() != null) {
@@ -1082,16 +1084,13 @@ public class TypeScriptClientCodegen extends AbstractTypeScriptClientCodegen imp
      */
     @Override
     public void setParameterExampleValue(CodegenParameter codegenParameter, RequestBody requestBody) {
-        if (codegenParameter.vendorExtensions != null && codegenParameter.vendorExtensions.containsKey("x-example")) {
-            codegenParameter.example = Json.pretty(codegenParameter.vendorExtensions.get("x-example"));
+        if (codegenParameter.vendorExtensions != null && codegenParameter.vendorExtensions.containsKey(X_EXAMPLE)) {
+            codegenParameter.example = Json.pretty(codegenParameter.vendorExtensions.get(X_EXAMPLE));
         }
 
         Content content = requestBody.getContent();
 
-        if (content.size() > 1) {
-            // @see ModelUtils.getSchemaFromContent()
-            once(LOGGER).debug("Multiple MediaTypes found, using only the first one");
-        }
+        Optional<Object> contentExample = ExamplesUtils.getContentExample(content);
 
         MediaType mediaType = content.values().iterator().next();
         Schema schema = mediaType.getSchema();
@@ -1100,14 +1099,7 @@ public class TypeScriptClientCodegen extends AbstractTypeScriptClientCodegen imp
             return;
         }
 
-        Object example = null;
-        if (mediaType.getExample() != null) {
-            example = mediaType.getExample();
-        } else if (mediaType.getExamples() != null && !mediaType.getExamples().isEmpty() && mediaType.getExamples().values().iterator().next().getValue() != null) {
-            example = mediaType.getExamples().values().iterator().next().getValue();
-        } else {
-            example = getObjectExample(schema);
-        }
+        Object example = contentExample.orElseGet(() -> getObjectExample(schema));
         example = exampleFromStringOrArraySchema(schema, example, codegenParameter.paramName);
         codegenParameter.example = toExampleValue(schema, example);
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ExamplesUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ExamplesUtils.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.examples.Example;
 import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.parameters.RequestBody;
 import io.swagger.v3.oas.models.responses.ApiResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,6 +35,36 @@ public class ExamplesUtils {
         } else {
             return getExamplesFromContent(result.getContent());
         }
+    }
+
+    /**
+     * Returns the example object for a request body. Note that the current implementation only fetches the first example
+     * found. If there are an {@code example} defined, then {@code examples} is not considered.
+     * <p>
+     * Only the first media type is considered.
+     * @see ModelUtils#getSchemaFromRequestBody(RequestBody)
+     * @see ModelUtils#getSchemaFromResponse(OpenAPI, ApiResponse)
+     *
+     * @param content The request body content
+     * @return The first example found, or an empty optional if no example is found
+     */
+    public static Optional<Object> getContentExample(Content content) {
+        if (content.size() > 1) {
+            once(LOGGER).debug("Multiple MediaTypes found, using only the first one");
+        }
+
+        MediaType mediaType = content.values().iterator().next();
+        if (mediaType.getExample() != null) {
+            return Optional.of(mediaType.getExample());
+        }
+
+        if (mediaType.getExamples() != null && !mediaType.getExamples().isEmpty()) {
+            Example example = mediaType.getExamples().values().iterator().next();
+            if (example.getValue() != null) {
+                return Optional.of(example.getValue());
+            }
+        }
+        return Optional.empty();
     }
 
     private static Map<String, Example> getExamplesFromContent(Content content) {


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

I saw https://github.com/OpenAPITools/openapi-generator/pull/24651 that changes what request body example structure that is propagated to the mustache template. It only changed `AbstractJavaCodegen` rather than `DefaultCodegen`, so I got curious regarding why this was the case. I would expect this change to be of interest to all generators. The reason seemed to be that `Java` overrode the default to some extent.

I have analyzed the structure and found that the generators still have almost everything in common, and that one is basically just the extension of the other. I have thus centralized the logic in the existing `ExamplesUtils`, and then used that in the different implementers. The reason for this is to ensure that all generators will benefit from improvements when they are introduced (e.g., all only read the first media type, but if someone introduces so that all are read, then that is also something all generators will want to be able to utilize).

This PR also centralized the definition of the reoccurring `x-example` vendor extension.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies request body example parsing by centralizing logic in `ExamplesUtils.getContentExample`. Standardizes the `x-example` vendor extension with `CodegenConstants.X_EXAMPLE` for consistent behavior and logging.

- **Refactors**
  - Centralizes content example extraction in `ExamplesUtils.getContentExample` and uses it in `DefaultCodegen` and `TypeScriptClientCodegen`; `AbstractJavaCodegen` keeps model behavior (warn and ignore complex examples) and delegates to shared logic for primitives.
  - Replaces literal `"x-example"` with `CodegenConstants.X_EXAMPLE` in `DefaultCodegen`, `AbstractJavaCodegen`, `AbstractFSharpCodegen`, `TypeScriptClientCodegen`, `RustServerCodegen`, and `RustServerCodegenDeprecated`.
  - Considers only the first media type when resolving examples; the single debug log now lives in `ExamplesUtils`.

<sup>Written for commit ba4d18ed5ad2d71468e5f979f9886dee548eb87b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24653?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

