### PR TITLE
Add null type only test to Java okhttp-gson client

### DIFF
--- a/modules/openapi-generator/src/test/resources/3_1/java/petstore.yaml
+++ b/modules/openapi-generator/src/test/resources/3_1/java/petstore.yaml
@@ -1125,3 +1125,6 @@ components:
             - "object"
             - "null"
           $ref: '#/components/schemas/Pet'
+        second_property:
+          description: just null type
+          type: null

--- a/samples/client/petstore/java/okhttp-gson-3.1/api/openapi.yaml
+++ b/samples/client/petstore/java/okhttp-gson-3.1/api/openapi.yaml
@@ -1204,6 +1204,8 @@ components:
       properties:
         first_property:
           $ref: "#/components/schemas/Pet"
+        second_property:
+          description: just null type
     updatePetWithForm_request:
       properties:
         name:

--- a/samples/client/petstore/java/okhttp-gson-3.1/docs/PetWithTypesObjectNullAndRef.md
+++ b/samples/client/petstore/java/okhttp-gson-3.1/docs/PetWithTypesObjectNullAndRef.md
@@ -8,6 +8,7 @@
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
 |**firstProperty** | [**Pet**](Pet.md) |  |  [optional] |
+|**secondProperty** | **Object** | just null type |  [optional] |
 
 
 

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/PetWithTypesObjectNullAndRef.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/PetWithTypesObjectNullAndRef.java
@@ -22,6 +22,7 @@ import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.util.Arrays;
 import org.openapitools.client.model.Pet;
+import org.openapitools.jackson.nullable.JsonNullable;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -57,6 +58,11 @@ public class PetWithTypesObjectNullAndRef {
   @javax.annotation.Nullable
   private Pet firstProperty;
 
+  public static final String SERIALIZED_NAME_SECOND_PROPERTY = "second_property";
+  @SerializedName(SERIALIZED_NAME_SECOND_PROPERTY)
+  @javax.annotation.Nullable
+  private Object secondProperty = null;
+
   public PetWithTypesObjectNullAndRef() {
   }
 
@@ -76,6 +82,25 @@ public class PetWithTypesObjectNullAndRef {
 
   public void setFirstProperty(@javax.annotation.Nullable Pet firstProperty) {
     this.firstProperty = firstProperty;
+  }
+
+
+  public PetWithTypesObjectNullAndRef secondProperty(@javax.annotation.Nullable Object secondProperty) {
+    this.secondProperty = secondProperty;
+    return this;
+  }
+
+  /**
+   * just null type
+   * @return secondProperty
+   */
+  @javax.annotation.Nullable
+  public Object getSecondProperty() {
+    return secondProperty;
+  }
+
+  public void setSecondProperty(@javax.annotation.Nullable Object secondProperty) {
+    this.secondProperty = secondProperty;
   }
 
   /**
@@ -133,13 +158,25 @@ public class PetWithTypesObjectNullAndRef {
       return false;
     }
     PetWithTypesObjectNullAndRef petWithTypesObjectNullAndRef = (PetWithTypesObjectNullAndRef) o;
-    return Objects.equals(this.firstProperty, petWithTypesObjectNullAndRef.firstProperty)&&
+    return Objects.equals(this.firstProperty, petWithTypesObjectNullAndRef.firstProperty) &&
+        Objects.equals(this.secondProperty, petWithTypesObjectNullAndRef.secondProperty)&&
         Objects.equals(this.additionalProperties, petWithTypesObjectNullAndRef.additionalProperties);
+  }
+
+  private static <T> boolean equalsNullable(JsonNullable<T> a, JsonNullable<T> b) {
+    return a == b || (a != null && b != null && a.isPresent() && b.isPresent() && Objects.deepEquals(a.get(), b.get()));
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(firstProperty, additionalProperties);
+    return Objects.hash(firstProperty, secondProperty, additionalProperties);
+  }
+
+  private static <T> int hashCodeNullable(JsonNullable<T> a) {
+    if (a == null) {
+      return 1;
+    }
+    return a.isPresent() ? Arrays.deepHashCode(new Object[]{a.get()}) : 31;
   }
 
   @Override
@@ -147,6 +184,7 @@ public class PetWithTypesObjectNullAndRef {
     StringBuilder sb = new StringBuilder();
     sb.append("class PetWithTypesObjectNullAndRef {\n");
     sb.append("    firstProperty: ").append(toIndentedString(firstProperty)).append("\n");
+    sb.append("    secondProperty: ").append(toIndentedString(secondProperty)).append("\n");
     sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
@@ -166,7 +204,7 @@ public class PetWithTypesObjectNullAndRef {
 
   static {
     // a set of all properties/fields (JSON key names)
-    openapiFields = new HashSet<String>(Arrays.asList("first_property"));
+    openapiFields = new HashSet<String>(Arrays.asList("first_property", "second_property"));
 
     // a set of required properties/fields (JSON key names)
     openapiRequiredFields = new HashSet<String>(0);


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a null-only schema property to the Java `okhttp-gson` 3.1 petstore sample to validate OpenAPI 3.1 `type: null` handling. This ensures the generator emits a nullable `Object` field and includes it in equality, hashing, and field validation.

- Spec: adds `second_property` with `type: null` and description "just null type".
- Model `PetWithTypesObjectNullAndRef`: new `secondProperty` (`Object`, `@javax.annotation.Nullable`), included in `equals`, `hashCode`, `toString`, and `openapiFields`.
- Docs: `PetWithTypesObjectNullAndRef` now lists `secondProperty` as optional `Object` with the description.
- Adds `JsonNullable` helpers; they are not used and do not change behavior.

**Review Notes**
- Focus on generated Java for `okhttp-gson` to confirm `type: null` maps to a nullable `Object` and passes validation.
- Regenerate samples to verify outputs stay consistent across generators.

<sup>Written for commit 9bda43edf30c3f028a3d29ad49a0c848e3f1ccf2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24701?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

