### PR TITLE
[rust-server] Generate the auth scheme precedence tests

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
@@ -1396,15 +1396,17 @@ public class RustServerCodegen extends AbstractRustCodegen implements CodegenCon
      * and make every later block unreachable (see issue #24095).
      *
      * Whether that is observable depends on block order, so the only thing the template cannot work
-     * out for itself is whether a block handling a given HTTP scheme precedes the first apiKey
-     * block. Everything else - which requests to send, which credentials to use - lives in the
-     * template.
+     * out for itself is whether a block handling a given HTTP scheme precedes the apiKey block it
+     * could shadow. Everything else - which requests to send, which credentials to use - lives in
+     * the template.
      */
     private void addAuthSchemeTestsToBundle(List<CodegenSecurity> authMethods, Map<String, Object> bundle) {
         boolean hasBasic = false;
         boolean hasBearer = false;
-        boolean basicPrecedesApiKey = false;
-        boolean bearerPrecedesApiKey = false;
+        boolean basicPrecedesHeaderApiKey = false;
+        boolean bearerPrecedesHeaderApiKey = false;
+        boolean basicPrecedesQueryApiKey = false;
+        boolean bearerPrecedesQueryApiKey = false;
         String apiKeyHeaderName = null;
         String apiKeyQueryName = null;
 
@@ -1420,10 +1422,16 @@ public class RustServerCodegen extends AbstractRustCodegen implements CodegenCon
 
                 hasBasic |= isBasic;
                 hasBearer |= isBearer;
-                // Only blocks generated before the first apiKey block can shadow it.
-                if (apiKeyHeaderName == null && apiKeyQueryName == null) {
-                    basicPrecedesApiKey |= isBasic;
-                    bearerPrecedesApiKey |= isBearer;
+                // Only blocks generated before an apiKey block can shadow it, and the header and
+                // query blocks are shadowed independently: each matches a different part of the
+                // request, so a block that fails to match one may still precede and claim the other.
+                if (apiKeyHeaderName == null) {
+                    basicPrecedesHeaderApiKey |= isBasic;
+                    bearerPrecedesHeaderApiKey |= isBearer;
+                }
+                if (apiKeyQueryName == null) {
+                    basicPrecedesQueryApiKey |= isBasic;
+                    bearerPrecedesQueryApiKey |= isBearer;
                 }
                 if (isApiKeyHeader && apiKeyHeaderName == null) {
                     apiKeyHeaderName = authMethod.keyParamName.toLowerCase(Locale.ROOT);
@@ -1436,8 +1444,10 @@ public class RustServerCodegen extends AbstractRustCodegen implements CodegenCon
 
         bundle.put("authTestHasBasic", hasBasic);
         bundle.put("authTestHasBearer", hasBearer);
-        bundle.put("authTestBasicPrecedesApiKey", basicPrecedesApiKey);
-        bundle.put("authTestBearerPrecedesApiKey", bearerPrecedesApiKey);
+        bundle.put("authTestBasicPrecedesHeaderApiKey", basicPrecedesHeaderApiKey);
+        bundle.put("authTestBearerPrecedesHeaderApiKey", bearerPrecedesHeaderApiKey);
+        bundle.put("authTestBasicPrecedesQueryApiKey", basicPrecedesQueryApiKey);
+        bundle.put("authTestBearerPrecedesQueryApiKey", bearerPrecedesQueryApiKey);
         bundle.put("authTestApiKeyHeader", apiKeyHeaderName);
         bundle.put("authTestApiKeyQuery", apiKeyQueryName);
         bundle.put("authTestHasApiKey", apiKeyHeaderName != null || apiKeyQueryName != null);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
@@ -1383,7 +1383,72 @@ public class RustServerCodegen extends AbstractRustCodegen implements CodegenCon
         }
         bundle.put("hasAuthScopes", hasAuthScopes);
 
+        addAuthSchemeTestsToBundle(authMethods, bundle);
+
         return super.postProcessSupportingFileData(bundle);
+    }
+
+    /**
+     * Derive the facts the generated auth-scheme precedence tests need.
+     *
+     * Each generated block in `context.rs` returns early once it matches, so a block that fails to
+     * check which `AuthData` variant it received will claim credentials belonging to another scheme
+     * and make every later block unreachable (see issue #24095).
+     *
+     * Whether that is observable depends on block order, so the only thing the template cannot work
+     * out for itself is whether a block handling a given HTTP scheme precedes the first apiKey
+     * block. Everything else - which requests to send, which credentials to use - lives in the
+     * template.
+     */
+    private void addAuthSchemeTestsToBundle(List<CodegenSecurity> authMethods, Map<String, Object> bundle) {
+        boolean hasBasic = false;
+        boolean hasBearer = false;
+        boolean basicPrecedesApiKey = false;
+        boolean bearerPrecedesApiKey = false;
+        String apiKeyHeaderName = null;
+        String apiKeyQueryName = null;
+
+        if (authMethods != null) {
+            for (CodegenSecurity authMethod : authMethods) {
+                boolean isBasic = Boolean.TRUE.equals(authMethod.isBasicBasic);
+                boolean isBearer = Boolean.TRUE.equals(authMethod.isBasicBearer)
+                        || Boolean.TRUE.equals(authMethod.isOAuth);
+                boolean isApiKeyHeader = Boolean.TRUE.equals(authMethod.isApiKey)
+                        && Boolean.TRUE.equals(authMethod.isKeyInHeader);
+                boolean isApiKeyQuery = Boolean.TRUE.equals(authMethod.isApiKey)
+                        && Boolean.TRUE.equals(authMethod.isKeyInQuery);
+
+                hasBasic |= isBasic;
+                hasBearer |= isBearer;
+                // Only blocks generated before the first apiKey block can shadow it.
+                if (apiKeyHeaderName == null && apiKeyQueryName == null) {
+                    basicPrecedesApiKey |= isBasic;
+                    bearerPrecedesApiKey |= isBearer;
+                }
+                if (isApiKeyHeader && apiKeyHeaderName == null) {
+                    apiKeyHeaderName = authMethod.keyParamName.toLowerCase(Locale.ROOT);
+                }
+                if (isApiKeyQuery && apiKeyQueryName == null) {
+                    apiKeyQueryName = authMethod.keyParamName;
+                }
+            }
+        }
+
+        bundle.put("authTestHasBasic", hasBasic);
+        bundle.put("authTestHasBearer", hasBearer);
+        bundle.put("authTestBasicPrecedesApiKey", basicPrecedesApiKey);
+        bundle.put("authTestBearerPrecedesApiKey", bearerPrecedesApiKey);
+        bundle.put("authTestApiKeyHeader", apiKeyHeaderName);
+        bundle.put("authTestApiKeyQuery", apiKeyQueryName);
+        bundle.put("authTestHasApiKey", apiKeyHeaderName != null || apiKeyQueryName != null);
+
+        SupportingFile authTestFile =
+                new SupportingFile("tests-auth-scheme-precedence.mustache", "tests", "auth_scheme_precedence.rs");
+        if (hasBasic || hasBearer || apiKeyHeaderName != null || apiKeyQueryName != null) {
+            supportingFiles.add(authTestFile);
+        } else {
+            supportingFiles.remove(authTestFile);
+        }
     }
 
     /**

--- a/modules/openapi-generator/src/main/resources/rust-server/tests-auth-scheme-precedence.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/tests-auth-scheme-precedence.mustache
@@ -68,7 +68,12 @@ fn no_credentials_resolve_to_no_auth_data() {
 }
 
 #[test]
-fn basic_credentials_resolve_to_the_declared_scheme() {
+{{#authTestHasBasic}}
+fn basic_credentials_resolve_to_the_declared_basic_scheme() {
+{{/authTestHasBasic}}
+{{^authTestHasBasic}}
+fn basic_credentials_resolve_to_none_when_no_basic_scheme_is_declared() {
+{{/authTestHasBasic}}
     assert_eq!(
         resolve_auth_data("/", &[("authorization", BASIC_HEADER)]),
         {{#authTestHasBasic}}Some(AuthData::Basic("user".to_owned(), "password".to_owned())){{/authTestHasBasic}}{{^authTestHasBasic}}None{{/authTestHasBasic}},
@@ -76,7 +81,12 @@ fn basic_credentials_resolve_to_the_declared_scheme() {
 }
 
 #[test]
-fn bearer_credentials_resolve_to_the_declared_scheme() {
+{{#authTestHasBearer}}
+fn bearer_credentials_resolve_to_the_declared_bearer_scheme() {
+{{/authTestHasBearer}}
+{{^authTestHasBearer}}
+fn bearer_credentials_resolve_to_none_when_no_bearer_scheme_is_declared() {
+{{/authTestHasBearer}}
     assert_eq!(
         resolve_auth_data("/", &[("authorization", BEARER_HEADER)]),
         {{#authTestHasBearer}}Some(AuthData::Bearer("some-token".to_owned())){{/authTestHasBearer}}{{^authTestHasBearer}}None{{/authTestHasBearer}},
@@ -98,7 +108,7 @@ fn header_api_key_resolves_when_it_is_the_only_credential() {
 fn header_api_key_is_reachable_alongside_bearer_credentials() {
     assert_eq!(
         resolve_auth_data("/", &[("authorization", BEARER_HEADER), ("{{{.}}}", API_KEY)]),
-        {{#authTestBearerPrecedesApiKey}}Some(AuthData::Bearer("some-token".to_owned())){{/authTestBearerPrecedesApiKey}}{{^authTestBearerPrecedesApiKey}}Some(AuthData::ApiKey(API_KEY.to_owned())){{/authTestBearerPrecedesApiKey}},
+        {{#authTestBearerPrecedesHeaderApiKey}}Some(AuthData::Bearer("some-token".to_owned())){{/authTestBearerPrecedesHeaderApiKey}}{{^authTestBearerPrecedesHeaderApiKey}}Some(AuthData::ApiKey(API_KEY.to_owned())){{/authTestBearerPrecedesHeaderApiKey}},
     );
 }
 
@@ -106,7 +116,7 @@ fn header_api_key_is_reachable_alongside_bearer_credentials() {
 fn header_api_key_is_reachable_alongside_basic_credentials() {
     assert_eq!(
         resolve_auth_data("/", &[("authorization", BASIC_HEADER), ("{{{.}}}", API_KEY)]),
-        {{#authTestBasicPrecedesApiKey}}Some(AuthData::Basic("user".to_owned(), "password".to_owned())){{/authTestBasicPrecedesApiKey}}{{^authTestBasicPrecedesApiKey}}Some(AuthData::ApiKey(API_KEY.to_owned())){{/authTestBasicPrecedesApiKey}},
+        {{#authTestBasicPrecedesHeaderApiKey}}Some(AuthData::Basic("user".to_owned(), "password".to_owned())){{/authTestBasicPrecedesHeaderApiKey}}{{^authTestBasicPrecedesHeaderApiKey}}Some(AuthData::ApiKey(API_KEY.to_owned())){{/authTestBasicPrecedesHeaderApiKey}},
     );
 }
 {{/authTestApiKeyHeader}}
@@ -117,6 +127,25 @@ fn query_api_key_resolves_when_it_is_the_only_credential() {
     assert_eq!(
         resolve_auth_data("/?{{{.}}}=test-api-key", &[]),
         Some(AuthData::ApiKey(API_KEY.to_owned())),
+    );
+}
+
+/// The query apiKey block is shadowed independently of the header one: an `Authorization`
+/// header must not claim a request whose credentials are in the query string unless a block
+/// that actually handles that scheme is generated before the query block.
+#[test]
+fn query_api_key_is_reachable_alongside_bearer_credentials() {
+    assert_eq!(
+        resolve_auth_data("/?{{{.}}}=test-api-key", &[("authorization", BEARER_HEADER)]),
+        {{#authTestBearerPrecedesQueryApiKey}}Some(AuthData::Bearer("some-token".to_owned())){{/authTestBearerPrecedesQueryApiKey}}{{^authTestBearerPrecedesQueryApiKey}}Some(AuthData::ApiKey(API_KEY.to_owned())){{/authTestBearerPrecedesQueryApiKey}},
+    );
+}
+
+#[test]
+fn query_api_key_is_reachable_alongside_basic_credentials() {
+    assert_eq!(
+        resolve_auth_data("/?{{{.}}}=test-api-key", &[("authorization", BASIC_HEADER)]),
+        {{#authTestBasicPrecedesQueryApiKey}}Some(AuthData::Basic("user".to_owned(), "password".to_owned())){{/authTestBasicPrecedesQueryApiKey}}{{^authTestBasicPrecedesQueryApiKey}}Some(AuthData::ApiKey(API_KEY.to_owned())){{/authTestBasicPrecedesQueryApiKey}},
     );
 }
 {{/authTestApiKeyQuery}}

--- a/modules/openapi-generator/src/main/resources/rust-server/tests-auth-scheme-precedence.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/tests-auth-scheme-precedence.mustache
@@ -17,7 +17,7 @@ use hyper::service::Service;
 use hyper::{Request, Response};
 use swagger::auth::AuthData;
 use swagger::{EmptyContext, Has};
-use overlapping_auth_schemes::context::AddContext;
+use {{{externCrateName}}}::context::AddContext;
 
 /// Innermost service: records the `Option<AuthData>` that `AddContext` pushed onto the context.
 #[derive(Clone, Default)]
@@ -58,7 +58,9 @@ fn resolve_auth_data(uri: &str, headers: &[(&str, &str)]) -> Option<AuthData> {
 /// `dXNlcjpwYXNzd29yZA==` is `user:password`.
 const BASIC_HEADER: &str = "Basic dXNlcjpwYXNzd29yZA==";
 const BEARER_HEADER: &str = "Bearer some-token";
+{{#authTestHasApiKey}}
 const API_KEY: &str = "test-api-key";
+{{/authTestHasApiKey}}
 
 #[test]
 fn no_credentials_resolve_to_no_auth_data() {
@@ -69,7 +71,7 @@ fn no_credentials_resolve_to_no_auth_data() {
 fn basic_credentials_resolve_to_the_declared_scheme() {
     assert_eq!(
         resolve_auth_data("/", &[("authorization", BASIC_HEADER)]),
-        Some(AuthData::Basic("user".to_owned(), "password".to_owned())),
+        {{#authTestHasBasic}}Some(AuthData::Basic("user".to_owned(), "password".to_owned())){{/authTestHasBasic}}{{^authTestHasBasic}}None{{/authTestHasBasic}},
     );
 }
 
@@ -77,14 +79,15 @@ fn basic_credentials_resolve_to_the_declared_scheme() {
 fn bearer_credentials_resolve_to_the_declared_scheme() {
     assert_eq!(
         resolve_auth_data("/", &[("authorization", BEARER_HEADER)]),
-        Some(AuthData::Bearer("some-token".to_owned())),
+        {{#authTestHasBearer}}Some(AuthData::Bearer("some-token".to_owned())){{/authTestHasBearer}}{{^authTestHasBearer}}None{{/authTestHasBearer}},
     );
 }
+{{#authTestApiKeyHeader}}
 
 #[test]
 fn header_api_key_resolves_when_it_is_the_only_credential() {
     assert_eq!(
-        resolve_auth_data("/", &[("x-api-key", API_KEY)]),
+        resolve_auth_data("/", &[("{{{.}}}", API_KEY)]),
         Some(AuthData::ApiKey(API_KEY.to_owned())),
     );
 }
@@ -94,15 +97,26 @@ fn header_api_key_resolves_when_it_is_the_only_credential() {
 #[test]
 fn header_api_key_is_reachable_alongside_bearer_credentials() {
     assert_eq!(
-        resolve_auth_data("/", &[("authorization", BEARER_HEADER), ("x-api-key", API_KEY)]),
-        Some(AuthData::ApiKey(API_KEY.to_owned())),
+        resolve_auth_data("/", &[("authorization", BEARER_HEADER), ("{{{.}}}", API_KEY)]),
+        {{#authTestBearerPrecedesApiKey}}Some(AuthData::Bearer("some-token".to_owned())){{/authTestBearerPrecedesApiKey}}{{^authTestBearerPrecedesApiKey}}Some(AuthData::ApiKey(API_KEY.to_owned())){{/authTestBearerPrecedesApiKey}},
     );
 }
 
 #[test]
 fn header_api_key_is_reachable_alongside_basic_credentials() {
     assert_eq!(
-        resolve_auth_data("/", &[("authorization", BASIC_HEADER), ("x-api-key", API_KEY)]),
-        Some(AuthData::Basic("user".to_owned(), "password".to_owned())),
+        resolve_auth_data("/", &[("authorization", BASIC_HEADER), ("{{{.}}}", API_KEY)]),
+        {{#authTestBasicPrecedesApiKey}}Some(AuthData::Basic("user".to_owned(), "password".to_owned())){{/authTestBasicPrecedesApiKey}}{{^authTestBasicPrecedesApiKey}}Some(AuthData::ApiKey(API_KEY.to_owned())){{/authTestBasicPrecedesApiKey}},
     );
 }
+{{/authTestApiKeyHeader}}
+{{#authTestApiKeyQuery}}
+
+#[test]
+fn query_api_key_resolves_when_it_is_the_only_credential() {
+    assert_eq!(
+        resolve_auth_data("/?{{{.}}}=test-api-key", &[]),
+        Some(AuthData::ApiKey(API_KEY.to_owned())),
+    );
+}
+{{/authTestApiKeyQuery}}

--- a/samples/server/petstore/rust-server/output/openapi-v3/.openapi-generator/FILES
+++ b/samples/server/petstore/rust-server/output/openapi-v3/.openapi-generator/FILES
@@ -64,3 +64,4 @@ src/models.rs
 src/server/callbacks.rs
 src/server/mod.rs
 src/server/server_auth.rs
+tests/auth_scheme_precedence.rs

--- a/samples/server/petstore/rust-server/output/openapi-v3/tests/auth_scheme_precedence.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/tests/auth_scheme_precedence.rs
@@ -65,7 +65,7 @@ fn no_credentials_resolve_to_no_auth_data() {
 }
 
 #[test]
-fn basic_credentials_resolve_to_the_declared_scheme() {
+fn basic_credentials_resolve_to_none_when_no_basic_scheme_is_declared() {
     assert_eq!(
         resolve_auth_data("/", &[("authorization", BASIC_HEADER)]),
         None,
@@ -73,7 +73,7 @@ fn basic_credentials_resolve_to_the_declared_scheme() {
 }
 
 #[test]
-fn bearer_credentials_resolve_to_the_declared_scheme() {
+fn bearer_credentials_resolve_to_the_declared_bearer_scheme() {
     assert_eq!(
         resolve_auth_data("/", &[("authorization", BEARER_HEADER)]),
         Some(AuthData::Bearer("some-token".to_owned())),

--- a/samples/server/petstore/rust-server/output/openapi-v3/tests/auth_scheme_precedence.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/tests/auth_scheme_precedence.rs
@@ -17,7 +17,7 @@ use hyper::service::Service;
 use hyper::{Request, Response};
 use swagger::auth::AuthData;
 use swagger::{EmptyContext, Has};
-use overlapping_auth_schemes::context::AddContext;
+use openapi_v3::context::AddContext;
 
 /// Innermost service: records the `Option<AuthData>` that `AddContext` pushed onto the context.
 #[derive(Clone, Default)]
@@ -58,7 +58,6 @@ fn resolve_auth_data(uri: &str, headers: &[(&str, &str)]) -> Option<AuthData> {
 /// `dXNlcjpwYXNzd29yZA==` is `user:password`.
 const BASIC_HEADER: &str = "Basic dXNlcjpwYXNzd29yZA==";
 const BEARER_HEADER: &str = "Bearer some-token";
-const API_KEY: &str = "test-api-key";
 
 #[test]
 fn no_credentials_resolve_to_no_auth_data() {
@@ -69,7 +68,7 @@ fn no_credentials_resolve_to_no_auth_data() {
 fn basic_credentials_resolve_to_the_declared_scheme() {
     assert_eq!(
         resolve_auth_data("/", &[("authorization", BASIC_HEADER)]),
-        Some(AuthData::Basic("user".to_owned(), "password".to_owned())),
+        None,
     );
 }
 
@@ -78,31 +77,5 @@ fn bearer_credentials_resolve_to_the_declared_scheme() {
     assert_eq!(
         resolve_auth_data("/", &[("authorization", BEARER_HEADER)]),
         Some(AuthData::Bearer("some-token".to_owned())),
-    );
-}
-
-#[test]
-fn header_api_key_resolves_when_it_is_the_only_credential() {
-    assert_eq!(
-        resolve_auth_data("/", &[("x-api-key", API_KEY)]),
-        Some(AuthData::ApiKey(API_KEY.to_owned())),
-    );
-}
-
-/// An `Authorization` header must not shadow the apiKey block unless a block that actually
-/// handles that scheme is generated before it.
-#[test]
-fn header_api_key_is_reachable_alongside_bearer_credentials() {
-    assert_eq!(
-        resolve_auth_data("/", &[("authorization", BEARER_HEADER), ("x-api-key", API_KEY)]),
-        Some(AuthData::ApiKey(API_KEY.to_owned())),
-    );
-}
-
-#[test]
-fn header_api_key_is_reachable_alongside_basic_credentials() {
-    assert_eq!(
-        resolve_auth_data("/", &[("authorization", BASIC_HEADER), ("x-api-key", API_KEY)]),
-        Some(AuthData::Basic("user".to_owned(), "password".to_owned())),
     );
 }

--- a/samples/server/petstore/rust-server/output/overlapping-auth-schemes/.openapi-generator/FILES
+++ b/samples/server/petstore/rust-server/output/overlapping-auth-schemes/.openapi-generator/FILES
@@ -21,3 +21,4 @@ src/lib.rs
 src/models.rs
 src/server/mod.rs
 src/server/server_auth.rs
+tests/auth_scheme_precedence.rs

--- a/samples/server/petstore/rust-server/output/overlapping-auth-schemes/tests/auth_scheme_precedence.rs
+++ b/samples/server/petstore/rust-server/output/overlapping-auth-schemes/tests/auth_scheme_precedence.rs
@@ -66,7 +66,7 @@ fn no_credentials_resolve_to_no_auth_data() {
 }
 
 #[test]
-fn basic_credentials_resolve_to_the_declared_scheme() {
+fn basic_credentials_resolve_to_the_declared_basic_scheme() {
     assert_eq!(
         resolve_auth_data("/", &[("authorization", BASIC_HEADER)]),
         Some(AuthData::Basic("user".to_owned(), "password".to_owned())),
@@ -74,7 +74,7 @@ fn basic_credentials_resolve_to_the_declared_scheme() {
 }
 
 #[test]
-fn bearer_credentials_resolve_to_the_declared_scheme() {
+fn bearer_credentials_resolve_to_the_declared_bearer_scheme() {
     assert_eq!(
         resolve_auth_data("/", &[("authorization", BEARER_HEADER)]),
         Some(AuthData::Bearer("some-token".to_owned())),

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/.openapi-generator/FILES
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/.openapi-generator/FILES
@@ -78,3 +78,4 @@ src/lib.rs
 src/models.rs
 src/server/mod.rs
 src/server/server_auth.rs
+tests/auth_scheme_precedence.rs

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/tests/auth_scheme_precedence.rs
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/tests/auth_scheme_precedence.rs
@@ -1,22 +1,13 @@
-//! Runtime regression tests for auth-scheme precedence in the generated `AddContext` middleware.
+//! Runtime checks for auth-scheme precedence in the generated `AddContext` middleware.
 //!
-//! `swagger::auth::from_headers` returns an *untyped* `AuthData`, matching an
-//! `Authorization` header that carries either `Basic` or `Bearer` credentials. Every
-//! generated auth block returns early once it matches, so a block that does not check
+//! This file is generated. `swagger::auth::from_headers` returns an *untyped* `AuthData`,
+//! matching an `Authorization` header that carries either `Basic` or `Bearer` credentials.
+//! Every generated auth block returns early once it matches, so a block that does not check
 //! which variant it received will claim credentials belonging to a different scheme and
 //! prevent every later block - including API-key blocks - from ever running.
 //!
-//! This spec generates the blocks in the following order, which is what makes the
-//! behaviour observable from the outside:
-//!
-//! 1. `petstore_auth`   - OAuth2, reads `Authorization: Bearer`
-//! 2. `api_key`         - API key, reads the `api_key` header
-//! 3. `api_key_query`   - API key, reads the `api_key_query` query parameter
-//! 4. `http_basic_test` - HTTP Basic, reads `Authorization: Basic`
-//!
-//! Presenting Basic credentials alongside an API key therefore proves whether block 1
-//! stays in its lane: if it wrongly claims the Basic credentials it also swallows
-//! blocks 2 and 3.
+//! The expectations below are derived from the security schemes this API declares, in the
+//! order their blocks are generated.
 
 #![cfg(feature = "server")]
 
@@ -24,9 +15,9 @@ use std::sync::{Arc, Mutex};
 
 use hyper::service::Service;
 use hyper::{Request, Response};
-use petstore_with_fake_endpoints_models_for_testing::context::AddContext;
 use swagger::auth::AuthData;
 use swagger::{EmptyContext, Has};
+use petstore_with_fake_endpoints_models_for_testing::context::AddContext;
 
 /// Innermost service: records the `Option<AuthData>` that `AddContext` pushed onto the context.
 #[derive(Clone, Default)]
@@ -66,11 +57,16 @@ fn resolve_auth_data(uri: &str, headers: &[(&str, &str)]) -> Option<AuthData> {
 
 /// `dXNlcjpwYXNzd29yZA==` is `user:password`.
 const BASIC_HEADER: &str = "Basic dXNlcjpwYXNzd29yZA==";
+const BEARER_HEADER: &str = "Bearer some-token";
+const API_KEY: &str = "test-api-key";
 
 #[test]
-fn bearer_block_does_not_claim_basic_credentials() {
-    // The OAuth2 (Bearer) block is generated first. It must ignore Basic credentials and
-    // let them fall through to the HTTP Basic block generated last.
+fn no_credentials_resolve_to_no_auth_data() {
+    assert_eq!(resolve_auth_data("/", &[]), None);
+}
+
+#[test]
+fn basic_credentials_resolve_to_the_declared_scheme() {
     assert_eq!(
         resolve_auth_data("/", &[("authorization", BASIC_HEADER)]),
         Some(AuthData::Basic("user".to_owned(), "password".to_owned())),
@@ -78,44 +74,43 @@ fn bearer_block_does_not_claim_basic_credentials() {
 }
 
 #[test]
-fn bearer_credentials_resolve_to_bearer_auth_data() {
-    // Note this cannot prove the *Basic* block stays in its lane: the OAuth block above it
-    // legitimately claims these credentials first, so a broken Basic block would be
-    // unobservable here. That direction is covered at request level by the
-    // `overlapping-auth-schemes` sample, whose spec interleaves an apiKey scheme between
-    // the Basic and Bearer blocks.
+fn bearer_credentials_resolve_to_the_declared_scheme() {
     assert_eq!(
-        resolve_auth_data("/", &[("authorization", "Bearer some-token")]),
+        resolve_auth_data("/", &[("authorization", BEARER_HEADER)]),
         Some(AuthData::Bearer("some-token".to_owned())),
     );
 }
 
 #[test]
-fn header_api_key_is_reachable_when_basic_credentials_are_also_present() {
-    // Regression test: an unguarded Bearer block matches the Basic credentials, returns
-    // early, and the `api_key` header block below it never runs.
+fn header_api_key_resolves_when_it_is_the_only_credential() {
     assert_eq!(
-        resolve_auth_data(
-            "/",
-            &[("authorization", BASIC_HEADER), ("api_key", "header-key")],
-        ),
-        Some(AuthData::ApiKey("header-key".to_owned())),
+        resolve_auth_data("/", &[("api_key", API_KEY)]),
+        Some(AuthData::ApiKey(API_KEY.to_owned())),
+    );
+}
+
+/// An `Authorization` header must not shadow the apiKey block unless a block that actually
+/// handles that scheme is generated before it.
+#[test]
+fn header_api_key_is_reachable_alongside_bearer_credentials() {
+    assert_eq!(
+        resolve_auth_data("/", &[("authorization", BEARER_HEADER), ("api_key", API_KEY)]),
+        Some(AuthData::Bearer("some-token".to_owned())),
     );
 }
 
 #[test]
-fn query_api_key_is_reachable_when_basic_credentials_are_also_present() {
-    // Same regression, for the query-parameter API-key block.
+fn header_api_key_is_reachable_alongside_basic_credentials() {
     assert_eq!(
-        resolve_auth_data(
-            "/?api_key_query=query-key",
-            &[("authorization", BASIC_HEADER)],
-        ),
-        Some(AuthData::ApiKey("query-key".to_owned())),
+        resolve_auth_data("/", &[("authorization", BASIC_HEADER), ("api_key", API_KEY)]),
+        Some(AuthData::ApiKey(API_KEY.to_owned())),
     );
 }
 
 #[test]
-fn no_credentials_resolve_to_no_auth_data() {
-    assert_eq!(resolve_auth_data("/", &[]), None);
+fn query_api_key_resolves_when_it_is_the_only_credential() {
+    assert_eq!(
+        resolve_auth_data("/?api_key_query=test-api-key", &[]),
+        Some(AuthData::ApiKey(API_KEY.to_owned())),
+    );
 }

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/tests/auth_scheme_precedence.rs
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/tests/auth_scheme_precedence.rs
@@ -66,7 +66,7 @@ fn no_credentials_resolve_to_no_auth_data() {
 }
 
 #[test]
-fn basic_credentials_resolve_to_the_declared_scheme() {
+fn basic_credentials_resolve_to_the_declared_basic_scheme() {
     assert_eq!(
         resolve_auth_data("/", &[("authorization", BASIC_HEADER)]),
         Some(AuthData::Basic("user".to_owned(), "password".to_owned())),
@@ -74,7 +74,7 @@ fn basic_credentials_resolve_to_the_declared_scheme() {
 }
 
 #[test]
-fn bearer_credentials_resolve_to_the_declared_scheme() {
+fn bearer_credentials_resolve_to_the_declared_bearer_scheme() {
     assert_eq!(
         resolve_auth_data("/", &[("authorization", BEARER_HEADER)]),
         Some(AuthData::Bearer("some-token".to_owned())),
@@ -111,6 +111,25 @@ fn header_api_key_is_reachable_alongside_basic_credentials() {
 fn query_api_key_resolves_when_it_is_the_only_credential() {
     assert_eq!(
         resolve_auth_data("/?api_key_query=test-api-key", &[]),
+        Some(AuthData::ApiKey(API_KEY.to_owned())),
+    );
+}
+
+/// The query apiKey block is shadowed independently of the header one: an `Authorization`
+/// header must not claim a request whose credentials are in the query string unless a block
+/// that actually handles that scheme is generated before the query block.
+#[test]
+fn query_api_key_is_reachable_alongside_bearer_credentials() {
+    assert_eq!(
+        resolve_auth_data("/?api_key_query=test-api-key", &[("authorization", BEARER_HEADER)]),
+        Some(AuthData::Bearer("some-token".to_owned())),
+    );
+}
+
+#[test]
+fn query_api_key_is_reachable_alongside_basic_credentials() {
+    assert_eq!(
+        resolve_auth_data("/?api_key_query=test-api-key", &[("authorization", BASIC_HEADER)]),
         Some(AuthData::ApiKey(API_KEY.to_owned())),
     );
 }

--- a/samples/server/petstore/rust-server/output/ping-bearer-auth/.openapi-generator/FILES
+++ b/samples/server/petstore/rust-server/output/ping-bearer-auth/.openapi-generator/FILES
@@ -21,3 +21,4 @@ src/lib.rs
 src/models.rs
 src/server/mod.rs
 src/server/server_auth.rs
+tests/auth_scheme_precedence.rs

--- a/samples/server/petstore/rust-server/output/ping-bearer-auth/tests/auth_scheme_precedence.rs
+++ b/samples/server/petstore/rust-server/output/ping-bearer-auth/tests/auth_scheme_precedence.rs
@@ -65,7 +65,7 @@ fn no_credentials_resolve_to_no_auth_data() {
 }
 
 #[test]
-fn basic_credentials_resolve_to_the_declared_scheme() {
+fn basic_credentials_resolve_to_none_when_no_basic_scheme_is_declared() {
     assert_eq!(
         resolve_auth_data("/", &[("authorization", BASIC_HEADER)]),
         None,
@@ -73,7 +73,7 @@ fn basic_credentials_resolve_to_the_declared_scheme() {
 }
 
 #[test]
-fn bearer_credentials_resolve_to_the_declared_scheme() {
+fn bearer_credentials_resolve_to_the_declared_bearer_scheme() {
     assert_eq!(
         resolve_auth_data("/", &[("authorization", BEARER_HEADER)]),
         Some(AuthData::Bearer("some-token".to_owned())),

--- a/samples/server/petstore/rust-server/output/ping-bearer-auth/tests/auth_scheme_precedence.rs
+++ b/samples/server/petstore/rust-server/output/ping-bearer-auth/tests/auth_scheme_precedence.rs
@@ -17,7 +17,7 @@ use hyper::service::Service;
 use hyper::{Request, Response};
 use swagger::auth::AuthData;
 use swagger::{EmptyContext, Has};
-use overlapping_auth_schemes::context::AddContext;
+use ping_bearer_auth::context::AddContext;
 
 /// Innermost service: records the `Option<AuthData>` that `AddContext` pushed onto the context.
 #[derive(Clone, Default)]
@@ -58,7 +58,6 @@ fn resolve_auth_data(uri: &str, headers: &[(&str, &str)]) -> Option<AuthData> {
 /// `dXNlcjpwYXNzd29yZA==` is `user:password`.
 const BASIC_HEADER: &str = "Basic dXNlcjpwYXNzd29yZA==";
 const BEARER_HEADER: &str = "Bearer some-token";
-const API_KEY: &str = "test-api-key";
 
 #[test]
 fn no_credentials_resolve_to_no_auth_data() {
@@ -69,7 +68,7 @@ fn no_credentials_resolve_to_no_auth_data() {
 fn basic_credentials_resolve_to_the_declared_scheme() {
     assert_eq!(
         resolve_auth_data("/", &[("authorization", BASIC_HEADER)]),
-        Some(AuthData::Basic("user".to_owned(), "password".to_owned())),
+        None,
     );
 }
 
@@ -78,31 +77,5 @@ fn bearer_credentials_resolve_to_the_declared_scheme() {
     assert_eq!(
         resolve_auth_data("/", &[("authorization", BEARER_HEADER)]),
         Some(AuthData::Bearer("some-token".to_owned())),
-    );
-}
-
-#[test]
-fn header_api_key_resolves_when_it_is_the_only_credential() {
-    assert_eq!(
-        resolve_auth_data("/", &[("x-api-key", API_KEY)]),
-        Some(AuthData::ApiKey(API_KEY.to_owned())),
-    );
-}
-
-/// An `Authorization` header must not shadow the apiKey block unless a block that actually
-/// handles that scheme is generated before it.
-#[test]
-fn header_api_key_is_reachable_alongside_bearer_credentials() {
-    assert_eq!(
-        resolve_auth_data("/", &[("authorization", BEARER_HEADER), ("x-api-key", API_KEY)]),
-        Some(AuthData::ApiKey(API_KEY.to_owned())),
-    );
-}
-
-#[test]
-fn header_api_key_is_reachable_alongside_basic_credentials() {
-    assert_eq!(
-        resolve_auth_data("/", &[("authorization", BASIC_HEADER), ("x-api-key", API_KEY)]),
-        Some(AuthData::Basic("user".to_owned(), "password".to_owned())),
     );
 }


### PR DESCRIPTION
The auth scheme precedence tests added in #24607 were hand-written and duplicated across two samples. Because they are not emitted by the templates, they only cover the specs someone remembered to write them for, and they have to be maintained by hand as new samples are added.

Emit them from a new `tests-auth-scheme-precedence.mustache` supporting file instead. `RustServerCodegen` publishes a small description of the spec's security schemes (which schemes are declared, the apiKey parameter names, and whether Basic/Bearer are dispatched before the apiKey block); the template selects the test cases and expected outcomes from those flags.

This drops the hand-written files and covers four samples instead of two. Reintroducing the untyped `from_headers` bug that #24607 fixed now fails in all four, where the hand-written tests caught it in two.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Follow-up to #24607.

#24607 fixed an authorization bypass in  rust-server : after swagger-rs made  swagger::auth::from_headers  untyped, an unrestricted  if let Some(auth) = from_headers(headers)  in the Basic block would swallow a  Bearer  request and make every later block — including the in-header apiKey block — unreachable. The fix was to bind with a type-restricted pattern ( Some(auth @ AuthData::Basic(..)) ,  Some(bearer @ AuthData::Bearer(..)) ).

That PR also added tests, but they were hand-written and checked straight into two sample output directories. That has two problems:

1. They only cover the specs someone remembered to write them for. The other rust-server samples with security schemes got nothing.
2. They live in  samples/ , which is otherwise entirely generated, so they have to be maintained by hand and are easy to lose when regenerating.

This PR emits them from the templates instead.

What changed

• New supporting file  rust-server/tests-auth-scheme-precedence.mustache , emitted as  tests/auth_scheme_precedence.rs  for any spec that declares a security scheme the generator dispatches on.
•  RustServerCodegen  gains ~60 lines that publish a small description of the spec's security schemes into the supporting-file bundle: which schemes are declared, the apiKey parameter names, and whether the Basic/Bearer blocks are emitted before the apiKey block. Test-case selection and expected outcomes live in the template, not in Java.
• Both hand-written  tests/auth_scheme_precedence.rs  files are deleted, replaced by generated ones.

The test drives the generated  Api::from(&request)  dispatch through a real  hyper::Request , so it exercises the emitted code rather than asserting on template text.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Generate auth‑scheme precedence tests for `rust-server` from a template and track apiKey shadowing per location. Old: hand‑written tests in two samples and a single “precedes first apiKey” flag. New: `RustServerCodegen` emits `tests/auth_scheme_precedence.rs` with separate header/query precedence, expanded cases, and updated samples, without changing runtime behavior.

- Java: `RustServerCodegen.addAuthSchemeTestsToBundle` publishes `authTestHasBasic`, `authTestHasBearer`, per‑location precedence flags (`authTestBasicPrecedesHeaderApiKey`, `authTestBearerPrecedesHeaderApiKey`, `authTestBasicPrecedesQueryApiKey`, `authTestBearerPrecedesQueryApiKey`), and apiKey names (`authTestApiKeyHeader` lowercased; `authTestApiKeyQuery` as declared). Adds the `tests-auth-scheme-precedence.mustache` supporting file only when any scheme exists. OAuth is treated as Bearer.
- Template: `tests-auth-scheme-precedence.mustache` generates sole‑credential and reachability tests for header and query apiKeys. Test names reflect declared schemes.
- Samples: replace hand‑written tests and add generated ones in `openapi-v3`, `overlapping-auth-schemes`, `petstore-with-fake-endpoints-models-for-testing`, and `ping-bearer-auth`. Reintroducing the untyped `from_headers` bug now fails across all four; total tests increase from 19 to 21.

<sup>Written for commit fb098e2a1b9103c3fecfab7473fd23424beaa3f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24690?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



