### PR TITLE
[scala-sttp4] Model named Request shadows sttp.client4.Request

### DIFF
--- a/modules/openapi-generator/src/main/resources/scala-sttp4/api.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-sttp4/api.mustache
@@ -20,7 +20,7 @@ class {{classname}}(baseUrl: String) {
 {{>javadoc}}
 
 {{/javadocRenderer}}
-  def {{operationId}}({{>methodParameters}}): Request[{{#separateErrorChannel}}Either[ResponseException[String], {{>operationReturnType}}]{{/separateErrorChannel}}{{^separateErrorChannel}}{{>operationReturnType}}{{/separateErrorChannel}}] =
+  def {{operationId}}({{>methodParameters}}): sttp.client4.Request[{{#separateErrorChannel}}Either[ResponseException[String], {{>operationReturnType}}]{{/separateErrorChannel}}{{^separateErrorChannel}}{{>operationReturnType}}{{/separateErrorChannel}}] =
     basicRequest
       .method(Method.{{httpMethod.toUpperCase}}, uri"$baseUrl{{{path}}}{{#queryParams.0}}?{{/queryParams.0}}{{#queryParams}}{{baseName}}=${ {{paramName}} }{{^-last}}&{{/-last}}{{/queryParams}}{{#authMethods}}{{#isApiKey}}{{#isKeyInQuery}}{{#queryParams.0}}&{{/queryParams.0}}{{^queryParams.0}}?{{/queryParams.0}}{{keyParamName}}=${apiKeyQuery}{{/isKeyInQuery}}{{/isApiKey}}{{/authMethods}}")
       .contentType({{#consumes.0}}"{{{mediaType}}}"{{/consumes.0}}{{^consumes}}"application/json"{{/consumes}}){{#headerParams}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/scala/Sttp4CodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/scala/Sttp4CodegenTest.java
@@ -410,4 +410,37 @@ public class Sttp4CodegenTest {
         Path petPath = Paths.get(outputPath + "/src/main/scala/org/openapitools/client/model/Pet.scala");
         assertFileContains(petPath, "implicit val encoder: Encoder[Pet] = deriveEncoder[Pet].mapJson(_.dropNullValues)");
     }
+
+    @Test
+    public void verifyModelNamedRequestDoesNotShadowSttpRequest() throws IOException {
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+        String outputPath = output.getAbsolutePath().replace('\\', '/');
+
+        OpenAPI openAPI = new OpenAPIParser()
+                .readLocation("src/test/resources/3_0/scala/sttp4-request-model-name.yaml", null, new ParseOptions())
+                .getOpenAPI();
+
+        ScalaSttp4ClientCodegen codegen = new ScalaSttp4ClientCodegen();
+        codegen.setOutputDir(output.getAbsolutePath());
+
+        ClientOptInput input = new ClientOptInput();
+        input.openAPI(openAPI);
+        input.config(codegen);
+
+        DefaultGenerator generator = new DefaultGenerator();
+
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODELS, "true");
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODEL_TESTS, "false");
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODEL_DOCS, "false");
+        generator.setGeneratorPropertyDefault(CodegenConstants.APIS, "true");
+        generator.setGeneratorPropertyDefault(CodegenConstants.SUPPORTING_FILES, "false");
+        generator.opts(input).generate();
+
+        // A model named Request is imported explicitly, which outranks the
+        // `import sttp.client4._` wildcard, so the return type must be qualified.
+        Path apiPath = Paths.get(outputPath + "/src/main/scala/org/openapitools/client/api/DefaultApi.scala");
+        assertFileContains(apiPath, "import org.openapitools.client.model.Request");
+        assertFileContains(apiPath, "): sttp.client4.Request[Either[ResponseException[String], Response]] =");
+    }
 }

--- a/modules/openapi-generator/src/test/resources/3_0/scala/sttp4-request-model-name.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/scala/sttp4-request-model-name.yaml
@@ -1,0 +1,34 @@
+openapi: 3.0.0
+info:
+  title: sttp4 model named Request
+  version: 1.0.0
+paths:
+  /predict:
+    post:
+      operationId: predict
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Request'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+components:
+  schemas:
+    Request:
+      type: object
+      required:
+        - userId
+      properties:
+        userId:
+          type: string
+    Response:
+      type: object
+      properties:
+        score:
+          type: number

--- a/samples/client/petstore/scala-sttp4-circe/src/main/scala/org/openapitools/client/api/PetApi.scala
+++ b/samples/client/petstore/scala-sttp4-circe/src/main/scala/org/openapitools/client/api/PetApi.scala
@@ -33,7 +33,7 @@ class PetApi(baseUrl: String) {
    * 
    * @param pet Pet object that needs to be added to the store
    */
-  def addPet(pet: Pet): Request[Either[ResponseException[String], Pet]] =
+  def addPet(pet: Pet): sttp.client4.Request[Either[ResponseException[String], Pet]] =
     basicRequest
       .method(Method.POST, uri"$baseUrl/pet")
       .contentType("application/json")
@@ -49,7 +49,7 @@ class PetApi(baseUrl: String) {
    * @param petId Pet id to delete
    * @param apiKey 
    */
-  def deletePet(petId: Long, apiKey: Option[String] = None): Request[Either[ResponseException[String], Unit]] =
+  def deletePet(petId: Long, apiKey: Option[String] = None): sttp.client4.Request[Either[ResponseException[String], Unit]] =
     basicRequest
       .method(Method.DELETE, uri"$baseUrl/pet/${petId}")
       .contentType("application/json")
@@ -65,7 +65,7 @@ class PetApi(baseUrl: String) {
    * 
    * @param status Status values that need to be considered for filter
    */
-  def findPetsByStatus(status: Seq[String] = Seq.empty): Request[Either[ResponseException[String], Seq[Pet]]] =
+  def findPetsByStatus(status: Seq[String] = Seq.empty): sttp.client4.Request[Either[ResponseException[String], Seq[Pet]]] =
     basicRequest
       .method(Method.GET, uri"$baseUrl/pet/findByStatus?status=${ status }")
       .contentType("application/json")
@@ -80,7 +80,7 @@ class PetApi(baseUrl: String) {
    * 
    * @param tags Tags to filter by
    */
-  def findPetsByTags(tags: Seq[String] = Seq.empty): Request[Either[ResponseException[String], Seq[Pet]]] =
+  def findPetsByTags(tags: Seq[String] = Seq.empty): sttp.client4.Request[Either[ResponseException[String], Seq[Pet]]] =
     basicRequest
       .method(Method.GET, uri"$baseUrl/pet/findByTags?tags=${ tags }")
       .contentType("application/json")
@@ -99,7 +99,7 @@ class PetApi(baseUrl: String) {
    * 
    * @param petId ID of pet to return
    */
-  def getPetById(apiKeyHeader: String)(petId: Long): Request[Either[ResponseException[String], Pet]] =
+  def getPetById(apiKeyHeader: String)(petId: Long): sttp.client4.Request[Either[ResponseException[String], Pet]] =
     basicRequest
       .method(Method.GET, uri"$baseUrl/pet/${petId}")
       .contentType("application/json")
@@ -117,7 +117,7 @@ class PetApi(baseUrl: String) {
    * 
    * @param pet Pet object that needs to be added to the store
    */
-  def updatePet(pet: Pet): Request[Either[ResponseException[String], Pet]] =
+  def updatePet(pet: Pet): sttp.client4.Request[Either[ResponseException[String], Pet]] =
     basicRequest
       .method(Method.PUT, uri"$baseUrl/pet")
       .contentType("application/json")
@@ -134,7 +134,7 @@ class PetApi(baseUrl: String) {
    * @param name Updated name of the pet
    * @param status Updated status of the pet
    */
-  def updatePetWithForm(petId: Long, name: Option[String] = None, status: Option[String] = None): Request[Either[ResponseException[String], Unit]] =
+  def updatePetWithForm(petId: Long, name: Option[String] = None, status: Option[String] = None): sttp.client4.Request[Either[ResponseException[String], Unit]] =
     basicRequest
       .method(Method.POST, uri"$baseUrl/pet/${petId}")
       .contentType("application/x-www-form-urlencoded")
@@ -154,7 +154,7 @@ class PetApi(baseUrl: String) {
    * @param additionalMetadata Additional data to pass to server
    * @param file file to upload
    */
-  def uploadFile(petId: Long, additionalMetadata: Option[String] = None, file: Option[File] = None): Request[Either[ResponseException[String], ApiResponse]] =
+  def uploadFile(petId: Long, additionalMetadata: Option[String] = None, file: Option[File] = None): sttp.client4.Request[Either[ResponseException[String], ApiResponse]] =
     basicRequest
       .method(Method.POST, uri"$baseUrl/pet/${petId}/uploadImage")
       .contentType("multipart/form-data")

--- a/samples/client/petstore/scala-sttp4-circe/src/main/scala/org/openapitools/client/api/StoreApi.scala
+++ b/samples/client/petstore/scala-sttp4-circe/src/main/scala/org/openapitools/client/api/StoreApi.scala
@@ -31,7 +31,7 @@ class StoreApi(baseUrl: String) {
    * 
    * @param orderId ID of the order that needs to be deleted
    */
-  def deleteOrder(orderId: String): Request[Either[ResponseException[String], Unit]] =
+  def deleteOrder(orderId: String): sttp.client4.Request[Either[ResponseException[String], Unit]] =
     basicRequest
       .method(Method.DELETE, uri"$baseUrl/store/order/${orderId}")
       .contentType("application/json")
@@ -46,7 +46,7 @@ class StoreApi(baseUrl: String) {
    * Available security schemes:
    *   api_key (apiKey)
    */
-  def getInventory(apiKeyHeader: String)(): Request[Either[ResponseException[String], Map[String, Int]]] =
+  def getInventory(apiKeyHeader: String)(): sttp.client4.Request[Either[ResponseException[String], Map[String, Int]]] =
     basicRequest
       .method(Method.GET, uri"$baseUrl/store/inventory")
       .contentType("application/json")
@@ -63,7 +63,7 @@ class StoreApi(baseUrl: String) {
    * 
    * @param orderId ID of pet that needs to be fetched
    */
-  def getOrderById(orderId: Long): Request[Either[ResponseException[String], Order]] =
+  def getOrderById(orderId: Long): sttp.client4.Request[Either[ResponseException[String], Order]] =
     basicRequest
       .method(Method.GET, uri"$baseUrl/store/order/${orderId}")
       .contentType("application/json")
@@ -78,7 +78,7 @@ class StoreApi(baseUrl: String) {
    * 
    * @param order order placed for purchasing the pet
    */
-  def placeOrder(order: Order): Request[Either[ResponseException[String], Order]] =
+  def placeOrder(order: Order): sttp.client4.Request[Either[ResponseException[String], Order]] =
     basicRequest
       .method(Method.POST, uri"$baseUrl/store/order")
       .contentType("application/json")

--- a/samples/client/petstore/scala-sttp4-circe/src/main/scala/org/openapitools/client/api/UserApi.scala
+++ b/samples/client/petstore/scala-sttp4-circe/src/main/scala/org/openapitools/client/api/UserApi.scala
@@ -34,7 +34,7 @@ class UserApi(baseUrl: String) {
    * 
    * @param user Created user object
    */
-  def createUser(apiKeyHeader: String)(user: User): Request[Either[ResponseException[String], Unit]] =
+  def createUser(apiKeyHeader: String)(user: User): sttp.client4.Request[Either[ResponseException[String], Unit]] =
     basicRequest
       .method(Method.POST, uri"$baseUrl/user")
       .contentType("application/json")
@@ -53,7 +53,7 @@ class UserApi(baseUrl: String) {
    * 
    * @param user List of user object
    */
-  def createUsersWithArrayInput(apiKeyHeader: String)(user: Seq[User]): Request[Either[ResponseException[String], Unit]] =
+  def createUsersWithArrayInput(apiKeyHeader: String)(user: Seq[User]): sttp.client4.Request[Either[ResponseException[String], Unit]] =
     basicRequest
       .method(Method.POST, uri"$baseUrl/user/createWithArray")
       .contentType("application/json")
@@ -72,7 +72,7 @@ class UserApi(baseUrl: String) {
    * 
    * @param user List of user object
    */
-  def createUsersWithListInput(apiKeyHeader: String)(user: Seq[User]): Request[Either[ResponseException[String], Unit]] =
+  def createUsersWithListInput(apiKeyHeader: String)(user: Seq[User]): sttp.client4.Request[Either[ResponseException[String], Unit]] =
     basicRequest
       .method(Method.POST, uri"$baseUrl/user/createWithList")
       .contentType("application/json")
@@ -92,7 +92,7 @@ class UserApi(baseUrl: String) {
    * 
    * @param username The name that needs to be deleted
    */
-  def deleteUser(apiKeyHeader: String)(username: String): Request[Either[ResponseException[String], Unit]] =
+  def deleteUser(apiKeyHeader: String)(username: String): sttp.client4.Request[Either[ResponseException[String], Unit]] =
     basicRequest
       .method(Method.DELETE, uri"$baseUrl/user/${username}")
       .contentType("application/json")
@@ -109,7 +109,7 @@ class UserApi(baseUrl: String) {
    * 
    * @param username The name that needs to be fetched. Use user1 for testing.
    */
-  def getUserByName(username: String): Request[Either[ResponseException[String], User]] =
+  def getUserByName(username: String): sttp.client4.Request[Either[ResponseException[String], User]] =
     basicRequest
       .method(Method.GET, uri"$baseUrl/user/${username}")
       .contentType("application/json")
@@ -129,7 +129,7 @@ class UserApi(baseUrl: String) {
    * @param username The user name for login
    * @param password The password for login in clear text
    */
-  def loginUser(username: String, password: String): Request[Either[ResponseException[String], String]] =
+  def loginUser(username: String, password: String): sttp.client4.Request[Either[ResponseException[String], String]] =
     basicRequest
       .method(Method.GET, uri"$baseUrl/user/login?username=${ username }&password=${ password }")
       .contentType("application/json")
@@ -144,7 +144,7 @@ class UserApi(baseUrl: String) {
    * Available security schemes:
    *   api_key (apiKey)
    */
-  def logoutUser(apiKeyHeader: String)(): Request[Either[ResponseException[String], Unit]] =
+  def logoutUser(apiKeyHeader: String)(): sttp.client4.Request[Either[ResponseException[String], Unit]] =
     basicRequest
       .method(Method.GET, uri"$baseUrl/user/logout")
       .contentType("application/json")
@@ -164,7 +164,7 @@ class UserApi(baseUrl: String) {
    * @param username name that need to be deleted
    * @param user Updated user object
    */
-  def updateUser(apiKeyHeader: String)(username: String, user: User): Request[Either[ResponseException[String], Unit]] =
+  def updateUser(apiKeyHeader: String)(username: String, user: User): sttp.client4.Request[Either[ResponseException[String], Unit]] =
     basicRequest
       .method(Method.PUT, uri"$baseUrl/user/${username}")
       .contentType("application/json")

--- a/samples/client/petstore/scala-sttp4/src/main/scala/org/openapitools/client/api/PetApi.scala
+++ b/samples/client/petstore/scala-sttp4/src/main/scala/org/openapitools/client/api/PetApi.scala
@@ -33,7 +33,7 @@ class PetApi(baseUrl: String) {
    * 
    * @param pet Pet object that needs to be added to the store
    */
-  def addPet(pet: Pet): Request[Either[ResponseException[String], Pet]] =
+  def addPet(pet: Pet): sttp.client4.Request[Either[ResponseException[String], Pet]] =
     basicRequest
       .method(Method.POST, uri"$baseUrl/pet")
       .contentType("application/json")
@@ -49,7 +49,7 @@ class PetApi(baseUrl: String) {
    * @param petId Pet id to delete
    * @param apiKey 
    */
-  def deletePet(petId: Long, apiKey: Option[String] = None): Request[Either[ResponseException[String], Unit]] =
+  def deletePet(petId: Long, apiKey: Option[String] = None): sttp.client4.Request[Either[ResponseException[String], Unit]] =
     basicRequest
       .method(Method.DELETE, uri"$baseUrl/pet/${petId}")
       .contentType("application/json")
@@ -65,7 +65,7 @@ class PetApi(baseUrl: String) {
    * 
    * @param status Status values that need to be considered for filter
    */
-  def findPetsByStatus(status: Seq[String] = Seq.empty): Request[Either[ResponseException[String], Seq[Pet]]] =
+  def findPetsByStatus(status: Seq[String] = Seq.empty): sttp.client4.Request[Either[ResponseException[String], Seq[Pet]]] =
     basicRequest
       .method(Method.GET, uri"$baseUrl/pet/findByStatus?status=${ status }")
       .contentType("application/json")
@@ -80,7 +80,7 @@ class PetApi(baseUrl: String) {
    * 
    * @param tags Tags to filter by
    */
-  def findPetsByTags(tags: Seq[String] = Seq.empty): Request[Either[ResponseException[String], Seq[Pet]]] =
+  def findPetsByTags(tags: Seq[String] = Seq.empty): sttp.client4.Request[Either[ResponseException[String], Seq[Pet]]] =
     basicRequest
       .method(Method.GET, uri"$baseUrl/pet/findByTags?tags=${ tags }")
       .contentType("application/json")
@@ -99,7 +99,7 @@ class PetApi(baseUrl: String) {
    * 
    * @param petId ID of pet to return
    */
-  def getPetById(apiKeyHeader: String)(petId: Long): Request[Either[ResponseException[String], Pet]] =
+  def getPetById(apiKeyHeader: String)(petId: Long): sttp.client4.Request[Either[ResponseException[String], Pet]] =
     basicRequest
       .method(Method.GET, uri"$baseUrl/pet/${petId}")
       .contentType("application/json")
@@ -117,7 +117,7 @@ class PetApi(baseUrl: String) {
    * 
    * @param pet Pet object that needs to be added to the store
    */
-  def updatePet(pet: Pet): Request[Either[ResponseException[String], Pet]] =
+  def updatePet(pet: Pet): sttp.client4.Request[Either[ResponseException[String], Pet]] =
     basicRequest
       .method(Method.PUT, uri"$baseUrl/pet")
       .contentType("application/json")
@@ -134,7 +134,7 @@ class PetApi(baseUrl: String) {
    * @param name Updated name of the pet
    * @param status Updated status of the pet
    */
-  def updatePetWithForm(petId: Long, name: Option[String] = None, status: Option[String] = None): Request[Either[ResponseException[String], Unit]] =
+  def updatePetWithForm(petId: Long, name: Option[String] = None, status: Option[String] = None): sttp.client4.Request[Either[ResponseException[String], Unit]] =
     basicRequest
       .method(Method.POST, uri"$baseUrl/pet/${petId}")
       .contentType("application/x-www-form-urlencoded")
@@ -154,7 +154,7 @@ class PetApi(baseUrl: String) {
    * @param additionalMetadata Additional data to pass to server
    * @param file file to upload
    */
-  def uploadFile(petId: Long, additionalMetadata: Option[String] = None, file: Option[File] = None): Request[Either[ResponseException[String], ApiResponse]] =
+  def uploadFile(petId: Long, additionalMetadata: Option[String] = None, file: Option[File] = None): sttp.client4.Request[Either[ResponseException[String], ApiResponse]] =
     basicRequest
       .method(Method.POST, uri"$baseUrl/pet/${petId}/uploadImage")
       .contentType("multipart/form-data")

--- a/samples/client/petstore/scala-sttp4/src/main/scala/org/openapitools/client/api/StoreApi.scala
+++ b/samples/client/petstore/scala-sttp4/src/main/scala/org/openapitools/client/api/StoreApi.scala
@@ -31,7 +31,7 @@ class StoreApi(baseUrl: String) {
    * 
    * @param orderId ID of the order that needs to be deleted
    */
-  def deleteOrder(orderId: String): Request[Either[ResponseException[String], Unit]] =
+  def deleteOrder(orderId: String): sttp.client4.Request[Either[ResponseException[String], Unit]] =
     basicRequest
       .method(Method.DELETE, uri"$baseUrl/store/order/${orderId}")
       .contentType("application/json")
@@ -46,7 +46,7 @@ class StoreApi(baseUrl: String) {
    * Available security schemes:
    *   api_key (apiKey)
    */
-  def getInventory(apiKeyHeader: String)(): Request[Either[ResponseException[String], Map[String, Int]]] =
+  def getInventory(apiKeyHeader: String)(): sttp.client4.Request[Either[ResponseException[String], Map[String, Int]]] =
     basicRequest
       .method(Method.GET, uri"$baseUrl/store/inventory")
       .contentType("application/json")
@@ -63,7 +63,7 @@ class StoreApi(baseUrl: String) {
    * 
    * @param orderId ID of pet that needs to be fetched
    */
-  def getOrderById(orderId: Long): Request[Either[ResponseException[String], Order]] =
+  def getOrderById(orderId: Long): sttp.client4.Request[Either[ResponseException[String], Order]] =
     basicRequest
       .method(Method.GET, uri"$baseUrl/store/order/${orderId}")
       .contentType("application/json")
@@ -78,7 +78,7 @@ class StoreApi(baseUrl: String) {
    * 
    * @param order order placed for purchasing the pet
    */
-  def placeOrder(order: Order): Request[Either[ResponseException[String], Order]] =
+  def placeOrder(order: Order): sttp.client4.Request[Either[ResponseException[String], Order]] =
     basicRequest
       .method(Method.POST, uri"$baseUrl/store/order")
       .contentType("application/json")

--- a/samples/client/petstore/scala-sttp4/src/main/scala/org/openapitools/client/api/UserApi.scala
+++ b/samples/client/petstore/scala-sttp4/src/main/scala/org/openapitools/client/api/UserApi.scala
@@ -34,7 +34,7 @@ class UserApi(baseUrl: String) {
    * 
    * @param user Created user object
    */
-  def createUser(apiKeyHeader: String)(user: User): Request[Either[ResponseException[String], Unit]] =
+  def createUser(apiKeyHeader: String)(user: User): sttp.client4.Request[Either[ResponseException[String], Unit]] =
     basicRequest
       .method(Method.POST, uri"$baseUrl/user")
       .contentType("application/json")
@@ -53,7 +53,7 @@ class UserApi(baseUrl: String) {
    * 
    * @param user List of user object
    */
-  def createUsersWithArrayInput(apiKeyHeader: String)(user: Seq[User]): Request[Either[ResponseException[String], Unit]] =
+  def createUsersWithArrayInput(apiKeyHeader: String)(user: Seq[User]): sttp.client4.Request[Either[ResponseException[String], Unit]] =
     basicRequest
       .method(Method.POST, uri"$baseUrl/user/createWithArray")
       .contentType("application/json")
@@ -72,7 +72,7 @@ class UserApi(baseUrl: String) {
    * 
    * @param user List of user object
    */
-  def createUsersWithListInput(apiKeyHeader: String)(user: Seq[User]): Request[Either[ResponseException[String], Unit]] =
+  def createUsersWithListInput(apiKeyHeader: String)(user: Seq[User]): sttp.client4.Request[Either[ResponseException[String], Unit]] =
     basicRequest
       .method(Method.POST, uri"$baseUrl/user/createWithList")
       .contentType("application/json")
@@ -92,7 +92,7 @@ class UserApi(baseUrl: String) {
    * 
    * @param username The name that needs to be deleted
    */
-  def deleteUser(apiKeyHeader: String)(username: String): Request[Either[ResponseException[String], Unit]] =
+  def deleteUser(apiKeyHeader: String)(username: String): sttp.client4.Request[Either[ResponseException[String], Unit]] =
     basicRequest
       .method(Method.DELETE, uri"$baseUrl/user/${username}")
       .contentType("application/json")
@@ -109,7 +109,7 @@ class UserApi(baseUrl: String) {
    * 
    * @param username The name that needs to be fetched. Use user1 for testing.
    */
-  def getUserByName(username: String): Request[Either[ResponseException[String], User]] =
+  def getUserByName(username: String): sttp.client4.Request[Either[ResponseException[String], User]] =
     basicRequest
       .method(Method.GET, uri"$baseUrl/user/${username}")
       .contentType("application/json")
@@ -129,7 +129,7 @@ class UserApi(baseUrl: String) {
    * @param username The user name for login
    * @param password The password for login in clear text
    */
-  def loginUser(username: String, password: String): Request[Either[ResponseException[String], String]] =
+  def loginUser(username: String, password: String): sttp.client4.Request[Either[ResponseException[String], String]] =
     basicRequest
       .method(Method.GET, uri"$baseUrl/user/login?username=${ username }&password=${ password }")
       .contentType("application/json")
@@ -144,7 +144,7 @@ class UserApi(baseUrl: String) {
    * Available security schemes:
    *   api_key (apiKey)
    */
-  def logoutUser(apiKeyHeader: String)(): Request[Either[ResponseException[String], Unit]] =
+  def logoutUser(apiKeyHeader: String)(): sttp.client4.Request[Either[ResponseException[String], Unit]] =
     basicRequest
       .method(Method.GET, uri"$baseUrl/user/logout")
       .contentType("application/json")
@@ -164,7 +164,7 @@ class UserApi(baseUrl: String) {
    * @param username name that need to be deleted
    * @param user Updated user object
    */
-  def updateUser(apiKeyHeader: String)(username: String, user: User): Request[Either[ResponseException[String], Unit]] =
+  def updateUser(apiKeyHeader: String)(username: String, user: User): sttp.client4.Request[Either[ResponseException[String], Unit]] =
     basicRequest
       .method(Method.PUT, uri"$baseUrl/user/${username}")
       .contentType("application/json")


### PR DESCRIPTION
Fixes #24680.

A schema named `Request` makes the generated `scala-sttp4` client fail to compile. Every generated API imports its models explicitly and then wildcard-imports sttp:

```scala
import org.openapitools.client.model.Request
import sttp.client4._
```

In Scala an explicit import outranks a wildcard import regardless of order, so `Request` resolves to the model, and the unqualified return type fails:

```
error: org.openapitools.client.model.Request does not take type parameters
  def predict(request: Request): Request[Either[ResponseException[String], Response]] =
                                 ^
```

`Request` is a common schema name for RPC-style APIs. The `scala-sttp` (sttp3) generator already emits the qualified `sttp.client3.Request[..., Any]` and is unaffected; this change brings `scala-sttp4` in line by emitting `sttp.client4.Request[...]`.

**Tests:** `Sttp4CodegenTest#verifyModelNamedRequestDoesNotShadowSttpRequest` with a new fixture (`sttp4-request-model-name.yaml`) declaring schemas named `Request` and `Response`, asserting both the explicit model import and the qualified return type. Verified by compiling the generated client for that spec, plus 13 real-world specs that declare a `Request` schema — all of which previously failed to compile and now succeed.

Samples regenerated via `./bin/generate-samples.sh bin/configs/scala-sttp4*.yaml`; the change is confined to API return types, and both the `scala-sttp4` and `scala-sttp4-circe` samples still compile. No generator options changed, so no doc export changes.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Built the project and updated samples; changes committed.
- [x] Filed against `master`.
- [x] Scala technical committee: @clasnake @jimschubert @shijinkui @ramzimaalej @chameleon82 @Bouillie


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Qualifies API method return types in generated `scala-sttp4` clients as `sttp.client4.Request[...]` to avoid collisions when a model is named `Request`. Fixes compile errors and aligns behavior with `scala-sttp`.

- **Bug Fixes**
  - Added `Sttp4CodegenTest#verifyModelNamedRequestDoesNotShadowSttpRequest` with a spec using `Request`/`Response` models.
  - Regenerated `scala-sttp4` and `scala-sttp4-circe` samples; both compile; no generator options or docs changed.

<sup>Written for commit d64ff7c05028306860fca871fbe26fdceaaa33ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24682?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

