### PR TITLE
[Java][Spring] Annotate deprecated fluent model setters with @Deprecated

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaSpring/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/pojo.mustache
@@ -156,7 +156,7 @@ public {{>sealed}}class {{classname}}{{#parent}} extends {{{parent}}}{{/parent}}
   {{! begin feature: fluent setter methods }}
   {{#deprecated}}
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   {{/deprecated}}
@@ -173,7 +173,7 @@ public {{>sealed}}class {{classname}}{{#parent}} extends {{{parent}}}{{/parent}}
 
   {{#deprecated}}
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   {{/deprecated}}
@@ -197,7 +197,7 @@ public {{>sealed}}class {{classname}}{{#parent}} extends {{{parent}}}{{/parent}}
 
   {{#deprecated}}
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   {{/deprecated}}
@@ -265,7 +265,7 @@ public {{>sealed}}class {{classname}}{{#parent}} extends {{{parent}}}{{/parent}}
   {{^lombok.Setter}}
   {{#deprecated}}
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   {{/deprecated}}
   {{#vendorExtensions.x-setter-extra-annotation}}
@@ -290,7 +290,7 @@ public {{>sealed}}class {{classname}}{{#parent}} extends {{{parent}}}{{/parent}}
   {{! begin feature: fluent setter methods for inherited properties }}
   {{#deprecated}}
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   {{/deprecated}}
@@ -302,7 +302,7 @@ public {{>sealed}}class {{classname}}{{#parent}} extends {{{parent}}}{{/parent}}
 
   {{#deprecated}}
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   {{/deprecated}}
@@ -315,7 +315,7 @@ public {{>sealed}}class {{classname}}{{#parent}} extends {{{parent}}}{{/parent}}
 
   {{#deprecated}}
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   {{/deprecated}}

--- a/modules/openapi-generator/src/main/resources/JavaSpring/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/pojo.mustache
@@ -154,6 +154,9 @@ public {{>sealed}}class {{classname}}{{#parent}} extends {{{parent}}}{{/parent}}
   {{^lombok.Data}}
 
   {{! begin feature: fluent setter methods }}
+  {{#deprecated}}
+  @Deprecated
+  {{/deprecated}}
   public {{classname}} {{name}}({{>nullableArgument_chainSetter}} {{name}}) {
     {{#openApiNullable}}
     this.{{name}} = {{#isNullable}}JsonNullable.of({{/isNullable}}{{#useOptional}}{{^required}}{{^isNullable}}{{^isContainer}}Optional.of{{#optionalAcceptNullable}}Nullable{{/optionalAcceptNullable}}({{/isContainer}}{{/isNullable}}{{/required}}{{/useOptional}}{{name}}{{#isNullable}}){{/isNullable}}{{#useOptional}}{{^required}}{{^isNullable}}{{^isContainer}}){{/isContainer}}{{/isNullable}}{{/required}}{{/useOptional}};
@@ -165,6 +168,9 @@ public {{>sealed}}class {{classname}}{{#parent}} extends {{{parent}}}{{/parent}}
   }
   {{#isArray}}
 
+  {{#deprecated}}
+  @Deprecated
+  {{/deprecated}}
   public {{classname}} add{{nameInPascalCase}}Item({{{items.datatypeWithEnum}}} {{name}}Item) {
     {{#openApiNullable}}
     if (this.{{name}} == null{{#isNullable}} || !this.{{name}}.isPresent() || this.{{name}}.get() == null{{/isNullable}}) {
@@ -183,6 +189,9 @@ public {{>sealed}}class {{classname}}{{#parent}} extends {{{parent}}}{{/parent}}
   {{/isArray}}
   {{#isMap}}
 
+  {{#deprecated}}
+  @Deprecated
+  {{/deprecated}}
   public {{classname}} put{{nameInPascalCase}}Item(String key, {{{items.datatypeWithEnum}}} {{name}}Item) {
     {{#openApiNullable}}
     if (this.{{name}} == null{{#isNullable}} || !this.{{name}}.isPresent() || this.{{name}}.get() == null{{/isNullable}}) {
@@ -270,12 +279,18 @@ public {{>sealed}}class {{classname}}{{#parent}} extends {{{parent}}}{{/parent}}
 
   {{^lombok.Setter}}
   {{! begin feature: fluent setter methods for inherited properties }}
+  {{#deprecated}}
+  @Deprecated
+  {{/deprecated}}
   public {{classname}} {{name}}({{{datatypeWithEnum}}} {{name}}) {
     super.{{name}}({{name}});
     return this;
   }
   {{#isArray}}
 
+  {{#deprecated}}
+  @Deprecated
+  {{/deprecated}}
   public {{classname}} add{{nameInPascalCase}}Item({{{items.datatypeWithEnum}}} {{name}}Item) {
     super.add{{nameInPascalCase}}Item({{name}}Item);
     return this;
@@ -283,6 +298,9 @@ public {{>sealed}}class {{classname}}{{#parent}} extends {{{parent}}}{{/parent}}
   {{/isArray}}
   {{#isMap}}
 
+  {{#deprecated}}
+  @Deprecated
+  {{/deprecated}}
   public {{classname}} put{{nameInPascalCase}}Item(String key, {{{items.datatypeWithEnum}}} {{name}}Item) {
     super.put{{nameInPascalCase}}Item(key, {{name}}Item);
     return this;

--- a/modules/openapi-generator/src/main/resources/JavaSpring/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/pojo.mustache
@@ -155,6 +155,9 @@ public {{>sealed}}class {{classname}}{{#parent}} extends {{{parent}}}{{/parent}}
 
   {{! begin feature: fluent setter methods }}
   {{#deprecated}}
+  /**
+   * @deprecated
+   */
   @Deprecated
   {{/deprecated}}
   public {{classname}} {{name}}({{>nullableArgument_chainSetter}} {{name}}) {
@@ -169,6 +172,9 @@ public {{>sealed}}class {{classname}}{{#parent}} extends {{{parent}}}{{/parent}}
   {{#isArray}}
 
   {{#deprecated}}
+  /**
+   * @deprecated
+   */
   @Deprecated
   {{/deprecated}}
   public {{classname}} add{{nameInPascalCase}}Item({{{items.datatypeWithEnum}}} {{name}}Item) {
@@ -190,6 +196,9 @@ public {{>sealed}}class {{classname}}{{#parent}} extends {{{parent}}}{{/parent}}
   {{#isMap}}
 
   {{#deprecated}}
+  /**
+   * @deprecated
+   */
   @Deprecated
   {{/deprecated}}
   public {{classname}} put{{nameInPascalCase}}Item(String key, {{{items.datatypeWithEnum}}} {{name}}Item) {
@@ -280,6 +289,9 @@ public {{>sealed}}class {{classname}}{{#parent}} extends {{{parent}}}{{/parent}}
   {{^lombok.Setter}}
   {{! begin feature: fluent setter methods for inherited properties }}
   {{#deprecated}}
+  /**
+   * @deprecated
+   */
   @Deprecated
   {{/deprecated}}
   public {{classname}} {{name}}({{{datatypeWithEnum}}} {{name}}) {
@@ -289,6 +301,9 @@ public {{>sealed}}class {{classname}}{{#parent}} extends {{{parent}}}{{/parent}}
   {{#isArray}}
 
   {{#deprecated}}
+  /**
+   * @deprecated
+   */
   @Deprecated
   {{/deprecated}}
   public {{classname}} add{{nameInPascalCase}}Item({{{items.datatypeWithEnum}}} {{name}}Item) {
@@ -299,6 +314,9 @@ public {{>sealed}}class {{classname}}{{#parent}} extends {{{parent}}}{{/parent}}
   {{#isMap}}
 
   {{#deprecated}}
+  /**
+   * @deprecated
+   */
   @Deprecated
   {{/deprecated}}
   public {{classname}} put{{nameInPascalCase}}Item(String key, {{{items.datatypeWithEnum}}} {{name}}Item) {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
@@ -3263,6 +3263,13 @@ public class SpringCodegenTest {
         );
 
         JavaFileAssert.assertThat(output.get("Example.java"))
+                .fileContains(
+                        "  /**\n   * @deprecated\n   */\n  @Deprecated\n  public Example deprecatedProperty(",
+                        "  /**\n   * @deprecated\n   */\n  @Deprecated\n  public Example deprecatedValues(",
+                        "  /**\n   * @deprecated\n   */\n  @Deprecated\n  public Example addDeprecatedValuesItem(",
+                        "  /**\n   * @deprecated\n   */\n  @Deprecated\n  public Example deprecatedMap(",
+                        "  /**\n   * @deprecated\n   */\n  @Deprecated\n  public Example putDeprecatedMapItem("
+                )
                 .assertMethod("deprecatedProperty", "String")
                 .hasAnnotation("Deprecated")
                 .toFileAssert()

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
@@ -3264,11 +3264,11 @@ public class SpringCodegenTest {
 
         JavaFileAssert.assertThat(output.get("Example.java"))
                 .fileContains(
-                        "  /**\n   * @deprecated\n   */\n  @Deprecated\n  public Example deprecatedProperty(",
-                        "  /**\n   * @deprecated\n   */\n  @Deprecated\n  public Example deprecatedValues(",
-                        "  /**\n   * @deprecated\n   */\n  @Deprecated\n  public Example addDeprecatedValuesItem(",
-                        "  /**\n   * @deprecated\n   */\n  @Deprecated\n  public Example deprecatedMap(",
-                        "  /**\n   * @deprecated\n   */\n  @Deprecated\n  public Example putDeprecatedMapItem("
+                        "  /**\n   * @deprecated deprecated\n   */\n  @Deprecated\n  public Example deprecatedProperty(",
+                        "  /**\n   * @deprecated deprecated\n   */\n  @Deprecated\n  public Example deprecatedValues(",
+                        "  /**\n   * @deprecated deprecated\n   */\n  @Deprecated\n  public Example addDeprecatedValuesItem(",
+                        "  /**\n   * @deprecated deprecated\n   */\n  @Deprecated\n  public Example deprecatedMap(",
+                        "  /**\n   * @deprecated deprecated\n   */\n  @Deprecated\n  public Example putDeprecatedMapItem("
                 )
                 .assertMethod("deprecatedProperty", "String")
                 .hasAnnotation("Deprecated")

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
@@ -3255,6 +3255,41 @@ public class SpringCodegenTest {
     }
 
     @Test
+    public void contractWithDeprecatedPropertiesAnnotatesFluentSettersAndCollectionHelpers() throws IOException {
+        Map<String, File> output = generateFromContract(
+                "src/test/resources/3_0/spring/issue_24704.yaml",
+                SPRING_BOOT,
+                Map.of(GENERATE_BUILDERS, true)
+        );
+
+        JavaFileAssert.assertThat(output.get("Example.java"))
+                .assertMethod("deprecatedProperty", "String")
+                .hasAnnotation("Deprecated")
+                .toFileAssert()
+                .assertMethod("deprecatedValues")
+                .hasAnnotation("Deprecated")
+                .toFileAssert()
+                .assertMethod("deprecatedMap")
+                .hasAnnotation("Deprecated")
+                .toFileAssert()
+                .assertMethod("addDeprecatedValuesItem", "String")
+                .hasAnnotation("Deprecated")
+                .toFileAssert()
+                .assertMethod("putDeprecatedMapItem", "String", "String")
+                .hasAnnotation("Deprecated")
+                .toFileAssert()
+                .assertMethod("currentProperty", "String")
+                .doesNotHaveAnnotation("Deprecated")
+                .toFileAssert()
+                .assertInnerClass("Builder")
+                .assertMethod("deprecatedProperty", "String")
+                .hasAnnotation("Deprecated")
+                .toInnerClassAssert()
+                .assertMethod("currentProperty", "String")
+                .doesNotHaveAnnotation("Deprecated");
+    }
+
+    @Test
     public void contractWithResolvedInnerEnumContainsEnumConverter() throws IOException {
         File output = Files.createTempDirectory("test").toFile();
         output.deleteOnExit();

--- a/modules/openapi-generator/src/test/resources/3_0/spring/issue_24704.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/spring/issue_24704.yaml
@@ -1,0 +1,35 @@
+openapi: 3.0.3
+info:
+  title: Deprecated property example
+  version: 1.0.0
+paths:
+  /example:
+    get:
+      operationId: getExample
+      responses:
+        "200":
+          description: Example response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Example"
+components:
+  schemas:
+    Example:
+      type: object
+      properties:
+        currentProperty:
+          type: string
+        deprecatedProperty:
+          type: string
+          deprecated: true
+        deprecatedValues:
+          type: array
+          deprecated: true
+          items:
+            type: string
+        deprecatedMap:
+          type: object
+          deprecated: true
+          additionalProperties:
+            type: string

--- a/samples/client/petstore/spring-cloud-deprecated/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/client/petstore/spring-cloud-deprecated/src/main/java/org/openapitools/model/Pet.java
@@ -162,7 +162,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   public Pet photoUrls(List<String> photoUrls) {
@@ -171,7 +171,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   public Pet addPhotoUrlsItem(String photoUrlsItem) {
@@ -196,7 +196,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   @JsonProperty("photoUrls")

--- a/samples/client/petstore/spring-cloud-deprecated/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/client/petstore/spring-cloud-deprecated/src/main/java/org/openapitools/model/Pet.java
@@ -161,12 +161,18 @@ public class Pet {
     this.name = name;
   }
 
+  /**
+   * @deprecated
+   */
   @Deprecated
   public Pet photoUrls(List<String> photoUrls) {
     this.photoUrls = photoUrls;
     return this;
   }
 
+  /**
+   * @deprecated
+   */
   @Deprecated
   public Pet addPhotoUrlsItem(String photoUrlsItem) {
     if (this.photoUrls == null) {

--- a/samples/client/petstore/spring-cloud-deprecated/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/client/petstore/spring-cloud-deprecated/src/main/java/org/openapitools/model/Pet.java
@@ -161,11 +161,13 @@ public class Pet {
     this.name = name;
   }
 
+  @Deprecated
   public Pet photoUrls(List<String> photoUrls) {
     this.photoUrls = photoUrls;
     return this;
   }
 
+  @Deprecated
   public Pet addPhotoUrlsItem(String photoUrlsItem) {
     if (this.photoUrls == null) {
       this.photoUrls = new ArrayList<>();

--- a/samples/client/petstore/spring-cloud-feign-without-url/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/client/petstore/spring-cloud-feign-without-url/src/main/java/org/openapitools/model/Pet.java
@@ -221,6 +221,9 @@ public class Pet {
     this.tags = tags;
   }
 
+  /**
+   * @deprecated
+   */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;

--- a/samples/client/petstore/spring-cloud-feign-without-url/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/client/petstore/spring-cloud-feign-without-url/src/main/java/org/openapitools/model/Pet.java
@@ -221,6 +221,7 @@ public class Pet {
     this.tags = tags;
   }
 
+  @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;
     return this;

--- a/samples/client/petstore/spring-cloud-feign-without-url/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/client/petstore/spring-cloud-feign-without-url/src/main/java/org/openapitools/model/Pet.java
@@ -222,7 +222,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {
@@ -244,7 +244,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   @JsonProperty("status")

--- a/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/model/Pet.java
@@ -221,6 +221,9 @@ public class Pet {
     this.tags = tags;
   }
 
+  /**
+   * @deprecated
+   */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;

--- a/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/model/Pet.java
@@ -221,6 +221,7 @@ public class Pet {
     this.tags = tags;
   }
 
+  @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;
     return this;

--- a/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/model/Pet.java
@@ -222,7 +222,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {
@@ -244,7 +244,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   @JsonProperty("status")

--- a/samples/client/petstore/spring-http-interface-bean-validation/src/main/java/org/openapitools/model/PetDto.java
+++ b/samples/client/petstore/spring-http-interface-bean-validation/src/main/java/org/openapitools/model/PetDto.java
@@ -213,7 +213,7 @@ public class PetDto {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   public PetDto status(@Nullable StatusEnum status) {
@@ -234,7 +234,7 @@ public class PetDto {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   @JsonProperty("status")

--- a/samples/client/petstore/spring-http-interface-bean-validation/src/main/java/org/openapitools/model/PetDto.java
+++ b/samples/client/petstore/spring-http-interface-bean-validation/src/main/java/org/openapitools/model/PetDto.java
@@ -212,6 +212,9 @@ public class PetDto {
     this.tags = tags;
   }
 
+  /**
+   * @deprecated
+   */
   @Deprecated
   public PetDto status(@Nullable StatusEnum status) {
     this.status = status;

--- a/samples/client/petstore/spring-http-interface-bean-validation/src/main/java/org/openapitools/model/PetDto.java
+++ b/samples/client/petstore/spring-http-interface-bean-validation/src/main/java/org/openapitools/model/PetDto.java
@@ -212,6 +212,7 @@ public class PetDto {
     this.tags = tags;
   }
 
+  @Deprecated
   public PetDto status(@Nullable StatusEnum status) {
     this.status = status;
     return this;

--- a/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/PetDto.java
+++ b/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/PetDto.java
@@ -211,6 +211,7 @@ public class PetDto {
     this.tags = tags;
   }
 
+  @Deprecated
   public PetDto status(@Nullable StatusEnum status) {
     this.status = status;
     return this;

--- a/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/PetDto.java
+++ b/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/PetDto.java
@@ -212,7 +212,7 @@ public class PetDto {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   public PetDto status(@Nullable StatusEnum status) {
@@ -233,7 +233,7 @@ public class PetDto {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   @JsonProperty("status")

--- a/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/PetDto.java
+++ b/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/PetDto.java
@@ -211,6 +211,9 @@ public class PetDto {
     this.tags = tags;
   }
 
+  /**
+   * @deprecated
+   */
   @Deprecated
   public PetDto status(@Nullable StatusEnum status) {
     this.status = status;

--- a/samples/client/petstore/spring-http-interface-oauth/src/main/java/org/openapitools/model/PetDto.java
+++ b/samples/client/petstore/spring-http-interface-oauth/src/main/java/org/openapitools/model/PetDto.java
@@ -213,7 +213,7 @@ public class PetDto {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   public PetDto status(@Nullable StatusEnum status) {
@@ -234,7 +234,7 @@ public class PetDto {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   @JsonProperty("status")

--- a/samples/client/petstore/spring-http-interface-oauth/src/main/java/org/openapitools/model/PetDto.java
+++ b/samples/client/petstore/spring-http-interface-oauth/src/main/java/org/openapitools/model/PetDto.java
@@ -212,6 +212,9 @@ public class PetDto {
     this.tags = tags;
   }
 
+  /**
+   * @deprecated
+   */
   @Deprecated
   public PetDto status(@Nullable StatusEnum status) {
     this.status = status;

--- a/samples/client/petstore/spring-http-interface-oauth/src/main/java/org/openapitools/model/PetDto.java
+++ b/samples/client/petstore/spring-http-interface-oauth/src/main/java/org/openapitools/model/PetDto.java
@@ -212,6 +212,7 @@ public class PetDto {
     this.tags = tags;
   }
 
+  @Deprecated
   public PetDto status(@Nullable StatusEnum status) {
     this.status = status;
     return this;

--- a/samples/client/petstore/spring-http-interface-reactive-bean-validation/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/client/petstore/spring-http-interface-reactive-bean-validation/src/main/java/org/openapitools/model/Pet.java
@@ -218,6 +218,7 @@ public class Pet {
     this.tags = tags;
   }
 
+  @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;
     return this;

--- a/samples/client/petstore/spring-http-interface-reactive-bean-validation/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/client/petstore/spring-http-interface-reactive-bean-validation/src/main/java/org/openapitools/model/Pet.java
@@ -219,7 +219,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {
@@ -240,7 +240,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   @JsonProperty("status")

--- a/samples/client/petstore/spring-http-interface-reactive-bean-validation/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/client/petstore/spring-http-interface-reactive-bean-validation/src/main/java/org/openapitools/model/Pet.java
@@ -218,6 +218,9 @@ public class Pet {
     this.tags = tags;
   }
 
+  /**
+   * @deprecated
+   */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;

--- a/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/Pet.java
@@ -218,7 +218,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {
@@ -239,7 +239,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   @JsonProperty("status")

--- a/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/Pet.java
@@ -217,6 +217,9 @@ public class Pet {
     this.tags = tags;
   }
 
+  /**
+   * @deprecated
+   */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;

--- a/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/Pet.java
@@ -217,6 +217,7 @@ public class Pet {
     this.tags = tags;
   }
 
+  @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;
     return this;

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/Pet.java
@@ -218,7 +218,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {
@@ -239,7 +239,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   @JsonProperty("status")

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/Pet.java
@@ -217,6 +217,9 @@ public class Pet {
     this.tags = tags;
   }
 
+  /**
+   * @deprecated
+   */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/Pet.java
@@ -217,6 +217,7 @@ public class Pet {
     this.tags = tags;
   }
 
+  @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;
     return this;

--- a/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/PetDto.java
+++ b/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/PetDto.java
@@ -218,6 +218,9 @@ public class PetDto {
     this.tags = tags;
   }
 
+  /**
+   * @deprecated
+   */
   @Deprecated
   public PetDto status(@Nullable StatusEnum status) {
     this.status = status;

--- a/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/PetDto.java
+++ b/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/PetDto.java
@@ -218,6 +218,7 @@ public class PetDto {
     this.tags = tags;
   }
 
+  @Deprecated
   public PetDto status(@Nullable StatusEnum status) {
     this.status = status;
     return this;

--- a/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/PetDto.java
+++ b/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/PetDto.java
@@ -219,7 +219,7 @@ public class PetDto {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   public PetDto status(@Nullable StatusEnum status) {
@@ -240,7 +240,7 @@ public class PetDto {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   @JsonProperty("status")

--- a/samples/client/petstore/spring-http-interface-useHttpServiceProxyFactoryInterfacesConfigurator/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/client/petstore/spring-http-interface-useHttpServiceProxyFactoryInterfacesConfigurator/src/main/java/org/openapitools/model/Pet.java
@@ -220,7 +220,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {
@@ -241,7 +241,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   @JsonProperty("status")

--- a/samples/client/petstore/spring-http-interface-useHttpServiceProxyFactoryInterfacesConfigurator/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/client/petstore/spring-http-interface-useHttpServiceProxyFactoryInterfacesConfigurator/src/main/java/org/openapitools/model/Pet.java
@@ -219,6 +219,7 @@ public class Pet {
     this.tags = tags;
   }
 
+  @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;
     return this;

--- a/samples/client/petstore/spring-http-interface-useHttpServiceProxyFactoryInterfacesConfigurator/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/client/petstore/spring-http-interface-useHttpServiceProxyFactoryInterfacesConfigurator/src/main/java/org/openapitools/model/Pet.java
@@ -219,6 +219,9 @@ public class Pet {
     this.tags = tags;
   }
 
+  /**
+   * @deprecated
+   */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;

--- a/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/PetDto.java
+++ b/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/PetDto.java
@@ -211,6 +211,7 @@ public class PetDto {
     this.tags = tags;
   }
 
+  @Deprecated
   public PetDto status(@Nullable StatusEnum status) {
     this.status = status;
     return this;

--- a/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/PetDto.java
+++ b/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/PetDto.java
@@ -212,7 +212,7 @@ public class PetDto {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   public PetDto status(@Nullable StatusEnum status) {
@@ -233,7 +233,7 @@ public class PetDto {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   @JsonProperty("status")

--- a/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/PetDto.java
+++ b/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/PetDto.java
@@ -211,6 +211,9 @@ public class PetDto {
     this.tags = tags;
   }
 
+  /**
+   * @deprecated
+   */
   @Deprecated
   public PetDto status(@Nullable StatusEnum status) {
     this.status = status;

--- a/samples/openapi3/client/petstore/spring-cloud-3-with-optional/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/client/petstore/spring-cloud-3-with-optional/src/main/java/org/openapitools/model/Pet.java
@@ -214,6 +214,7 @@ public class Pet {
     this.tags = tags;
   }
 
+  @Deprecated
   public Pet status(StatusEnum status) {
     this.status = Optional.ofNullable(status);
     return this;

--- a/samples/openapi3/client/petstore/spring-cloud-3-with-optional/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/client/petstore/spring-cloud-3-with-optional/src/main/java/org/openapitools/model/Pet.java
@@ -214,6 +214,9 @@ public class Pet {
     this.tags = tags;
   }
 
+  /**
+   * @deprecated
+   */
   @Deprecated
   public Pet status(StatusEnum status) {
     this.status = Optional.ofNullable(status);

--- a/samples/openapi3/client/petstore/spring-cloud-3-with-optional/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/client/petstore/spring-cloud-3-with-optional/src/main/java/org/openapitools/model/Pet.java
@@ -215,7 +215,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   public Pet status(StatusEnum status) {
@@ -236,7 +236,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   @JsonProperty("status")

--- a/samples/openapi3/client/petstore/spring-cloud-3/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/client/petstore/spring-cloud-3/src/main/java/org/openapitools/model/Pet.java
@@ -221,6 +221,9 @@ public class Pet {
     this.tags = tags;
   }
 
+  /**
+   * @deprecated
+   */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;

--- a/samples/openapi3/client/petstore/spring-cloud-3/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/client/petstore/spring-cloud-3/src/main/java/org/openapitools/model/Pet.java
@@ -221,6 +221,7 @@ public class Pet {
     this.tags = tags;
   }
 
+  @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;
     return this;

--- a/samples/openapi3/client/petstore/spring-cloud-3/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/client/petstore/spring-cloud-3/src/main/java/org/openapitools/model/Pet.java
@@ -222,7 +222,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {
@@ -244,7 +244,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   @JsonProperty("status")

--- a/samples/openapi3/client/petstore/spring-cloud-4-with-optional/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/client/petstore/spring-cloud-4-with-optional/src/main/java/org/openapitools/model/Pet.java
@@ -219,6 +219,7 @@ public class Pet {
     this.tags = tags;
   }
 
+  @Deprecated
   public Pet status(StatusEnum status) {
     this.status = status;
     return this;

--- a/samples/openapi3/client/petstore/spring-cloud-4-with-optional/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/client/petstore/spring-cloud-4-with-optional/src/main/java/org/openapitools/model/Pet.java
@@ -220,7 +220,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   public Pet status(StatusEnum status) {
@@ -241,7 +241,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   @JsonProperty("status")

--- a/samples/openapi3/client/petstore/spring-cloud-4-with-optional/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/client/petstore/spring-cloud-4-with-optional/src/main/java/org/openapitools/model/Pet.java
@@ -219,6 +219,9 @@ public class Pet {
     this.tags = tags;
   }
 
+  /**
+   * @deprecated
+   */
   @Deprecated
   public Pet status(StatusEnum status) {
     this.status = status;

--- a/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/model/Pet.java
@@ -221,6 +221,9 @@ public class Pet {
     this.tags = tags;
   }
 
+  /**
+   * @deprecated
+   */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;

--- a/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/model/Pet.java
@@ -221,6 +221,7 @@ public class Pet {
     this.tags = tags;
   }
 
+  @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;
     return this;

--- a/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/model/Pet.java
@@ -222,7 +222,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {
@@ -244,7 +244,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   @JsonProperty("status")

--- a/samples/openapi3/client/petstore/spring-cloud-http-basic/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/client/petstore/spring-cloud-http-basic/src/main/java/org/openapitools/model/Pet.java
@@ -221,6 +221,9 @@ public class Pet {
     this.tags = tags;
   }
 
+  /**
+   * @deprecated
+   */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;

--- a/samples/openapi3/client/petstore/spring-cloud-http-basic/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/client/petstore/spring-cloud-http-basic/src/main/java/org/openapitools/model/Pet.java
@@ -221,6 +221,7 @@ public class Pet {
     this.tags = tags;
   }
 
+  @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;
     return this;

--- a/samples/openapi3/client/petstore/spring-cloud-http-basic/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/client/petstore/spring-cloud-http-basic/src/main/java/org/openapitools/model/Pet.java
@@ -222,7 +222,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {
@@ -244,7 +244,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   @JsonProperty("status")

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/Pet.java
@@ -216,6 +216,7 @@ public class Pet {
     this.tags = tags;
   }
 
+  @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;
     return this;

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/Pet.java
@@ -217,7 +217,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {
@@ -239,7 +239,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   @JsonProperty("status")

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/Pet.java
@@ -216,6 +216,9 @@ public class Pet {
     this.tags = tags;
   }
 
+  /**
+   * @deprecated
+   */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;

--- a/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/model/Pet.java
@@ -221,6 +221,9 @@ public class Pet {
     this.tags = tags;
   }
 
+  /**
+   * @deprecated
+   */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;

--- a/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/model/Pet.java
@@ -221,6 +221,7 @@ public class Pet {
     this.tags = tags;
   }
 
+  @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;
     return this;

--- a/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/model/Pet.java
@@ -222,7 +222,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {
@@ -244,7 +244,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   @JsonProperty("status")

--- a/samples/openapi3/client/petstore/spring-stubs-skip-default-interface/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/client/petstore/spring-stubs-skip-default-interface/src/main/java/org/openapitools/model/Pet.java
@@ -221,6 +221,9 @@ public class Pet {
     this.tags = tags;
   }
 
+  /**
+   * @deprecated
+   */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;

--- a/samples/openapi3/client/petstore/spring-stubs-skip-default-interface/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/client/petstore/spring-stubs-skip-default-interface/src/main/java/org/openapitools/model/Pet.java
@@ -221,6 +221,7 @@ public class Pet {
     this.tags = tags;
   }
 
+  @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;
     return this;

--- a/samples/openapi3/client/petstore/spring-stubs-skip-default-interface/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/client/petstore/spring-stubs-skip-default-interface/src/main/java/org/openapitools/model/Pet.java
@@ -222,7 +222,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {
@@ -244,7 +244,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   @JsonProperty("status")

--- a/samples/openapi3/client/petstore/spring-stubs/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/client/petstore/spring-stubs/src/main/java/org/openapitools/model/Pet.java
@@ -221,6 +221,9 @@ public class Pet {
     this.tags = tags;
   }
 
+  /**
+   * @deprecated
+   */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;

--- a/samples/openapi3/client/petstore/spring-stubs/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/client/petstore/spring-stubs/src/main/java/org/openapitools/model/Pet.java
@@ -221,6 +221,7 @@ public class Pet {
     this.tags = tags;
   }
 
+  @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;
     return this;

--- a/samples/openapi3/client/petstore/spring-stubs/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/client/petstore/spring-stubs/src/main/java/org/openapitools/model/Pet.java
@@ -222,7 +222,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {
@@ -244,7 +244,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   @JsonProperty("status")

--- a/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/model/Pet.java
@@ -221,6 +221,9 @@ public class Pet {
     this.tags = tags;
   }
 
+  /**
+   * @deprecated
+   */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;

--- a/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/model/Pet.java
@@ -221,6 +221,7 @@ public class Pet {
     this.tags = tags;
   }
 
+  @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;
     return this;

--- a/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/model/Pet.java
@@ -222,7 +222,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {
@@ -244,7 +244,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   @JsonProperty("status")

--- a/samples/openapi3/server/petstore/springboot-3-include-http-request-context/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/server/petstore/springboot-3-include-http-request-context/src/main/java/org/openapitools/model/Pet.java
@@ -262,6 +262,7 @@ public class Pet {
     this.tags = tags;
   }
 
+  @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;
     return this;

--- a/samples/openapi3/server/petstore/springboot-3-include-http-request-context/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/server/petstore/springboot-3-include-http-request-context/src/main/java/org/openapitools/model/Pet.java
@@ -263,7 +263,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {
@@ -287,7 +287,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   @JsonProperty("status")

--- a/samples/openapi3/server/petstore/springboot-3-include-http-request-context/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/server/petstore/springboot-3-include-http-request-context/src/main/java/org/openapitools/model/Pet.java
@@ -262,6 +262,9 @@ public class Pet {
     this.tags = tags;
   }
 
+  /**
+   * @deprecated
+   */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;

--- a/samples/openapi3/server/petstore/springboot-3/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/server/petstore/springboot-3/src/main/java/org/openapitools/model/Pet.java
@@ -261,6 +261,9 @@ public class Pet {
     this.tags = tags;
   }
 
+  /**
+   * @deprecated
+   */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;

--- a/samples/openapi3/server/petstore/springboot-3/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/server/petstore/springboot-3/src/main/java/org/openapitools/model/Pet.java
@@ -261,6 +261,7 @@ public class Pet {
     this.tags = tags;
   }
 
+  @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;
     return this;

--- a/samples/openapi3/server/petstore/springboot-3/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/server/petstore/springboot-3/src/main/java/org/openapitools/model/Pet.java
@@ -262,7 +262,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {
@@ -286,7 +286,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   @JsonProperty("status")

--- a/samples/openapi3/server/petstore/springboot-4/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/server/petstore/springboot-4/src/main/java/org/openapitools/model/Pet.java
@@ -267,6 +267,7 @@ public class Pet {
     this.tags = tags;
   }
 
+  @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;
     return this;

--- a/samples/openapi3/server/petstore/springboot-4/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/server/petstore/springboot-4/src/main/java/org/openapitools/model/Pet.java
@@ -267,6 +267,9 @@ public class Pet {
     this.tags = tags;
   }
 
+  /**
+   * @deprecated
+   */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;

--- a/samples/openapi3/server/petstore/springboot-4/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/server/petstore/springboot-4/src/main/java/org/openapitools/model/Pet.java
@@ -268,7 +268,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {
@@ -292,7 +292,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   @JsonProperty("status")

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Pet.java
@@ -224,6 +224,9 @@ public class Pet {
     this.tags = tags;
   }
 
+  /**
+   * @deprecated
+   */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Pet.java
@@ -225,7 +225,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {
@@ -247,7 +247,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   @JsonProperty("status")

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Pet.java
@@ -224,6 +224,7 @@ public class Pet {
     this.tags = tags;
   }
 
+  @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;
     return this;

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Pet.java
@@ -224,6 +224,9 @@ public class Pet {
     this.tags = tags;
   }
 
+  /**
+   * @deprecated
+   */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Pet.java
@@ -225,7 +225,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {
@@ -247,7 +247,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   @JsonProperty("status")

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Pet.java
@@ -224,6 +224,7 @@ public class Pet {
     this.tags = tags;
   }
 
+  @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;
     return this;

--- a/samples/openapi3/server/petstore/springboot-source/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/server/petstore/springboot-source/src/main/java/org/openapitools/model/Pet.java
@@ -215,7 +215,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {
@@ -236,7 +236,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   @JsonProperty("status")

--- a/samples/openapi3/server/petstore/springboot-source/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/server/petstore/springboot-source/src/main/java/org/openapitools/model/Pet.java
@@ -214,6 +214,9 @@ public class Pet {
     this.tags = tags;
   }
 
+  /**
+   * @deprecated
+   */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;

--- a/samples/openapi3/server/petstore/springboot-source/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/server/petstore/springboot-source/src/main/java/org/openapitools/model/Pet.java
@@ -214,6 +214,7 @@ public class Pet {
     this.tags = tags;
   }
 
+  @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;
     return this;

--- a/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/model/Pet.java
@@ -218,7 +218,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {
@@ -240,7 +240,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   @JsonProperty("status")

--- a/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/model/Pet.java
@@ -217,6 +217,9 @@ public class Pet {
     this.tags = tags;
   }
 
+  /**
+   * @deprecated
+   */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;

--- a/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/model/Pet.java
@@ -217,6 +217,7 @@ public class Pet {
     this.tags = tags;
   }
 
+  @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;
     return this;

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/Pet.java
@@ -224,6 +224,9 @@ public class Pet {
     this.tags = tags;
   }
 
+  /**
+   * @deprecated
+   */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/Pet.java
@@ -225,7 +225,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {
@@ -247,7 +247,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   @JsonProperty("status")

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/Pet.java
@@ -224,6 +224,7 @@ public class Pet {
     this.tags = tags;
   }
 
+  @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;
     return this;

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/Pet.java
@@ -229,6 +229,7 @@ public class Pet {
     this.tags = tags;
   }
 
+  @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;
     return this;

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/Pet.java
@@ -229,6 +229,9 @@ public class Pet {
     this.tags = tags;
   }
 
+  /**
+   * @deprecated
+   */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/Pet.java
@@ -230,7 +230,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {
@@ -252,7 +252,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   @JsonProperty("status")

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Pet.java
@@ -224,6 +224,9 @@ public class Pet {
     this.tags = tags;
   }
 
+  /**
+   * @deprecated
+   */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Pet.java
@@ -225,7 +225,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {
@@ -247,7 +247,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   @JsonProperty("status")

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Pet.java
@@ -224,6 +224,7 @@ public class Pet {
     this.tags = tags;
   }
 
+  @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;
     return this;

--- a/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/Pet.java
@@ -224,6 +224,9 @@ public class Pet {
     this.tags = tags;
   }
 
+  /**
+   * @deprecated
+   */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;

--- a/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/Pet.java
@@ -225,7 +225,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {
@@ -247,7 +247,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   @JsonProperty("status")

--- a/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/Pet.java
@@ -224,6 +224,7 @@ public class Pet {
     this.tags = tags;
   }
 
+  @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;
     return this;

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/Pet.java
@@ -224,6 +224,9 @@ public class Pet {
     this.tags = tags;
   }
 
+  /**
+   * @deprecated
+   */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/Pet.java
@@ -225,7 +225,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {
@@ -247,7 +247,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   @JsonProperty("status")

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/Pet.java
@@ -224,6 +224,7 @@ public class Pet {
     this.tags = tags;
   }
 
+  @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;
     return this;

--- a/samples/server/petstore/springboot-delegate-no-response-entity/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-delegate-no-response-entity/src/main/java/org/openapitools/model/Pet.java
@@ -221,6 +221,9 @@ public class Pet {
     this.tags = tags;
   }
 
+  /**
+   * @deprecated
+   */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;

--- a/samples/server/petstore/springboot-delegate-no-response-entity/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-delegate-no-response-entity/src/main/java/org/openapitools/model/Pet.java
@@ -221,6 +221,7 @@ public class Pet {
     this.tags = tags;
   }
 
+  @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;
     return this;

--- a/samples/server/petstore/springboot-delegate-no-response-entity/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-delegate-no-response-entity/src/main/java/org/openapitools/model/Pet.java
@@ -222,7 +222,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {
@@ -244,7 +244,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   @JsonProperty("status")

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Pet.java
@@ -237,7 +237,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {
@@ -259,7 +259,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   @JsonProperty("status")

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Pet.java
@@ -236,6 +236,9 @@ public class Pet {
     this.tags = tags;
   }
 
+  /**
+   * @deprecated
+   */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Pet.java
@@ -236,6 +236,7 @@ public class Pet {
     this.tags = tags;
   }
 
+  @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;
     return this;

--- a/samples/server/petstore/springboot-implicitHeaders-annotationLibrary/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-implicitHeaders-annotationLibrary/src/main/java/org/openapitools/model/Pet.java
@@ -215,7 +215,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {
@@ -236,7 +236,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   @JsonProperty("status")

--- a/samples/server/petstore/springboot-implicitHeaders-annotationLibrary/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-implicitHeaders-annotationLibrary/src/main/java/org/openapitools/model/Pet.java
@@ -214,6 +214,9 @@ public class Pet {
     this.tags = tags;
   }
 
+  /**
+   * @deprecated
+   */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;

--- a/samples/server/petstore/springboot-implicitHeaders-annotationLibrary/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-implicitHeaders-annotationLibrary/src/main/java/org/openapitools/model/Pet.java
@@ -214,6 +214,7 @@ public class Pet {
     this.tags = tags;
   }
 
+  @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;
     return this;

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Pet.java
@@ -224,6 +224,9 @@ public class Pet {
     this.tags = tags;
   }
 
+  /**
+   * @deprecated
+   */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Pet.java
@@ -225,7 +225,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {
@@ -247,7 +247,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   @JsonProperty("status")

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Pet.java
@@ -224,6 +224,7 @@ public class Pet {
     this.tags = tags;
   }
 
+  @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;
     return this;

--- a/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/PetDto.java
+++ b/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/PetDto.java
@@ -226,6 +226,7 @@ public class PetDto {
     this.tags = tags;
   }
 
+  @Deprecated
   public PetDto status(@Nullable StatusEnum status) {
     this.status = status;
     return this;

--- a/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/PetDto.java
+++ b/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/PetDto.java
@@ -227,7 +227,7 @@ public class PetDto {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   public PetDto status(@Nullable StatusEnum status) {
@@ -249,7 +249,7 @@ public class PetDto {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   @JsonProperty("status")

--- a/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/PetDto.java
+++ b/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/PetDto.java
@@ -226,6 +226,9 @@ public class PetDto {
     this.tags = tags;
   }
 
+  /**
+   * @deprecated
+   */
   @Deprecated
   public PetDto status(@Nullable StatusEnum status) {
     this.status = status;

--- a/samples/server/petstore/springboot-lombok-tostring/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-lombok-tostring/src/main/java/org/openapitools/model/Pet.java
@@ -152,7 +152,7 @@ public class Pet {
 
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {

--- a/samples/server/petstore/springboot-lombok-tostring/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-lombok-tostring/src/main/java/org/openapitools/model/Pet.java
@@ -151,6 +151,7 @@ public class Pet {
   }
 
 
+  @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;
     return this;

--- a/samples/server/petstore/springboot-lombok-tostring/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-lombok-tostring/src/main/java/org/openapitools/model/Pet.java
@@ -151,6 +151,9 @@ public class Pet {
   }
 
 
+  /**
+   * @deprecated
+   */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;

--- a/samples/server/petstore/springboot-petstore-with-api-response-examples/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-petstore-with-api-response-examples/src/main/java/org/openapitools/model/Pet.java
@@ -221,6 +221,9 @@ public class Pet {
     this.tags = tags;
   }
 
+  /**
+   * @deprecated
+   */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;

--- a/samples/server/petstore/springboot-petstore-with-api-response-examples/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-petstore-with-api-response-examples/src/main/java/org/openapitools/model/Pet.java
@@ -221,6 +221,7 @@ public class Pet {
     this.tags = tags;
   }
 
+  @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;
     return this;

--- a/samples/server/petstore/springboot-petstore-with-api-response-examples/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-petstore-with-api-response-examples/src/main/java/org/openapitools/model/Pet.java
@@ -222,7 +222,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {
@@ -244,7 +244,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   @JsonProperty("status")

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/Pet.java
@@ -224,6 +224,9 @@ public class Pet {
     this.tags = tags;
   }
 
+  /**
+   * @deprecated
+   */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/Pet.java
@@ -225,7 +225,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {
@@ -247,7 +247,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   @JsonProperty("status")

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/Pet.java
@@ -224,6 +224,7 @@ public class Pet {
     this.tags = tags;
   }
 
+  @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;
     return this;

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Pet.java
@@ -224,6 +224,9 @@ public class Pet {
     this.tags = tags;
   }
 
+  /**
+   * @deprecated
+   */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Pet.java
@@ -225,7 +225,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {
@@ -247,7 +247,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   @JsonProperty("status")

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Pet.java
@@ -224,6 +224,7 @@ public class Pet {
     this.tags = tags;
   }
 
+  @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;
     return this;

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Pet.java
@@ -224,6 +224,9 @@ public class Pet {
     this.tags = tags;
   }
 
+  /**
+   * @deprecated
+   */
   @Deprecated
   public Pet status(StatusEnum status) {
     this.status = Optional.ofNullable(status);

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Pet.java
@@ -225,7 +225,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   public Pet status(StatusEnum status) {
@@ -247,7 +247,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   @JsonProperty("status")

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Pet.java
@@ -224,6 +224,7 @@ public class Pet {
     this.tags = tags;
   }
 
+  @Deprecated
   public Pet status(StatusEnum status) {
     this.status = Optional.ofNullable(status);
     return this;

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Pet.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Pet.java
@@ -224,6 +224,9 @@ public class Pet {
     this.tags = tags;
   }
 
+  /**
+   * @deprecated
+   */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Pet.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Pet.java
@@ -225,7 +225,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   public Pet status(@Nullable StatusEnum status) {
@@ -247,7 +247,7 @@ public class Pet {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   @JsonProperty("status")

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Pet.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Pet.java
@@ -224,6 +224,7 @@ public class Pet {
     this.tags = tags;
   }
 
+  @Deprecated
   public Pet status(@Nullable StatusEnum status) {
     this.status = status;
     return this;

--- a/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/ObjectWithDeprecatedFieldsDto.java
+++ b/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/ObjectWithDeprecatedFieldsDto.java
@@ -67,7 +67,7 @@ public class ObjectWithDeprecatedFieldsDto {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   public ObjectWithDeprecatedFieldsDto id(@Nullable BigDecimal id) {
@@ -89,7 +89,7 @@ public class ObjectWithDeprecatedFieldsDto {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   @JsonProperty("id")
@@ -98,7 +98,7 @@ public class ObjectWithDeprecatedFieldsDto {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   public ObjectWithDeprecatedFieldsDto deprecatedRef(@Nullable DeprecatedObjectDto deprecatedRef) {
@@ -120,7 +120,7 @@ public class ObjectWithDeprecatedFieldsDto {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   @JsonProperty("deprecatedRef")
@@ -129,7 +129,7 @@ public class ObjectWithDeprecatedFieldsDto {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   public ObjectWithDeprecatedFieldsDto bars(List<String> bars) {
@@ -138,7 +138,7 @@ public class ObjectWithDeprecatedFieldsDto {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   public ObjectWithDeprecatedFieldsDto addBarsItem(String barsItem) {
@@ -163,7 +163,7 @@ public class ObjectWithDeprecatedFieldsDto {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   @JsonProperty("bars")

--- a/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/ObjectWithDeprecatedFieldsDto.java
+++ b/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/ObjectWithDeprecatedFieldsDto.java
@@ -66,6 +66,9 @@ public class ObjectWithDeprecatedFieldsDto {
     this.uuid = uuid;
   }
 
+  /**
+   * @deprecated
+   */
   @Deprecated
   public ObjectWithDeprecatedFieldsDto id(@Nullable BigDecimal id) {
     this.id = id;
@@ -94,6 +97,9 @@ public class ObjectWithDeprecatedFieldsDto {
     this.id = id;
   }
 
+  /**
+   * @deprecated
+   */
   @Deprecated
   public ObjectWithDeprecatedFieldsDto deprecatedRef(@Nullable DeprecatedObjectDto deprecatedRef) {
     this.deprecatedRef = deprecatedRef;
@@ -122,12 +128,18 @@ public class ObjectWithDeprecatedFieldsDto {
     this.deprecatedRef = deprecatedRef;
   }
 
+  /**
+   * @deprecated
+   */
   @Deprecated
   public ObjectWithDeprecatedFieldsDto bars(List<String> bars) {
     this.bars = bars;
     return this;
   }
 
+  /**
+   * @deprecated
+   */
   @Deprecated
   public ObjectWithDeprecatedFieldsDto addBarsItem(String barsItem) {
     if (this.bars == null) {

--- a/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/ObjectWithDeprecatedFieldsDto.java
+++ b/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/ObjectWithDeprecatedFieldsDto.java
@@ -66,6 +66,7 @@ public class ObjectWithDeprecatedFieldsDto {
     this.uuid = uuid;
   }
 
+  @Deprecated
   public ObjectWithDeprecatedFieldsDto id(@Nullable BigDecimal id) {
     this.id = id;
     return this;
@@ -93,6 +94,7 @@ public class ObjectWithDeprecatedFieldsDto {
     this.id = id;
   }
 
+  @Deprecated
   public ObjectWithDeprecatedFieldsDto deprecatedRef(@Nullable DeprecatedObjectDto deprecatedRef) {
     this.deprecatedRef = deprecatedRef;
     return this;
@@ -120,11 +122,13 @@ public class ObjectWithDeprecatedFieldsDto {
     this.deprecatedRef = deprecatedRef;
   }
 
+  @Deprecated
   public ObjectWithDeprecatedFieldsDto bars(List<String> bars) {
     this.bars = bars;
     return this;
   }
 
+  @Deprecated
   public ObjectWithDeprecatedFieldsDto addBarsItem(String barsItem) {
     if (this.bars == null) {
       this.bars = new ArrayList<>();

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/PetDto.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/PetDto.java
@@ -227,6 +227,7 @@ public class PetDto {
     this.tags = tags;
   }
 
+  @Deprecated
   public PetDto status(@Nullable StatusEnum status) {
     this.status = status;
     return this;

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/PetDto.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/PetDto.java
@@ -227,6 +227,9 @@ public class PetDto {
     this.tags = tags;
   }
 
+  /**
+   * @deprecated
+   */
   @Deprecated
   public PetDto status(@Nullable StatusEnum status) {
     this.status = status;

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/PetDto.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/PetDto.java
@@ -228,7 +228,7 @@ public class PetDto {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   public PetDto status(@Nullable StatusEnum status) {
@@ -250,7 +250,7 @@ public class PetDto {
   }
 
   /**
-   * @deprecated
+   * @deprecated deprecated
    */
   @Deprecated
   @JsonProperty("status")


### PR DESCRIPTION
The Java Spring generator already annotates fields, getters, regular setters, and nested builder methods for properties marked `deprecated: true`. Fluent model setters and collection helpers (`addXItem` / `putXItem`) were missing `@Deprecated`.

This updates `JavaSpring/pojo.mustache` so those methods emit `@Deprecated` as well, including inherited fluent helpers.

Fixes #24704

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the following to build the project and update samples:
  ```
  ./mvnw -pl modules/openapi-generator-cli -am package -DskipTests=true -Dmaven.javadoc.skip=true -Djacoco.skip=true
  ./bin/generate-samples.sh ./bin/configs/spring*.yaml
  ```
  Regenerated Spring samples only. The sample delta is `@Deprecated` on fluent setters and collection helpers for already-deprecated properties (for example `Pet.status`).
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/OpenAPITools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

Java Spring @cachescrubber (2022/02) @welshm (2022/02) @MelleD (2022/02) @atextor (2022/02) @manedev79 (2022/02) @javisst (2022/02) @borsch (2022/02) @banlevente (2022/02) @Zomzog (2022/09) @martin-mfg (2023/08) @KannaKim (2026/07)

### Tests

Executed:

- `./mvnw -pl modules/openapi-generator -am test -Dtest=SpringCodegenTest#contractWithDeprecatedPropertiesAnnotatesFluentSettersAndCollectionHelpers` RED then GREEN
- `./mvnw -pl modules/openapi-generator -am test -Dtest=SpringCodegenTest#contractWithDeprecatedEnumGeneratesDeprecatedAnnotation,SpringCodegenTest#contractWithDeprecatedPropertiesAnnotatesFluentSettersAndCollectionHelpers,SpringCodegenTest#shouldGenerateSingleDeprecatedAnnotation` 3/3 GREEN

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Annotates Spring-generated fluent setters and collection helpers for deprecated properties. Old: no markers on fluent methods and some `@deprecated` Javadoc tags were empty. New: fluent and inherited helpers emit `@Deprecated` and `@deprecated deprecated`; regular setters’ Javadoc tag now includes text to avoid Javadoc warnings.

- Template: updates `modules/openapi-generator/src/main/resources/JavaSpring/pojo.mustache` to add `@Deprecated` and `@deprecated deprecated` on fluent setters (`prop(value)`), `addXItem(...)`, `putXItem(...)`, and inherited equivalents when the schema property is deprecated; also updates existing setter Javadoc to `@deprecated deprecated`.
- Tests/samples: adds `src/test/resources/3_0/spring/issue_24704.yaml`; extends `SpringCodegenTest` to assert annotations/Javadoc on fluent, collection helper, and builder methods; regenerates Spring samples.
- Impact: No runtime change. IDE/compiler/Javadoc may now warn on deprecated fluent calls. No migration required.

<sup>Written for commit 656ac60a16cc4b0311b7fcfa3c28a86fc373c6b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24705?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

