### PR TITLE
Update TypeScript workflow to run only if TS-related samples change

### DIFF
--- a/.github/workflows/samples-java-client-jdk11.yaml
+++ b/.github/workflows/samples-java-client-jdk11.yaml
@@ -2,8 +2,6 @@ name: Samples Java Client JDK11
 
 on:
   push:
-    branches:
-      - master
     paths:
       - 'samples/client/petstore/java/**'
       - samples/client/petstore/jaxrs-cxf-client/**

--- a/.github/workflows/samples-java-client-jdk11.yaml
+++ b/.github/workflows/samples-java-client-jdk11.yaml
@@ -2,6 +2,8 @@ name: Samples Java Client JDK11
 
 on:
   push:
+    branches:
+      - master
     paths:
       - 'samples/client/petstore/java/**'
       - samples/client/petstore/jaxrs-cxf-client/**

--- a/.github/workflows/samples-typescript-typecheck.yaml
+++ b/.github/workflows/samples-typescript-typecheck.yaml
@@ -1,9 +1,22 @@
 name: TypeScript clients type checks
 
 on:
+  push:
+    paths:
+      - samples/client/petstore/typescript*/**
+      - samples/client/others/typescript*/**
+      - samples/client/echo_api/typescript*/**
+      - samples/openapi3/client/petstore/typescript/**
+      - samples/server/petstore/typescript-nestjs-server/**
+      - bin/ts-typecheck-all.sh
+      - .github/workflows/samples-typescript-typecheck.yaml
   pull_request:
     paths:
-      - samples/**
+      - samples/client/petstore/typescript*/**
+      - samples/client/others/typescript*/**
+      - samples/client/echo_api/typescript*/**
+      - samples/openapi3/client/petstore/typescript/**
+      - samples/server/petstore/typescript-nestjs-server/**
       - bin/ts-typecheck-all.sh
       - .github/workflows/samples-typescript-typecheck.yaml
 jobs:

--- a/.github/workflows/samples-typescript-typecheck.yaml
+++ b/.github/workflows/samples-typescript-typecheck.yaml
@@ -2,6 +2,8 @@ name: TypeScript clients type checks
 
 on:
   push:
+    branches:
+      - master
     paths:
       - samples/client/petstore/typescript*/**
       - samples/client/others/typescript*/**

--- a/.github/workflows/samples-typescript-typecheck.yaml
+++ b/.github/workflows/samples-typescript-typecheck.yaml
@@ -8,7 +8,7 @@ on:
       - samples/client/petstore/typescript*/**
       - samples/client/others/typescript*/**
       - samples/client/echo_api/typescript*/**
-      - samples/openapi3/client/petstore/typescript/**
+      - samples/openapi3/client/petstore*/typescript/**
       - samples/server/petstore/typescript-nestjs-server/**
       - bin/ts-typecheck-all.sh
       - .github/workflows/samples-typescript-typecheck.yaml
@@ -17,7 +17,7 @@ on:
       - samples/client/petstore/typescript*/**
       - samples/client/others/typescript*/**
       - samples/client/echo_api/typescript*/**
-      - samples/openapi3/client/petstore/typescript/**
+      - samples/openapi3/client/petstore*/typescript/**
       - samples/server/petstore/typescript-nestjs-server/**
       - bin/ts-typecheck-all.sh
       - .github/workflows/samples-typescript-typecheck.yaml


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Limits the TypeScript samples type-check workflow to TypeScript-only changes and adds a push trigger on `master`. Previously it ran on any PR change under `samples` and did not run on push.

- Pull requests: triggers only for changes under `samples/client/petstore/typescript*/**`, `samples/client/others/typescript*/**`, `samples/client/echo_api/typescript*/**`, `samples/openapi3/client/petstore*/typescript/**`, `samples/server/petstore/typescript-nestjs-server/**`, `bin/ts-typecheck-all.sh`, or `.github/workflows/samples-typescript-typecheck.yaml`.
- Push: runs on `master` only with the same path filters.
- Effect: fewer CI runs; non-TypeScript sample changes no longer trigger this workflow.

<sup>Written for commit ca8dd40b61926a36393627b206a0165bc7f7b460. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24691?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

