### PR TITLE
fix(typescript-fetch): import FromJSON for discriminator mapped models

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
@@ -13,7 +13,7 @@ import {
 {{/hasImports}}
 {{#discriminator}}
 {{#discriminator.mappedModels}}
-import { type {{modelName}}, {{modelName}}FromJSONTyped, {{modelName}}ToJSON, {{modelName}}ToJSONTyped } from './{{modelName}}{{importFileExtension}}';
+import { type {{modelName}}, {{modelName}}FromJSON, {{modelName}}FromJSONTyped, {{modelName}}ToJSON, {{modelName}}ToJSONTyped } from './{{modelName}}{{importFileExtension}}';
 {{/discriminator.mappedModels}}
 {{/discriminator}}
 {{>modelGenericInterfaces}}

--- a/samples/client/others/typescript-fetch/infinite-recursion-issue/models/TestBaseDto.ts
+++ b/samples/client/others/typescript-fetch/infinite-recursion-issue/models/TestBaseDto.ts
@@ -21,7 +21,7 @@ import {
     TestObjectTypeToJSONTyped,
 } from './TestObjectType';
 
-import { type ExtendDto, ExtendDtoFromJSONTyped, ExtendDtoToJSON, ExtendDtoToJSONTyped } from './ExtendDto';
+import { type ExtendDto, ExtendDtoFromJSON, ExtendDtoFromJSONTyped, ExtendDtoToJSON, ExtendDtoToJSONTyped } from './ExtendDto';
 /**
  * 
  * @export

--- a/samples/client/others/typescript-fetch/self-import-issue/models/AbstractUserDto.ts
+++ b/samples/client/others/typescript-fetch/self-import-issue/models/AbstractUserDto.ts
@@ -21,8 +21,8 @@ import {
     BranchDtoToJSONTyped,
 } from './BranchDto';
 
-import { type InternalAuthenticatedUserDto, InternalAuthenticatedUserDtoFromJSONTyped, InternalAuthenticatedUserDtoToJSON, InternalAuthenticatedUserDtoToJSONTyped } from './InternalAuthenticatedUserDto';
-import { type RemoteAuthenticatedUserDto, RemoteAuthenticatedUserDtoFromJSONTyped, RemoteAuthenticatedUserDtoToJSON, RemoteAuthenticatedUserDtoToJSONTyped } from './RemoteAuthenticatedUserDto';
+import { type InternalAuthenticatedUserDto, InternalAuthenticatedUserDtoFromJSON, InternalAuthenticatedUserDtoFromJSONTyped, InternalAuthenticatedUserDtoToJSON, InternalAuthenticatedUserDtoToJSONTyped } from './InternalAuthenticatedUserDto';
+import { type RemoteAuthenticatedUserDto, RemoteAuthenticatedUserDtoFromJSON, RemoteAuthenticatedUserDtoFromJSONTyped, RemoteAuthenticatedUserDtoToJSON, RemoteAuthenticatedUserDtoToJSONTyped } from './RemoteAuthenticatedUserDto';
 /**
  * 
  * @export

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Animal.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Animal.ts
@@ -13,8 +13,8 @@
  */
 
 import { mapValues } from '../runtime';
-import { type Cat, CatFromJSONTyped, CatToJSON, CatToJSONTyped } from './Cat';
-import { type Dog, DogFromJSONTyped, DogToJSON, DogToJSONTyped } from './Dog';
+import { type Cat, CatFromJSON, CatFromJSONTyped, CatToJSON, CatToJSONTyped } from './Cat';
+import { type Dog, DogFromJSON, DogFromJSONTyped, DogToJSON, DogToJSONTyped } from './Dog';
 /**
  * 
  * @export

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ParentWithNullable.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ParentWithNullable.ts
@@ -13,7 +13,7 @@
  */
 
 import { mapValues } from '../runtime';
-import { type ChildWithNullable, ChildWithNullableFromJSONTyped, ChildWithNullableToJSON, ChildWithNullableToJSONTyped } from './ChildWithNullable';
+import { type ChildWithNullable, ChildWithNullableFromJSON, ChildWithNullableFromJSONTyped, ChildWithNullableToJSON, ChildWithNullableToJSONTyped } from './ChildWithNullable';
 /**
  * 
  * @export

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/animal.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/animal.ts
@@ -13,8 +13,8 @@
  */
 
 import { mapValues } from '../runtime';
-import { type Cat, CatFromJSONTyped, CatToJSON, CatToJSONTyped } from './Cat';
-import { type Dog, DogFromJSONTyped, DogToJSON, DogToJSONTyped } from './Dog';
+import { type Cat, CatFromJSON, CatFromJSONTyped, CatToJSON, CatToJSONTyped } from './Cat';
+import { type Dog, DogFromJSON, DogFromJSONTyped, DogToJSON, DogToJSONTyped } from './Dog';
 /**
  * 
  * @export

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/parent-with-nullable.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/parent-with-nullable.ts
@@ -13,7 +13,7 @@
  */
 
 import { mapValues } from '../runtime';
-import { type ChildWithNullable, ChildWithNullableFromJSONTyped, ChildWithNullableToJSON, ChildWithNullableToJSONTyped } from './ChildWithNullable';
+import { type ChildWithNullable, ChildWithNullableFromJSON, ChildWithNullableFromJSONTyped, ChildWithNullableToJSON, ChildWithNullableToJSONTyped } from './ChildWithNullable';
 /**
  * 
  * @export

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Animal.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Animal.ts
@@ -13,8 +13,8 @@
  */
 
 import { mapValues } from '../runtime';
-import { type Cat, CatFromJSONTyped, CatToJSON, CatToJSONTyped } from './Cat';
-import { type Dog, DogFromJSONTyped, DogToJSON, DogToJSONTyped } from './Dog';
+import { type Cat, CatFromJSON, CatFromJSONTyped, CatToJSON, CatToJSONTyped } from './Cat';
+import { type Dog, DogFromJSON, DogFromJSONTyped, DogToJSON, DogToJSONTyped } from './Dog';
 /**
  * 
  * @export


### PR DESCRIPTION
Fixes #24654.

Mapped models are removed from `tsImports` (#15637 / #19195), so the discriminator import line in `modelGeneric.mustache` is their only import. It omits `XFromJSON`, which breaks when the parent also has a property typed as that child: deserialization emits `XFromJSON(...)` and tsc fails with TS2552.

Adding `{{modelName}}FromJSON` keeps that line's shape; it already imports `XToJSON`.

With the spec from the issue: TS2552 before, `tsc --noEmit --strict` clean after. Regenerated typescript-fetch samples. `./mvnw -B -pl modules/openapi-generator -am test`: 4750 tests, 0 failures.

TypeScript (Fetch) technical committee: @leonyu

### PR checklist
- [x] Read the contribution guidelines.
- [x] Built the project and regenerated the typescript-fetch samples.
- [x] @mentioned the technical committee above.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes TS2552 compile errors in generated `typescript-fetch` clients where discriminator-mapped models were missing their `XFromJSON` import. The discriminator import line now includes `{{modelName}}FromJSON`, matching the `XFromJSON(...)` calls emitted when a mapped child is also a property type on the parent.

- Updated `modelGeneric.mustache` and regenerated `typescript-fetch` samples. Codegen-only change with no runtime impact.

**Rollout**
- Regenerate clients with the `typescript-fetch` generator to pick up the fix. No other migration required.

<sup>Written for commit c0f5cc69bdf2076c9e25e1ad84b28f4f76428a68. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24702?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

