### PR TITLE
[GRADLE-WRAPPER] Generator status message visibility update

### DIFF
--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/GenerateTask.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/GenerateTask.kt
@@ -248,7 +248,10 @@ abstract class OpenApiWorkAction : WorkAction<OpenApiWorkParameters> {
             DefaultGenerator(isDryRun).opts(clientOptInput).generate()
 
             params.outputDir.orNull?.let { dir ->
-                logger.lifecycle("Successfully generated code to ${dir.asFile.absolutePath}")
+                val quietMode = params.quiet.getOrElse(false)
+                if (!quietMode) {
+                    logger.lifecycle("Successfully generated code to ${dir.asFile.absolutePath}")
+                }
             }
 
         } catch (e: Exception) {
@@ -1065,7 +1068,10 @@ abstract class GenerateTask : DefaultTask() {
         cleanupOutput.orNull?.let { cleanup ->
             if (cleanup && outputDir.isPresent) {
                 fs.delete { delete(outputDir) }
-                logger.lifecycle("Cleaned up output directory ${outputDir.get().asFile.path} before code generation.")
+                val quietMode = quiet.getOrElse(false)
+                if (!quietMode) {
+                    logger.lifecycle("Cleaned up output directory ${outputDir.get().asFile.path} before code generation.")
+                }
             }
         }
 


### PR DESCRIPTION
After quite mode implementation in https://github.com/OpenAPITools/openapi-generator/issues/11211 the build output is shorter but still every generator task logs a single success generation output message:

> Successfully generated code to /path/to/output

This PR hides behind the same `quiteMode` to make the build output clean in case of succesfull run.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Gradle plugin quiet mode fully quiet by suppressing success and cleanup lifecycle messages. The "Successfully generated code..." and "Cleaned up output directory ..." logs now appear only when quietMode is false, keeping successful builds clean.

<sup>Written for commit 2918bf68ff0a588b242ba5db9575fc6143118d92. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24670?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

