### PR TITLE
fix(go): emit the oneOf no-match error once instead of once per member

### DIFF
--- a/modules/openapi-generator/src/main/resources/go/model_oneof.mustache
+++ b/modules/openapi-generator/src/main/resources/go/model_oneof.mustache
@@ -80,16 +80,11 @@ func (dst *{{classname}}) UnmarshalJSON(data []byte) error {
 	} else if match == 1 {
 		return nil // exactly one match
 	} else { // no match
-        {{#oneOf}}
-        if err != nil {
-		   return fmt.Errorf("data failed to match schemas in oneOf({{classname}}): %v", err)
-        } else {
-           return fmt.Errorf("data failed to match schemas in oneOf({{classname}})")
-        }
-        {{/oneOf}}
-        {{^oneOf}}
-        return fmt.Errorf("data failed to match schemas in oneOf({{classname}})")
-        {{/oneOf}}
+		if err != nil {
+			return fmt.Errorf("data failed to match schemas in oneOf({{classname}}): %v", err)
+		}
+
+		return fmt.Errorf("data failed to match schemas in oneOf({{classname}})")
 	}
 	{{/discriminator}}
 	{{/useOneOfDiscriminatorLookup}}
@@ -124,16 +119,11 @@ func (dst *{{classname}}) UnmarshalJSON(data []byte) error {
 	} else if match == 1 {
 		return nil // exactly one match
 	} else { // no match
-        {{#oneOf}}
-        if err != nil {
-            return fmt.Errorf("data failed to match schemas in oneOf({{classname}}): %v", err)
-        } else {
-            return fmt.Errorf("data failed to match schemas in oneOf({{classname}})")
-        }
-        {{/oneOf}}
-        {{^oneOf}}
-        return fmt.Errorf("data failed to match schemas in oneOf({{classname}})")
-        {{/oneOf}}
+		if err != nil {
+			return fmt.Errorf("data failed to match schemas in oneOf({{classname}}): %v", err)
+		}
+
+		return fmt.Errorf("data failed to match schemas in oneOf({{classname}})")
 	}
 	{{/useOneOfDiscriminatorLookup}}
 }

--- a/samples/client/others/go/oneof-anyof-required/model_object.go
+++ b/samples/client/others/go/oneof-anyof-required/model_object.go
@@ -84,16 +84,11 @@ func (dst *Object) UnmarshalJSON(data []byte) error {
 	} else if match == 1 {
 		return nil // exactly one match
 	} else { // no match
-        if err != nil {
-            return fmt.Errorf("data failed to match schemas in oneOf(Object): %v", err)
-        } else {
-            return fmt.Errorf("data failed to match schemas in oneOf(Object)")
-        }
-        if err != nil {
-            return fmt.Errorf("data failed to match schemas in oneOf(Object): %v", err)
-        } else {
-            return fmt.Errorf("data failed to match schemas in oneOf(Object)")
-        }
+		if err != nil {
+			return fmt.Errorf("data failed to match schemas in oneOf(Object): %v", err)
+		}
+
+		return fmt.Errorf("data failed to match schemas in oneOf(Object)")
 	}
 }
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_fruit.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_fruit.go
@@ -84,16 +84,11 @@ func (dst *Fruit) UnmarshalJSON(data []byte) error {
 	} else if match == 1 {
 		return nil // exactly one match
 	} else { // no match
-        if err != nil {
-            return fmt.Errorf("data failed to match schemas in oneOf(Fruit): %v", err)
-        } else {
-            return fmt.Errorf("data failed to match schemas in oneOf(Fruit)")
-        }
-        if err != nil {
-            return fmt.Errorf("data failed to match schemas in oneOf(Fruit): %v", err)
-        } else {
-            return fmt.Errorf("data failed to match schemas in oneOf(Fruit)")
-        }
+		if err != nil {
+			return fmt.Errorf("data failed to match schemas in oneOf(Fruit): %v", err)
+		}
+
+		return fmt.Errorf("data failed to match schemas in oneOf(Fruit)")
 	}
 }
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_fruit_req.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_fruit_req.go
@@ -84,16 +84,11 @@ func (dst *FruitReq) UnmarshalJSON(data []byte) error {
 	} else if match == 1 {
 		return nil // exactly one match
 	} else { // no match
-        if err != nil {
-            return fmt.Errorf("data failed to match schemas in oneOf(FruitReq): %v", err)
-        } else {
-            return fmt.Errorf("data failed to match schemas in oneOf(FruitReq)")
-        }
-        if err != nil {
-            return fmt.Errorf("data failed to match schemas in oneOf(FruitReq): %v", err)
-        } else {
-            return fmt.Errorf("data failed to match schemas in oneOf(FruitReq)")
-        }
+		if err != nil {
+			return fmt.Errorf("data failed to match schemas in oneOf(FruitReq): %v", err)
+		}
+
+		return fmt.Errorf("data failed to match schemas in oneOf(FruitReq)")
 	}
 }
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_incident_data.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_incident_data.go
@@ -89,16 +89,11 @@ func (dst *IncidentData) UnmarshalJSON(data []byte) error {
 	} else if match == 1 {
 		return nil // exactly one match
 	} else { // no match
-        if err != nil {
-            return fmt.Errorf("data failed to match schemas in oneOf(IncidentData): %v", err)
-        } else {
-            return fmt.Errorf("data failed to match schemas in oneOf(IncidentData)")
-        }
-        if err != nil {
-            return fmt.Errorf("data failed to match schemas in oneOf(IncidentData): %v", err)
-        } else {
-            return fmt.Errorf("data failed to match schemas in oneOf(IncidentData)")
-        }
+		if err != nil {
+			return fmt.Errorf("data failed to match schemas in oneOf(IncidentData): %v", err)
+		}
+
+		return fmt.Errorf("data failed to match schemas in oneOf(IncidentData)")
 	}
 }
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_mammal.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_mammal.go
@@ -84,16 +84,11 @@ func (dst *Mammal) UnmarshalJSON(data []byte) error {
 	} else if match == 1 {
 		return nil // exactly one match
 	} else { // no match
-        if err != nil {
-            return fmt.Errorf("data failed to match schemas in oneOf(Mammal): %v", err)
-        } else {
-            return fmt.Errorf("data failed to match schemas in oneOf(Mammal)")
-        }
-        if err != nil {
-            return fmt.Errorf("data failed to match schemas in oneOf(Mammal): %v", err)
-        } else {
-            return fmt.Errorf("data failed to match schemas in oneOf(Mammal)")
-        }
+		if err != nil {
+			return fmt.Errorf("data failed to match schemas in oneOf(Mammal): %v", err)
+		}
+
+		return fmt.Errorf("data failed to match schemas in oneOf(Mammal)")
 	}
 }
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_one_of_primitive_type.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_one_of_primitive_type.go
@@ -110,21 +110,11 @@ func (dst *OneOfPrimitiveType) UnmarshalJSON(data []byte) error {
 	} else if match == 1 {
 		return nil // exactly one match
 	} else { // no match
-        if err != nil {
-            return fmt.Errorf("data failed to match schemas in oneOf(OneOfPrimitiveType): %v", err)
-        } else {
-            return fmt.Errorf("data failed to match schemas in oneOf(OneOfPrimitiveType)")
-        }
-        if err != nil {
-            return fmt.Errorf("data failed to match schemas in oneOf(OneOfPrimitiveType): %v", err)
-        } else {
-            return fmt.Errorf("data failed to match schemas in oneOf(OneOfPrimitiveType)")
-        }
-        if err != nil {
-            return fmt.Errorf("data failed to match schemas in oneOf(OneOfPrimitiveType): %v", err)
-        } else {
-            return fmt.Errorf("data failed to match schemas in oneOf(OneOfPrimitiveType)")
-        }
+		if err != nil {
+			return fmt.Errorf("data failed to match schemas in oneOf(OneOfPrimitiveType): %v", err)
+		}
+
+		return fmt.Errorf("data failed to match schemas in oneOf(OneOfPrimitiveType)")
 	}
 }
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_one_of_primitive_types.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_one_of_primitive_types.go
@@ -85,16 +85,11 @@ func (dst *OneOfPrimitiveTypes) UnmarshalJSON(data []byte) error {
 	} else if match == 1 {
 		return nil // exactly one match
 	} else { // no match
-        if err != nil {
-            return fmt.Errorf("data failed to match schemas in oneOf(OneOfPrimitiveTypes): %v", err)
-        } else {
-            return fmt.Errorf("data failed to match schemas in oneOf(OneOfPrimitiveTypes)")
-        }
-        if err != nil {
-            return fmt.Errorf("data failed to match schemas in oneOf(OneOfPrimitiveTypes): %v", err)
-        } else {
-            return fmt.Errorf("data failed to match schemas in oneOf(OneOfPrimitiveTypes)")
-        }
+		if err != nil {
+			return fmt.Errorf("data failed to match schemas in oneOf(OneOfPrimitiveTypes): %v", err)
+		}
+
+		return fmt.Errorf("data failed to match schemas in oneOf(OneOfPrimitiveTypes)")
 	}
 }
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_one_of_with_complex_type.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_one_of_with_complex_type.go
@@ -84,16 +84,11 @@ func (dst *OneOfWithComplexType) UnmarshalJSON(data []byte) error {
 	} else if match == 1 {
 		return nil // exactly one match
 	} else { // no match
-        if err != nil {
-            return fmt.Errorf("data failed to match schemas in oneOf(OneOfWithComplexType): %v", err)
-        } else {
-            return fmt.Errorf("data failed to match schemas in oneOf(OneOfWithComplexType)")
-        }
-        if err != nil {
-            return fmt.Errorf("data failed to match schemas in oneOf(OneOfWithComplexType): %v", err)
-        } else {
-            return fmt.Errorf("data failed to match schemas in oneOf(OneOfWithComplexType)")
-        }
+		if err != nil {
+			return fmt.Errorf("data failed to match schemas in oneOf(OneOfWithComplexType): %v", err)
+		}
+
+		return fmt.Errorf("data failed to match schemas in oneOf(OneOfWithComplexType)")
 	}
 }
 


### PR DESCRIPTION
### Description

`go/model_oneof.mustache` renders the "no match" error return inside a `{{#oneOf}}` section, so the `if err != nil { ... } else { ... }` block added by #24349 is emitted once per `oneOf` member. Only the first copy can ever run; the remaining copies are dead code and grow with the member count.

Committed sample output shows it today, e.g. `samples/openapi3/client/petstore/go/go-petstore/model_one_of_primitive_type.go` (3 members, so 3 copies).

The fix renders the block once, outside the section. `err` is declared unconditionally as `var err error` at the top of `UnmarshalJSON`, so the `{{^oneOf}}` fallback that existed for the empty-`oneOf` case is no longer needed. The `else` is dropped in favour of an early return, which is what gofmt-style Go looks like here.

Behaviour is unchanged: the first (and only reachable) copy is exactly what the new single block renders. Both branches of the template (`useOneOfDiscriminatorLookup` on and off) had the same duplication and both are fixed.

fix #24661

### Verification

- `./mvnw clean package -DskipTests` — BUILD SUCCESS.
- `./bin/generate-samples.sh ./bin/configs/go-*.yaml` — 21 generators, no unrelated churn; 8 sample files changed, all of them the duplicated block collapsing to one.
- Go generator unit tests: `AbstractGoCodegenTest`, `GoClientCodegenTest`, `GoClientOptionsTest`, `GoModelTest` — 53 tests, 0 failures.
- `go build ./...` and `go vet ./...` on the regenerated `samples/openapi3/client/petstore/go/go-petstore` and `samples/client/others/go/oneof-anyof-required` (golang:1.23) — both clean.
- Runtime check that the `#24349` behaviour survives, against the regenerated petstore sample:

  ```
  payload true    -> data failed to match schemas in oneOf(OneOfPrimitiveType): json: cannot unmarshal bool into Go value of type int32
  payload "abc"   -> data failed to match schemas in oneOf(OneOfPrimitiveType): json: cannot unmarshal string into Go value of type int32
  ```

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

/cc @antihax @grokify @kemokemo @jirikuncar @ph4r5h4d @lwj5


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emit the `oneOf` no-match error once in generated Go `UnmarshalJSON` methods instead of once per member, removing unreachable duplicates as `oneOf` grows. Behavior is unchanged; regenerated Go samples now contain a single error block.

- **Bug Fixes**
  - Move the no-match error block outside the `{{#oneOf}}` section in `model_oneof.mustache`; drop the empty-`oneOf` fallback and replace `else` with an early return.
  - Apply the fix to both discriminator paths; update Go samples to collapse duplicated error code.

<sup>Written for commit 0050666ca329ed55d58c51a1bd546e7ec4bf21ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24683?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

