### PR TITLE
refactor: introduce EnumVarMap for improved enum handling across code generators

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
@@ -488,19 +488,6 @@ public class CodegenConstants {
     public static final String DEFAULT_TO_EMPTY_CONTAINER = "defaultToEmptyContainer";
     public static final String DEFAULT_TO_EMPTY_CONTAINER_DESC = "Initialize containers (array/set/map) to empty containers instead of null by default. Usage: https://github.com/OpenAPITools/openapi-generator/blob/master/docs/customization.md#default-values";
 
-    // The raw enum values from the OpenAPI specification
-    public static final String ENUM_VALUES = "values";
-    // The map that stores all enum values and their metadata (name, value, enumDescription...)
-    public static final String ENUM_VARS = "enumVars";
-    // The name of the enum, for example NAME("value") in Java
-    public static final String ENUM_NAME = "name";
-    // The on-the-line value, i.e., the one present in the "values"
-    public static final String ENUM_VALUE = "value";
-    // If the enum is typed as a string
-    public static final String ENUM_IS_STRING = "isString";
-    // The description that should be attached to an entry in "enumVars"
-    public static final String ENUM_DESCRIPTION = "enumDescription";
-
     // Vendor extensions
     public static final String X_EXAMPLE = "x-example";
     public static final String X_INTERNAL = "x-internal";

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -63,6 +63,7 @@ import org.openapitools.codegen.model.ModelMap;
 import org.openapitools.codegen.model.ModelsMap;
 import org.openapitools.codegen.model.OperationsMap;
 import org.openapitools.codegen.model.WebhooksMap;
+import org.openapitools.codegen.model.EnumVarMap;
 import org.openapitools.codegen.serializer.SerializerUtils;
 import org.openapitools.codegen.templating.MustacheEngineAdapter;
 import org.openapitools.codegen.templating.mustache.*;
@@ -92,6 +93,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.openapitools.codegen.CodegenConstants.*;
+import static org.openapitools.codegen.model.EnumVarMap.*;
 import static org.openapitools.codegen.utils.CamelizeOption.LOWERCASE_FIRST_LETTER;
 import static org.openapitools.codegen.utils.DiscriminatorUtils.*;
 import static org.openapitools.codegen.utils.EnumUtils.*;
@@ -901,7 +903,7 @@ public class DefaultCodegen implements CodegenConfig {
             // for enum model
             if (cm.isEnum && cm.allowableValues != null) {
                 List<Object> values = getEnumValues(cm.allowableValues);
-                List<Map<String, Object>> enumVars = buildEnumVars(values, cm.dataType);
+                List<EnumVarMap> enumVars = buildEnumVars(values, cm.dataType);
                 postProcessEnumVars(enumVars);
                 // if "x-enum-varnames" or "x-enum-descriptions" defined, update varnames
                 updateEnumVarsWithExtensions(enumVars, cm.getVendorExtensions(), cm.dataType);
@@ -7008,7 +7010,7 @@ public class DefaultCodegen implements CodegenConfig {
     }
 
     /**
-     * Update codegen property's enum by adding {@value CodegenConstants#ENUM_VARS} (with name and value)
+     * Update codegen property's enum by adding {@value EnumVarMap#ENUM_VARS} (with name and value)
      *
      * @param var list of CodegenProperty
      */
@@ -7035,7 +7037,7 @@ public class DefaultCodegen implements CodegenConfig {
                 .map(Map.Entry::getValue)
                 .findFirst();
         String dataType = (referencedSchema.isPresent()) ? getTypeDeclaration(referencedSchema.get()) : varDataType;
-        List<Map<String, Object>> enumVars = buildEnumVars(values, dataType);
+        List<EnumVarMap> enumVars = buildEnumVars(values, dataType);
         postProcessEnumVars(enumVars);
 
         // if "x-enum-varnames" or "x-enum-descriptions" defined, update varnames
@@ -7051,9 +7053,9 @@ public class DefaultCodegen implements CodegenConfig {
             final String enumDefaultValue = getEnumDefaultValue(var.defaultValue, dataType);
 
             String enumName = null;
-            for (Map<String, Object> enumVar : enumVars) {
-                if (enumDefaultValue.equals(enumVar.get(ENUM_VALUE))) {
-                    enumName = (String) enumVar.get(ENUM_NAME);
+            for (EnumVarMap enumVar : enumVars) {
+                if (enumDefaultValue.equals(enumVar.getEnumValue())) {
+                    enumName = (String) enumVar.getEnumName();
                     break;
                 }
             }
@@ -7073,8 +7075,8 @@ public class DefaultCodegen implements CodegenConfig {
         return enumDefaultValue;
     }
 
-    protected List<Map<String, Object>> buildEnumVars(List<Object> values, String dataType) {
-        List<Map<String, Object>> enumVars = new ArrayList<>();
+    protected List<EnumVarMap> buildEnumVars(List<Object> values, String dataType) {
+        List<EnumVarMap> enumVars = new ArrayList<>();
         int truncateIdx = isRemoveEnumValuePrefix()
                 ? findCommonPrefixOfVars(values).length()
                 : 0;
@@ -7085,7 +7087,7 @@ public class DefaultCodegen implements CodegenConfig {
                 // attributes, not actual enum values, so we remove them here
                 continue;
             }
-            Map<String, Object> enumVar = new HashMap<>();
+            EnumVarMap enumVar = new EnumVarMap();
             String enumName = truncateIdx == 0
                     ? String.valueOf(value)
                     : value.toString().substring(truncateIdx);
@@ -7096,9 +7098,7 @@ public class DefaultCodegen implements CodegenConfig {
 
             final String finalEnumName = toEnumVarName(enumName, dataType);
 
-            enumVar.put(ENUM_NAME, finalEnumName);
-            enumVar.put(ENUM_VALUE, toEnumValue(String.valueOf(value), dataType));
-            enumVar.put(ENUM_IS_STRING, isDataTypeString(dataType));
+            enumVar.enumVar(finalEnumName, toEnumValue(String.valueOf(value), dataType), isDataTypeString(dataType));
             // TODO: add isNumeric
             enumVars.add(enumVar);
         }
@@ -7117,8 +7117,8 @@ public class DefaultCodegen implements CodegenConfig {
      * @param enumVars the enumVars
      * @param dataType the data type of the enum parameter
      */
-    private void injectEnumUnknownDefaultCase(List<Map<String, Object>> enumVars, String dataType) {
-        Map<String, Object> enumVar = new HashMap<>();
+    private void injectEnumUnknownDefaultCase(List<EnumVarMap> enumVars, String dataType) {
+        EnumVarMap enumVar = new EnumVarMap();
         String enumName = enumUnknownDefaultCaseName;
 
         String enumValue = isDataTypeString(dataType)
@@ -7131,9 +7131,7 @@ public class DefaultCodegen implements CodegenConfig {
                 // https://github.com/OpenAPITools/openapi-generator/pull/11013
                 String.valueOf(11184809);
 
-        enumVar.put(ENUM_NAME, toEnumVarName(enumName, dataType));
-        enumVar.put(ENUM_VALUE, toEnumValue(enumValue, dataType));
-        enumVar.put(ENUM_IS_STRING, isDataTypeString(dataType));
+        enumVar.enumVar(toEnumVarName(enumName, dataType), toEnumValue(enumValue, dataType), isDataTypeString(dataType));
         // TODO: add isNumeric
         enumVars.add(enumVar);
     }
@@ -7148,31 +7146,31 @@ public class DefaultCodegen implements CodegenConfig {
     protected void removeEnumUnknownDefaultCase(CodegenOperation operation) {
         for (CodegenParameter param : operation.allParams) {
             if (!param.isBodyParam && param.isEnum && hasEnumVars(param.allowableValues)) {
-                List<Map<String, Object>> enumVars = getEnumVars(param.allowableValues);
+                List<EnumVarMap> enumVars = getEnumVars(param.allowableValues);
                 if (enumVars != null) {
                     String unknownName = toEnumVarName(enumUnknownDefaultCaseName, param.dataType);
-                    enumVars.removeIf(ev -> unknownName.equals(ev.get(ENUM_NAME)));
+                    enumVars.removeIf(ev -> unknownName.equals(ev.getEnumName()));
                 }
             }
         }
     }
 
-    protected void postProcessEnumVars(List<Map<String, Object>> enumVars) {
+    protected void postProcessEnumVars(List<EnumVarMap> enumVars) {
         Collections.reverse(enumVars);
         enumVars.forEach(v -> {
-            String name = (String) v.get(ENUM_NAME);
-            long count = enumVars.stream().filter(v1 -> v1.get(ENUM_NAME).equals(name)).count();
+            String name = (String) v.getEnumName();
+            long count = enumVars.stream().filter(v1 -> v1.getEnumName().equals(name)).count();
             if (count > 1) {
                 String uniqueEnumName = getUniqueEnumName(name, enumVars);
-                LOGGER.debug("Changing duplicate enumeration name from {} to {}", v.get(ENUM_NAME), uniqueEnumName);
-                v.put(ENUM_NAME, uniqueEnumName);
+                LOGGER.debug("Changing duplicate enumeration name from {} to {}", v.getEnumName(), uniqueEnumName);
+                v.setEnumName(uniqueEnumName);
             }
         });
         Collections.reverse(enumVars);
     }
 
-    private String getUniqueEnumName(String name, List<Map<String, Object>> enumVars) {
-        long count = enumVars.stream().filter(v -> v.get(ENUM_NAME).equals(name)).count();
+    private String getUniqueEnumName(String name, List<EnumVarMap> enumVars) {
+        long count = enumVars.stream().filter(v -> v.getEnumName().equals(name)).count();
         return count > 1
                 ? getUniqueEnumName(name + count, enumVars)
                 : name;
@@ -7185,7 +7183,7 @@ public class DefaultCodegen implements CodegenConfig {
      * @param vendorExtensions vendor extensions
      * @param dataType data type
      */
-    protected void updateEnumVarsWithExtensions(List<Map<String, Object>> enumVars, Map<String, Object> vendorExtensions, String dataType) {
+    protected void updateEnumVarsWithExtensions(List<EnumVarMap> enumVars, Map<String, Object> vendorExtensions, String dataType) {
         if (vendorExtensions != null) {
             updateEnumVarsWithExtensions(enumVars, vendorExtensions, X_ENUM_VARNAMES, ENUM_NAME, dataType);
             updateEnumVarsWithExtensions(enumVars, vendorExtensions, X_ENUM_DESCRIPTIONS, ENUM_DESCRIPTION, dataType);
@@ -7201,7 +7199,7 @@ public class DefaultCodegen implements CodegenConfig {
      * @param key key
      * @param dataType data type
      */
-    protected void updateEnumVarsWithExtensions(List<Map<String, Object>> enumVars, Map<String, Object> vendorExtensions, String extensionKey, String key, String dataType) {
+    protected void updateEnumVarsWithExtensions(List<EnumVarMap> enumVars, Map<String, Object> vendorExtensions, String extensionKey, String key, String dataType) {
         updateEnumVarsWithExtensions(enumVars, vendorExtensions, extensionKey, key, dataType, (a, b) -> a);
     }
 
@@ -7214,7 +7212,7 @@ public class DefaultCodegen implements CodegenConfig {
      * @param dataType data type
      * @param enumDataTypeMapping functions that accepts 2 arguments
      */
-    protected void updateEnumVarsWithExtensions(List<Map<String, Object>> enumVars,
+    protected void updateEnumVarsWithExtensions(List<EnumVarMap> enumVars,
                                                 Map<String, Object> vendorExtensions,
                                                 String extensionKey,
                                                 String key,
@@ -7230,8 +7228,8 @@ public class DefaultCodegen implements CodegenConfig {
                 }
             } else if (extensionValue instanceof Map) {
                 Map<String, String> valueMap = (Map<String, String>) extensionValue;
-                for (Map<String, Object> enumVar : enumVars) {
-                    String enumValue = (String) enumVar.get(ENUM_VALUE);
+                for (EnumVarMap enumVar : enumVars) {
+                    String enumValue = (String) enumVar.getEnumValue();
                     for (Map.Entry<String, String> entry : valueMap.entrySet()) {
                         if (toEnumValue(entry.getKey(), dataType).equals(enumValue)) {
                             enumVar.put(key, enumDataTypeMapping.apply(entry.getValue(), dataType));

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCSharpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCSharpCodegen.java
@@ -32,6 +32,7 @@ import org.openapitools.codegen.model.ModelsMap;
 import org.openapitools.codegen.model.OperationMap;
 import org.openapitools.codegen.model.OperationsMap;
 import org.openapitools.codegen.model.WebhooksMap;
+import org.openapitools.codegen.model.EnumVarMap;
 import org.openapitools.codegen.templating.mustache.*;
 import org.openapitools.codegen.templating.mustache.CopyLambda.CopyContent;
 import org.openapitools.codegen.templating.mustache.CopyLambda.WhiteSpaceStrategy;
@@ -899,15 +900,15 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen {
     }
 
     @Override
-    protected List<Map<String, Object>> buildEnumVars(List<Object> values, String dataType) {
-        List<Map<String, Object>> enumVars = super.buildEnumVars(values, dataType);
+    protected List<EnumVarMap> buildEnumVars(List<Object> values, String dataType) {
+        List<EnumVarMap> enumVars = super.buildEnumVars(values, dataType);
 
         // this is needed for enumRefs like OuterEnum marked as nullable and also have string values
         // keep isString true so that the index will be used as the enum value instead of a string
         // this is inline with C# enums with string values
         if ("string?".equals(dataType)) {
             enumVars.forEach((enumVar) -> {
-                enumVar.put(ENUM_IS_STRING, true);
+                enumVar.isString(true);
             });
         }
 
@@ -920,7 +921,7 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen {
     }
 
     /**
-     * Update codegen property's enum by adding {@value CodegenConstants#ENUM_VARS} (with name and value)
+     * Update codegen property's enum by adding {@value EnumVarMap#ENUM_VARS} (with name and value)
      *
      * @param var list of CodegenProperty
      */

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractDartCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractDartCodegen.java
@@ -13,6 +13,7 @@ import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.openapitools.codegen.*;
 import org.openapitools.codegen.meta.features.*;
+import org.openapitools.codegen.model.EnumVarMap;
 import org.openapitools.codegen.model.ModelMap;
 import org.openapitools.codegen.model.ModelsMap;
 import org.openapitools.codegen.model.OperationMap;
@@ -28,7 +29,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.stream.Stream;
 
-import static org.openapitools.codegen.CodegenConstants.*;
+import static org.openapitools.codegen.model.EnumVarMap.*;
 import static org.openapitools.codegen.utils.CamelizeOption.LOWERCASE_FIRST_LETTER;
 import static org.openapitools.codegen.utils.EnumUtils.BUNGIE_X_ENUM_VALUES;
 import static org.openapitools.codegen.utils.EnumUtils.getBungieEnumValues;
@@ -860,7 +861,7 @@ public abstract class AbstractDartCodegen extends DefaultCodegen {
     }
 
     @Override
-    protected void updateEnumVarsWithExtensions(List<Map<String, Object>> enumVars, Map<String, Object> vendorExtensions, String dataType) {
+    protected void updateEnumVarsWithExtensions(List<EnumVarMap> enumVars, Map<String, Object> vendorExtensions, String dataType) {
         if (vendorExtensions != null && useEnumExtension && vendorExtensions.containsKey(BUNGIE_X_ENUM_VALUES)) {
             // Use the x-enum-values extension for this enum
             // Existing enumVars added by the default handling need to be removed first
@@ -870,10 +871,8 @@ public abstract class AbstractDartCodegen extends DefaultCodegen {
 
             boolean isString = isDataTypeString(dataType);
             for (Map<String, String> value : bungieEnumValues) {
-                Map<String, Object> enumVar = new HashMap<>(value);
-                enumVar.put(ENUM_NAME, toEnumVarName(value.get(ENUM_NAME), dataType));
-                enumVar.put(ENUM_VALUE, toEnumValue(value.get(ENUM_VALUE), dataType));
-                enumVar.put(ENUM_IS_STRING, isString);
+                EnumVarMap enumVar = new EnumVarMap(value);
+                enumVar.enumVar(toEnumVarName(value.get(ENUM_NAME), dataType), toEnumValue(value.get(ENUM_VALUE), dataType), isString);
                 enumVars.add(enumVar);
             }
         } else {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractFSharpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractFSharpCodegen.java
@@ -25,6 +25,7 @@ import lombok.Setter;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.openapitools.codegen.*;
+import org.openapitools.codegen.model.EnumVarMap;
 import org.openapitools.codegen.model.ModelMap;
 import org.openapitools.codegen.model.ModelsMap;
 import org.openapitools.codegen.model.OperationMap;
@@ -39,6 +40,7 @@ import java.util.*;
 
 import static org.openapitools.codegen.CodegenConstants.X_ENUM_BYTE;
 import static org.openapitools.codegen.CodegenConstants.X_EXAMPLE;
+import static org.openapitools.codegen.model.EnumVarMap.ENUM_VARS;
 import static org.openapitools.codegen.utils.CamelizeOption.LOWERCASE_FIRST_LETTER;
 import static org.openapitools.codegen.utils.EnumUtils.getEnumVars;
 import static org.openapitools.codegen.utils.StringUtils.camelize;
@@ -450,12 +452,12 @@ public abstract class AbstractFSharpCodegen extends DefaultCodegen implements Co
 
                     // Since we iterate enumVars for modelInnerEnum and enumClass templates, and CodegenModel is missing some of CodegenProperty's properties,
                     // we can take advantage of Mustache's contextual lookup to add the same "properties" to the model's enumVars scope rather than CodegenProperty's scope.
-                    List<Map<String, Object>> enumVars = getEnumVars(model.allowableValues);
-                    List<Map<String, Object>> newEnumVars = new ArrayList<>();
-                    for (Map<String, Object> enumVar : enumVars) {
-                        Map<String, Object> mixedVars = new HashMap<>(enumVar);
+                    List<EnumVarMap> enumVars = getEnumVars(model.allowableValues);
+                    List<EnumVarMap> newEnumVars = new ArrayList<>();
+                    for (EnumVarMap enumVar : enumVars) {
+                        EnumVarMap mixedVars = new EnumVarMap(enumVar);
 
-                        mixedVars.put(ENUM_IS_STRING, isString);
+                        mixedVars.isString(isString);
                         mixedVars.put("isLong", isLong);
                         mixedVars.put("isInteger", isInteger);
                         mixedVars.put("isByte", isByte);
@@ -474,7 +476,7 @@ public abstract class AbstractFSharpCodegen extends DefaultCodegen implements Co
     }
 
     /**
-     * Update codegen property's enum by adding {@value CodegenConstants#ENUM_VARS} (with name and value)
+     * Update codegen property's enum by adding {@value EnumVarMap#ENUM_VARS} (with name and value)
      *
      * @param var list of CodegenProperty
      */

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractFSharpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractFSharpCodegen.java
@@ -37,11 +37,10 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.util.*;
 
-import static org.openapitools.codegen.CodegenConstants.ENUM_VARS;
 import static org.openapitools.codegen.CodegenConstants.X_ENUM_BYTE;
 import static org.openapitools.codegen.CodegenConstants.X_EXAMPLE;
 import static org.openapitools.codegen.utils.CamelizeOption.LOWERCASE_FIRST_LETTER;
-import static org.openapitools.codegen.utils.EnumUtils.getEnumVarsAsString;
+import static org.openapitools.codegen.utils.EnumUtils.getEnumVars;
 import static org.openapitools.codegen.utils.StringUtils.camelize;
 import static org.openapitools.codegen.utils.StringUtils.underscore;
 
@@ -451,12 +450,12 @@ public abstract class AbstractFSharpCodegen extends DefaultCodegen implements Co
 
                     // Since we iterate enumVars for modelInnerEnum and enumClass templates, and CodegenModel is missing some of CodegenProperty's properties,
                     // we can take advantage of Mustache's contextual lookup to add the same "properties" to the model's enumVars scope rather than CodegenProperty's scope.
-                    List<Map<String, String>> enumVars = getEnumVarsAsString(model.allowableValues);
+                    List<Map<String, Object>> enumVars = getEnumVars(model.allowableValues);
                     List<Map<String, Object>> newEnumVars = new ArrayList<>();
-                    for (Map<String, String> enumVar : enumVars) {
+                    for (Map<String, Object> enumVar : enumVars) {
                         Map<String, Object> mixedVars = new HashMap<>(enumVar);
 
-                        mixedVars.put("isString", isString);
+                        mixedVars.put(ENUM_IS_STRING, isString);
                         mixedVars.put("isLong", isLong);
                         mixedVars.put("isInteger", isInteger);
                         mixedVars.put("isByte", isByte);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
@@ -24,6 +24,7 @@ import lombok.Setter;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.openapitools.codegen.*;
+import org.openapitools.codegen.model.EnumVarMap;
 import org.openapitools.codegen.model.ModelMap;
 import org.openapitools.codegen.model.ModelsMap;
 import org.openapitools.codegen.model.OperationMap;
@@ -39,6 +40,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static org.openapitools.codegen.CodegenConstants.*;
+import static org.openapitools.codegen.model.EnumVarMap.ENUM_DESCRIPTION;
+import static org.openapitools.codegen.model.EnumVarMap.ENUM_NAME;
 import static org.openapitools.codegen.utils.CamelizeOption.LOWERCASE_FIRST_LETTER;
 import static org.openapitools.codegen.utils.CamelizeOption.UPPERCASE_FIRST_CHAR;
 import static org.openapitools.codegen.utils.StringUtils.camelize;
@@ -822,7 +825,7 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
     }
 
     @Override
-    protected void updateEnumVarsWithExtensions(List<Map<String, Object>> enumVars, Map<String, Object> vendorExtensions, String dataType) {
+    protected void updateEnumVarsWithExtensions(List<EnumVarMap> enumVars, Map<String, Object> vendorExtensions, String dataType) {
         if (vendorExtensions != null) {
             updateEnumVarsWithExtensions(enumVars, vendorExtensions, X_ENUM_VARNAMES, ENUM_NAME, dataType, this::toEnumVarName);
             updateEnumVarsWithExtensions(enumVars, vendorExtensions, X_ENUM_DESCRIPTIONS, ENUM_DESCRIPTION, dataType);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
@@ -29,6 +29,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.openapitools.codegen.*;
 import org.openapitools.codegen.meta.features.SecurityFeature;
 import org.openapitools.codegen.meta.features.DataTypeFeature;
+import org.openapitools.codegen.model.EnumVarMap;
 import org.openapitools.codegen.model.ModelMap;
 import org.openapitools.codegen.model.ModelsMap;
 import org.openapitools.codegen.model.OperationMap;
@@ -1138,18 +1139,18 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
 
             // set enum type in extensions and update `name` in enumVars
             if (model.isEnum) {
-                for (Map<String, Object> enumVars : getEnumVars(model.getAllowableValues())) {
-                    if ((Boolean) enumVars.get(ENUM_IS_STRING)) {
+                for (EnumVarMap enumVars : getEnumVars(model.getAllowableValues())) {
+                    if (enumVars.isString()) {
                         model.vendorExtensions.putIfAbsent(X_PY_ENUM_TYPE, "str");
                         // Do not overwrite the variable name if already set through x-enum-varnames
                         if (model.vendorExtensions.get(X_ENUM_VARNAMES) == null) {
-                            enumVars.put(ENUM_NAME, toEnumVariableName((String) enumVars.get(ENUM_VALUE), "str"));
+                            enumVars.setEnumName(toEnumVariableName((String) enumVars.getEnumValue(), "str"));
                         }
                     } else {
                         model.vendorExtensions.putIfAbsent(X_PY_ENUM_TYPE, "int");
                         // Do not overwrite the variable name if already set through x-enum-varnames
                         if (model.vendorExtensions.get(X_ENUM_VARNAMES) == null) {
-                            enumVars.put(ENUM_NAME, toEnumVariableName((String) enumVars.get(ENUM_VALUE), "int"));
+                            enumVars.setEnumName(toEnumVariableName((String) enumVars.getEnumValue(), "int"));
                         }
                     }
                 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonPydanticV1Codegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonPydanticV1Codegen.java
@@ -27,10 +27,12 @@ import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.openapitools.codegen.*;
 import org.openapitools.codegen.meta.features.SecurityFeature;
+import org.openapitools.codegen.model.EnumVarMap;
 import org.openapitools.codegen.model.ModelMap;
 import org.openapitools.codegen.model.ModelsMap;
 import org.openapitools.codegen.model.OperationMap;
 import org.openapitools.codegen.model.OperationsMap;
+import org.openapitools.codegen.utils.EnumUtils;
 import org.openapitools.codegen.utils.ModelUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -978,14 +980,14 @@ public abstract class AbstractPythonPydanticV1Codegen extends DefaultCodegen imp
 
             // set enum type in extensions and update `name` in enumVars
             if (model.isEnum) {
-                for (Map<String, Object> enumVars : (List<Map<String, Object>>) model.getAllowableValues().get(ENUM_VARS)) {
-                    if ((Boolean) enumVars.get(ENUM_IS_STRING)) {
+                for (EnumVarMap enumVars : EnumUtils.getEnumVars(model.getAllowableValues())) {
+                    if (enumVars.isString()) {
                         model.vendorExtensions.putIfAbsent(X_PY_ENUM_TYPE, "str");
                         // update `name`, e.g.
-                        enumVars.put(ENUM_NAME, toEnumVariableName((String) enumVars.get(ENUM_VALUE), "str"));
+                        enumVars.setEnumName(toEnumVariableName((String) enumVars.getEnumValue(), "str"));
                     } else {
                         model.vendorExtensions.putIfAbsent(X_PY_ENUM_TYPE, "int");
-                        enumVars.put(ENUM_NAME, toEnumVariableName((String) enumVars.get(ENUM_VALUE), "int"));
+                        enumVars.setEnumName(toEnumVariableName((String) enumVars.getEnumValue(), "int"));
                     }
                 }
             }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AvroSchemaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AvroSchemaCodegen.java
@@ -26,6 +26,7 @@ import org.openapitools.codegen.*;
 import org.openapitools.codegen.meta.GeneratorMetadata;
 import org.openapitools.codegen.meta.Stability;
 import org.openapitools.codegen.meta.features.*;
+import org.openapitools.codegen.model.EnumVarMap;
 import org.openapitools.codegen.model.ModelsMap;
 import org.openapitools.codegen.utils.ModelUtils;
 import org.slf4j.Logger;
@@ -251,7 +252,7 @@ public class AvroSchemaCodegen extends DefaultCodegen implements CodegenConfig {
     }
 
     @Override
-    protected List<Map<String, Object>> buildEnumVars(List<Object> values, String dataType) {
+    protected List<EnumVarMap> buildEnumVars(List<Object> values, String dataType) {
         List<Object> sanitizedValues = values.stream()
                 .filter(x -> x != null)
                 .map(Object::toString)

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppHttplibServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppHttplibServerCodegen.java
@@ -59,7 +59,7 @@ import io.swagger.v3.oas.models.media.MediaType;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.responses.ApiResponse;
 
-import static org.openapitools.codegen.CodegenConstants.*;
+import static org.openapitools.codegen.model.EnumVarMap.*;
 import static org.openapitools.codegen.utils.EnumUtils.getEnumValues;
 import static org.openapitools.codegen.utils.EnumUtils.hasEnumValues;
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CrystalClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CrystalClientCodegen.java
@@ -41,7 +41,7 @@ import java.util.*;
 
 import static org.openapitools.codegen.CodegenConstants.*;
 import static org.openapitools.codegen.utils.EnumUtils.getEnumValues;
-import static org.openapitools.codegen.utils.EnumUtils.getEnumVarsAsString;
+import static org.openapitools.codegen.utils.EnumUtils.getEnumVars;
 import static org.openapitools.codegen.utils.StringUtils.camelize;
 import static org.openapitools.codegen.utils.StringUtils.underscore;
 
@@ -1100,7 +1100,7 @@ public class CrystalClientCodegen extends DefaultCodegen {
                 throw new RuntimeException("Invalid count when constructing example: " + count);
             }
         } else if (codegenModel.isEnum) {
-            List<Map<String, String>> enumVars = getEnumVarsAsString(codegenModel.allowableValues);
+            List<Map<String, Object>> enumVars = getEnumVars(codegenModel.allowableValues);
             return moduleName + "::" + codegenModel.classname + "::" + enumVars.get(0).get(ENUM_NAME);
         } else if (codegenModel.oneOf != null && !codegenModel.oneOf.isEmpty()) {
             String subModel = (String) codegenModel.oneOf.toArray()[0];

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CrystalClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CrystalClientCodegen.java
@@ -24,6 +24,7 @@ import org.openapitools.codegen.*;
 import org.openapitools.codegen.meta.GeneratorMetadata;
 import org.openapitools.codegen.meta.Stability;
 import org.openapitools.codegen.meta.features.*;
+import org.openapitools.codegen.model.EnumVarMap;
 import org.openapitools.codegen.model.ModelMap;
 import org.openapitools.codegen.model.ModelsMap;
 import org.openapitools.codegen.model.OperationMap;
@@ -39,7 +40,6 @@ import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.*;
 
-import static org.openapitools.codegen.CodegenConstants.*;
 import static org.openapitools.codegen.utils.EnumUtils.getEnumValues;
 import static org.openapitools.codegen.utils.EnumUtils.getEnumVars;
 import static org.openapitools.codegen.utils.StringUtils.camelize;
@@ -825,9 +825,9 @@ public class CrystalClientCodegen extends DefaultCodegen {
      * Shared post-processing for one generated api class, whether its operations come from
      * {@code paths} or from {@code webhooks}.
      *
-     * @param objs       the template bundle for the api file (also carries specHelperPath)
-     * @param operations the operations to process, or null when the group is empty
-     * @param allModels  every generated model, used to qualify model types and build examples
+     * @param objs        the template bundle for the api file (also carries specHelperPath)
+     * @param operations0 the operations to process, or null when the group is empty
+     * @param allModels   every generated model, used to qualify model types and build examples
      */
     private void processApiGroup(Map<String, Object> objs, OperationMap operations0, List<ModelMap> allModels) {
         String classname = (operations0 != null) ? operations0.getClassname() : "";
@@ -1100,8 +1100,8 @@ public class CrystalClientCodegen extends DefaultCodegen {
                 throw new RuntimeException("Invalid count when constructing example: " + count);
             }
         } else if (codegenModel.isEnum) {
-            List<Map<String, Object>> enumVars = getEnumVars(codegenModel.allowableValues);
-            return moduleName + "::" + codegenModel.classname + "::" + enumVars.get(0).get(ENUM_NAME);
+            List<EnumVarMap> enumVars = getEnumVars(codegenModel.allowableValues);
+            return moduleName + "::" + codegenModel.classname + "::" + enumVars.get(0).getEnumName();
         } else if (codegenModel.oneOf != null && !codegenModel.oneOf.isEmpty()) {
             String subModel = (String) codegenModel.oneOf.toArray()[0];
             if (modelMaps.get(subModel) == null) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientCodegen.java
@@ -28,6 +28,7 @@ import org.openapitools.codegen.*;
 import org.openapitools.codegen.meta.GeneratorMetadata;
 import org.openapitools.codegen.meta.Stability;
 import org.openapitools.codegen.meta.features.*;
+import org.openapitools.codegen.model.EnumVarMap;
 import org.openapitools.codegen.model.ModelMap;
 import org.openapitools.codegen.model.ModelsMap;
 import org.openapitools.codegen.model.OperationMap;
@@ -40,10 +41,9 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.util.*;
 
-import static org.openapitools.codegen.CodegenConstants.*;
+import static org.openapitools.codegen.model.EnumVarMap.ENUM_VARS;
 import static org.openapitools.codegen.utils.CamelizeOption.LOWERCASE_FIRST_LETTER;
 import static org.openapitools.codegen.utils.EnumUtils.getEnumValues;
-import static org.openapitools.codegen.utils.EnumUtils.getEnumVars;
 import static org.openapitools.codegen.utils.ModelUtils.hasAnyOf;
 import static org.openapitools.codegen.utils.ModelUtils.hasOneOf;
 import static org.openapitools.codegen.utils.StringUtils.camelize;
@@ -610,10 +610,10 @@ public class GoClientCodegen extends AbstractGoCodegen {
         }
 
         // Prefix only the fallback name so user-defined enum values keep their existing generated names.
-        Map<String, Object> fallbackEnumVar = (Map<String, Object>) enumVars.get(enumVars.size() - 1);
-        Object fallbackName = fallbackEnumVar.get(ENUM_NAME);
+        EnumVarMap fallbackEnumVar = (EnumVarMap) enumVars.get(enumVars.size() - 1);
+        Object fallbackName = fallbackEnumVar.getEnumName();
         if (fallbackName instanceof String) {
-            fallbackEnumVar.put(ENUM_NAME, model.classname.toUpperCase(Locale.ROOT) + "_" + fallbackName);
+            fallbackEnumVar.setEnumName(model.classname.toUpperCase(Locale.ROOT) + "_" + fallbackName);
         }
     }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/HaskellHttpClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/HaskellHttpClientCodegen.java
@@ -42,10 +42,9 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static org.openapitools.codegen.CodegenConstants.ENUM_NAME;
-import static org.openapitools.codegen.CodegenConstants.ENUM_VARS;
 import static org.openapitools.codegen.utils.CamelizeOption.LOWERCASE_FIRST_LETTER;
 import static org.openapitools.codegen.utils.CamelizeOption.UPPERCASE_FIRST_CHAR;
-import static org.openapitools.codegen.utils.EnumUtils.getEnumVarsAsString;
+import static org.openapitools.codegen.utils.EnumUtils.getEnumVars;
 import static org.openapitools.codegen.utils.StringUtils.camelize;
 import static org.openapitools.codegen.utils.StringUtils.underscore;
 
@@ -1413,7 +1412,7 @@ public class HaskellHttpClientCodegen extends DefaultCodegen implements CodegenC
         if (allowableValues == null) {
             return;
         }
-        for (Map<String, String> enumVar : getEnumVarsAsString(allowableValues)) {
+        for (Map<String, Object> enumVar : getEnumVars(allowableValues)) {
             enumVar.put(ENUM_NAME, paramNameType + enumVar.get(ENUM_NAME));
         }
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/HaskellHttpClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/HaskellHttpClientCodegen.java
@@ -27,6 +27,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.apache.commons.text.StringEscapeUtils;
 import org.openapitools.codegen.*;
 import org.openapitools.codegen.meta.features.*;
+import org.openapitools.codegen.model.EnumVarMap;
 import org.openapitools.codegen.model.ModelMap;
 import org.openapitools.codegen.model.ModelsMap;
 import org.openapitools.codegen.model.OperationMap;
@@ -41,7 +42,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import static org.openapitools.codegen.CodegenConstants.ENUM_NAME;
 import static org.openapitools.codegen.utils.CamelizeOption.LOWERCASE_FIRST_LETTER;
 import static org.openapitools.codegen.utils.CamelizeOption.UPPERCASE_FIRST_CHAR;
 import static org.openapitools.codegen.utils.EnumUtils.getEnumVars;
@@ -1412,8 +1412,8 @@ public class HaskellHttpClientCodegen extends DefaultCodegen implements CodegenC
         if (allowableValues == null) {
             return;
         }
-        for (Map<String, Object> enumVar : getEnumVars(allowableValues)) {
-            enumVar.put(ENUM_NAME, paramNameType + enumVar.get(ENUM_NAME));
+        for (EnumVarMap enumVar : getEnumVars(allowableValues)) {
+            enumVar.setEnumName(paramNameType + enumVar.getEnumName());
         }
     }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaCXFExtServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaCXFExtServerCodegen.java
@@ -26,6 +26,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.StringEscapeUtils;
 import org.openapitools.codegen.*;
 import org.openapitools.codegen.languages.features.CXFExtServerFeatures;
+import org.openapitools.codegen.model.EnumVarMap;
 import org.openapitools.codegen.model.ModelMap;
 import org.openapitools.codegen.model.ModelsMap;
 import org.openapitools.codegen.model.OperationMap;
@@ -47,7 +48,6 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.*;
 
-import static org.openapitools.codegen.CodegenConstants.*;
 import static org.openapitools.codegen.utils.EnumUtils.getEnumValues;
 import static org.openapitools.codegen.utils.EnumUtils.getEnumVars;
 
@@ -666,13 +666,13 @@ public class JavaCXFExtServerCodegen extends JavaCXFServerCodegen implements CXF
             boolean usingEnumLiteral = false;
             String definingClass = (String) var.varVendorExtensions.get("x-defining-class");
             if (definingClass != null) {
-                List<Map<String, Object>> enumVars = getEnumVars(var.allowableValues);
+                List<EnumVarMap> enumVars = getEnumVars(var.allowableValues);
                 if (enumVars != null) {
                     if (!loadTestDataFromFile) {
-                        Map<String, Object> randomEnumVar = enumVars.get(i);
+                        EnumVarMap randomEnumVar = enumVars.get(i);
                         // NOTE: to disambiguate identically named inner enums, qualify enum name with defining class.
                         buffer.append(definingClass).append('.').append(var.enumName).append('.')
-                                .append(randomEnumVar.get(ENUM_NAME));
+                                .append(randomEnumVar.getEnumName());
                         op.imports.add(definingClass);
                     }
                     usingEnumLiteral = true;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
@@ -31,11 +31,13 @@ import org.openapitools.codegen.languages.features.PerformBeanValidationFeatures
 import org.openapitools.codegen.meta.features.DocumentationFeature;
 import org.openapitools.codegen.meta.features.GlobalFeature;
 import org.openapitools.codegen.meta.features.SecurityFeature;
+import org.openapitools.codegen.model.EnumVarMap;
 import org.openapitools.codegen.model.ModelMap;
 import org.openapitools.codegen.model.ModelsMap;
 import org.openapitools.codegen.model.OperationMap;
 import org.openapitools.codegen.model.OperationsMap;
 import org.openapitools.codegen.templating.mustache.CaseFormatLambda;
+import org.openapitools.codegen.utils.EnumUtils;
 import org.openapitools.codegen.utils.ProcessUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -1235,10 +1237,10 @@ public class JavaClientCodegen extends AbstractJavaCodegen
 
                         if (StringUtils.isNotEmpty(var.defaultValue)) { // has default value
                             String defaultValue = var.defaultValue.substring(var.defaultValue.lastIndexOf('.') + 1);
-                            for (Map<String, Object> enumVars : (List<Map<String, Object>>) var.getAllowableValues().get(ENUM_VARS)) {
-                                if (defaultValue.equals(enumVars.get(ENUM_NAME))) {
+                            for (EnumVarMap enumVars : EnumUtils.getEnumVars(var.allowableValues)) {
+                                if (defaultValue.equals(enumVars.getEnumName())) {
                                     // update default to use the string directly instead of enum string
-                                    var.defaultValue = (String) enumVars.get(ENUM_VALUE);
+                                    var.defaultValue = (String) enumVars.getEnumValue();
                                 }
                             }
                         }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaHelidonClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaHelidonClientCodegen.java
@@ -29,9 +29,11 @@ import org.openapitools.codegen.meta.GeneratorMetadata;
 import org.openapitools.codegen.meta.Stability;
 import org.openapitools.codegen.meta.features.DocumentationFeature;
 import org.openapitools.codegen.meta.features.GlobalFeature;
+import org.openapitools.codegen.model.EnumVarMap;
 import org.openapitools.codegen.model.ModelMap;
 import org.openapitools.codegen.model.ModelsMap;
 import org.openapitools.codegen.model.OperationsMap;
+import org.openapitools.codegen.utils.EnumUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -412,10 +414,10 @@ public class JavaHelidonClientCodegen extends JavaHelidonCommonCodegen {
 
                         if (StringUtils.isNotEmpty(var.defaultValue)) { // has default value
                             String defaultValue = var.defaultValue.substring(var.defaultValue.lastIndexOf('.') + 1);
-                            for (Map<String, Object> enumVars : (List<Map<String, Object>>) var.getAllowableValues().get(ENUM_VARS)) {
-                                if (defaultValue.equals(enumVars.get(ENUM_NAME))) {
+                            for (EnumVarMap enumVars : EnumUtils.getEnumVars(var.getAllowableValues())) {
+                                if (defaultValue.equals(enumVars.getEnumName())) {
                                     // update default to use the string directly instead of enum string
-                                    var.defaultValue = (String) enumVars.get(ENUM_VALUE);
+                                    var.defaultValue = (String) enumVars.getEnumValue();
                                 }
                             }
                         }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinClientCodegen.java
@@ -58,9 +58,6 @@ import org.openapitools.codegen.meta.features.WireFormatFeature;
 import org.openapitools.codegen.templating.mustache.ReplaceAllLambda;
 
 import static java.util.Collections.sort;
-import static org.openapitools.codegen.CodegenConstants.ENUM_NAME;
-import static org.openapitools.codegen.utils.EnumUtils.getEnumVars;
-import static org.openapitools.codegen.utils.EnumUtils.hasEnumVars;
 
 /**
  * <p>Mustache templates are located in

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/MysqlSchemaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/MysqlSchemaCodegen.java
@@ -31,7 +31,6 @@ import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static org.openapitools.codegen.CodegenConstants.ENUM_VALUES;
 import static org.openapitools.codegen.utils.EnumUtils.getEnumValues;
 import static org.openapitools.codegen.utils.StringUtils.underscore;
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/NimClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/NimClientCodegen.java
@@ -23,6 +23,7 @@ import org.openapitools.codegen.*;
 import org.openapitools.codegen.meta.GeneratorMetadata;
 import org.openapitools.codegen.meta.Stability;
 import org.openapitools.codegen.meta.features.*;
+import org.openapitools.codegen.model.EnumVarMap;
 import org.openapitools.codegen.model.ModelMap;
 import org.openapitools.codegen.model.ModelsMap;
 import org.openapitools.codegen.model.OperationMap;
@@ -37,8 +38,6 @@ import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static org.openapitools.codegen.CodegenConstants.ENUM_VALUE;
-import static org.openapitools.codegen.CodegenConstants.ENUM_VARS;
 import static org.openapitools.codegen.utils.CamelizeOption.LOWERCASE_FIRST_LETTER;
 import static org.openapitools.codegen.utils.EnumUtils.getEnumVars;
 import static org.openapitools.codegen.utils.EnumUtils.hasEnumVars;
@@ -259,14 +258,14 @@ public class NimClientCodegen extends DefaultCodegen implements CodegenConfig {
             return;
         }
 
-        List<Map<String, Object>> enumVars = getEnumVars(allowableValues);
-        for (Map<String, Object> enumVar : enumVars) {
-            Object value = enumVar.get(ENUM_VALUE);
+        List<EnumVarMap> enumVars = getEnumVars(allowableValues);
+        for (EnumVarMap enumVar : enumVars) {
+            Object value = enumVar.getEnumValue();
             if (value instanceof String) {
                 String strValue = (String) value;
                 // Remove surrounding quotes if present
                 if (strValue.startsWith("\"") && strValue.endsWith("\"")) {
-                    enumVar.put(ENUM_VALUE, strValue.substring(1, strValue.length() - 1));
+                    enumVar.setEnumValue(strValue.substring(1, strValue.length() - 1));
                 }
             }
         }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/OCamlClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/OCamlClientCodegen.java
@@ -28,6 +28,7 @@ import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.openapitools.codegen.*;
 import org.openapitools.codegen.meta.features.*;
+import org.openapitools.codegen.model.EnumVarMap;
 import org.openapitools.codegen.model.ModelMap;
 import org.openapitools.codegen.model.ModelsMap;
 import org.openapitools.codegen.model.OperationMap;
@@ -41,8 +42,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import static org.apache.commons.lang3.StringUtils.capitalize;
-import static org.openapitools.codegen.CodegenConstants.ENUM_NAME;
-import static org.openapitools.codegen.CodegenConstants.ENUM_VALUES;
+import static org.openapitools.codegen.model.EnumVarMap.ENUM_VALUES;
 import static org.openapitools.codegen.utils.ModelUtils.hasAnyOf;
 import static org.openapitools.codegen.utils.ModelUtils.hasOneOf;
 import static org.openapitools.codegen.utils.StringUtils.escape;
@@ -812,13 +812,13 @@ public class OCamlClientCodegen extends DefaultCodegen implements CodegenConfig 
         return result;
     }
 
-    private List<Map<String, Object>> buildEnumValues(String valueString) {
-        List<Map<String, Object>> result = new ArrayList<>();
+    private List<EnumVarMap> buildEnumValues(String valueString) {
+        List<EnumVarMap> result = new ArrayList<>();
 
         for (String v : valueString.split(",")) {
-            Map<String, Object> m = new HashMap<>();
+            EnumVarMap m = new EnumVarMap();
             String value = v.isEmpty() ? "empty" : v;
-            m.put(ENUM_NAME, value);
+            m.setEnumName(value);
             m.put("camlEnumValueName", ocamlizeEnumValue(value));
             result.add(m);
         }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PostgresqlSchemaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PostgresqlSchemaCodegen.java
@@ -33,7 +33,6 @@ import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static org.openapitools.codegen.CodegenConstants.ENUM_VALUES;
 import static org.openapitools.codegen.utils.EnumUtils.getEnumValues;
 import static org.openapitools.codegen.utils.StringUtils.underscore;
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ProtobufSchemaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ProtobufSchemaCodegen.java
@@ -32,6 +32,7 @@ import org.openapitools.codegen.meta.Stability;
 import org.openapitools.codegen.meta.features.DocumentationFeature;
 import org.openapitools.codegen.meta.features.SecurityFeature;
 import org.openapitools.codegen.meta.features.WireFormatFeature;
+import org.openapitools.codegen.model.EnumVarMap;
 import org.openapitools.codegen.model.ModelMap;
 import org.openapitools.codegen.model.ModelsMap;
 import org.openapitools.codegen.model.OperationMap;
@@ -48,7 +49,7 @@ import java.util.stream.Collectors;
 
 import com.google.common.base.CaseFormat;
 
-import static org.openapitools.codegen.CodegenConstants.*;
+import static org.openapitools.codegen.model.EnumVarMap.*;
 import static org.openapitools.codegen.utils.EnumUtils.*;
 import static org.openapitools.codegen.utils.ModelUtils.*;
 import static org.openapitools.codegen.utils.StringUtils.*;
@@ -570,12 +571,12 @@ public class ProtobufSchemaCodegen extends DefaultCodegen implements CodegenConf
      */
     public void addEnumValuesPrefix(Map<String, Object> allowableValues, String prefix) {
         if (hasEnumVars(allowableValues)) {
-            List<Map<String, Object>> enumVars = getEnumVars(allowableValues);
+            List<EnumVarMap> enumVars = getEnumVars(allowableValues);
             prefix = CaseFormat.LOWER_CAMEL.to(CaseFormat.UPPER_UNDERSCORE, prefix);
-            for (Map<String, Object> value : enumVars) {
-                String name = (String) value.get(ENUM_NAME);
-                value.put(ENUM_NAME, useSimplifiedEnumNames ? name : prefix + "_" + name);
-                value.put(ENUM_VALUE, useSimplifiedEnumNames ? name : "\"" + prefix + "_" + name + "\"");
+            for (EnumVarMap value : enumVars) {
+                String name = (String) value.getEnumName();
+                value.setEnumName(useSimplifiedEnumNames ? name : prefix + "_" + name);
+                value.setEnumValue(useSimplifiedEnumNames ? name : "\"" + prefix + "_" + name + "\"");
             }
         }
 
@@ -598,14 +599,12 @@ public class ProtobufSchemaCodegen extends DefaultCodegen implements CodegenConf
 
         if (startEnumsWithUnspecified) {
             if (hasEnumVars(allowableValues)) {
-                List<Map<String, Object>> enumVars = getEnumVars(allowableValues);
+                List<EnumVarMap> enumVars = getEnumVars(allowableValues);
                 boolean unspecifiedPresent = enumVars.stream()
-                        .anyMatch(e -> UNSPECIFIED.equals(e.get(ENUM_NAME)));
+                        .anyMatch(e -> UNSPECIFIED.equals(e.getEnumName()));
                 if (!unspecifiedPresent) {
-                    HashMap<String, Object> unspecifiedEnum = new HashMap<>();
-                    unspecifiedEnum.put(ENUM_NAME, UNSPECIFIED);
-                    unspecifiedEnum.put(ENUM_IS_STRING, false);
-                    unspecifiedEnum.put(ENUM_VALUE, "\"" + UNSPECIFIED + "\"");
+                    EnumVarMap unspecifiedEnum = new EnumVarMap();
+                    unspecifiedEnum.enumVar(UNSPECIFIED, "\"" + UNSPECIFIED + "\"", false);
                     enumVars.add(0, unspecifiedEnum);
                 }
             }
@@ -626,9 +625,9 @@ public class ProtobufSchemaCodegen extends DefaultCodegen implements CodegenConf
      *
      * @param enumVars list of enum vars
      */
-    public void addEnumIndexes(List<Map<String, Object>> enumVars) {
+    public void addEnumIndexes(List<EnumVarMap> enumVars) {
         int enumIndex = 0;
-        for (Map<String, Object> enumVar : enumVars) {
+        for (EnumVarMap enumVar : enumVars) {
             enumVar.put("protobuf-enum-index", enumIndex);
             enumIndex++;
         }
@@ -734,7 +733,7 @@ public class ProtobufSchemaCodegen extends DefaultCodegen implements CodegenConf
                 addUnspecifiedToAllowableValues(allowableValues);
                 addEnumValuesPrefix(allowableValues, cm.getClassname());
                 if (hasEnumVars(allowableValues)) {
-                    List<Map<String, Object>> enumVars = getEnumVars(allowableValues);
+                    List<EnumVarMap> enumVars = getEnumVars(allowableValues);
                     addEnumIndexes(enumVars);
                 }
             }
@@ -790,7 +789,7 @@ public class ProtobufSchemaCodegen extends DefaultCodegen implements CodegenConf
                     addEnumValuesPrefix(enumProperty.allowableValues, enumProperty.getEnumName());
 
                     if (hasEnumVars(enumProperty.allowableValues)) {
-                        List<Map<String, Object>> enumVars = getEnumVars(enumProperty.allowableValues);
+                        List<EnumVarMap> enumVars = getEnumVars(enumProperty.allowableValues);
                         addEnumIndexes(enumVars);
                     }
                     

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ProtobufSchemaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ProtobufSchemaCodegen.java
@@ -600,13 +600,11 @@ public class ProtobufSchemaCodegen extends DefaultCodegen implements CodegenConf
             if (hasEnumVars(allowableValues)) {
                 List<Map<String, Object>> enumVars = getEnumVars(allowableValues);
                 boolean unspecifiedPresent = enumVars.stream()
-                        .anyMatch(e -> {
-                            return UNSPECIFIED.equals(e.get(ENUM_NAME));
-                        });
+                        .anyMatch(e -> UNSPECIFIED.equals(e.get(ENUM_NAME)));
                 if (!unspecifiedPresent) {
-                    HashMap<String, Object> unspecifiedEnum = new HashMap<String, Object>();
+                    HashMap<String, Object> unspecifiedEnum = new HashMap<>();
                     unspecifiedEnum.put(ENUM_NAME, UNSPECIFIED);
-                    unspecifiedEnum.put(ENUM_IS_STRING, "false");
+                    unspecifiedEnum.put(ENUM_IS_STRING, false);
                     unspecifiedEnum.put(ENUM_VALUE, "\"" + UNSPECIFIED + "\"");
                     enumVars.add(0, unspecifiedEnum);
                 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RClientCodegen.java
@@ -40,7 +40,6 @@ import java.io.Writer;
 import java.util.*;
 import java.util.regex.Pattern;
 
-import static org.openapitools.codegen.CodegenConstants.ENUM_VALUES;
 import static org.openapitools.codegen.utils.CamelizeOption.LOWERCASE_FIRST_LETTER;
 import static org.openapitools.codegen.utils.EnumUtils.getEnumValues;
 import static org.openapitools.codegen.utils.StringUtils.camelize;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RubyClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RubyClientCodegen.java
@@ -39,7 +39,7 @@ import java.util.*;
 
 import static org.openapitools.codegen.CodegenConstants.*;
 import static org.openapitools.codegen.utils.EnumUtils.getEnumValues;
-import static org.openapitools.codegen.utils.EnumUtils.getEnumVarsAsString;
+import static org.openapitools.codegen.utils.EnumUtils.getEnumVars;
 import static org.openapitools.codegen.utils.StringUtils.camelize;
 import static org.openapitools.codegen.utils.StringUtils.underscore;
 
@@ -784,7 +784,7 @@ public class RubyClientCodegen extends AbstractRubyCodegen {
                 throw new RuntimeException("Invalid count when constructing example: " + count);
             }
         } else if (codegenModel.isEnum) {
-            List<Map<String, String>> enumVars = getEnumVarsAsString(codegenModel.allowableValues);
+            List<Map<String, Object>> enumVars = getEnumVars(codegenModel.allowableValues);
             return moduleName + "::" + codegenModel.classname + "::" + enumVars.get(0).get(ENUM_NAME);
         } else if (codegenModel.oneOf != null && !codegenModel.oneOf.isEmpty()) {
             String subModel = (String) codegenModel.oneOf.toArray()[0];

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RubyClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RubyClientCodegen.java
@@ -28,6 +28,7 @@ import org.openapitools.codegen.model.ModelMap;
 import org.openapitools.codegen.model.ModelsMap;
 import org.openapitools.codegen.model.OperationMap;
 import org.openapitools.codegen.model.OperationsMap;
+import org.openapitools.codegen.model.EnumVarMap;
 import org.openapitools.codegen.utils.ModelUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,7 +38,6 @@ import java.io.IOException;
 import java.io.Writer;
 import java.util.*;
 
-import static org.openapitools.codegen.CodegenConstants.*;
 import static org.openapitools.codegen.utils.EnumUtils.getEnumValues;
 import static org.openapitools.codegen.utils.EnumUtils.getEnumVars;
 import static org.openapitools.codegen.utils.StringUtils.camelize;
@@ -784,8 +784,8 @@ public class RubyClientCodegen extends AbstractRubyCodegen {
                 throw new RuntimeException("Invalid count when constructing example: " + count);
             }
         } else if (codegenModel.isEnum) {
-            List<Map<String, Object>> enumVars = getEnumVars(codegenModel.allowableValues);
-            return moduleName + "::" + codegenModel.classname + "::" + enumVars.get(0).get(ENUM_NAME);
+            List<EnumVarMap> enumVars = getEnumVars(codegenModel.allowableValues);
+            return moduleName + "::" + codegenModel.classname + "::" + enumVars.get(0).getEnumName();
         } else if (codegenModel.oneOf != null && !codegenModel.oneOf.isEmpty()) {
             String subModel = (String) codegenModel.oneOf.toArray()[0];
             if (modelMaps.containsKey(subModel)) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
@@ -1652,10 +1652,10 @@ public class RustServerCodegen extends AbstractRustCodegen implements CodegenCon
                 additionalProperties.put("apiUsesIntegerEnums", true);
 
                 // Add numeric discriminant values for enum variants
-                List<Map<String, Object>> enumVars = getEnumVars(model.allowableValues);
+                List<EnumVarMap> enumVars = getEnumVars(model.allowableValues);
 
                 if (enumVars != null) {
-                    for (Map<String, Object> enumVar : enumVars) {
+                    for (EnumVarMap enumVar : enumVars) {
                         String value = (String) enumVar.get("value");
                         if (value != null) {
                             // Strip quotes to get raw numeric value

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaLagomServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaLagomServerCodegen.java
@@ -31,7 +31,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.*;
 
-import static org.openapitools.codegen.CodegenConstants.ENUM_VALUES;
 import static org.openapitools.codegen.utils.CamelizeOption.LOWERCASE_FIRST_LETTER;
 import static org.openapitools.codegen.utils.EnumUtils.getEnumValues;
 import static org.openapitools.codegen.utils.StringUtils.camelize;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
@@ -49,7 +49,7 @@ import static java.util.Objects.nonNull;
 import static org.openapitools.codegen.CodegenConstants.ENUM_NAME;
 import static org.openapitools.codegen.CodegenConstants.ENUM_VARS;
 import static org.openapitools.codegen.utils.CamelizeOption.LOWERCASE_FIRST_LETTER;
-import static org.openapitools.codegen.utils.EnumUtils.getEnumVarsAsString;
+import static org.openapitools.codegen.utils.EnumUtils.getEnumVars;
 import static org.openapitools.codegen.utils.OnceLogger.once;
 import static org.openapitools.codegen.utils.StringUtils.*;
 
@@ -606,7 +606,7 @@ public class TypeScriptFetchClientCodegen extends AbstractTypeScriptClientCodege
             var.defaultValue = "false";
         } else {
             if (var.allowableValues != null && var.allowableValues.get(ENUM_VARS) instanceof ArrayList && ((ArrayList<?>) var.allowableValues.get(ENUM_VARS)).get(0) instanceof HashMap) {
-                var.defaultValue = var.dataTypeAlternate + "." + getEnumVarsAsString(var.allowableValues).get(0).get(ENUM_NAME);
+                var.defaultValue = var.dataTypeAlternate + "." + getEnumVars(var.allowableValues).get(0).get(ENUM_NAME);
             }
         }
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
@@ -46,8 +46,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static java.util.Objects.nonNull;
-import static org.openapitools.codegen.CodegenConstants.ENUM_NAME;
-import static org.openapitools.codegen.CodegenConstants.ENUM_VARS;
+import static org.openapitools.codegen.model.EnumVarMap.ENUM_VARS;
 import static org.openapitools.codegen.utils.CamelizeOption.LOWERCASE_FIRST_LETTER;
 import static org.openapitools.codegen.utils.EnumUtils.getEnumVars;
 import static org.openapitools.codegen.utils.OnceLogger.once;
@@ -606,7 +605,7 @@ public class TypeScriptFetchClientCodegen extends AbstractTypeScriptClientCodege
             var.defaultValue = "false";
         } else {
             if (var.allowableValues != null && var.allowableValues.get(ENUM_VARS) instanceof ArrayList && ((ArrayList<?>) var.allowableValues.get(ENUM_VARS)).get(0) instanceof HashMap) {
-                var.defaultValue = var.dataTypeAlternate + "." + getEnumVars(var.allowableValues).get(0).get(ENUM_NAME);
+                var.defaultValue = var.dataTypeAlternate + "." + getEnumVars(var.allowableValues).get(0).getEnumName();
             }
         }
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/model/EnumVarMap.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/model/EnumVarMap.java
@@ -1,0 +1,68 @@
+package org.openapitools.codegen.model;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class EnumVarMap extends HashMap<String, Object> {
+
+    // The raw enum values from the OpenAPI specification
+    public static final String ENUM_VALUES = "values";
+    // The map that stores all enum values and their metadata (name, value, enumDescription...)
+    public static final String ENUM_VARS = "enumVars";
+    // The name of the enum, for example NAME("value") in Java
+    public static final String ENUM_NAME = "name";
+    // The on-the-line value, i.e., the one present in the "values"
+    public static final String ENUM_VALUE = "value";
+    // If the enum is typed as a string
+    public static final String ENUM_IS_STRING = "isString";
+    // The description that should be attached to an entry in "enumVars"
+    public static final String ENUM_DESCRIPTION = "enumDescription";
+
+    public EnumVarMap() {
+
+    }
+
+    public EnumVarMap(EnumVarMap init) {
+        putAll(init);
+    }
+
+    public EnumVarMap(Map<String, String> init) {
+        putAll(init);
+    }
+
+    public void enumVar(String enumName, String enumValue, boolean isString) {
+        put(ENUM_NAME, enumName);
+        put(ENUM_VALUE, enumValue);
+        put(ENUM_IS_STRING, isString);
+    }
+
+    public void setEnumName(String name) {
+        put(ENUM_NAME, name);
+    }
+
+    public Object getEnumName() {
+        return get(ENUM_NAME);
+    }
+
+    public void setEnumValue(String value) {
+        put(ENUM_VALUE, value);
+    }
+
+    public Object getEnumValue() {
+        return get(ENUM_VALUE);
+    }
+
+    public void isString(boolean isString) {
+        put(ENUM_IS_STRING, isString);
+    }
+
+    public boolean isString() {
+        Object value = get(ENUM_IS_STRING);
+        if (!(value instanceof Boolean)) {
+            throw new IllegalStateException(ENUM_IS_STRING + " is not a boolean: " + value);
+        }
+        return (Boolean) value;
+    }
+
+}

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/EnumUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/EnumUtils.java
@@ -2,12 +2,14 @@ package org.openapitools.codegen.utils;
 
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.media.Schema;
-import org.openapitools.codegen.CodegenConstants;
+import org.openapitools.codegen.model.EnumVarMap;
 
 import java.util.*;
 import java.util.stream.Collectors;
 
-import static org.openapitools.codegen.CodegenConstants.*;
+import static org.openapitools.codegen.CodegenConstants.X_ENUM_DEPRECATED;
+import static org.openapitools.codegen.CodegenConstants.X_ENUM_DESCRIPTIONS;
+import static org.openapitools.codegen.model.EnumVarMap.*;
 
 public class EnumUtils {
 
@@ -22,7 +24,7 @@ public class EnumUtils {
     /**
      *
      * @param allowableValues The allowableValues map
-     * @return whether the allowableValues map contains {@value CodegenConstants#ENUM_VARS}
+     * @return whether the allowableValues map contains {@value EnumVarMap#ENUM_VARS}
      */
     public static boolean hasEnumVars(Map<String, Object> allowableValues) {
         return allowableValues != null && allowableValues.containsKey(ENUM_VARS);
@@ -31,25 +33,26 @@ public class EnumUtils {
     /**
      *
      * @param allowableValues The allowableValues map
-     * @return whether the allowableValues map contains {@value CodegenConstants#ENUM_VALUES}
+     * @return whether the allowableValues map contains {@value EnumVarMap#ENUM_VALUES}
      */
     public static boolean hasEnumValues(Map<String, Object> allowableValues) {
         return allowableValues != null && allowableValues.containsKey(ENUM_VALUES);
     }
 
     /**
-     * Get the {@value CodegenConstants#ENUM_VARS} from the allowableValues map.
+     * Get the {@value EnumVarMap#ENUM_VARS} from the allowableValues map.
+     *
      * @param allowableValues The allowableValues map
      * @return the list of enumVars
      */
-    public static List<Map<String, Object>> getEnumVars(Map<String, Object> allowableValues) {
+    public static List<EnumVarMap> getEnumVars(Map<String, Object> allowableValues) {
         @SuppressWarnings("unchecked")
-        List<Map<String, Object>> enumVars = (List<Map<String, Object>>) allowableValues.get(ENUM_VARS);
+        List<EnumVarMap> enumVars = (List<EnumVarMap>) allowableValues.get(ENUM_VARS);
         return enumVars;
     }
 
     /**
-     * Get the {@value CodegenConstants#ENUM_VALUES} from the allowableValues map.
+     * Get the {@value EnumVarMap#ENUM_VALUES} from the allowableValues map.
      * @param allowableValues The allowableValues map
      * @return the list of enumValues
      */
@@ -60,7 +63,7 @@ public class EnumUtils {
     }
 
     /**
-     * Get the {@value CodegenConstants#ENUM_VALUES} from the allowableValues map.
+     * Get the {@value EnumVarMap#ENUM_VALUES} from the allowableValues map.
      * @param allowableValues The allowableValues map
      * @return the list of enumValues
      */

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/EnumUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/EnumUtils.java
@@ -60,17 +60,6 @@ public class EnumUtils {
     }
 
     /**
-     * Get the {@value CodegenConstants#ENUM_VARS} from the allowableValues map.
-     * @param allowableValues The allowableValues map
-     * @return the list of enumVars
-     */
-    public static List<Map<String, String>> getEnumVarsAsString(Map<String, Object> allowableValues) {
-        @SuppressWarnings("unchecked")
-        List<Map<String, String>> enumVars = (List<Map<String, String>>) allowableValues.get(ENUM_VARS);
-        return enumVars;
-    }
-
-    /**
      * Get the {@value CodegenConstants#ENUM_VALUES} from the allowableValues map.
      * @param allowableValues The allowableValues map
      * @return the list of enumValues

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/protobuf/ProtobufSchemaCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/protobuf/ProtobufSchemaCodegenTest.java
@@ -312,7 +312,7 @@ public class ProtobufSchemaCodegenTest {
 
         Assert.assertEquals(enumVars1.get(0).get("name"), "UNSPECIFIED");
         Assert.assertEquals(enumVars1.get(0).get("value"), "UNSPECIFIED");
-        Assert.assertEquals(Boolean.valueOf((String) enumVars1.get(0).get("isString")), false);
+        Assert.assertEquals(enumVars1.get(0).get("isString"), false);
 
         Assert.assertEquals(enumVars1.get(1).get("name"), "FOO");
         Assert.assertEquals(enumVars1.get(1).get("value"), "FOO");


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Introduces a enum wrapper model that collects the common operations that are done when creating an enum variable. 

This is done as a `HashMap` wrapper rather than a `Codegen` model since we want to retain the easy extension of the data. This structure mimics the already existing `XMap` models that are within the [model folder](https://github.com/OpenAPITools/openapi-generator/tree/master/modules/openapi-generator/src/main/java/org/openapitools/codegen/model).

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces `EnumVarMap` to standardize and type-safe enum handling across generators, moving enum constants off `CodegenConstants` and replacing `getEnumVarsAsString` with `getEnumVars`. Refactor spans multiple generators with no changes to generated outputs.

- **Refactors**
  - Added `EnumVarMap` (HashMap wrapper) with helpers and `ENUM_*` constants.
  - Switched enum flows to `List<EnumVarMap>` in core (`buildEnumVars`, post-processing, extension updates).
  - Removed `EnumUtils.getEnumVarsAsString`; updated generators to `EnumUtils.getEnumVars` (C#, Dart, F#, PHP, Python incl. Pydantic V1, Java/Helidon, Go, Nim, OCaml, Haskell, Crystal, Ruby, TypeScript Fetch, Avro, Protobuf, etc.).
  - Protobuf: migrated to `EnumVarMap`, added enum indexes; tests updated to assert boolean `isString`.

- **Migration**
  - Signatures now use `List<EnumVarMap>`:
    - `buildEnumVars(List<Object>, String)` returns `List<EnumVarMap>`.
    - `updateEnumVarsWithExtensions(...)` accepts `List<EnumVarMap>`.
  - Replace `CodegenConstants.ENUM_*` with `EnumVarMap.ENUM_*`.
  - Replace `EnumUtils.getEnumVarsAsString(...)` with `EnumUtils.getEnumVars(...)`.
  - When mutating enum vars, use `EnumVarMap` methods: `enumVar(...)`, `setEnumName(...)`, `setEnumValue(...)`, `isString(boolean)`, `getEnumName()`, `getEnumValue()`, `isString()`.

<sup>Written for commit 889607d535ed6129f37d429d1c628aaf3b8df786. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24665?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

