### PR TITLE
[php-nextgen] Fix object query parameters given as a model, fixes #24684

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-nextgen/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/ObjectSerializer.mustache
@@ -262,6 +262,11 @@ class ObjectSerializer
             return ["{$paramName}" => $value->format(self::$dateTimeFormat)];
         }
 
+        // A model is typed with its class name rather than "object", but serializes as one.
+        if ($value instanceof ModelInterface) {
+            $openApiType = 'object';
+        }
+
         $query = [];
         if ($openApiType === 'object' && is_object($value)) {
             // Read the model's values through its getters; a plain (array) cast

--- a/modules/openapi-generator/src/main/resources/php-nextgen/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/ObjectSerializer.mustache
@@ -199,6 +199,31 @@ class ObjectSerializer
     }
 
     /**
+     * Convert objects into arrays, recursively.
+     *
+     * sanitizeForSerialization() returns an object per model, but query parameters
+     * are flattened from arrays.
+     *
+     * @param mixed $data
+     *
+     * @return mixed the data with every object converted to an array
+     */
+    private static function toArrayRecursive(mixed $data): mixed
+    {
+        if (is_array($data) || is_object($data)) {
+            $result = [];
+
+            foreach ($data as $key => $value) {
+                $result[$key] = self::toArrayRecursive($value);
+            }
+
+            return $result;
+        }
+
+        return $data;
+    }
+
+    /**
      * Take query parameter properties and turn it into an array suitable for
      * native http_build_query or GuzzleHttp\Psr7\Query::build.
      *
@@ -238,7 +263,13 @@ class ObjectSerializer
         }
 
         $query = [];
-        $value = (in_array($openApiType, ['object', 'array'], true)) ? (array)$value : $value;
+        if ($openApiType === 'object' && is_object($value)) {
+            // Read the model's values through its getters; a plain (array) cast
+            // would expose only the protected $container holding them.
+            $value = self::toArrayRecursive(self::sanitizeForSerialization($value));
+        } elseif (in_array($openApiType, ['object', 'array'], true)) {
+            $value = (array) $value;
+        }
 
         // since \GuzzleHttp\Psr7\Query::build fails with nested arrays
         // need to flatten array first

--- a/modules/openapi-generator/src/main/resources/php-nextgen/phpunit.xml.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/phpunit.xml.mustache
@@ -8,8 +8,7 @@
   </coverage>
   <testsuites>
     <testsuite name="tests">
-      <directory>{{apiTestPath}}</directory>
-      <directory>{{modelTestPath}}</directory>
+      <directory>./{{testBasePath}}</directory>
     </testsuite>
   </testsuites>
   <php>

--- a/samples/client/echo_api/php-nextgen-streaming/phpunit.xml.dist
+++ b/samples/client/echo_api/php-nextgen-streaming/phpunit.xml.dist
@@ -8,8 +8,7 @@
   </coverage>
   <testsuites>
     <testsuite name="tests">
-      <directory>./tests/Api</directory>
-      <directory>./tests/Model</directory>
+      <directory>./tests</directory>
     </testsuite>
   </testsuites>
   <php>

--- a/samples/client/echo_api/php-nextgen-streaming/src/ObjectSerializer.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/ObjectSerializer.php
@@ -271,6 +271,11 @@ class ObjectSerializer
             return ["{$paramName}" => $value->format(self::$dateTimeFormat)];
         }
 
+        // A model is typed with its class name rather than "object", but serializes as one.
+        if ($value instanceof ModelInterface) {
+            $openApiType = 'object';
+        }
+
         $query = [];
         if ($openApiType === 'object' && is_object($value)) {
             // Read the model's values through its getters; a plain (array) cast

--- a/samples/client/echo_api/php-nextgen-streaming/src/ObjectSerializer.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/ObjectSerializer.php
@@ -208,6 +208,31 @@ class ObjectSerializer
     }
 
     /**
+     * Convert objects into arrays, recursively.
+     *
+     * sanitizeForSerialization() returns an object per model, but query parameters
+     * are flattened from arrays.
+     *
+     * @param mixed $data
+     *
+     * @return mixed the data with every object converted to an array
+     */
+    private static function toArrayRecursive(mixed $data): mixed
+    {
+        if (is_array($data) || is_object($data)) {
+            $result = [];
+
+            foreach ($data as $key => $value) {
+                $result[$key] = self::toArrayRecursive($value);
+            }
+
+            return $result;
+        }
+
+        return $data;
+    }
+
+    /**
      * Take query parameter properties and turn it into an array suitable for
      * native http_build_query or GuzzleHttp\Psr7\Query::build.
      *
@@ -247,7 +272,13 @@ class ObjectSerializer
         }
 
         $query = [];
-        $value = (in_array($openApiType, ['object', 'array'], true)) ? (array)$value : $value;
+        if ($openApiType === 'object' && is_object($value)) {
+            // Read the model's values through its getters; a plain (array) cast
+            // would expose only the protected $container holding them.
+            $value = self::toArrayRecursive(self::sanitizeForSerialization($value));
+        } elseif (in_array($openApiType, ['object', 'array'], true)) {
+            $value = (array) $value;
+        }
 
         // since \GuzzleHttp\Psr7\Query::build fails with nested arrays
         // need to flatten array first

--- a/samples/client/echo_api/php-nextgen/phpunit.xml.dist
+++ b/samples/client/echo_api/php-nextgen/phpunit.xml.dist
@@ -8,8 +8,7 @@
   </coverage>
   <testsuites>
     <testsuite name="tests">
-      <directory>./tests/Api</directory>
-      <directory>./tests/Model</directory>
+      <directory>./tests</directory>
     </testsuite>
   </testsuites>
   <php>

--- a/samples/client/echo_api/php-nextgen/src/ObjectSerializer.php
+++ b/samples/client/echo_api/php-nextgen/src/ObjectSerializer.php
@@ -271,6 +271,11 @@ class ObjectSerializer
             return ["{$paramName}" => $value->format(self::$dateTimeFormat)];
         }
 
+        // A model is typed with its class name rather than "object", but serializes as one.
+        if ($value instanceof ModelInterface) {
+            $openApiType = 'object';
+        }
+
         $query = [];
         if ($openApiType === 'object' && is_object($value)) {
             // Read the model's values through its getters; a plain (array) cast

--- a/samples/client/echo_api/php-nextgen/src/ObjectSerializer.php
+++ b/samples/client/echo_api/php-nextgen/src/ObjectSerializer.php
@@ -208,6 +208,31 @@ class ObjectSerializer
     }
 
     /**
+     * Convert objects into arrays, recursively.
+     *
+     * sanitizeForSerialization() returns an object per model, but query parameters
+     * are flattened from arrays.
+     *
+     * @param mixed $data
+     *
+     * @return mixed the data with every object converted to an array
+     */
+    private static function toArrayRecursive(mixed $data): mixed
+    {
+        if (is_array($data) || is_object($data)) {
+            $result = [];
+
+            foreach ($data as $key => $value) {
+                $result[$key] = self::toArrayRecursive($value);
+            }
+
+            return $result;
+        }
+
+        return $data;
+    }
+
+    /**
      * Take query parameter properties and turn it into an array suitable for
      * native http_build_query or GuzzleHttp\Psr7\Query::build.
      *
@@ -247,7 +272,13 @@ class ObjectSerializer
         }
 
         $query = [];
-        $value = (in_array($openApiType, ['object', 'array'], true)) ? (array)$value : $value;
+        if ($openApiType === 'object' && is_object($value)) {
+            // Read the model's values through its getters; a plain (array) cast
+            // would expose only the protected $container holding them.
+            $value = self::toArrayRecursive(self::sanitizeForSerialization($value));
+        } elseif (in_array($openApiType, ['object', 'array'], true)) {
+            $value = (array) $value;
+        }
 
         // since \GuzzleHttp\Psr7\Query::build fails with nested arrays
         // need to flatten array first

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/phpunit.xml.dist
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/phpunit.xml.dist
@@ -8,8 +8,7 @@
   </coverage>
   <testsuites>
     <testsuite name="tests">
-      <directory>./tests/Api</directory>
-      <directory>./tests/Model</directory>
+      <directory>./tests</directory>
     </testsuite>
   </testsuites>
   <php>

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/ObjectSerializer.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/ObjectSerializer.php
@@ -207,6 +207,31 @@ class ObjectSerializer
     }
 
     /**
+     * Convert objects into arrays, recursively.
+     *
+     * sanitizeForSerialization() returns an object per model, but query parameters
+     * are flattened from arrays.
+     *
+     * @param mixed $data
+     *
+     * @return mixed the data with every object converted to an array
+     */
+    private static function toArrayRecursive(mixed $data): mixed
+    {
+        if (is_array($data) || is_object($data)) {
+            $result = [];
+
+            foreach ($data as $key => $value) {
+                $result[$key] = self::toArrayRecursive($value);
+            }
+
+            return $result;
+        }
+
+        return $data;
+    }
+
+    /**
      * Take query parameter properties and turn it into an array suitable for
      * native http_build_query or GuzzleHttp\Psr7\Query::build.
      *
@@ -246,7 +271,13 @@ class ObjectSerializer
         }
 
         $query = [];
-        $value = (in_array($openApiType, ['object', 'array'], true)) ? (array)$value : $value;
+        if ($openApiType === 'object' && is_object($value)) {
+            // Read the model's values through its getters; a plain (array) cast
+            // would expose only the protected $container holding them.
+            $value = self::toArrayRecursive(self::sanitizeForSerialization($value));
+        } elseif (in_array($openApiType, ['object', 'array'], true)) {
+            $value = (array) $value;
+        }
 
         // since \GuzzleHttp\Psr7\Query::build fails with nested arrays
         // need to flatten array first

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/ObjectSerializer.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/ObjectSerializer.php
@@ -270,6 +270,11 @@ class ObjectSerializer
             return ["{$paramName}" => $value->format(self::$dateTimeFormat)];
         }
 
+        // A model is typed with its class name rather than "object", but serializes as one.
+        if ($value instanceof ModelInterface) {
+            $openApiType = 'object';
+        }
+
         $query = [];
         if ($openApiType === 'object' && is_object($value)) {
             // Read the model's values through its getters; a plain (array) cast

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/ObjectSerializerTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/ObjectSerializerTest.php
@@ -16,6 +16,87 @@ use PHPUnit\Framework\TestCase;
 class ObjectSerializerTest extends TestCase
 {
     /**
+     * @covers ObjectSerializer::toQueryValue
+     * @dataProvider provideQueryParams
+     */
+    public function testToQueryValue(
+        mixed $data,
+        string $paramName,
+        string $openApiType,
+        string $style,
+        bool $explode,
+        bool $required,
+        mixed $expected
+    ): void {
+        $value = ObjectSerializer::toQueryValue($data, $paramName, $openApiType, $style, $explode, $required);
+        $query = ObjectSerializer::buildQuery($value);
+
+        $this->assertEquals($expected, $query);
+    }
+
+    /**
+     * Query params provider
+     *
+     * Values that are not model instances, whose serialization is unchanged.
+     *
+     * @return array[]
+     */
+    public static function provideQueryParams(): array
+    {
+        $statuses = ['available', 'pending', 'sold'];
+        $filter = ['name' => 'Rex', 'status' => 'available'];
+
+        $stdClass = new \stdClass();
+        $stdClass->name = 'Rex';
+        $stdClass->category = ['name' => 'Dogs'];
+
+        return [
+            // style form
+            // status=available&status=pending&status=sold
+            'form array, explode on, required true' => [
+                $statuses, 'status', 'array', 'form', true, true, 'status=available&status=pending&status=sold',
+            ],
+            // status=available,pending,sold
+            'form array, explode off, required true' => [
+                $statuses, 'status', 'array', 'form', false, true, 'status=available%2Cpending%2Csold',
+            ],
+            // name=Rex&status=available
+            'form object, explode on, required true' => [
+                $filter, 'filter', 'object', 'form', true, true, 'name=Rex&status=available',
+            ],
+            // filter=name,Rex,status,available
+            'form object, explode off, required true' => [
+                $filter, 'filter', 'object', 'form', false, true, 'filter=name%2CRex%2Cstatus%2Cavailable',
+            ],
+            // status=available
+            'form string, explode on, required true' => [
+                'available', 'status', 'string', 'form', true, true, 'status=available',
+            ],
+            // quantity=0
+            'form 0 integer, explode on, required false' => [
+                0, 'quantity', 'integer', 'form', true, false, 'quantity=0',
+            ],
+
+            // DEEP OBJECT
+            // status[0]=available&status[1]=pending&status[2]=sold
+            'deepObject array, explode on, required true' => [
+                $statuses, 'status', 'array', 'deepObject', true, true,
+                'status%5B0%5D=available&status%5B1%5D=pending&status%5B2%5D=sold',
+            ],
+            // filter[name]=Rex&filter[status]=available
+            'deepObject object, explode on, required true' => [
+                $filter, 'filter', 'object', 'deepObject', true, true,
+                'filter%5Bname%5D=Rex&filter%5Bstatus%5D=available',
+            ],
+            // filter[name]=Rex&filter[category][name]=Dogs
+            'deepObject stdClass, explode on, required true' => [
+                $stdClass, 'filter', 'object', 'deepObject', true, true,
+                'filter%5Bname%5D=Rex&filter%5Bcategory%5D%5Bname%5D=Dogs',
+            ],
+        ];
+    }
+
+    /**
      * An object-typed query parameter given as a model must serialize to the model's
      * values, read through its getters and keyed by its attributeMap - note photoUrls.
      *

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/ObjectSerializerTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/ObjectSerializerTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace OpenAPI\Client;
+
+use OpenAPI\Client\Model\ArrayTest;
+use OpenAPI\Client\Model\Category;
+use OpenAPI\Client\Model\Pet;
+use OpenAPI\Client\Model\Tag;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * class ObjectSerializerTest
+ *
+ * @package OpenAPI\Client
+ */
+class ObjectSerializerTest extends TestCase
+{
+    /**
+     * An object-typed query parameter given as a model must serialize to the model's
+     * values, read through its getters and keyed by its attributeMap - note photoUrls.
+     *
+     * @see https://github.com/OpenAPITools/openapi-generator/issues/11222
+     * @covers ObjectSerializer::toQueryValue
+     */
+    public function testToQueryValueWithModelInstance(): void
+    {
+        // photo_urls is required and non-nullable, so it must be set for its getter to return.
+        $pet = new Pet([
+            'id' => 1,
+            'name' => 'Rex',
+            'photo_urls' => ['a.png', 'b.png'],
+            'status' => 'available',
+        ]);
+
+        $query = ObjectSerializer::toQueryValue($pet, 'filter', 'object', 'deepObject', true, false);
+
+        $this->assertEquals(
+            'filter[id]=1&filter[name]=Rex&filter[photoUrls][0]=a.png'
+                . '&filter[photoUrls][1]=b.png&filter[status]=available',
+            urldecode(ObjectSerializer::buildQuery($query))
+        );
+    }
+
+    /**
+     * Array properties keep their indexes, at every depth.
+     *
+     * @covers ObjectSerializer::toQueryValue
+     */
+    public function testToQueryValueWithArrayPropertiesOfAModelInstance(): void
+    {
+        $model = new ArrayTest([
+            'array_of_string' => ['a', 'b'],
+            'array_array_of_integer' => [[1, 2]],
+        ]);
+
+        $query = ObjectSerializer::toQueryValue($model, 'filter', 'object', 'deepObject', true, false);
+
+        $this->assertEquals(
+            'filter[array_of_string][0]=a&filter[array_of_string][1]=b'
+                . '&filter[array_array_of_integer][0][0]=1&filter[array_array_of_integer][0][1]=2',
+            urldecode(ObjectSerializer::buildQuery($query))
+        );
+    }
+
+    /**
+     * Nested models must be flattened too, so the whole object graph is converted to
+     * arrays first: a shallow cast would leave them as objects and fail to stringify.
+     *
+     * @covers ObjectSerializer::toQueryValue
+     */
+    public function testToQueryValueWithNestedModelInstances(): void
+    {
+        $pet = new Pet([
+            'id' => 1,
+            'name' => 'Rex',
+            'photo_urls' => [],
+            'category' => new Category(['id' => 7, 'name' => 'Dogs']),
+            'tags' => [new Tag(['id' => 2, 'name' => 'cute'])],
+        ]);
+
+        $query = ObjectSerializer::toQueryValue($pet, 'filter', 'object', 'deepObject', true, false);
+
+        $this->assertEquals(
+            'filter[id]=1&filter[category][id]=7&filter[category][name]=Dogs'
+                . '&filter[name]=Rex&filter[tags][0][id]=2&filter[tags][0][name]=cute',
+            urldecode(ObjectSerializer::buildQuery($query))
+        );
+    }
+}

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/ObjectSerializerTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/ObjectSerializerTest.php
@@ -123,6 +123,84 @@ class ObjectSerializerTest extends TestCase
     }
 
     /**
+     * A composed (allOf/oneOf/anyOf) parameter is typed with a model name rather than
+     * "object", so models are recognised by their interface instead of that type.
+     *
+     * @covers ObjectSerializer::toQueryValue
+     * @dataProvider provideModelTypedStyles
+     */
+    public function testToQueryValueWithModelInstanceTypedByItsModelName(
+        string $style,
+        string $expected
+    ): void {
+        $pet = new Pet(['id' => 1, 'name' => 'Rex', 'photo_urls' => [], 'status' => 'available']);
+
+        $query = ObjectSerializer::toQueryValue($pet, 'filter', Pet::class, $style, true, false);
+
+        $this->assertSame($expected, urldecode(ObjectSerializer::buildQuery($query)));
+    }
+
+    /**
+     * Styles provider for a parameter typed with a model name
+     *
+     * @return array[]
+     */
+    public static function provideModelTypedStyles(): array
+    {
+        return [
+            'deepObject, explode on' => [
+                'deepObject', 'filter[id]=1&filter[name]=Rex&filter[status]=available',
+            ],
+            'form, explode on' => [
+                'form', 'id=1&name=Rex&status=available',
+            ],
+        ];
+    }
+
+    /**
+     * A model holding no values flattens to nothing, so the parameter is dropped instead
+     * of being sent as an empty container key.
+     *
+     * A deepObject has no key of its own to fall back on, so a required parameter is
+     * dropped just the same - hence the identical result for both.
+     *
+     * @covers ObjectSerializer::toQueryValue
+     */
+    public function testToQueryValueWithAnEmptyModelInstance(): void
+    {
+        $this->assertSame(
+            [],
+            ObjectSerializer::toQueryValue(new Tag(), 'filter', Tag::class, 'deepObject', true, false)
+        );
+        $this->assertSame(
+            [],
+            ObjectSerializer::toQueryValue(new Tag(), 'filter', Tag::class, 'deepObject', true, true)
+        );
+    }
+
+    /**
+     * Objects nested in a plain object are converted as well: a shallow (array) cast would
+     * leave them in place, and building the query would then fail to stringify them.
+     *
+     * @covers ObjectSerializer::toQueryValue
+     */
+    public function testToQueryValueWithAPlainObjectHoldingNestedObjects(): void
+    {
+        $filter = new \stdClass();
+        $filter->name = 'Rex';
+        $filter->tag = new Tag(['id' => 2, 'name' => 'stray']);
+        $filter->bornAt = new \DateTime('2024-01-02T03:04:05Z');
+
+        $query = ObjectSerializer::toQueryValue($filter, 'filter', 'object', 'deepObject', true, false);
+
+        $this->assertSame(
+            'filter[name]=Rex&filter[tag][id]=2&filter[tag][name]=stray'
+                . '&filter[bornAt]=2024-01-02T03:04:05+00:00',
+            urldecode(ObjectSerializer::buildQuery($query))
+        );
+    }
+
+    /**
      * Array properties keep their indexes, at every depth.
      *
      * @covers ObjectSerializer::toQueryValue


### PR DESCRIPTION
Fixes the query serialization of object-typed parameters when the value is a generated model
instance.

fix #24684

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee]
@jebentier @dkarlovi @mandrean @jfastnacht @ybelenko @renepardon

##### What was wrong

`ObjectSerializer::toQueryValue()` prepared object-typed values with a plain `(array)` cast:

```php
$value = (in_array($openApiType, ['object', 'array'], true)) ? (array)$value : $value;
```

Generated models keep their values in a single `protected array $container`, not in public
properties, so casting a model with `(array)` yields PHP's mangled property name
(`"\0*\0container"`) as the only key instead of the model's fields. The result was a query string
the server cannot interpret, produced silently.

Given this spec:

```yaml
openapi: 3.0.3
info:
  title: deepObject query param repro
  version: 1.0.0
paths:
  /items:
    get:
      operationId: listItems
      parameters:
        - name: filter
          in: query
          style: deepObject
          explode: true
          schema:
            $ref: '#/components/schemas/Filter'
      responses:
        '200':
          description: ok
components:
  schemas:
    Filter:
      type: object
      properties:
        requirements:
          type: array
          items:
            type: integer
        status:
          type: string
```

and `new Filter(['requirements' => [1, 2], 'status' => 'published'])`:

```
# before (url-decoded; \0 shown as <NUL>)
filter[<NUL>*<NUL>container][requirements][0]=1&filter[<NUL>*<NUL>container][requirements][1]=2&filter[<NUL>*<NUL>container][status]=published

# after
filter[requirements][0]=1&filter[requirements][1]=2&filter[status]=published
```

##### The fix

Object-typed values now go through `sanitizeForSerialization()`, which for anything implementing
`ModelInterface` walks `openAPITypes()`, calls the real getters and keys the result by
`attributeMap()` — the same mechanism already used for JSON request bodies. Query and body
serialization therefore share one code path, and this keeps working for any future model without
further special-casing. Plain arrays and scalars keep the original `(array)` cast, so nothing else
changes.

`sanitizeForSerialization()` returns an object at every level, while the `$flattenArray` step below
dispatches on `is_array()`, so the object graph is converted to arrays first via a small recursive
`toArrayRecursive()` helper. A shallow `(array)` cast is not sufficient: nested models stay objects
and later fail with `Object of class stdClass could not be converted to string`. 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix query serialization for object and model-typed parameters when the value is a generated model. Models now serialize via getters instead of a shallow array cast, producing correct deepObject and form query strings. Fixes #24684.

- **Bug Fixes**
  - Treat any model value as an object (even when typed by its class) and serialize via `sanitizeForSerialization()` with a recursive `toArrayRecursive()`.
  - Preserve existing behavior for arrays/scalars; only models change.
  - Tests cover model-typed and non-model params, nested models, and arrays; unify PHPUnit test paths.

<sup>Written for commit e89ccaca27ba4e8c803b7865183683ca20c53014. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24685?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

