### PR TITLE
[dart] Do not convert `format: date` to UTC before formatting

### DIFF
--- a/modules/openapi-generator/src/main/resources/dart2/serialization/native/native_class.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/serialization/native/native_class.mustache
@@ -82,10 +82,10 @@ class {{{classname}}} {
         {{#pattern}}
       json[r'{{{baseName}}}'] = value == null ? null : (_isEpochMarker(r'{{{pattern}}}')
         ? value.millisecondsSinceEpoch
-        : _dateFormatter.format(value.toUtc()));
+        : _dateFormatter.format(value));
         {{/pattern}}
         {{^pattern}}
-      json[r'{{{baseName}}}'] = value == null ? null : _dateFormatter.format(value.toUtc());
+      json[r'{{{baseName}}}'] = value == null ? null : _dateFormatter.format(value);
         {{/pattern}}
       {{/isDate}}
       {{^isDateTime}}
@@ -120,10 +120,10 @@ class {{{classname}}} {
       {{#pattern}}
       json[r'{{{baseName}}}'] = _isEpochMarker(r'{{{pattern}}}')
         ? this.{{{name}}}{{#isNullable}}!{{/isNullable}}{{^isNullable}}{{^required}}{{^defaultValue}}!{{/defaultValue}}{{/required}}{{/isNullable}}.millisecondsSinceEpoch
-        : _dateFormatter.format(this.{{{name}}}{{#isNullable}}!{{/isNullable}}{{^isNullable}}{{^required}}{{^defaultValue}}!{{/defaultValue}}{{/required}}{{/isNullable}}.toUtc());
+        : _dateFormatter.format(this.{{{name}}}{{#isNullable}}!{{/isNullable}}{{^isNullable}}{{^required}}{{^defaultValue}}!{{/defaultValue}}{{/required}}{{/isNullable}});
       {{/pattern}}
       {{^pattern}}
-      json[r'{{{baseName}}}'] = _dateFormatter.format(this.{{{name}}}{{#isNullable}}!{{/isNullable}}{{^isNullable}}{{^required}}{{^defaultValue}}!{{/defaultValue}}{{/required}}{{/isNullable}}.toUtc());
+      json[r'{{{baseName}}}'] = _dateFormatter.format(this.{{{name}}}{{#isNullable}}!{{/isNullable}}{{^isNullable}}{{^required}}{{^defaultValue}}!{{/defaultValue}}{{/required}}{{/isNullable}});
       {{/pattern}}
     {{/isDate}}
     {{^isDateTime}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/dart/DartClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/dart/DartClientCodegenTest.java
@@ -199,4 +199,27 @@ public class DartClientCodegenTest {
         TestUtils.assertFileContains(modelFile.toPath(),
                 "e == null ? null : NullableRequiredModel.listFromJson(e)");
     }
+
+    @Test(description = "format: date must not be converted to UTC before formatting")
+    public void testDateOnlyFieldsAreNotConvertedToUtc() throws Exception {
+        List<File> files = generateDartNativeFromSpec(
+                "src/test/resources/3_0/dart/dart-native-deserialization-bugs.yaml");
+
+        File modelFile = files.stream()
+                .filter(f -> f.getName().equals("date_only_model.dart"))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("date_only_model.dart not found in generated files"));
+
+        // _dateFormatter is DateFormat('yyyy-MM-dd'), which formats the y/m/d the
+        // DateTime already carries and performs no timezone conversion. Calling
+        // toUtc() first therefore does nothing except roll the clock back past
+        // midnight in UTC+X zones, so the formatter prints the previous day.
+        // This model has no date-time properties, so no toUtc() belongs in it.
+        TestUtils.assertFileNotContains(modelFile.toPath(), ".toUtc()");
+
+        TestUtils.assertFileContains(modelFile.toPath(),
+                "json[r'requiredDate'] = _dateFormatter.format(this.requiredDate);");
+        TestUtils.assertFileContains(modelFile.toPath(),
+                "json[r'optionalDate'] = _dateFormatter.format(this.optionalDate!);");
+    }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/dart/DartClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/dart/DartClientCodegenTest.java
@@ -32,6 +32,7 @@ import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 public class DartClientCodegenTest {
 
@@ -101,6 +102,10 @@ public class DartClientCodegenTest {
     }
 
     private List<File> generateDartNativeFromSpec(String specPath) throws Exception {
+        return generateDartNativeFromSpec(specPath, Map.of());
+    }
+
+    private List<File> generateDartNativeFromSpec(String specPath, Map<String, Object> additionalProperties) throws Exception {
         File output = Files.createTempDirectory("dart-native-test").toFile();
         output.deleteOnExit();
 
@@ -108,6 +113,7 @@ public class DartClientCodegenTest {
                 .setGeneratorName("dart")
                 .setInputSpec(specPath)
                 .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+        additionalProperties.forEach(configurator::addAdditionalProperty);
 
         ClientOptInput opts = configurator.toClientOptInput();
         DefaultGenerator generator = new DefaultGenerator();
@@ -200,6 +206,9 @@ public class DartClientCodegenTest {
                 "e == null ? null : NullableRequiredModel.listFromJson(e)");
     }
 
+    // DateFormat('yyyy-MM-dd') does no timezone conversion, it just formats the y/m/d the
+    // DateTime already carries. So toUtc() only shifts the value across a day boundary and
+    // the date comes out off by one - back a day east of UTC, forward a day west of it.
     @Test(description = "format: date must not be converted to UTC before formatting")
     public void testDateOnlyFieldsAreNotConvertedToUtc() throws Exception {
         List<File> files = generateDartNativeFromSpec(
@@ -210,16 +219,29 @@ public class DartClientCodegenTest {
                 .findFirst()
                 .orElseThrow(() -> new AssertionError("date_only_model.dart not found in generated files"));
 
-        // _dateFormatter is DateFormat('yyyy-MM-dd'), which formats the y/m/d the
-        // DateTime already carries and performs no timezone conversion. Calling
-        // toUtc() first therefore does nothing except roll the clock back past
-        // midnight in UTC+X zones, so the formatter prints the previous day.
-        // This model has no date-time properties, so no toUtc() belongs in it.
-        TestUtils.assertFileNotContains(modelFile.toPath(), ".toUtc()");
-
         TestUtils.assertFileContains(modelFile.toPath(),
                 "json[r'requiredDate'] = _dateFormatter.format(this.requiredDate);");
         TestUtils.assertFileContains(modelFile.toPath(),
                 "json[r'optionalDate'] = _dateFormatter.format(this.optionalDate!);");
+        // A pattern routes it through the _isEpochMarker ternary, non-epoch side formats the same way
+        TestUtils.assertFileContains(modelFile.toPath(),
+                ": _dateFormatter.format(this.patternedDate!);");
+    }
+
+    @Test(description = "format: date must not be converted to UTC in the Optional<T> path either")
+    public void testDateOnlyFieldsAreNotConvertedToUtcWithUseOptional() throws Exception {
+        List<File> files = generateDartNativeFromSpec(
+                "src/test/resources/3_0/dart/dart-native-deserialization-bugs.yaml",
+                Map.of("useOptional", true));
+
+        File modelFile = files.stream()
+                .filter(f -> f.getName().equals("date_only_model.dart"))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("date_only_model.dart not found in generated files"));
+
+        TestUtils.assertFileContains(modelFile.toPath(),
+                "json[r'optionalDate'] = value == null ? null : _dateFormatter.format(value);");
+        TestUtils.assertFileContains(modelFile.toPath(),
+                ": _dateFormatter.format(value));");
     }
 }

--- a/modules/openapi-generator/src/test/resources/3_0/dart/dart-native-deserialization-bugs.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/dart/dart-native-deserialization-bugs.yaml
@@ -58,3 +58,7 @@ components:
         optionalDate:
           type: string
           format: date
+        patternedDate:
+          type: string
+          format: date
+          pattern: '^\d{4}-\d{2}-\d{2}$'

--- a/modules/openapi-generator/src/test/resources/3_0/dart/dart-native-deserialization-bugs.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/dart/dart-native-deserialization-bugs.yaml
@@ -47,3 +47,14 @@ components:
             nullable: true
             items:
               $ref: '#/components/schemas/NullableRequiredModel'
+    DateOnlyModel:
+      type: object
+      required:
+        - requiredDate
+      properties:
+        requiredDate:
+          type: string
+          format: date
+        optionalDate:
+          type: string
+          format: date

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/format_test.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/format_test.dart
@@ -233,7 +233,7 @@ class FormatTest {
     } else {
       json[r'binary'] = null;
     }
-      json[r'date'] = _dateFormatter.format(this.date.toUtc());
+      json[r'date'] = _dateFormatter.format(this.date);
     if (this.dateTime != null) {
       json[r'dateTime'] = this.dateTime!.toUtc().toIso8601String();
     } else {

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/nullable_class.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/nullable_class.dart
@@ -108,7 +108,7 @@ class NullableClass {
       json[r'string_prop'] = null;
     }
     if (this.dateProp != null) {
-      json[r'date_prop'] = _dateFormatter.format(this.dateProp!.toUtc());
+      json[r'date_prop'] = _dateFormatter.format(this.dateProp!);
     } else {
       json[r'date_prop'] = null;
     }


### PR DESCRIPTION
fix #24703

The dart generator emits this for a `format: date` property:

```dart
json[r'dueDate'] = _dateFormatter.format(this.dueDate!.toUtc());
```

`_dateFormatter` is `DateFormat('yyyy-MM-dd')`, which formats the y/m/d the DateTime already carries. It does no timezone conversion, so that `.toUtc()` does nothing except move the value across a day boundary before the date is read.

Coming the other way, `mapDateTime` parses the bare wire value `"2026-09-12"` with `DateTime.tryParse`, which gives you *local* midnight. Round trip in Oslo:

```
"2026-09-12" -> DateTime 2026-09-12 00:00 local -> toUtc() 2026-09-11 22:00Z -> "2026-09-11"
```

It is stable in UTC, which I bet is why this has been around so long. We only noticed because a payment deadline got printed one day early on a physical parking fine.

Removing `.toUtc()` should be safe in both directions. `toUtc()` returns `this` when the DateTime is already UTC, so UTC callers are unaffected, and local callers stop being shifted. The `isDateTime` branch right next to it keeps its `.toUtc()`, an instant needs a zone, a calendar date does not.

FWIW `dart-dio` already handles this correctly with its own `Date` class (plain year/month/day ints), so the two dart generators disagree about this today.

### Tests

Added a `DateOnlyModel` fixture and two tests that between them pin all four changed template lines:

| branch | covered by |
| --- | --- |
| plain, no pattern | `requiredDate`, `optionalDate` |
| plain, with pattern | `patternedDate` |
| `Optional<T>`, no pattern | `optionalDate` with `useOptional=true` |
| `Optional<T>`, with pattern | `patternedDate` with `useOptional=true` |

Both tests fail against the old template and pass with the fix. Samples regenerated, it comes out as two lines.

### Not fixed here

While I was in there I noticed `format: date` is also wrong in a few other places: query, header and form parameters go through `parameterToString`, which is type-erased and cannot tell `date` from `date-time`, path parameters use plain `.toString()`, and arrays of dates do not compile at all (`DateTime.listFromJson` does not exist). There is also an epoch-marker branch that still normalizes to UTC, and `_dateFormatter` has no explicit locale so it can emit non-ASCII digits if `Intl.defaultLocale` is set.

Those are separate defects with separate fixes and much bigger diffs, so I left them alone to keep this one small. Happy to look at them after if you want.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ```
  (I ran the two dart configs, `dart-petstore-client-lib.yaml` and `dart-petstore-client-lib-fake.yaml`, since the template only affects dart native.)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@jaumard @amondnet @sbu-WBT @kuhnroyal @agilob @ahmednfwela


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop converting Dart `format: date` fields to UTC before formatting. Previously we emitted `_dateFormatter.format(value.toUtc())`, which shifted local-midnight dates across day boundaries and serialized the wrong day; now we call `_dateFormatter.format(value)`. The `format: date-time` path is unchanged and still uses `.toUtc()`.

- **Review notes**
  - Update `modules/openapi-generator/src/main/resources/dart2/serialization/native/native_class.mustache` to remove `.toUtc()` in all `isDate` branches (plain and pattern).
  - Add tests in `DartClientCodegenTest` plus a `DateOnlyModel` fixture to cover plain/pattern and `useOptional=true` paths; assertions check the exact emitted lines.
  - Regenerate samples: one-line changes in `format_test.dart` and `nullable_class.dart`.

- **Impact**
  - No migration required for correct clients; serialized dates now match the calendar date carried by the `DateTime`.
  - If any code compensated for the previous off-by-one shift, remove those workarounds.

<sup>Written for commit e27bf96274998bd446dd264183aad17e98e4e05d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24706?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

