### PR TITLE
feat(core): expose request body named examples to templates

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -2457,6 +2457,18 @@ public class DefaultCodegen implements CodegenConfig {
     }
 
     /**
+     * Return the examples of the parameter.
+     *
+     * @param codegenParameter Codegen parameter
+     * @param mediaType        Media type
+     */
+    public void setParameterExamples(CodegenParameter codegenParameter, MediaType mediaType) {
+        if (mediaType.getExamples() != null && !mediaType.getExamples().isEmpty()) {
+            codegenParameter.examples = mediaType.getExamples();
+        }
+    }
+
+    /**
      * Return the example value of the parameter.
      *
      * @param codegenParameter Codegen parameter
@@ -7442,11 +7454,31 @@ public class DefaultCodegen implements CodegenConfig {
     }
 
     protected String getContentType(RequestBody requestBody) {
-        if (requestBody == null || requestBody.getContent() == null || requestBody.getContent().isEmpty()) {
+        if (!hasMediaType(requestBody)) {
             LOGGER.debug("Cannot determine the content type. Returning null.");
             return null;
         }
         return new ArrayList<>(requestBody.getContent().keySet()).get(0);
+    }
+
+    /**
+     *
+     * @param requestBody The request body
+     * @return The first media type of the request body's content, if it exists. Otherwise, returns an empty Optional.
+     */
+    private Optional<MediaType> getFirstContentMediaType(RequestBody requestBody) {
+        if (hasMediaType(requestBody)) {
+            return Optional.of(requestBody.getContent().values().iterator().next());
+        }
+        return Optional.empty();
+    }
+
+    private static boolean hasMediaType(RequestBody requestBody) {
+        return requestBody != null && requestBody.getContent() != null && !requestBody.getContent().isEmpty();
+    }
+
+    private static boolean hasMediaType(ApiResponse apiResponse) {
+        return apiResponse != null && apiResponse.getContent() != null && !apiResponse.getContent().isEmpty();
     }
 
     private void setOauth2Info(CodegenSecurity codegenSecurity, OAuthFlow flow) {
@@ -7481,7 +7513,7 @@ public class DefaultCodegen implements CodegenConfig {
 
     private void addConsumesInfo(Operation operation, CodegenOperation codegenOperation) {
         RequestBody requestBody = ModelUtils.getReferencedRequestBody(this.openAPI, operation.getRequestBody());
-        if (requestBody == null || requestBody.getContent() == null || requestBody.getContent().isEmpty()) {
+        if (!hasMediaType(requestBody)) {
             return;
         }
 
@@ -7512,7 +7544,7 @@ public class DefaultCodegen implements CodegenConfig {
     public static Set<String> getConsumesInfo(OpenAPI openAPI, Operation operation) {
         RequestBody requestBody = ModelUtils.getReferencedRequestBody(openAPI, operation.getRequestBody());
 
-        if (requestBody == null || requestBody.getContent() == null || requestBody.getContent().isEmpty()) {
+        if (!hasMediaType(requestBody)) {
             return Collections.emptySet(); // return empty set
         }
         return requestBody.getContent().keySet();
@@ -7548,7 +7580,7 @@ public class DefaultCodegen implements CodegenConfig {
 
     private void addProducesInfo(ApiResponse inputResponse, CodegenOperation codegenOperation) {
         ApiResponse response = ModelUtils.getReferencedApiResponse(this.openAPI, inputResponse);
-        if (response == null || response.getContent() == null || response.getContent().isEmpty()) {
+        if (!hasMediaType(response)) {
             return;
         }
 
@@ -8375,6 +8407,9 @@ public class DefaultCodegen implements CodegenConfig {
         // set the parameter's example value
         // should be overridden by lang codegen
         setParameterExampleValue(codegenParameter, body);
+
+        getFirstContentMediaType(body)
+                .ifPresent(mediaType -> setParameterExamples(codegenParameter, mediaType));
 
         // restore original schema with description, extensions etc
         if (original != null) {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -1157,6 +1157,26 @@ public class DefaultCodegenTest {
     }
 
     @Test
+    public void testExample6MultipleRequestBodyExamples() {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/examples.yaml");
+        final DefaultCodegen codegen = new DefaultCodegen();
+        codegen.setOpenAPI(openAPI);
+        String path = "/example6/multiple_examples";
+
+        Operation operation = openAPI.getPaths().get(path).getPost();
+        CodegenOperation codegenOperation = codegen.fromOperation(path, "POST", operation, null);
+        CodegenParameter bodyParam = codegenOperation.bodyParam;
+
+        assertEquals("An example6 value 1", bodyParam.example);
+
+        // verify all named examples are populated in the body parameter's examples
+        assertEquals(3, bodyParam.examples.size());
+        assertEquals("An example6 value 1", bodyParam.examples.get("FirstExample").getValue());
+        assertEquals("An example6 value 2", bodyParam.examples.get("SecondExample").getValue());
+        assertEquals("An example6 value 3", bodyParam.examples.get("ThirdExample").getValue());
+    }
+
+    @Test
     public void testDiscriminator() {
         final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml");
         DefaultCodegen codegen = new DefaultCodegen();

--- a/modules/openapi-generator/src/test/resources/3_0/examples.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/examples.yaml
@@ -139,6 +139,30 @@ paths:
               schema:
                 type: string
                 example: an internal server error response example
+  /example6/multiple_examples:
+    post:
+      operationId: example6PostMultipleExamples
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+            examples:
+              FirstExample:
+                summary: The first example value
+                value: 'An example6 value 1'
+              SecondExample:
+                summary: The second example value
+                value: 'An example6 value 2'
+              ThirdExample:
+                summary: The third example value
+                value: 'An example6 value 3'
+      responses:
+        '200':
+          description: successful operation
 components:
   schemas:
     User:


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Adds so that any `examples` defined in a request body are properly attached to a `CodegenParameter`'s `examples` so that they can be accessed within the mustache templates. This logic already exists for when reading a swagger-core OAS `Parameter` object, but have now also been extended to request bodies.

Fixes https://github.com/OpenAPITools/openapi-generator/issues/23607

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose all named request body examples to mustache via CodegenParameter.examples. Previously only a single example value was available; now the examples map from the request body’s first media type is attached while CodegenParameter.example remains unchanged.

- fromRequestBody now sets examples from the first content media type when present.
- Add getFirstContentMediaType and hasMediaType helpers; refactor getContentType, addConsumesInfo, getConsumesInfo, and addProducesInfo to use them (null-safety, no behavior change).
- Add tests and a spec path (/example6/multiple_examples) verifying multiple request body examples are accessible.
- No template migrations required; templates can iterate over request body examples.

<sup>Written for commit 321ce8d009d5edde22bed33c6c729968737919e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24707?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

