### PR TITLE
[dart-dio][json_serializable] fix unknownEnumValue for collection-typed enum properties

### DIFF
--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/json_serializable/class.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/json_serializable/class.mustache
@@ -66,9 +66,11 @@ class {{{classname}}} {
   {{/items.isEnumOrRef}}
   {{/isArray}}
   {{^isArray}}
+  {{^isMap}}
   {{#isEnumOrRef}}
   unknownEnumValue: {{{datatypeWithEnum}}}.unknownDefaultOpenApi,
   {{/isEnumOrRef}}
+  {{/isMap}}
   {{/isArray}}
   {{/enumUnknownDefaultCase}}
   )

--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/json_serializable/class.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/json_serializable/class.mustache
@@ -59,11 +59,18 @@ class {{{classname}}} {
     required: {{#required}}true{{/required}}{{^required}}false{{/required}},
     includeIfNull: {{#required}}{{#isNullable}}true{{/isNullable}}{{^isNullable}}false{{/isNullable}}{{/required}}{{^required}}false{{/required}},{{^required}}{{#useOptional}}
     readValue: readOptionalValue,{{/useOptional}}{{/required}}
-  {{#isEnumOrRef}}
   {{#enumUnknownDefaultCase}}
+  {{#isArray}}
+  {{#items.isEnumOrRef}}
+  unknownEnumValue: {{{items.datatypeWithEnum}}}.unknownDefaultOpenApi,
+  {{/items.isEnumOrRef}}
+  {{/isArray}}
+  {{^isArray}}
+  {{#isEnumOrRef}}
   unknownEnumValue: {{{datatypeWithEnum}}}.unknownDefaultOpenApi,
-  {{/enumUnknownDefaultCase}}
   {{/isEnumOrRef}}
+  {{/isArray}}
+  {{/enumUnknownDefaultCase}}
   )
   {{/isBinary}}
   {{#isBinary}}

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/model/enum_arrays.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/model/enum_arrays.dart
@@ -43,7 +43,7 @@ class EnumArrays {
     name: r'array_enum',
     required: false,
     includeIfNull: false,
-  unknownEnumValue: List<EnumArraysArrayEnumEnum>.unknownDefaultOpenApi,
+  unknownEnumValue: EnumArraysArrayEnumEnum.unknownDefaultOpenApi,
   )
 
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/model/map_test.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/model/map_test.dart
@@ -46,7 +46,6 @@ class MapTest {
     name: r'map_of_enum_string',
     required: false,
     includeIfNull: false,
-  unknownEnumValue: Map<String, MapTestMapOfEnumStringEnum>.unknownDefaultOpenApi,
   )
 
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/model/object_with_duplicate_inline_enum.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/model/object_with_duplicate_inline_enum.dart
@@ -29,7 +29,7 @@ class ObjectWithDuplicateInlineEnum {
     name: r'attribute',
     required: false,
     includeIfNull: false,
-  unknownEnumValue: Set<ObjectWithDuplicateInlineEnumAttributeEnum>.unknownDefaultOpenApi,
+  unknownEnumValue: ObjectWithDuplicateInlineEnumAttributeEnum.unknownDefaultOpenApi,
   )
 
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/model/object_with_inline_enum.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/model/object_with_inline_enum.dart
@@ -29,7 +29,7 @@ class ObjectWithInlineEnum {
     name: r'attribute',
     required: false,
     includeIfNull: false,
-  unknownEnumValue: Set<ObjectWithInlineEnumAttributeEnum>.unknownDefaultOpenApi,
+  unknownEnumValue: ObjectWithInlineEnumAttributeEnum.unknownDefaultOpenApi,
   )
 
 


### PR DESCRIPTION
`enumUnknownDefaultCase` is unusable with `serializationLibrary=json_serializable` whenever a spec contains a collection of enums. The template emits the fallback from the *property's* `datatypeWithEnum`, guarded on the *property's* `isEnumOrRef`. Both are wrong for collection-typed properties, in opposite directions.

**1. List/Set of inline enums → invalid Dart.** The property type is the container, so the template produces:

```dart
unknownEnumValue: List<EnumArraysArrayEnumEnum>.unknownDefaultOpenApi,
```

`dart analyze` on the current sample:

```
error - enum_arrays.dart:46:21 - The class 'List' doesn't have a constructor
        named 'unknownDefaultOpenApi'. - class_instantiation_access_to_member
error - enum_arrays.dart:46:21 - Arguments of a constant creation must be
        constant expressions. - const_with_non_constant_argument
```

Both errors are gone after this change, and no other diagnostic in the file changes. Three committed samples contain this today — `enum_arrays.dart`, `object_with_inline_enum.dart`, `object_with_duplicate_inline_enum.dart` — so it reproduces straight from `bin/configs/dart-dio-petstore-client-lib-fake-json_serializable.yaml`, which already sets `enumUnknownDefaultCase: "true"`.

**2. List of `$ref`'d enums → no fallback at all.** `isEnumOrRef` is `false` on the property, so nothing is emitted and those fields still throw ``ArgumentError: `x` is not one of the supported values`` on an unknown value — the exact failure `enumUnknownDefaultCase` exists to prevent. No sample covers this shape, so it produces no sample diff; reproduce by pointing an array property at a `$ref`'d enum.

**Fix.** Key the guard and the type off `items` for collections, and off the property otherwise. `json_serializable` applies `unknownValue:` per element for iterables of enums, so the element type is the correct target in both cases — confirmed in the generated `.g.dart`:

```dart
availableMethods: (v as List<dynamic>)
    .map((e) => $enumDecode(_$RefundMethodEnumMap, e,
          unknownValue: RefundMethod.unknownDefaultOpenApi))
    .toList(),
```

`uniqueItems: true` properties (`Set<…>`) were affected identically and are fixed by the same branch.

Fixes #22160

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran `./mvnw clean package`, `./bin/generate-samples.sh`, `./bin/utils/export_docs_generators.sh` and committed all changed files. Sample diff is 3 lines across 3 files; `export_docs_generators.sh` produces no diff, as this is a template-only change that adds no option.
- [x] @mention the technical committee: @yissachar @joernahrens @swipesight @jaumard

*Note on verification:* I confirmed the fix with `dart analyze` rather than a full `build_runner` run — the json_serializable sample fails `build_runner` with 46 `FormatterException`s on my machine **both before and after** this change, a pre-existing SDK / `dart_style` mismatch unrelated to it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `enumUnknownDefaultCase` in `dart-dio` with `json_serializable` for collection-typed enums. Generates valid Dart, applies per-element fallbacks for arrays/sets, and omits unsupported maps and nested collections.

- **Bug Fixes**
  - Use element type for `unknownEnumValue` on array/set properties; fall back to property type otherwise.
  - Drop invalid `List<...>.unknownDefaultOpenApi` / `Set<...>.unknownDefaultOpenApi` and omit `unknownEnumValue` on map and nested collection fields.
  - Emit fallbacks for `$ref` enums in arrays so unknown values no longer throw.
  - Template-only change in `class.mustache`; updated samples accordingly. Fixes #22160.

<sup>Written for commit df5ced50c0dd32ea766e32ffc6260710c42bf59e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24673?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

