### PR TITLE
Minor enhancements to java dubbo server generator

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaDubboServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaDubboServerCodegen.java
@@ -157,7 +157,6 @@ public class JavaDubboServerCodegen extends AbstractJavaCodegen {
         typeMapping.put("uuid", "UUID");
         typeMapping.put("byte", "byte[]");
         typeMapping.put("ByteArray", "byte[]");
-        typeMapping.put("binary", "byte[]");
         typeMapping.put("password", "String");
 
         languageSpecificPrimitives.clear();
@@ -273,13 +272,6 @@ public class JavaDubboServerCodegen extends AbstractJavaCodegen {
             }
         }
 
-        return outputFolder;
-    }
-
-    public String getIgnoreFileOutputPath() {
-        if (isOutputFolderPointingToSourceDirectory()) {
-            return outputFolder + File.separator + ".." + File.separator + ".." + File.separator + "..";
-        }
         return outputFolder;
     }
 
@@ -405,7 +397,6 @@ public class JavaDubboServerCodegen extends AbstractJavaCodegen {
             if (isUserTitle) {
                 String titleName = (String) additionalProperties.get(TITLE);
                 mainClassName = (camelize(titleName.trim(), CamelizeOption.UPPERCASE_FIRST_CHAR) + "Application").replaceAll("\\s+", "");
-                ;
             } else {
                 mainClassName = "OpenApiGeneratorApplication";
             }
@@ -466,7 +457,7 @@ public class JavaDubboServerCodegen extends AbstractJavaCodegen {
                 return major > 3 || (major == 3 && minor >= 3);
             }
         } catch (NumberFormatException e) {
-            LOGGER.warn("Unable to parse Dubbo version: " + version);
+            LOGGER.warn("Unable to parse Dubbo version: {}", version);
         }
 
         return false;
@@ -608,17 +599,6 @@ public class JavaDubboServerCodegen extends AbstractJavaCodegen {
         return baseFolder;
     }
 
-    public String getPackageForTemplate(String templateName) {
-        if ("api.mustache".equals(templateName)) {
-            return apiPackage() + ".interfaces";
-        } else if ("apiController.mustache".equals(templateName)) {
-            return apiPackage() + ".consumer";
-        } else if ("apiDubbo.mustache".equals(templateName)) {
-            return apiPackage() + ".provider";
-        }
-        return apiPackage();
-    }
-
     @Override
     public String modelFileFolder() {
         if (isOutputFolderPointingToSourceDirectory()) {
@@ -656,7 +636,7 @@ public class JavaDubboServerCodegen extends AbstractJavaCodegen {
 
     @Override
     public String toApiName(String name) {
-        if (name.length() == 0) {
+        if (name.isEmpty()) {
             return "DefaultService";
         }
         name = sanitizeName(name);
@@ -681,7 +661,7 @@ public class JavaDubboServerCodegen extends AbstractJavaCodegen {
                 basePath = basePath.substring(0, pos);
             }
 
-            if (basePath.length() == 0) {
+            if (basePath.isEmpty()) {
                 basePath = "default";
             } else {
                 String subPath = resourcePath;
@@ -693,7 +673,6 @@ public class JavaDubboServerCodegen extends AbstractJavaCodegen {
                 }
                 co.vendorExtensions.put("x-sub-path", subPath);
                 co.subresourceOperation = !subPath.equals("/");
-
                 co.vendorExtensions.put("x-base-path", "/" + basePath);
 
                 if ("a".equals(basePath)) {
@@ -711,18 +690,13 @@ public class JavaDubboServerCodegen extends AbstractJavaCodegen {
     }
 
     @Override
-    public boolean isDataTypeString(String dataType) {
-        return "String".equals(dataType);
-    }
-
-    @Override
     public String getTypeDeclaration(Schema p) {
         if (ModelUtils.isArraySchema(p)) {
-            Schema inner = ModelUtils.getSchemaItems(p);
+            Schema<?> inner = ModelUtils.getSchemaItems(p);
             String innerType = getTypeDeclaration(inner);
             return "List<" + innerType + ">";
         } else if (ModelUtils.isMapSchema(p)) {
-            Schema inner = ModelUtils.getAdditionalProperties(p);
+            Schema<?> inner = ModelUtils.getAdditionalProperties(p);
             String innerType = getTypeDeclaration(inner);
             return "Map<String, " + innerType + ">";
         }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Streamlined the `JavaDubboServerCodegen` by removing unused code, improving logging, and tightening type handling. Also dropped the explicit `binary` → `byte[]` mapping to rely on default behavior.

- **Refactors**
  - Removed unused methods: `getIgnoreFileOutputPath` and `getPackageForTemplate`.
  - Switched to parameterized logging for Dubbo version parsing warnings.
  - Replaced length checks with `isEmpty()` and cleaned minor redundancies.
  - Updated generics to `Schema<?>` in collection type declarations.
  - Removed redundant `isDataTypeString` override.
  - Removed explicit `typeMapping` for `binary` (defaults now apply).

<sup>Written for commit 77fc7fd4d65a412224f55333e616c86101f40674. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24660?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

