### PR TITLE
fix: resolve ShellCheck issues mentioned in #24675

### DIFF
--- a/modules/openapi-generator/src/main/resources/_common/git_push.sh.mustache
+++ b/modules/openapi-generator/src/main/resources/_common/git_push.sh.mustache
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="{{{gitHost}}}"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="{{{gitUserId}}}"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="{{{gitRepoId}}}"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="{{{releaseNote}}}"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/echo_api/csharp/restsharp/net8/EchoApi/git_push.sh
+++ b/samples/client/echo_api/csharp/restsharp/net8/EchoApi/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/echo_api/go-external-refs/git_push.sh
+++ b/samples/client/echo_api/go-external-refs/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/echo_api/go/git_push.sh
+++ b/samples/client/echo_api/go/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/echo_api/java/apache-httpclient/git_push.sh
+++ b/samples/client/echo_api/java/apache-httpclient/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/echo_api/java/feign-gson/git_push.sh
+++ b/samples/client/echo_api/java/feign-gson/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/echo_api/java/native/git_push.sh
+++ b/samples/client/echo_api/java/native/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/echo_api/java/okhttp-gson-user-defined-templates/git_push.sh
+++ b/samples/client/echo_api/java/okhttp-gson-user-defined-templates/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/echo_api/java/okhttp-gson/git_push.sh
+++ b/samples/client/echo_api/java/okhttp-gson/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/echo_api/java/restclient/git_push.sh
+++ b/samples/client/echo_api/java/restclient/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/echo_api/java/resteasy/git_push.sh
+++ b/samples/client/echo_api/java/resteasy/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/echo_api/java/resttemplate/git_push.sh
+++ b/samples/client/echo_api/java/resttemplate/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/echo_api/php-nextgen-streaming/git_push.sh
+++ b/samples/client/echo_api/php-nextgen-streaming/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/echo_api/php-nextgen/git_push.sh
+++ b/samples/client/echo_api/php-nextgen/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/git_push.sh
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/echo_api/python-pydantic-v1/git_push.sh
+++ b/samples/client/echo_api/python-pydantic-v1/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/echo_api/python/git_push.sh
+++ b/samples/client/echo_api/python/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/echo_api/r/git_push.sh
+++ b/samples/client/echo_api/r/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/echo_api/ruby-faraday/git_push.sh
+++ b/samples/client/echo_api/ruby-faraday/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/echo_api/ruby-httpx/git_push.sh
+++ b/samples/client/echo_api/ruby-httpx/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/echo_api/ruby-typhoeus/git_push.sh
+++ b/samples/client/echo_api/ruby-typhoeus/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/echo_api/typescript-axios/build/git_push.sh
+++ b/samples/client/echo_api/typescript-axios/build/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/others/crystal-qdrant/git_push.sh
+++ b/samples/client/others/crystal-qdrant/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/others/csharp-complex-files/git_push.sh
+++ b/samples/client/others/csharp-complex-files/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/others/go/allof_multiple_ref_and_discriminator/git_push.sh
+++ b/samples/client/others/go/allof_multiple_ref_and_discriminator/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/others/go/issue_20079_go_regex_wrongly_translated/git_push.sh
+++ b/samples/client/others/go/issue_20079_go_regex_wrongly_translated/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/others/go/oneof-anyof-required/git_push.sh
+++ b/samples/client/others/go/oneof-anyof-required/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/others/go/oneof-discriminator-lookup/git_push.sh
+++ b/samples/client/others/go/oneof-discriminator-lookup/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/others/java/jersey2-oneOf-Mixed/git_push.sh
+++ b/samples/client/others/java/jersey2-oneOf-Mixed/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/others/java/jersey2-oneOf-duplicates/git_push.sh
+++ b/samples/client/others/java/jersey2-oneOf-duplicates/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/others/java/okhttp-gson-oneOf-array/git_push.sh
+++ b/samples/client/others/java/okhttp-gson-oneOf-array/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/others/java/okhttp-gson-oneOf/git_push.sh
+++ b/samples/client/others/java/okhttp-gson-oneOf/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/others/java/okhttp-gson-streaming/git_push.sh
+++ b/samples/client/others/java/okhttp-gson-streaming/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/others/java/restclient-enum-in-multipart/git_push.sh
+++ b/samples/client/others/java/restclient-enum-in-multipart/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/others/java/restclient-sealedInterface/git_push.sh
+++ b/samples/client/others/java/restclient-sealedInterface/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/others/java/restclient-useAbstractionForFiles/git_push.sh
+++ b/samples/client/others/java/restclient-useAbstractionForFiles/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/others/java/resttemplate-list-schema-validation/git_push.sh
+++ b/samples/client/others/java/resttemplate-list-schema-validation/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/others/java/resttemplate-useAbstractionForFiles/git_push.sh
+++ b/samples/client/others/java/resttemplate-useAbstractionForFiles/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/others/java/webclient-sealedInterface/git_push.sh
+++ b/samples/client/others/java/webclient-sealedInterface/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/others/java/webclient-sealedInterface_3_1/git_push.sh
+++ b/samples/client/others/java/webclient-sealedInterface_3_1/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/others/java/webclient-useAbstractionForFiles/git_push.sh
+++ b/samples/client/others/java/webclient-useAbstractionForFiles/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/others/python-legacy-model-dictionaries/git_push.sh
+++ b/samples/client/others/python-legacy-model-dictionaries/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/others/rust/hyper/api-with-ref-param/git_push.sh
+++ b/samples/client/others/rust/hyper/api-with-ref-param/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/others/rust/hyper/composed-oneof/git_push.sh
+++ b/samples/client/others/rust/hyper/composed-oneof/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/others/rust/hyper/emptyObject/git_push.sh
+++ b/samples/client/others/rust/hyper/emptyObject/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/others/rust/hyper/oneOf-array-map/git_push.sh
+++ b/samples/client/others/rust/hyper/oneOf-array-map/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/others/rust/hyper/oneOf-reuseRef/git_push.sh
+++ b/samples/client/others/rust/hyper/oneOf-reuseRef/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/others/rust/hyper/oneOf/git_push.sh
+++ b/samples/client/others/rust/hyper/oneOf/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/others/rust/reqwest-regression-16119/git_push.sh
+++ b/samples/client/others/rust/reqwest-regression-16119/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/others/rust/reqwest/api-with-ref-param/git_push.sh
+++ b/samples/client/others/rust/reqwest/api-with-ref-param/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/others/rust/reqwest/composed-oneof/git_push.sh
+++ b/samples/client/others/rust/reqwest/composed-oneof/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/others/rust/reqwest/emptyObject/git_push.sh
+++ b/samples/client/others/rust/reqwest/emptyObject/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/others/rust/reqwest/enum-query-params/git_push.sh
+++ b/samples/client/others/rust/reqwest/enum-query-params/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/others/rust/reqwest/multipart-async/git_push.sh
+++ b/samples/client/others/rust/reqwest/multipart-async/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/others/rust/reqwest/nullable-enum-query-params/git_push.sh
+++ b/samples/client/others/rust/reqwest/nullable-enum-query-params/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/others/rust/reqwest/oneOf-array-map/git_push.sh
+++ b/samples/client/others/rust/reqwest/oneOf-array-map/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/others/rust/reqwest/oneOf-reuseRef/git_push.sh
+++ b/samples/client/others/rust/reqwest/oneOf-reuseRef/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/others/rust/reqwest/oneOf/git_push.sh
+++ b/samples/client/others/rust/reqwest/oneOf/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/others/typescript-angular-v20/builds/query-param-deep-object/git_push.sh
+++ b/samples/client/others/typescript-angular-v20/builds/query-param-deep-object/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/others/typescript-angular-v20/builds/query-param-form/git_push.sh
+++ b/samples/client/others/typescript-angular-v20/builds/query-param-form/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/others/typescript-angular-v20/builds/query-param-json/git_push.sh
+++ b/samples/client/others/typescript-angular-v20/builds/query-param-json/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/others/typescript-angular/builds/composed-schemas-tagged-unions/git_push.sh
+++ b/samples/client/others/typescript-angular/builds/composed-schemas-tagged-unions/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/others/typescript-angular/builds/composed-schemas/git_push.sh
+++ b/samples/client/others/typescript-angular/builds/composed-schemas/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/others/typescript-axios/with-separate-models-and-api-inheritance/git_push.sh
+++ b/samples/client/others/typescript-axios/with-separate-models-and-api-inheritance/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/others/typescript-node/encode-decode/build/git_push.sh
+++ b/samples/client/others/typescript-node/encode-decode/build/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/R-httr2-wrapper/git_push.sh
+++ b/samples/client/petstore/R-httr2-wrapper/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/R-httr2/git_push.sh
+++ b/samples/client/petstore/R-httr2/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/R/git_push.sh
+++ b/samples/client/petstore/R/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/cpp-restsdk/client/git_push.sh
+++ b/samples/client/petstore/cpp-restsdk/client/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/crystal/git_push.sh
+++ b/samples/client/petstore/crystal/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/csharp/httpclient/net10/Petstore-nonPublicApi/git_push.sh
+++ b/samples/client/petstore/csharp/httpclient/net10/Petstore-nonPublicApi/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/csharp/httpclient/net10/Petstore/git_push.sh
+++ b/samples/client/petstore/csharp/httpclient/net10/Petstore/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/csharp/httpclient/net9/Petstore-nonPublicApi/git_push.sh
+++ b/samples/client/petstore/csharp/httpclient/net9/Petstore-nonPublicApi/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/csharp/httpclient/net9/Petstore/git_push.sh
+++ b/samples/client/petstore/csharp/httpclient/net9/Petstore/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/csharp/httpclient/standard2.0/Petstore/git_push.sh
+++ b/samples/client/petstore/csharp/httpclient/standard2.0/Petstore/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/csharp/restsharp/net10/EnumMappings/git_push.sh
+++ b/samples/client/petstore/csharp/restsharp/net10/EnumMappings/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/csharp/restsharp/net10/Petstore/git_push.sh
+++ b/samples/client/petstore/csharp/restsharp/net10/Petstore/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/csharp/restsharp/net4.7/MultipleFrameworks/git_push.sh
+++ b/samples/client/petstore/csharp/restsharp/net4.7/MultipleFrameworks/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/csharp/restsharp/net4.7/Petstore/git_push.sh
+++ b/samples/client/petstore/csharp/restsharp/net4.7/Petstore/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/csharp/restsharp/net4.8/Petstore/git_push.sh
+++ b/samples/client/petstore/csharp/restsharp/net4.8/Petstore/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/csharp/restsharp/net8/EnumMappings/git_push.sh
+++ b/samples/client/petstore/csharp/restsharp/net8/EnumMappings/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/csharp/restsharp/net8/ParameterMappings/git_push.sh
+++ b/samples/client/petstore/csharp/restsharp/net8/ParameterMappings/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/csharp/restsharp/net8/Petstore/git_push.sh
+++ b/samples/client/petstore/csharp/restsharp/net8/Petstore/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/csharp/restsharp/net8/UseDateTimeForDate/git_push.sh
+++ b/samples/client/petstore/csharp/restsharp/net8/UseDateTimeForDate/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/csharp/restsharp/net8/useVirtualForHooks/git_push.sh
+++ b/samples/client/petstore/csharp/restsharp/net8/useVirtualForHooks/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/csharp/restsharp/net9/EnumMappings/git_push.sh
+++ b/samples/client/petstore/csharp/restsharp/net9/EnumMappings/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/git_push.sh
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/git_push.sh
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/csharp/unityWebRequest/net10/Petstore/git_push.sh
+++ b/samples/client/petstore/csharp/unityWebRequest/net10/Petstore/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/csharp/unityWebRequest/net9/Petstore/git_push.sh
+++ b/samples/client/petstore/csharp/unityWebRequest/net9/Petstore/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/csharp/unityWebRequest/standard2.0/Petstore/git_push.sh
+++ b/samples/client/petstore/csharp/unityWebRequest/standard2.0/Petstore/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/go/go-petstore/git_push.sh
+++ b/samples/client/petstore/go/go-petstore/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/haskell-http-client/git_push.sh
+++ b/samples/client/petstore/haskell-http-client/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/java/apache-httpclient-jackson3/git_push.sh
+++ b/samples/client/petstore/java/apache-httpclient-jackson3/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/java/apache-httpclient/git_push.sh
+++ b/samples/client/petstore/java/apache-httpclient/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/java/feign-hc5/git_push.sh
+++ b/samples/client/petstore/java/feign-hc5/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/java/feign-no-nullable/git_push.sh
+++ b/samples/client/petstore/java/feign-no-nullable/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/java/feign/git_push.sh
+++ b/samples/client/petstore/java/feign/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/java/google-api-client/git_push.sh
+++ b/samples/client/petstore/java/google-api-client/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/git_push.sh
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/java/jersey2-java8/git_push.sh
+++ b/samples/client/petstore/java/jersey2-java8/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/java/jersey3-jackson3/git_push.sh
+++ b/samples/client/petstore/java/jersey3-jackson3/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/java/jersey3-oneOf/git_push.sh
+++ b/samples/client/petstore/java/jersey3-oneOf/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/java/jersey3/git_push.sh
+++ b/samples/client/petstore/java/jersey3/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/java/native-async/git_push.sh
+++ b/samples/client/petstore/java/native-async/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/java/native-jackson3-jspecify/git_push.sh
+++ b/samples/client/petstore/java/native-jackson3-jspecify/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/java/native-jackson3/git_push.sh
+++ b/samples/client/petstore/java/native-jackson3/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/java/native-jakarta/git_push.sh
+++ b/samples/client/petstore/java/native-jakarta/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/java/native-useGzipFeature/git_push.sh
+++ b/samples/client/petstore/java/native-useGzipFeature/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/java/native/git_push.sh
+++ b/samples/client/petstore/java/native/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/java/okhttp-gson-3.1-duplicated-operationid/git_push.sh
+++ b/samples/client/petstore/java/okhttp-gson-3.1-duplicated-operationid/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/java/okhttp-gson-3.1/git_push.sh
+++ b/samples/client/petstore/java/okhttp-gson-3.1/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/java/okhttp-gson-awsv4signature/git_push.sh
+++ b/samples/client/petstore/java/okhttp-gson-awsv4signature/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/git_push.sh
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/java/okhttp-gson-group-parameter/git_push.sh
+++ b/samples/client/petstore/java/okhttp-gson-group-parameter/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/java/okhttp-gson-nullable-required/git_push.sh
+++ b/samples/client/petstore/java/okhttp-gson-nullable-required/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/git_push.sh
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/java/okhttp-gson-swagger1/git_push.sh
+++ b/samples/client/petstore/java/okhttp-gson-swagger1/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/java/okhttp-gson-swagger2/git_push.sh
+++ b/samples/client/petstore/java/okhttp-gson-swagger2/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/java/okhttp-gson/git_push.sh
+++ b/samples/client/petstore/java/okhttp-gson/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/java/rest-assured-jackson/git_push.sh
+++ b/samples/client/petstore/java/rest-assured-jackson/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/java/rest-assured/git_push.sh
+++ b/samples/client/petstore/java/rest-assured/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/java/restclient-nullable-arrays/git_push.sh
+++ b/samples/client/petstore/java/restclient-nullable-arrays/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/java/restclient-springBoot4-jackson2/git_push.sh
+++ b/samples/client/petstore/java/restclient-springBoot4-jackson2/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/java/restclient-springBoot4-jackson3-jspecify-openapiNullable/git_push.sh
+++ b/samples/client/petstore/java/restclient-springBoot4-jackson3-jspecify-openapiNullable/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/java/restclient-springBoot4-jackson3-jspecify/git_push.sh
+++ b/samples/client/petstore/java/restclient-springBoot4-jackson3-jspecify/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/java/restclient-springBoot4-jackson3/git_push.sh
+++ b/samples/client/petstore/java/restclient-springBoot4-jackson3/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/java/restclient-swagger2/git_push.sh
+++ b/samples/client/petstore/java/restclient-swagger2/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/java/restclient-useSingleRequestParameter-static/git_push.sh
+++ b/samples/client/petstore/java/restclient-useSingleRequestParameter-static/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/java/restclient-useSingleRequestParameter/git_push.sh
+++ b/samples/client/petstore/java/restclient-useSingleRequestParameter/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/java/restclient/git_push.sh
+++ b/samples/client/petstore/java/restclient/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/java/resteasy/git_push.sh
+++ b/samples/client/petstore/java/resteasy/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/java/resttemplate-jakarta/git_push.sh
+++ b/samples/client/petstore/java/resttemplate-jakarta/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/java/resttemplate-springBoot4-jackson2/git_push.sh
+++ b/samples/client/petstore/java/resttemplate-springBoot4-jackson2/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/java/resttemplate-springBoot4-jackson3-jspecify/git_push.sh
+++ b/samples/client/petstore/java/resttemplate-springBoot4-jackson3-jspecify/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/java/resttemplate-springBoot4-jackson3/git_push.sh
+++ b/samples/client/petstore/java/resttemplate-springBoot4-jackson3/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/java/resttemplate-swagger1/git_push.sh
+++ b/samples/client/petstore/java/resttemplate-swagger1/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/java/resttemplate-swagger2/git_push.sh
+++ b/samples/client/petstore/java/resttemplate-swagger2/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/java/resttemplate-withXml/git_push.sh
+++ b/samples/client/petstore/java/resttemplate-withXml/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/java/resttemplate/git_push.sh
+++ b/samples/client/petstore/java/resttemplate/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/java/retrofit2-play26/git_push.sh
+++ b/samples/client/petstore/java/retrofit2-play26/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/java/retrofit2/git_push.sh
+++ b/samples/client/petstore/java/retrofit2/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/java/retrofit2rx2/git_push.sh
+++ b/samples/client/petstore/java/retrofit2rx2/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/java/retrofit2rx3/git_push.sh
+++ b/samples/client/petstore/java/retrofit2rx3/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/java/vertx-no-nullable/git_push.sh
+++ b/samples/client/petstore/java/vertx-no-nullable/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/java/vertx-supportVertxFuture/git_push.sh
+++ b/samples/client/petstore/java/vertx-supportVertxFuture/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/java/vertx/git_push.sh
+++ b/samples/client/petstore/java/vertx/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/java/vertx5-supportVertxFuture/git_push.sh
+++ b/samples/client/petstore/java/vertx5-supportVertxFuture/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/java/vertx5/git_push.sh
+++ b/samples/client/petstore/java/vertx5/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/java/webclient-jakarta/git_push.sh
+++ b/samples/client/petstore/java/webclient-jakarta/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/java/webclient-nullable-arrays/git_push.sh
+++ b/samples/client/petstore/java/webclient-nullable-arrays/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/java/webclient-springBoot4-jackson3-jspecify/git_push.sh
+++ b/samples/client/petstore/java/webclient-springBoot4-jackson3-jspecify/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/java/webclient-springBoot4-jackson3/git_push.sh
+++ b/samples/client/petstore/java/webclient-springBoot4-jackson3/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/java/webclient-swagger2/git_push.sh
+++ b/samples/client/petstore/java/webclient-swagger2/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/java/webclient-useSingleRequestParameter/git_push.sh
+++ b/samples/client/petstore/java/webclient-useSingleRequestParameter/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/java/webclient/git_push.sh
+++ b/samples/client/petstore/java/webclient/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/javascript-apollo/git_push.sh
+++ b/samples/client/petstore/javascript-apollo/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/javascript-es6/git_push.sh
+++ b/samples/client/petstore/javascript-es6/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/javascript-promise-es6/git_push.sh
+++ b/samples/client/petstore/javascript-promise-es6/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/lua/git_push.sh
+++ b/samples/client/petstore/lua/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/objc/core-data/git_push.sh
+++ b/samples/client/petstore/objc/core-data/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/objc/default/git_push.sh
+++ b/samples/client/petstore/objc/default/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/perl/git_push.sh
+++ b/samples/client/petstore/perl/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/git_push.sh
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/php/OpenAPIClient-php/git_push.sh
+++ b/samples/client/petstore/php/OpenAPIClient-php/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/php/psr-18/git_push.sh
+++ b/samples/client/petstore/php/psr-18/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/ruby-autoload/git_push.sh
+++ b/samples/client/petstore/ruby-autoload/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/ruby-faraday/git_push.sh
+++ b/samples/client/petstore/ruby-faraday/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/ruby-httpx/git_push.sh
+++ b/samples/client/petstore/ruby-httpx/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/ruby/git_push.sh
+++ b/samples/client/petstore/ruby/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/rust/hyper/petstore/git_push.sh
+++ b/samples/client/petstore/rust/hyper/petstore/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/rust/hyper/test-duplicates/git_push.sh
+++ b/samples/client/petstore/rust/hyper/test-duplicates/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/rust/hyper0x/petstore/git_push.sh
+++ b/samples/client/petstore/rust/hyper0x/petstore/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/rust/reqwest-trait/petstore/git_push.sh
+++ b/samples/client/petstore/rust/reqwest-trait/petstore/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/rust/reqwest/name-mapping/git_push.sh
+++ b/samples/client/petstore/rust/reqwest/name-mapping/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/rust/reqwest/petstore-async-middleware/git_push.sh
+++ b/samples/client/petstore/rust/reqwest/petstore-async-middleware/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/rust/reqwest/petstore-async-tokensource/git_push.sh
+++ b/samples/client/petstore/rust/reqwest/petstore-async-tokensource/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/rust/reqwest/petstore-async/git_push.sh
+++ b/samples/client/petstore/rust/reqwest/petstore-async/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/rust/reqwest/petstore-avoid-box/git_push.sh
+++ b/samples/client/petstore/rust/reqwest/petstore-avoid-box/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/rust/reqwest/petstore-awsv4signature/git_push.sh
+++ b/samples/client/petstore/rust/reqwest/petstore-awsv4signature/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/rust/reqwest/petstore-model-name-prefix/git_push.sh
+++ b/samples/client/petstore/rust/reqwest/petstore-model-name-prefix/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/rust/reqwest/petstore-no-chrono/git_push.sh
+++ b/samples/client/petstore/rust/reqwest/petstore-no-chrono/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/rust/reqwest/petstore-serde-path-to-error/git_push.sh
+++ b/samples/client/petstore/rust/reqwest/petstore-serde-path-to-error/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/rust/reqwest/petstore/git_push.sh
+++ b/samples/client/petstore/rust/reqwest/petstore/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/rust/reqwest/test-duplicates/git_push.sh
+++ b/samples/client/petstore/rust/reqwest/test-duplicates/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/swift5/alamofireLibrary/git_push.sh
+++ b/samples/client/petstore/swift5/alamofireLibrary/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/swift5/asyncAwaitLibrary/git_push.sh
+++ b/samples/client/petstore/swift5/asyncAwaitLibrary/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/swift5/combineLibrary/git_push.sh
+++ b/samples/client/petstore/swift5/combineLibrary/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/swift5/default/git_push.sh
+++ b/samples/client/petstore/swift5/default/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/swift5/objcCompatible/git_push.sh
+++ b/samples/client/petstore/swift5/objcCompatible/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/swift5/oneOf/git_push.sh
+++ b/samples/client/petstore/swift5/oneOf/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/swift5/promisekitLibrary/git_push.sh
+++ b/samples/client/petstore/swift5/promisekitLibrary/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/swift5/resultLibrary/git_push.sh
+++ b/samples/client/petstore/swift5/resultLibrary/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/swift5/rxswiftLibrary/git_push.sh
+++ b/samples/client/petstore/swift5/rxswiftLibrary/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/swift5/urlsessionLibrary/git_push.sh
+++ b/samples/client/petstore/swift5/urlsessionLibrary/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/swift5/validation/git_push.sh
+++ b/samples/client/petstore/swift5/validation/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/swift6/alamofireLibrary/git_push.sh
+++ b/samples/client/petstore/swift6/alamofireLibrary/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/swift6/apiNonStaticMethod/git_push.sh
+++ b/samples/client/petstore/swift6/apiNonStaticMethod/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/swift6/asyncAwaitLibrary/git_push.sh
+++ b/samples/client/petstore/swift6/asyncAwaitLibrary/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/swift6/combineDeferredLibrary/git_push.sh
+++ b/samples/client/petstore/swift6/combineDeferredLibrary/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/swift6/combineLibrary/git_push.sh
+++ b/samples/client/petstore/swift6/combineLibrary/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/swift6/default/git_push.sh
+++ b/samples/client/petstore/swift6/default/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/swift6/objcCompatible/git_push.sh
+++ b/samples/client/petstore/swift6/objcCompatible/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/swift6/oneOf/git_push.sh
+++ b/samples/client/petstore/swift6/oneOf/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/swift6/promisekitLibrary/git_push.sh
+++ b/samples/client/petstore/swift6/promisekitLibrary/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/swift6/resultLibrary/git_push.sh
+++ b/samples/client/petstore/swift6/resultLibrary/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/swift6/rxswiftLibrary/git_push.sh
+++ b/samples/client/petstore/swift6/rxswiftLibrary/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/swift6/urlsessionLibrary/git_push.sh
+++ b/samples/client/petstore/swift6/urlsessionLibrary/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/swift6/validation/git_push.sh
+++ b/samples/client/petstore/swift6/validation/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/typescript-angular-v18-provided-in-root/builds/default/git_push.sh
+++ b/samples/client/petstore/typescript-angular-v18-provided-in-root/builds/default/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/typescript-angular-v19-provided-in-root/builds/default/git_push.sh
+++ b/samples/client/petstore/typescript-angular-v19-provided-in-root/builds/default/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/typescript-angular-v19-with-angular-dependency-params/builds/default/git_push.sh
+++ b/samples/client/petstore/typescript-angular-v19-with-angular-dependency-params/builds/default/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/typescript-angular-v19/builds/default/git_push.sh
+++ b/samples/client/petstore/typescript-angular-v19/builds/default/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/typescript-angular-v20-provided-in-root/builds/default/git_push.sh
+++ b/samples/client/petstore/typescript-angular-v20-provided-in-root/builds/default/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/typescript-angular-v20/builds/default/git_push.sh
+++ b/samples/client/petstore/typescript-angular-v20/builds/default/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/typescript-angular-v21-provided-in-root/builds/default/git_push.sh
+++ b/samples/client/petstore/typescript-angular-v21-provided-in-root/builds/default/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/typescript-angular-v21/builds/default/git_push.sh
+++ b/samples/client/petstore/typescript-angular-v21/builds/default/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/typescript-angular-v22-provided-in-root/builds/default/git_push.sh
+++ b/samples/client/petstore/typescript-angular-v22-provided-in-root/builds/default/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/typescript-angular-v22/builds/default/git_push.sh
+++ b/samples/client/petstore/typescript-angular-v22/builds/default/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/typescript-aurelia/default/git_push.sh
+++ b/samples/client/petstore/typescript-aurelia/default/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/typescript-axios/builds/composed-schemas/git_push.sh
+++ b/samples/client/petstore/typescript-axios/builds/composed-schemas/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/typescript-axios/builds/default/git_push.sh
+++ b/samples/client/petstore/typescript-axios/builds/default/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/typescript-axios/builds/es6-target/git_push.sh
+++ b/samples/client/petstore/typescript-axios/builds/es6-target/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/typescript-axios/builds/test-petstore/git_push.sh
+++ b/samples/client/petstore/typescript-axios/builds/test-petstore/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/typescript-axios/builds/with-complex-headers/git_push.sh
+++ b/samples/client/petstore/typescript-axios/builds/with-complex-headers/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/typescript-axios/builds/with-fake-endpoints-models-for-testing-with-http-signature/git_push.sh
+++ b/samples/client/petstore/typescript-axios/builds/with-fake-endpoints-models-for-testing-with-http-signature/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/typescript-axios/builds/with-interfaces-and-with-single-request-param/git_push.sh
+++ b/samples/client/petstore/typescript-axios/builds/with-interfaces-and-with-single-request-param/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/typescript-axios/builds/with-interfaces/git_push.sh
+++ b/samples/client/petstore/typescript-axios/builds/with-interfaces/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/typescript-axios/builds/with-node-imports/git_push.sh
+++ b/samples/client/petstore/typescript-axios/builds/with-node-imports/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/git_push.sh
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version/git_push.sh
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/typescript-axios/builds/with-single-request-parameters/git_push.sh
+++ b/samples/client/petstore/typescript-axios/builds/with-single-request-parameters/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/typescript-axios/builds/with-string-enums/git_push.sh
+++ b/samples/client/petstore/typescript-axios/builds/with-string-enums/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/typescript-jquery/default/git_push.sh
+++ b/samples/client/petstore/typescript-jquery/default/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/typescript-jquery/npm/git_push.sh
+++ b/samples/client/petstore/typescript-jquery/npm/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/typescript-nestjs-v6-provided-in-root/builds/default/git_push.sh
+++ b/samples/client/petstore/typescript-nestjs-v6-provided-in-root/builds/default/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/typescript-nestjs-v8-provided-in-root/builds/default/git_push.sh
+++ b/samples/client/petstore/typescript-nestjs-v8-provided-in-root/builds/default/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/typescript-nestjs/builds/reservedParamNames/git_push.sh
+++ b/samples/client/petstore/typescript-nestjs/builds/reservedParamNames/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/typescript-node/3_0/git_push.sh
+++ b/samples/client/petstore/typescript-node/3_0/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/typescript-node/default/git_push.sh
+++ b/samples/client/petstore/typescript-node/default/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/client/petstore/typescript-node/npm/git_push.sh
+++ b/samples/client/petstore/typescript-node/npm/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/openapi3/client/extensions/x-auth-id-alias/go-experimental/git_push.sh
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/go-experimental/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/git_push.sh
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/openapi3/client/extensions/x-auth-id-alias/ruby-client/git_push.sh
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/ruby-client/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/openapi3/client/features/dynamic-servers/ruby/git_push.sh
+++ b/samples/openapi3/client/features/dynamic-servers/ruby/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/openapi3/client/features/generate-alias-as-model/ruby-client/git_push.sh
+++ b/samples/openapi3/client/features/generate-alias-as-model/ruby-client/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/git_push.sh
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/git_push.sh
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/openapi3/client/petstore/go-petstore-generateMarshalJSON-false/git_push.sh
+++ b/samples/openapi3/client/petstore/go-petstore-generateMarshalJSON-false/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/openapi3/client/petstore/go-petstore-withXml/git_push.sh
+++ b/samples/openapi3/client/petstore/go-petstore-withXml/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/openapi3/client/petstore/go/go-petstore-aws-signature/git_push.sh
+++ b/samples/openapi3/client/petstore/go/go-petstore-aws-signature/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/openapi3/client/petstore/go/go-petstore/git_push.sh
+++ b/samples/openapi3/client/petstore/go/go-petstore/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/git_push.sh
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/openapi3/client/petstore/java/jersey2-java8-swagger1/git_push.sh
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-swagger1/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/openapi3/client/petstore/java/jersey2-java8-swagger2/git_push.sh
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-swagger2/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/openapi3/client/petstore/java/jersey2-java8/git_push.sh
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/openapi3/client/petstore/python-aiohttp/git_push.sh
+++ b/samples/openapi3/client/petstore/python-aiohttp/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/openapi3/client/petstore/python-httpx-sync/git_push.sh
+++ b/samples/openapi3/client/petstore/python-httpx-sync/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/openapi3/client/petstore/python-httpx/git_push.sh
+++ b/samples/openapi3/client/petstore/python-httpx/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/openapi3/client/petstore/python-lazyImports/git_push.sh
+++ b/samples/openapi3/client/petstore/python-lazyImports/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/git_push.sh
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/openapi3/client/petstore/python-pydantic-v1/git_push.sh
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="GIT_HOST"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/openapi3/client/petstore/python/git_push.sh
+++ b/samples/openapi3/client/petstore/python/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/server/petstore/cpp-restbed/generated/3_0/git_push.sh
+++ b/samples/server/petstore/cpp-restbed/generated/3_0/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/git_push.sh
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="openapitools"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="petstore"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/server/petstore/python-flask-connexion3/git_push.sh
+++ b/samples/server/petstore/python-flask-connexion3/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master

--- a/samples/server/petstore/python-flask/git_push.sh
+++ b/samples/server/petstore/python-flask/git_push.sh
@@ -8,24 +8,24 @@ git_repo_id=$2
 release_note=$3
 git_host=$4
 
-if [ "$git_host" = "" ]; then
+if [ -z "${git_host}" ]; then
     git_host="github.com"
-    echo "[INFO] No command line input provided. Set \$git_host to $git_host"
+    echo "[INFO] No command line input provided. Set \${git_host} to ${git_host}"
 fi
 
-if [ "$git_user_id" = "" ]; then
+if [ -z "${git_user_id}" ]; then
     git_user_id="GIT_USER_ID"
-    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+    echo "[INFO] No command line input provided. Set \${git_user_id} to ${git_user_id}"
 fi
 
-if [ "$git_repo_id" = "" ]; then
+if [ -z "${git_repo_id}" ]; then
     git_repo_id="GIT_REPO_ID"
-    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+    echo "[INFO] No command line input provided. Set \${git_repo_id} to ${git_repo_id}"
 fi
 
-if [ "$release_note" = "" ]; then
+if [ -z "${release_note}" ]; then
     release_note="Minor update"
-    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+    echo "[INFO] No command line input provided. Set \${release_note} to ${release_note}"
 fi
 
 # Initialize the local directory as a Git repository
@@ -35,19 +35,16 @@ git init
 git add .
 
 # Commits the tracked changes and prepares them to be pushed to a remote repository.
-git commit -m "$release_note"
+git commit -m "${release_note}"
 
 # Sets the new remote
-git_remote=$(git remote)
-if [ "$git_remote" = "" ]; then # git remote not defined
-
-    if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://${git_host}/${git_user_id}/${git_repo_id}.git
+if [ -z "$(git remote)" ]; then # git remote not defined
+    if [ -z "${GIT_TOKEN:-}" ]; then
+        echo "[INFO] \${GIT_TOKEN} (environment variable) is not set. Using the git credential in your environment."
+        git remote add origin "https://${git_host}/${git_user_id}/${git_repo_id}.git"
     else
-        git remote add origin https://${git_user_id}:"${GIT_TOKEN}"@${git_host}/${git_user_id}/${git_repo_id}.git
+        git remote add origin "https://${git_user_id}:${GIT_TOKEN}@${git_host}/${git_user_id}/${git_repo_id}.git"
     fi
-
 fi
 
 git pull origin master


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Closes #24675

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ShellCheck warnings in git_push.sh by using safer empty checks and clearer messages. Updates the `_common/git_push.sh.mustache` template and regenerates sample scripts to apply the fix. Closes #24675.

- **Bug Fixes**
  - Replace [ "$var" = "" ] with [ -z "${var}" ] and keep quoted expansions.
  - Use braces in echoes and escape variable names in info logs (e.g., print ${git_host} literally).
  - Regenerate sample `git_push.sh` scripts across clients via `./bin/generate-samples.sh ./bin/configs/*.yaml`.

<sup>Written for commit b71a783b9f040ed8c9a0c84097dbc23f19250f1e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24689?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

