### PR TITLE
[Java][Spring] Add deprecation annotations to enum classes

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaSpring/enumClass.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/enumClass.mustache
@@ -1,7 +1,9 @@
   /**
-   * {{^description}}Gets or Sets {{{name}}}{{/description}}{{{description}}}
+   * {{^description}}Gets or Sets {{{name}}}{{/description}}{{{description}}}{{#deprecated}}
+   * @deprecated deprecated{{/deprecated}}
    */
-  {{>additionalEnumTypeAnnotations}}public enum {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}{{#vendorExtensions.x-implements}}{{#-first}} implements {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{/vendorExtensions.x-implements}} {
+  {{>additionalEnumTypeAnnotations}}{{#deprecated}}@Deprecated
+  {{/deprecated}}public enum {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}{{#vendorExtensions.x-implements}}{{#-first}} implements {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{/vendorExtensions.x-implements}} {
     {{#gson}}
         {{#allowableValues}}
             {{#enumVars}}

--- a/modules/openapi-generator/src/main/resources/JavaSpring/enumOuterClass.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/enumOuterClass.mustache
@@ -4,10 +4,14 @@ import com.fasterxml.jackson.annotation.JsonValue;
 {{/jackson}}
 
 /**
- * {{^description}}Gets or Sets {{{name}}}{{/description}}{{{description}}}
+ * {{^description}}Gets or Sets {{{name}}}{{/description}}{{{description}}}{{#isDeprecated}}
+ * @deprecated deprecated{{/isDeprecated}}
  */
 {{>additionalEnumTypeAnnotations}}
 
+{{#isDeprecated}}
+@Deprecated
+{{/isDeprecated}}
 {{>generatedAnnotation}}
 
 public enum {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}{{#vendorExtensions.x-implements}}{{#-first}} implements {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{/vendorExtensions.x-implements}} {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
@@ -3243,6 +3243,18 @@ public class SpringCodegenTest {
     }
 
     @Test
+    public void contractWithDeprecatedEnumGeneratesDeprecatedAnnotation() throws IOException {
+        Map<String, File> output = generateFromContract(
+                "src/test/resources/3_0/java/petstore-with-fake-endpoints-models-for-testing-okhttp-gson.yaml", SPRING_BOOT);
+
+        JavaFileAssert.assertThat(output.get("OuterEnumInteger.java"))
+                .fileContains("@Deprecated", "public enum OuterEnumInteger");
+
+        JavaFileAssert.assertThat(output.get("OuterEnum.java"))
+                .fileDoesNotContain("@Deprecated");
+    }
+
+    @Test
     public void contractWithResolvedInnerEnumContainsEnumConverter() throws IOException {
         File output = Files.createTempDirectory("test").toFile();
         output.deleteOnExit();

--- a/samples/client/petstore/spring-cloud-feign-without-url/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/client/petstore/spring-cloud-feign-without-url/src/main/java/org/openapitools/model/Pet.java
@@ -47,7 +47,9 @@ public class Pet {
 
   /**
    * pet status in the store
+   * @deprecated deprecated
    */
+  @Deprecated
   public enum StatusEnum {
     AVAILABLE("available"),
     

--- a/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/model/Pet.java
@@ -47,7 +47,9 @@ public class Pet {
 
   /**
    * pet status in the store
+   * @deprecated deprecated
    */
+  @Deprecated
   public enum StatusEnum {
     AVAILABLE("available"),
     

--- a/samples/client/petstore/spring-http-interface-bean-validation/src/main/java/org/openapitools/model/PetDto.java
+++ b/samples/client/petstore/spring-http-interface-bean-validation/src/main/java/org/openapitools/model/PetDto.java
@@ -50,7 +50,9 @@ public class PetDto {
 
   /**
    * pet status in the store
+   * @deprecated deprecated
    */
+  @Deprecated
   public enum StatusEnum {
     AVAILABLE("available"),
     

--- a/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/PetDto.java
+++ b/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/PetDto.java
@@ -49,7 +49,9 @@ public class PetDto {
 
   /**
    * pet status in the store
+   * @deprecated deprecated
    */
+  @Deprecated
   public enum StatusEnum {
     AVAILABLE("available"),
     

--- a/samples/client/petstore/spring-http-interface-oauth/src/main/java/org/openapitools/model/PetDto.java
+++ b/samples/client/petstore/spring-http-interface-oauth/src/main/java/org/openapitools/model/PetDto.java
@@ -50,7 +50,9 @@ public class PetDto {
 
   /**
    * pet status in the store
+   * @deprecated deprecated
    */
+  @Deprecated
   public enum StatusEnum {
     AVAILABLE("available"),
     

--- a/samples/client/petstore/spring-http-interface-reactive-bean-validation/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/client/petstore/spring-http-interface-reactive-bean-validation/src/main/java/org/openapitools/model/Pet.java
@@ -48,7 +48,9 @@ public class Pet {
 
   /**
    * pet status in the store
+   * @deprecated deprecated
    */
+  @Deprecated
   public enum StatusEnum {
     AVAILABLE("available"),
     

--- a/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/Pet.java
@@ -47,7 +47,9 @@ public class Pet {
 
   /**
    * pet status in the store
+   * @deprecated deprecated
    */
+  @Deprecated
   public enum StatusEnum {
     AVAILABLE("available"),
     

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/Pet.java
@@ -47,7 +47,9 @@ public class Pet {
 
   /**
    * pet status in the store
+   * @deprecated deprecated
    */
+  @Deprecated
   public enum StatusEnum {
     AVAILABLE("available"),
     

--- a/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/PetDto.java
+++ b/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/PetDto.java
@@ -55,7 +55,9 @@ public class PetDto {
 
   /**
    * pet status in the store
+   * @deprecated deprecated
    */
+  @Deprecated
   public enum StatusEnum {
     AVAILABLE("available"),
     

--- a/samples/client/petstore/spring-http-interface-useHttpServiceProxyFactoryInterfacesConfigurator/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/client/petstore/spring-http-interface-useHttpServiceProxyFactoryInterfacesConfigurator/src/main/java/org/openapitools/model/Pet.java
@@ -49,7 +49,9 @@ public class Pet {
 
   /**
    * pet status in the store
+   * @deprecated deprecated
    */
+  @Deprecated
   public enum StatusEnum {
     AVAILABLE("available"),
     

--- a/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/PetDto.java
+++ b/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/PetDto.java
@@ -49,7 +49,9 @@ public class PetDto {
 
   /**
    * pet status in the store
+   * @deprecated deprecated
    */
+  @Deprecated
   public enum StatusEnum {
     AVAILABLE("available"),
     

--- a/samples/openapi3/client/petstore/spring-cloud-3-with-optional/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/client/petstore/spring-cloud-3-with-optional/src/main/java/org/openapitools/model/Pet.java
@@ -45,7 +45,9 @@ public class Pet {
 
   /**
    * pet status in the store
+   * @deprecated deprecated
    */
+  @Deprecated
   public enum StatusEnum {
     AVAILABLE("available"),
     

--- a/samples/openapi3/client/petstore/spring-cloud-3/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/client/petstore/spring-cloud-3/src/main/java/org/openapitools/model/Pet.java
@@ -47,7 +47,9 @@ public class Pet {
 
   /**
    * pet status in the store
+   * @deprecated deprecated
    */
+  @Deprecated
   public enum StatusEnum {
     AVAILABLE("available"),
     

--- a/samples/openapi3/client/petstore/spring-cloud-4-with-optional/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/client/petstore/spring-cloud-4-with-optional/src/main/java/org/openapitools/model/Pet.java
@@ -49,7 +49,9 @@ public class Pet {
 
   /**
    * pet status in the store
+   * @deprecated deprecated
    */
+  @Deprecated
   public enum StatusEnum {
     AVAILABLE("available"),
     

--- a/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/model/Pet.java
@@ -47,7 +47,9 @@ public class Pet {
 
   /**
    * pet status in the store
+   * @deprecated deprecated
    */
+  @Deprecated
   public enum StatusEnum {
     AVAILABLE("available"),
     

--- a/samples/openapi3/client/petstore/spring-cloud-http-basic/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/client/petstore/spring-cloud-http-basic/src/main/java/org/openapitools/model/Pet.java
@@ -47,7 +47,9 @@ public class Pet {
 
   /**
    * pet status in the store
+   * @deprecated deprecated
    */
+  @Deprecated
   public enum StatusEnum {
     AVAILABLE("available"),
     

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/Pet.java
@@ -49,7 +49,9 @@ public class Pet {
 
   /**
    * pet status in the store
+   * @deprecated deprecated
    */
+  @Deprecated
   public enum StatusEnum {
     AVAILABLE("available"),
     

--- a/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/model/Pet.java
@@ -47,7 +47,9 @@ public class Pet {
 
   /**
    * pet status in the store
+   * @deprecated deprecated
    */
+  @Deprecated
   public enum StatusEnum {
     AVAILABLE("available"),
     

--- a/samples/openapi3/client/petstore/spring-stubs-skip-default-interface/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/client/petstore/spring-stubs-skip-default-interface/src/main/java/org/openapitools/model/Pet.java
@@ -47,7 +47,9 @@ public class Pet {
 
   /**
    * pet status in the store
+   * @deprecated deprecated
    */
+  @Deprecated
   public enum StatusEnum {
     AVAILABLE("available"),
     

--- a/samples/openapi3/client/petstore/spring-stubs/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/client/petstore/spring-stubs/src/main/java/org/openapitools/model/Pet.java
@@ -47,7 +47,9 @@ public class Pet {
 
   /**
    * pet status in the store
+   * @deprecated deprecated
    */
+  @Deprecated
   public enum StatusEnum {
     AVAILABLE("available"),
     

--- a/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/model/Pet.java
@@ -47,7 +47,9 @@ public class Pet {
 
   /**
    * pet status in the store
+   * @deprecated deprecated
    */
+  @Deprecated
   public enum StatusEnum {
     AVAILABLE("available"),
     

--- a/samples/openapi3/server/petstore/springboot-3-include-http-request-context/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/server/petstore/springboot-3-include-http-request-context/src/main/java/org/openapitools/model/Pet.java
@@ -55,7 +55,9 @@ public class Pet {
 
   /**
    * pet status in the store
+   * @deprecated deprecated
    */
+  @Deprecated
   public enum StatusEnum implements ValuedEnum<String> {
     AVAILABLE("available"),
     

--- a/samples/openapi3/server/petstore/springboot-3/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/server/petstore/springboot-3/src/main/java/org/openapitools/model/Pet.java
@@ -54,7 +54,9 @@ public class Pet {
 
   /**
    * pet status in the store
+   * @deprecated deprecated
    */
+  @Deprecated
   public enum StatusEnum {
     AVAILABLE("available"),
     

--- a/samples/openapi3/server/petstore/springboot-4/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/server/petstore/springboot-4/src/main/java/org/openapitools/model/Pet.java
@@ -59,7 +59,9 @@ public class Pet {
 
   /**
    * pet status in the store
+   * @deprecated deprecated
    */
+  @Deprecated
   public enum StatusEnum implements ValuedEnum<String> {
     AVAILABLE("available"),
     

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Pet.java
@@ -49,7 +49,9 @@ public class Pet {
 
   /**
    * pet status in the store
+   * @deprecated deprecated
    */
+  @Deprecated
   public enum StatusEnum {
     AVAILABLE("available"),
     

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Pet.java
@@ -49,7 +49,9 @@ public class Pet {
 
   /**
    * pet status in the store
+   * @deprecated deprecated
    */
+  @Deprecated
   public enum StatusEnum {
     AVAILABLE("available"),
     

--- a/samples/openapi3/server/petstore/springboot-source/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/server/petstore/springboot-source/src/main/java/org/openapitools/model/Pet.java
@@ -45,7 +45,9 @@ public class Pet {
 
   /**
    * pet status in the store
+   * @deprecated deprecated
    */
+  @Deprecated
   public enum StatusEnum {
     AVAILABLE("available"),
     

--- a/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/model/Pet.java
@@ -44,7 +44,9 @@ public class Pet {
 
   /**
    * pet status in the store
+   * @deprecated deprecated
    */
+  @Deprecated
   public enum StatusEnum {
     AVAILABLE("available"),
     

--- a/samples/server/petstore/java-camel/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/java-camel/src/main/java/org/openapitools/model/Pet.java
@@ -50,7 +50,9 @@ public class Pet {
 
   /**
    * pet status in the store
+   * @deprecated deprecated
    */
+  @Deprecated
   public enum StatusEnum {
     AVAILABLE("available"),
     

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/Pet.java
@@ -49,7 +49,9 @@ public class Pet {
 
   /**
    * pet status in the store
+   * @deprecated deprecated
    */
+  @Deprecated
   public enum StatusEnum {
     AVAILABLE("available"),
     

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/Pet.java
@@ -53,7 +53,9 @@ public class Pet {
 
   /**
    * pet status in the store
+   * @deprecated deprecated
    */
+  @Deprecated
   public enum StatusEnum {
     AVAILABLE("available"),
     

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Pet.java
@@ -49,7 +49,9 @@ public class Pet {
 
   /**
    * pet status in the store
+   * @deprecated deprecated
    */
+  @Deprecated
   public enum StatusEnum {
     AVAILABLE("available"),
     

--- a/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/Pet.java
@@ -49,7 +49,9 @@ public class Pet {
 
   /**
    * pet status in the store
+   * @deprecated deprecated
    */
+  @Deprecated
   public enum StatusEnum {
     AVAILABLE("available"),
     

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/Pet.java
@@ -49,7 +49,9 @@ public class Pet {
 
   /**
    * pet status in the store
+   * @deprecated deprecated
    */
+  @Deprecated
   public enum StatusEnum {
     AVAILABLE("available"),
     

--- a/samples/server/petstore/springboot-delegate-no-response-entity/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-delegate-no-response-entity/src/main/java/org/openapitools/model/Pet.java
@@ -47,7 +47,9 @@ public class Pet {
 
   /**
    * pet status in the store
+   * @deprecated deprecated
    */
+  @Deprecated
   public enum StatusEnum {
     AVAILABLE("available"),
     

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Pet.java
@@ -49,7 +49,9 @@ public class Pet {
 
   /**
    * pet status in the store
+   * @deprecated deprecated
    */
+  @Deprecated
   public enum StatusEnum {
     AVAILABLE("available"),
     

--- a/samples/server/petstore/springboot-implicitHeaders-annotationLibrary/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-implicitHeaders-annotationLibrary/src/main/java/org/openapitools/model/Pet.java
@@ -45,7 +45,9 @@ public class Pet {
 
   /**
    * pet status in the store
+   * @deprecated deprecated
    */
+  @Deprecated
   public enum StatusEnum {
     AVAILABLE("available"),
     

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Pet.java
@@ -49,7 +49,9 @@ public class Pet {
 
   /**
    * pet status in the store
+   * @deprecated deprecated
    */
+  @Deprecated
   public enum StatusEnum {
     AVAILABLE("available"),
     

--- a/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/PetDto.java
+++ b/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/PetDto.java
@@ -51,7 +51,9 @@ public class PetDto {
 
   /**
    * pet status in the store
+   * @deprecated deprecated
    */
+  @Deprecated
   public enum StatusEnum {
     AVAILABLE("available"),
     

--- a/samples/server/petstore/springboot-lombok-data/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-lombok-data/src/main/java/org/openapitools/model/Pet.java
@@ -73,7 +73,9 @@ public class Pet {
 
   /**
    * pet status in the store
+   * @deprecated deprecated
    */
+  @Deprecated
   public enum StatusEnum {
     AVAILABLE("available"),
     

--- a/samples/server/petstore/springboot-lombok-tostring/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-lombok-tostring/src/main/java/org/openapitools/model/Pet.java
@@ -52,7 +52,9 @@ public class Pet {
 
   /**
    * pet status in the store
+   * @deprecated deprecated
    */
+  @Deprecated
   public enum StatusEnum {
     AVAILABLE("available"),
     

--- a/samples/server/petstore/springboot-petstore-with-api-response-examples/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-petstore-with-api-response-examples/src/main/java/org/openapitools/model/Pet.java
@@ -47,7 +47,9 @@ public class Pet {
 
   /**
    * pet status in the store
+   * @deprecated deprecated
    */
+  @Deprecated
   public enum StatusEnum {
     AVAILABLE("available"),
     

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/Pet.java
@@ -49,7 +49,9 @@ public class Pet {
 
   /**
    * pet status in the store
+   * @deprecated deprecated
    */
+  @Deprecated
   public enum StatusEnum {
     AVAILABLE("available"),
     

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Pet.java
@@ -49,7 +49,9 @@ public class Pet {
 
   /**
    * pet status in the store
+   * @deprecated deprecated
    */
+  @Deprecated
   public enum StatusEnum {
     AVAILABLE("available"),
     

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Pet.java
@@ -49,7 +49,9 @@ public class Pet {
 
   /**
    * pet status in the store
+   * @deprecated deprecated
    */
+  @Deprecated
   public enum StatusEnum {
     AVAILABLE("available"),
     

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Pet.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Pet.java
@@ -49,7 +49,9 @@ public class Pet {
 
   /**
    * pet status in the store
+   * @deprecated deprecated
    */
+  @Deprecated
   public enum StatusEnum {
     AVAILABLE("available"),
     

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/PetDto.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/PetDto.java
@@ -52,7 +52,9 @@ public class PetDto {
 
   /**
    * pet status in the store
+   * @deprecated deprecated
    */
+  @Deprecated
   public enum StatusEnum implements ValuedEnum<String> {
     AVAILABLE("available"),
     


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Adds so that `@Deprecated` is present on enum classes for the Java Spring generator.

Fixes https://github.com/OpenAPITools/openapi-generator/issues/24694

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

Java Spring @cachescrubber (2022/02) @welshm (2022/02) @MelleD (2022/02) @atextor (2022/02) @manedev79 (2022/02) @javisst (2022/02) @borsch (2022/02) @banlevente (2022/02) @Zomzog (2022/09) @martin-mfg (2023/08) @KannaKim (2026/07)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Annotates Java Spring–generated enum types with Javadoc @deprecated and `@Deprecated` when the source schema marks them deprecated. Previously enums were never annotated; now IDEs and compilers surface deprecation without runtime impact. Fixes #24694.

- Update `JavaSpring/enumClass.mustache` (uses `deprecated`) and `JavaSpring/enumOuterClass.mustache` (uses `isDeprecated`) to render both the Javadoc tag and `@Deprecated` on enum types.
- Add `SpringCodegenTest` to assert deprecated enums (e.g., `OuterEnumInteger`) are annotated and non-deprecated enums (e.g., `OuterEnum`) are not.
- Regenerate samples to reflect `@Deprecated` on affected `StatusEnum` types.
- Migration: downstream builds may emit deprecation warnings; adjust warnings-as-errors settings or suppressions as needed.

<sup>Written for commit 2e2d98de24e1435048435d61edf61b7db681c2f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24695?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

