### PR TITLE
Update apache http client to newer version

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/apache-httpclient/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/apache-httpclient/build.gradle.mustache
@@ -142,7 +142,7 @@ ext {
     {{/openApiNullable}}
     {{/useJackson3}}
     jakarta_annotation_version = "1.3.5"
-    httpclient_version = "5.1.3"
+    httpclient_version = "5.6.3"
     jodatime_version = "2.9.9"
     junit_version = "5.10.2"
 }

--- a/modules/openapi-generator/src/main/resources/Java/libraries/apache-httpclient/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/apache-httpclient/pom.mustache
@@ -391,7 +391,7 @@
         {{#swagger2AnnotationLibrary}}
         <swagger-annotations-version>2.2.15</swagger-annotations-version>
         {{/swagger2AnnotationLibrary}}
-        <httpclient-version>5.2.1</httpclient-version>
+        <httpclient-version>5.6.3</httpclient-version>
         {{^useJackson3}}
         <jackson-version>2.21.5</jackson-version>
         <jackson-annotations-version>2.21</jackson-annotations-version>

--- a/samples/client/echo_api/java/apache-httpclient/build.gradle
+++ b/samples/client/echo_api/java/apache-httpclient/build.gradle
@@ -125,7 +125,7 @@ ext {
     jackson_databind_version = "2.21.5"
     jackson_databind_nullable_version = "0.2.11"
     jakarta_annotation_version = "1.3.5"
-    httpclient_version = "5.1.3"
+    httpclient_version = "5.6.3"
     jodatime_version = "2.9.9"
     junit_version = "5.10.2"
 }

--- a/samples/client/echo_api/java/apache-httpclient/pom.xml
+++ b/samples/client/echo_api/java/apache-httpclient/pom.xml
@@ -269,7 +269,7 @@
     </dependencies>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <httpclient-version>5.2.1</httpclient-version>
+        <httpclient-version>5.6.3</httpclient-version>
         <jackson-version>2.21.5</jackson-version>
         <jackson-annotations-version>2.21</jackson-annotations-version>
         <jackson-databind-version>2.21.5</jackson-databind-version>

--- a/samples/client/petstore/java/apache-httpclient-jackson3/build.gradle
+++ b/samples/client/petstore/java/apache-httpclient-jackson3/build.gradle
@@ -124,7 +124,7 @@ ext {
     jackson_annotations_version = "2.21"
     jackson_databind_nullable_version = "0.2.11"
     jakarta_annotation_version = "1.3.5"
-    httpclient_version = "5.1.3"
+    httpclient_version = "5.6.3"
     jodatime_version = "2.9.9"
     junit_version = "5.10.2"
 }

--- a/samples/client/petstore/java/apache-httpclient-jackson3/pom.xml
+++ b/samples/client/petstore/java/apache-httpclient-jackson3/pom.xml
@@ -265,7 +265,7 @@
     </dependencies>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <httpclient-version>5.2.1</httpclient-version>
+        <httpclient-version>5.6.3</httpclient-version>
         <jackson3-version>3.1.5</jackson3-version>
         <jackson-annotations-version>2.21</jackson-annotations-version>
         <jackson-databind-nullable-version>0.2.11</jackson-databind-nullable-version>

--- a/samples/client/petstore/java/apache-httpclient/build.gradle
+++ b/samples/client/petstore/java/apache-httpclient/build.gradle
@@ -125,7 +125,7 @@ ext {
     jackson_databind_version = "2.21.5"
     jackson_databind_nullable_version = "0.2.11"
     jakarta_annotation_version = "1.3.5"
-    httpclient_version = "5.1.3"
+    httpclient_version = "5.6.3"
     jodatime_version = "2.9.9"
     junit_version = "5.10.2"
 }

--- a/samples/client/petstore/java/apache-httpclient/pom.xml
+++ b/samples/client/petstore/java/apache-httpclient/pom.xml
@@ -269,7 +269,7 @@
     </dependencies>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <httpclient-version>5.2.1</httpclient-version>
+        <httpclient-version>5.6.3</httpclient-version>
         <jackson-version>2.21.5</jackson-version>
         <jackson-annotations-version>2.21</jackson-annotations-version>
         <jackson-databind-version>2.21.5</jackson-databind-version>


### PR DESCRIPTION
to close https://github.com/OpenAPITools/openapi-generator/pull/24697
to close https://github.com/OpenAPITools/openapi-generator/pull/24696

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies the Apache HttpClient version used by the Java `apache-httpclient` generator to 5.6.3 to pick up upstream fixes and align Gradle and Maven outputs. Previously Gradle templates/samples used 5.1.3 and Maven used 5.2.1; now both use 5.6.3.

- Updates `httpclient_version` in `build.gradle.mustache` and `<httpclient-version>` in `pom.mustache`; regenerates affected samples.
- No generator logic changes; only dependency version bump. Generated clients will now reference `org.apache.httpcomponents.client5:httpclient5` 5.6.3.
- Migration: Regenerate Java clients to adopt 5.6.3. If you pin the dependency in your project, no action is required.

<sup>Written for commit 2155e0005b00e58f983693de367f012740163245. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24698?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

