### PR TITLE
Fix multipart fields in vertx

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaVertXWebServer/formParams.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaVertXWebServer/formParams.mustache
@@ -4,14 +4,15 @@
         JsonObject {{paramName}} = body != null ? body.getJsonObject() : null;
 {{/isFile}}
 {{#isFile}}
-        {{{dataType}}} {{paramName}} = null;
-        if (routingContext.fileUploads().isEmpty()) {
+        {{{dataType}}} {{paramName}} = routingContext.fileUploads().stream()
+            .filter(upload -> "{{baseName}}".equals(upload.name()))
+            .findFirst()
+            .orElse(null);
+        if ({{paramName}} == null) {
 {{#required}}
             routingContext.fail(400);
             return;
 {{/required}}
-        } else {
-            {{paramName}} = routingContext.fileUploads().iterator().next();
         }
 {{/isFile}}
 {{/isFormParam}}

--- a/samples/client/petstore/java/resttemplate-springBoot4-jackson3/pom.xml
+++ b/samples/client/petstore/java/resttemplate-springBoot4-jackson3/pom.xml
@@ -269,7 +269,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <spring-web-version>7.0.5</spring-web-version>
+        <spring-web-version>7.0.8</spring-web-version>
         <jackson-version>3.1.5</jackson-version>
         <jakarta-annotation-version>3.0.0</jakarta-annotation-version>
 

--- a/samples/server/petstore/java-vertx-web-interface-only/src/main/java/org/openapitools/vertxweb/server/api/PetApiHandler.java
+++ b/samples/server/petstore/java-vertx-web-interface-only/src/main/java/org/openapitools/vertxweb/server/api/PetApiHandler.java
@@ -208,10 +208,11 @@ public class PetApiHandler {
         RequestParameters requestParameters = routingContext.get(ValidationHandler.REQUEST_CONTEXT_KEY);
 
         Long petId = requestParameters.pathParameter("petId") != null ? requestParameters.pathParameter("petId").getLong() : null;
-        FileUpload _file = null;
-        if (routingContext.fileUploads().isEmpty()) {
-        } else {
-            _file = routingContext.fileUploads().iterator().next();
+        FileUpload _file = routingContext.fileUploads().stream()
+            .filter(upload -> "file".equals(upload.name()))
+            .findFirst()
+            .orElse(null);
+        if (_file == null) {
         }
 
         logger.debug("Parameter petId is {}", petId);

--- a/samples/server/petstore/java-vertx-web/src/main/java/org/openapitools/vertxweb/server/api/PetApiHandler.java
+++ b/samples/server/petstore/java-vertx-web/src/main/java/org/openapitools/vertxweb/server/api/PetApiHandler.java
@@ -212,10 +212,11 @@ public class PetApiHandler {
         RequestParameters requestParameters = routingContext.get(ValidationHandler.REQUEST_CONTEXT_KEY);
 
         Long petId = requestParameters.pathParameter("petId") != null ? requestParameters.pathParameter("petId").getLong() : null;
-        FileUpload _file = null;
-        if (routingContext.fileUploads().isEmpty()) {
-        } else {
-            _file = routingContext.fileUploads().iterator().next();
+        FileUpload _file = routingContext.fileUploads().stream()
+            .filter(upload -> "file".equals(upload.name()))
+            .findFirst()
+            .orElse(null);
+        if (_file == null) {
         }
 
         logger.debug("Parameter petId is {}", petId);


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix multipart form file handling in Vert.x server generator to select uploads by field name, preventing wrong file mapping when multiple files or fields are present. Updated sample handlers and bumped `spring-web` in a sample.

- **Bug Fixes**
  - In `JavaVertXWebServer/formParams.mustache`, file params now filter `routingContext.fileUploads()` by the form field name and return 400 when required and missing.
  - Updated Vert.x sample `PetApiHandler` implementations to use the same logic.

- **Dependencies**
  - Bump `spring-web` to `7.0.8` in `samples/client/petstore/java/resttemplate-springBoot4-jackson3/pom.xml`.

<sup>Written for commit 0e71892693004916a3e3f803dcc221ba816a92bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24668?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

