### PR TITLE
[typescript-fetch] Add Temporal support

### DIFF
--- a/docs/generators/typescript-angular.md
+++ b/docs/generators/typescript-angular.md
@@ -107,6 +107,8 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 <li>ReturnType</li>
 <li>Set</li>
 <li>String</li>
+<li>Temporal.Instant</li>
+<li>Temporal.PlainDate</li>
 <li>ThisParameterType</li>
 <li>ThisType</li>
 <li>Uncapitalize</li>

--- a/docs/generators/typescript-aurelia.md
+++ b/docs/generators/typescript-aurelia.md
@@ -86,6 +86,8 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 <li>ReturnType</li>
 <li>Set</li>
 <li>String</li>
+<li>Temporal.Instant</li>
+<li>Temporal.PlainDate</li>
 <li>ThisParameterType</li>
 <li>ThisType</li>
 <li>Uncapitalize</li>

--- a/docs/generators/typescript-axios.md
+++ b/docs/generators/typescript-axios.md
@@ -98,6 +98,8 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 <li>ReturnType</li>
 <li>Set</li>
 <li>String</li>
+<li>Temporal.Instant</li>
+<li>Temporal.PlainDate</li>
 <li>ThisParameterType</li>
 <li>ThisType</li>
 <li>Uncapitalize</li>

--- a/docs/generators/typescript-fetch.md
+++ b/docs/generators/typescript-fetch.md
@@ -43,6 +43,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
 |stringEnums|Generate string enums instead of objects for enum values.| |false|
 |supportsES6|Generate code that conforms to ES6.| |false|
+|temporal|Setting this property to true will use Temporal data types instead of Date.| |false|
 |useSingleRequestParameter|Setting this property to true will generate functions with a single argument containing all API endpoint parameters instead of one argument per parameter.| |true|
 |useSquareBracketsInArrayNames|Setting this property to true will add brackets to array attribute names, e.g. my_values[].| |false|
 |validationAttributes|Setting this property to true will generate the validation attributes of model properties.| |false|
@@ -98,6 +99,8 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 <li>ReturnType</li>
 <li>Set</li>
 <li>String</li>
+<li>Temporal.Instant</li>
+<li>Temporal.PlainDate</li>
 <li>ThisParameterType</li>
 <li>ThisType</li>
 <li>Uncapitalize</li>

--- a/docs/generators/typescript-inversify.md
+++ b/docs/generators/typescript-inversify.md
@@ -92,6 +92,8 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 <li>ReturnType</li>
 <li>Set</li>
 <li>String</li>
+<li>Temporal.Instant</li>
+<li>Temporal.PlainDate</li>
 <li>ThisParameterType</li>
 <li>ThisType</li>
 <li>Uncapitalize</li>

--- a/docs/generators/typescript-jquery.md
+++ b/docs/generators/typescript-jquery.md
@@ -88,6 +88,8 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 <li>ReturnType</li>
 <li>Set</li>
 <li>String</li>
+<li>Temporal.Instant</li>
+<li>Temporal.PlainDate</li>
 <li>ThisParameterType</li>
 <li>ThisType</li>
 <li>Uncapitalize</li>

--- a/docs/generators/typescript-nestjs-server.md
+++ b/docs/generators/typescript-nestjs-server.md
@@ -99,6 +99,8 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 <li>ReturnType</li>
 <li>Set</li>
 <li>String</li>
+<li>Temporal.Instant</li>
+<li>Temporal.PlainDate</li>
 <li>ThisParameterType</li>
 <li>ThisType</li>
 <li>Uncapitalize</li>

--- a/docs/generators/typescript-nestjs.md
+++ b/docs/generators/typescript-nestjs.md
@@ -98,6 +98,8 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 <li>ReturnType</li>
 <li>Set</li>
 <li>String</li>
+<li>Temporal.Instant</li>
+<li>Temporal.PlainDate</li>
 <li>ThisParameterType</li>
 <li>ThisType</li>
 <li>Uncapitalize</li>

--- a/docs/generators/typescript-node.md
+++ b/docs/generators/typescript-node.md
@@ -91,6 +91,8 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 <li>ReturnType</li>
 <li>Set</li>
 <li>String</li>
+<li>Temporal.Instant</li>
+<li>Temporal.PlainDate</li>
 <li>ThisParameterType</li>
 <li>ThisType</li>
 <li>Uncapitalize</li>

--- a/docs/generators/typescript-redux-query.md
+++ b/docs/generators/typescript-redux-query.md
@@ -89,6 +89,8 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 <li>ReturnType</li>
 <li>Set</li>
 <li>String</li>
+<li>Temporal.Instant</li>
+<li>Temporal.PlainDate</li>
 <li>ThisParameterType</li>
 <li>ThisType</li>
 <li>Uncapitalize</li>

--- a/docs/generators/typescript-rxjs.md
+++ b/docs/generators/typescript-rxjs.md
@@ -89,6 +89,8 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 <li>ReturnType</li>
 <li>Set</li>
 <li>String</li>
+<li>Temporal.Instant</li>
+<li>Temporal.PlainDate</li>
 <li>ThisParameterType</li>
 <li>ThisType</li>
 <li>Uncapitalize</li>

--- a/docs/generators/typescript.md
+++ b/docs/generators/typescript.md
@@ -97,6 +97,8 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 <li>ReturnType</li>
 <li>Set</li>
 <li>String</li>
+<li>Temporal.Instant</li>
+<li>Temporal.PlainDate</li>
 <li>ThisParameterType</li>
 <li>ThisType</li>
 <li>Uncapitalize</li>

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractTypeScriptClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractTypeScriptClientCodegen.java
@@ -350,8 +350,6 @@ public abstract class AbstractTypeScriptClientCodegen extends DefaultCodegen imp
                 "Object",
                 "Array",
                 "ReadonlyArray",
-                "Temporal.Instant",
-                "Temporal.PlainDate",
                 "Date",
                 "number",
                 "any",

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractTypeScriptClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractTypeScriptClientCodegen.java
@@ -350,6 +350,8 @@ public abstract class AbstractTypeScriptClientCodegen extends DefaultCodegen imp
                 "Object",
                 "Array",
                 "ReadonlyArray",
+                "Temporal.Instant",
+                "Temporal.PlainDate",
                 "Date",
                 "number",
                 "any",

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
@@ -322,9 +322,13 @@ public class TypeScriptFetchClientCodegen extends AbstractTypeScriptClientCodege
             this.setFileNaming(additionalProperties.get(FILE_NAMING).toString());
         }
 
+        if (additionalProperties.containsKey(TEMPORAL)) {
+            convertPropertyToBooleanAndWriteBack(TEMPORAL);
+        }
+
         if (!withoutRuntimeChecks) {
             this.modelTemplateFiles.put("models.mustache", ".ts");
-            if (additionalProperties.containsKey(TEMPORAL) && convertPropertyToBoolean(TEMPORAL)) {
+            if (additionalProperties.containsKey(TEMPORAL) && Boolean.TRUE.equals(additionalProperties.get(TEMPORAL))) {
                 typeMapping.put("date", "Temporal.PlainDate");
                 typeMapping.put("DateTime", "Temporal.Instant");
             } else {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
@@ -135,6 +135,11 @@ public class TypeScriptFetchClientCodegen extends AbstractTypeScriptClientCodege
 
         this.addExtraReservedWords();
 
+        languageSpecificPrimitives.addAll(Arrays.asList(
+                "Temporal.Instant",
+                "Temporal.PlainDate"
+        ));
+
         supportModelPropertyNaming(CodegenConstants.MODEL_PROPERTY_NAMING_TYPE.camelCase);
         this.cliOptions.add(new CliOption(NPM_REPOSITORY, "Use this property to set an url your private npmRepo in the package.json"));
         this.cliOptions.add(new CliOption(WITH_INTERFACES, "Setting this property to true will generate interfaces next to the default class implementations.", SchemaTypeUtil.BOOLEAN_TYPE).defaultValue(Boolean.FALSE.toString()));

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
@@ -319,7 +319,7 @@ public class TypeScriptFetchClientCodegen extends AbstractTypeScriptClientCodege
 
         if (!withoutRuntimeChecks) {
             this.modelTemplateFiles.put("models.mustache", ".ts");
-            if (additionalProperties.containsKey(TEMPORAL)) {
+            if (additionalProperties.containsKey(TEMPORAL) && convertPropertyToBoolean(TEMPORAL)) {
                 typeMapping.put("date", "Temporal.PlainDate");
                 typeMapping.put("DateTime", "Temporal.Instant");
             } else {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
@@ -74,6 +74,7 @@ public class TypeScriptFetchClientCodegen extends AbstractTypeScriptClientCodege
     public static final String USE_SQUARE_BRACKETS_IN_ARRAY_NAMES = "useSquareBracketsInArrayNames";
     public static final String VALIDATION_ATTRIBUTES = "validationAttributes";
     public static final String WITH_REQUEST_OPTS_IN_INTERFACE = "withRequestOptsInInterface";
+    public static final String TEMPORAL = "temporal";
 
     @Getter @Setter
     protected String npmRepository = null;
@@ -147,6 +148,7 @@ public class TypeScriptFetchClientCodegen extends AbstractTypeScriptClientCodege
         this.cliOptions.add(new CliOption(USE_SQUARE_BRACKETS_IN_ARRAY_NAMES, "Setting this property to true will add brackets to array attribute names, e.g. my_values[].", SchemaTypeUtil.BOOLEAN_TYPE).defaultValue(Boolean.FALSE.toString()));
         this.cliOptions.add(new CliOption(VALIDATION_ATTRIBUTES, "Setting this property to true will generate the validation attributes of model properties.", SchemaTypeUtil.BOOLEAN_TYPE).defaultValue(Boolean.FALSE.toString()));
         this.cliOptions.add(new CliOption(WITH_REQUEST_OPTS_IN_INTERFACE, "Setting this property to true will include *RequestOpts methods in the API interface declarations. Set to false to keep them only on the class.", SchemaTypeUtil.BOOLEAN_TYPE).defaultValue(Boolean.TRUE.toString()));
+        this.cliOptions.add(new CliOption(TEMPORAL, "Setting this property to true will use Temporal data types instead of Date.", SchemaTypeUtil.BOOLEAN_TYPE).defaultValue(Boolean.FALSE.toString()));
     }
 
     @Override
@@ -317,8 +319,13 @@ public class TypeScriptFetchClientCodegen extends AbstractTypeScriptClientCodege
 
         if (!withoutRuntimeChecks) {
             this.modelTemplateFiles.put("models.mustache", ".ts");
-            typeMapping.put("date", "Date");
-            typeMapping.put("DateTime", "Date");
+            if (additionalProperties.containsKey(TEMPORAL)) {
+                typeMapping.put("date", "Temporal.PlainDate");
+                typeMapping.put("DateTime", "Temporal.Instant");
+            } else {
+                typeMapping.put("date", "Date");
+                typeMapping.put("DateTime", "Date");
+            }
         }
 
         if (additionalProperties.containsKey(SAGAS_AND_RECORDS)) {
@@ -1484,11 +1491,11 @@ public class TypeScriptFetchClientCodegen extends AbstractTypeScriptClientCodege
         }
 
         public boolean isDateType() {
-            return isDate && "Date".equals(dataType);
+            return isDate && ("Date".equals(dataType) || "Temporal.PlainDate".equals(dataType));
         }
 
         public boolean isDateTimeType() {
-            return isDateTime && "Date".equals(dataType);
+            return isDateTime && ("Date".equals(dataType) || "Temporal.Instant".equals(dataType));
         }
 
         public ExtendedCodegenParameter(CodegenParameter cp) {
@@ -1635,11 +1642,11 @@ public class TypeScriptFetchClientCodegen extends AbstractTypeScriptClientCodege
         }
 
         public boolean isDateType() {
-            return isDate && "Date".equals(dataType);
+            return isDate && ("Date".equals(dataType) || "Temporal.PlainDate".equals(dataType));
         }
 
         public boolean isDateTimeType() {
-            return isDateTime && "Date".equals(dataType);
+            return isDateTime && ("Date".equals(dataType) || "Temporal.Instant".equals(dataType));
         }
 
         public ExtendedCodegenProperty(CodegenProperty cp) {
@@ -1924,11 +1931,11 @@ public class TypeScriptFetchClientCodegen extends AbstractTypeScriptClientCodege
             return selfReferencingDiscriminatorMapping != null;
         }
         public boolean isDateType() {
-            return isDate && "Date".equals(dataType);
+            return isDate && ("Date".equals(dataType) || "Temporal.PlainDate".equals(dataType));
         }
 
         public boolean isDateTimeType() {
-            return isDateTime && "Date".equals(dataType);
+            return isDateTime && ("Date".equals(dataType) || "Temporal.Instant".equals(dataType));
         }
 
         public ExtendedCodegenModel(CodegenModel cm) {

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
@@ -307,16 +307,28 @@ export class {{classname}} extends runtime.BaseAPI {
         let urlPath = `{{{path}}}`;
         {{#pathParams}}
         {{#isDateTimeType}}
+        {{#temporal}}
+        if (requestParameters['{{paramName}}'] instanceof Temporal.Instant) {
+            urlPath = urlPath.replace({{=<< >>=}}'{<<baseName>>}'<<={{ }}=>>, encodeURIComponent(requestParameters['{{paramName}}'].toString()));
+        {{/temporal}}
+        {{^temporal}}
         if (requestParameters['{{paramName}}'] instanceof Date) {
             urlPath = urlPath.replace({{=<< >>=}}'{<<baseName>>}'<<={{ }}=>>, encodeURIComponent(requestParameters['{{paramName}}'].toISOString()));
+        {{/temporal}}
         } else {
             urlPath = urlPath.replace({{=<< >>=}}'{<<baseName>>}'<<={{ }}=>>, encodeURIComponent(String(requestParameters['{{paramName}}'])));
         }
         {{/isDateTimeType}}
         {{^isDateTimeType}}
         {{#isDateType}}
+        {{#temporal}}
+        if (requestParameters['{{paramName}}'] instanceof Temporal.PlainDate) {
+            urlPath = urlPath.replace({{=<< >>=}}'{<<baseName>>}'<<={{ }}=>>, encodeURIComponent(requestParameters['{{paramName}}'].toString()));
+        {{/temporal}}
+        {{^temporal}}
         if (requestParameters['{{paramName}}'] instanceof Date) {
             urlPath = urlPath.replace({{=<< >>=}}'{<<baseName>>}'<<={{ }}=>>, encodeURIComponent(requestParameters['{{paramName}}'].toISOString().substring(0,10)));
+        {{/temporal}}
         } else {
             urlPath = urlPath.replace({{=<< >>=}}'{<<baseName>>}'<<={{ }}=>>, encodeURIComponent(String(requestParameters['{{paramName}}'])));
         }

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/apisAssignQueryParam.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/apisAssignQueryParam.mustache
@@ -1,10 +1,10 @@
 {{! Assign query parameters based on their type }}
 {{#isDateTimeType}}
-            queryParameters['{{baseName}}'] = (requestParameters['{{paramName}}'] as any).toISOString();
+            queryParameters['{{baseName}}'] = {{#temporal}}(requestParameters['{{paramName}}'] as any).toString(){{/temporal}}{{^temporal}}(requestParameters['{{paramName}}'] as any).toISOString(){{/temporal}};
 {{/isDateTimeType}}
 {{^isDateTimeType}}
 {{#isDateType}}
-            queryParameters['{{baseName}}'] = (requestParameters['{{paramName}}'] as any).toISOString().substring(0,10);
+            queryParameters['{{baseName}}'] = {{#temporal}}(requestParameters['{{paramName}}'] as any).toString(){{/temporal}}{{^temporal}}(requestParameters['{{paramName}}'] as any).toISOString().substring(0,10){{/temporal}};
 {{/isDateType}}
 {{^isDateType}}
             queryParameters['{{baseName}}'] = requestParameters['{{paramName}}'];

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/apisFormParams.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/apisFormParams.mustache
@@ -37,7 +37,12 @@
         {{^isArray}}
         if (requestParameters['{{paramName}}'] != null) {
             {{#isDateTimeType}}
+            {{#temporal}}
+            formParams.append('{{baseName}}', (requestParameters['{{paramName}}'] as any).toString());
+            {{/temporal}}
+            {{^temporal}}
             formParams.append('{{baseName}}', (requestParameters['{{paramName}}'] as any).toISOString());
+            {{/temporal}}
             {{/isDateTimeType}}
             {{^isDateTimeType}}
             {{#isPrimitiveType}}

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
@@ -98,10 +98,10 @@ export function {{classname}}FromJSONTyped(json: any, ignoreDiscriminator: boole
         {{/isArray}}
         {{^isArray}}
         {{#isDateType}}
-        '{{name}}': {{^required}}{{#isNullable}}json['{{baseName}}'] === undefined ? undefined : json['{{baseName}}'] === null ? null : {{/isNullable}}{{^isNullable}}json['{{baseName}}'] == null ? undefined : {{/isNullable}}{{/required}}({{#required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}{{^isNullable}}json['{{baseName}}'] == null ? json['{{baseName}}'] : {{/isNullable}}{{/required}}new Date(json['{{baseName}}'])),
+        '{{name}}': {{^required}}{{#isNullable}}json['{{baseName}}'] === undefined ? undefined : json['{{baseName}}'] === null ? null : {{/isNullable}}{{^isNullable}}json['{{baseName}}'] == null ? undefined : {{/isNullable}}{{/required}}({{#required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}{{^isNullable}}json['{{baseName}}'] == null ? json['{{baseName}}'] : {{/isNullable}}{{/required}}{{#temporal}}Temporal.PlainDate.from(json['{{baseName}}']){{/temporal}}{{^temporal}}new Date(json['{{baseName}}']){{/temporal}}),
         {{/isDateType}}
         {{#isDateTimeType}}
-        '{{name}}': {{^required}}{{#isNullable}}json['{{baseName}}'] === undefined ? undefined : json['{{baseName}}'] === null ? null : {{/isNullable}}{{^isNullable}}json['{{baseName}}'] == null ? undefined : {{/isNullable}}{{/required}}({{#required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}{{^isNullable}}json['{{baseName}}'] == null ? json['{{baseName}}'] : {{/isNullable}}{{/required}}new Date(json['{{baseName}}'])),
+        '{{name}}': {{^required}}{{#isNullable}}json['{{baseName}}'] === undefined ? undefined : json['{{baseName}}'] === null ? null : {{/isNullable}}{{^isNullable}}json['{{baseName}}'] == null ? undefined : {{/isNullable}}{{/required}}({{#required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}{{^isNullable}}json['{{baseName}}'] == null ? json['{{baseName}}'] : {{/isNullable}}{{/required}}{{#temporal}}Temporal.Instant.from(json['{{baseName}}']){{/temporal}}{{^temporal}}new Date(json['{{baseName}}']){{/temporal}}),
         {{/isDateTimeType}}
         {{^isDateType}}
         {{^isDateTimeType}}
@@ -173,10 +173,10 @@ export function {{classname}}ToJSONTyped(value?: {{#hasReadOnly}}Omit<{{classnam
         {{^isReadOnly}}
         {{#isPrimitiveType}}
         {{#isDateType}}
-        '{{baseName}}': value['{{name}}'] == null ? value['{{name}}'] : value['{{name}}'].toISOString().substring(0,10),
+        '{{baseName}}': value['{{name}}'] == null ? value['{{name}}'] : {{#temporal}}value['{{name}}'].toString(){{/temporal}}{{^temporal}}value['{{name}}'].toISOString().substring(0,10){{/temporal}},
         {{/isDateType}}
         {{#isDateTimeType}}
-        '{{baseName}}': value['{{name}}'] == null ? value['{{name}}'] : value['{{name}}'].toISOString(),
+        '{{baseName}}': value['{{name}}'] == null ? value['{{name}}'] : {{#temporal}}value['{{name}}'].toString(){{/temporal}}{{^temporal}}value['{{name}}'].toISOString(){{/temporal}},
         {{/isDateTimeType}}
         {{#isArray}}
         '{{baseName}}': {{#uniqueItems}}{{^required}}value['{{name}}'] == null ? undefined : {{/required}}{{#required}}{{#isNullable}}value['{{name}}'] == null ? null : {{/isNullable}}{{/required}}Array.from(value['{{name}}'] as Set<any>){{/uniqueItems}}{{^uniqueItems}}value['{{name}}']{{/uniqueItems}},

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelOneOf.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelOneOf.mustache
@@ -69,16 +69,30 @@ export function {{classname}}FromJSONTyped(json: any, ignoreDiscriminator: boole
     {{#items}}
     {{#isDateType}}
     if (Array.isArray(json)) {
+    {{#temporal}}
+        try {
+            return json.map(value => Temporal.PlainDate.from(value));
+        } catch {}
+    {{/temporal}}
+    {{^temporal}}
         if (json.every(item => !(isNaN(new Date(item).getTime())))) {
             return json.map(value => new Date(value));
         }
+    {{/temporal}}
     }
     {{/isDateType}}
     {{#isDateTimeType}}
     if (Array.isArray(json)) {
+    {{#temporal}}
+        try {
+            return json.map(value => Temporal.Instant.from(value));
+        } catch {}
+    {{/temporal}}
+    {{^temporal}}
         if (json.every(item => !(isNaN(new Date(item).getTime())))) {
             return json.map(value => new Date(value));
         }
+    {{/temporal}}
     }
     {{/isDateTimeType}}
     {{#isNumeric}}
@@ -115,15 +129,29 @@ export function {{classname}}FromJSONTyped(json: any, ignoreDiscriminator: boole
     {{#oneOfPrimitives}}
     {{^isArray}}
     {{#isDateType}}
+    {{#temporal}}
+    try {
+        return {{^required}}json == null ? undefined : {{/required}}({{#required}}{{#isNullable}}json == null ? null : {{/isNullable}}{{/required}}Temporal.PlainDate.from(json));
+    } catch {}
+    {{/temporal}}
+    {{^temporal}}
     if (!(isNaN(new Date(json).getTime()))) {
         return {{^required}}json == null ? undefined : {{/required}}({{#required}}{{#isNullable}}json == null ? null : {{/isNullable}}{{/required}}new Date(json));
     }
+    {{/temporal}}
     {{/isDateType}}
     {{^isDateType}}
     {{#isDateTimeType}}
+    {{#temporal}}
+    try {
+      return {{^required}}json == null ? undefined : {{/required}}({{#required}}{{#isNullable}}json == null ? null : {{/isNullable}}{{/required}}Temporal.Instant.from(json));
+    } catch {}
+    {{/temporal}}
+    {{^temporal}}
     if (!(isNaN(new Date(json).getTime()))) {
         return {{^required}}json == null ? undefined : {{/required}}({{#required}}{{#isNullable}}json == null ? null : {{/isNullable}}{{/required}}new Date(json));
     }
+    {{/temporal}}
     {{/isDateTimeType}}
     {{/isDateType}}
     {{#isNumeric}}
@@ -194,16 +222,30 @@ export function {{classname}}ToJSONTyped(value?: {{classname}} | null, ignoreDis
     {{#items}}
     {{#isDateType}}
     if (Array.isArray(value)) {
+    {{#temporal}}
+        if (value.every(item => item instanceof Temporal.PlainDate)) {
+            return value.map(value => value.toString());
+        }
+    {{/temporal}}
+    {{^temporal}}
         if (value.every(item => item instanceof Date)) {
             return value.map(value => value.toISOString().substring(0,10));
         }
+    {{/temporal}}
     }
     {{/isDateType}}
     {{#isDateTimeType}}
     if (Array.isArray(value)) {
+    {{#temporal}}
+        if (value.every(item => item instanceof Temporal.Instant)) {
+            return value.map(item => item.toString());
+        }
+    {{/temporal}}
+    {{^temporal}}
         if (value.every(item => item instanceof Date)) {
             return value.map(item => item.toISOString());
         }
+    {{/temporal}}
     }
     {{/isDateTimeType}}
     {{#isNumeric}}
@@ -240,14 +282,28 @@ export function {{classname}}ToJSONTyped(value?: {{classname}} | null, ignoreDis
     {{#oneOfPrimitives}}
     {{^isArray}}
     {{#isDateType}}
+    {{#temporal}}
+    if (value instanceof Temporal.PlainDate) {
+        return ((value{{#isNullable}} as any{{/isNullable}}){{^required}}{{#isNullable}}?{{/isNullable}}{{/required}}.toString());
+    }
+    {{/temporal}}
+    {{^temporal}}
     if (value instanceof Date) {
         return ((value{{#isNullable}} as any{{/isNullable}}){{^required}}{{#isNullable}}?{{/isNullable}}{{/required}}.toISOString().substring(0,10));
     }
+    {{/temporal}}
     {{/isDateType}}
     {{#isDateTimeType}}
+    {{#temporal}}
+    if (value instanceof Temporal.Instant) {
+        return {{^required}}{{#isNullable}}value === null ? null : {{/isNullable}}{{^isNullable}}value == null ? undefined : {{/isNullable}}{{/required}}((value{{#isNullable}} as any{{/isNullable}}){{^required}}{{#isNullable}}?{{/isNullable}}{{/required}}.toString());
+    }
+    {{/temporal}}
+    {{^temporal}}
     if (value instanceof Date) {
         return {{^required}}{{#isNullable}}value === null ? null : {{/isNullable}}{{^isNullable}}value == null ? undefined : {{/isNullable}}{{/required}}((value{{#isNullable}} as any{{/isNullable}}){{^required}}{{#isNullable}}?{{/isNullable}}{{/required}}.toISOString());
     }
+    {{/temporal}}
     {{/isDateTimeType}}
     {{#isNumeric}}
     if (typeof value === 'number'{{#isEnum}} && ({{#allowableValues}}{{#values}}value === {{.}}{{^-last}} || {{/-last}}{{/values}}{{/allowableValues}}){{/isEnum}}) {

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
@@ -350,9 +350,19 @@ function querystringSingleKey(key: string, value: string | number | null | undef
         const valueAsArray = Array.from(value);
         return querystringSingleKey(key, valueAsArray, keyPrefix);
     }
+{{#temporal}}
+    if (value instanceof Temporal.Instant) {
+        return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toString())}`;
+    }
+    if (value instanceof Temporal.PlainDate) {
+        return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toString())}`;
+    }
+{{/temporal}}
+{{^temporal}}
     if (value instanceof Date) {
         return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
     }
+{{/temporal}}
     if (value instanceof Object) {
         return querystring(value as HTTPQuery, fullKey);
     }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/TypeScriptFetchClientOptionsProvider.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/TypeScriptFetchClientOptionsProvider.java
@@ -54,6 +54,7 @@ public class TypeScriptFetchClientOptionsProvider implements TypeScriptSharedCli
                 .put(TypeScriptFetchClientCodegen.USE_SQUARE_BRACKETS_IN_ARRAY_NAMES, Boolean.FALSE.toString())
                 .put(TypeScriptFetchClientCodegen.VALIDATION_ATTRIBUTES, Boolean.FALSE.toString())
                 .put(TypeScriptFetchClientCodegen.WITH_REQUEST_OPTS_IN_INTERFACE, Boolean.TRUE.toString())
+                .put(TypeScriptFetchClientCodegen.TEMPORAL, Boolean.FALSE.toString())
                 .build();
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchClientCodegenTest.java
@@ -1074,6 +1074,41 @@ public class TypeScriptFetchClientCodegenTest {
                 "'optionalDateTime': value['optionalDateTime'] == null ? value['optionalDateTime'] : value['optionalDateTime'].toISOString(),");
     }
 
+    @Test(description = "Verify required Temporal date and date-time properties are null-guarded on serialization and deserialization")
+    public void testRequiredTemporalInstancesAreNullGuarded() throws Exception {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("temporal", Boolean.TRUE);
+        File output = generate(
+                properties,
+                "src/test/resources/3_0/typescript-fetch/required-date.yaml"
+        );
+
+        Path modelPath = Paths.get(output + "/models/Event.ts");
+        TestUtils.assertFileExists(modelPath);
+
+        TestUtils.assertFileContains(modelPath,
+                "'requiredDate': (json['requiredDate'] == null ? json['requiredDate'] : Temporal.PlainDate.from(json['requiredDate'])),");
+        TestUtils.assertFileContains(modelPath,
+                "'requiredDateTime': (json['requiredDateTime'] == null ? json['requiredDateTime'] : Temporal.Instant.from(json['requiredDateTime'])),");
+        TestUtils.assertFileContains(modelPath,
+                "'requiredNullableDate': (json['requiredNullableDate'] == null ? null : Temporal.PlainDate.from(json['requiredNullableDate'])),");
+        TestUtils.assertFileContains(modelPath,
+                "'requiredNullableDateTime': (json['requiredNullableDateTime'] == null ? null : Temporal.Instant.from(json['requiredNullableDateTime'])),");
+        TestUtils.assertFileContains(modelPath,
+                "'optionalDate': json['optionalDate'] == null ? undefined : (Temporal.PlainDate.from(json['optionalDate'])),");
+        TestUtils.assertFileContains(modelPath,
+                "'optionalDateTime': json['optionalDateTime'] == null ? undefined : (Temporal.Instant.from(json['optionalDateTime'])),");
+
+        TestUtils.assertFileContains(modelPath,
+                "'requiredDate': value['requiredDate'] == null ? value['requiredDate'] : value['requiredDate'].toString(),");
+        TestUtils.assertFileContains(modelPath,
+                "'requiredDateTime': value['requiredDateTime'] == null ? value['requiredDateTime'] : value['requiredDateTime'].toString(),");
+        TestUtils.assertFileContains(modelPath,
+                "'requiredNullableDate': value['requiredNullableDate'] == null ? value['requiredNullableDate'] : value['requiredNullableDate'].toString(),");
+        TestUtils.assertFileContains(modelPath,
+                "'optionalDateTime': value['optionalDateTime'] == null ? value['optionalDateTime'] : value['optionalDateTime'].toString(),");
+    }
+
     private static File generate(
         Map<String, Object> properties
     ) throws IOException {


### PR DESCRIPTION
This adds a new configuration option to the typescript-fetch generator: "temporal" (boolean). If it is set to true, the generator uses Temporal.Instant for "type: string, format: date-time" and Temporal.PlainDate for "type: string, format: date".

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

This is my very first contribution here, so please let me know about anything I'm missing.

It does what the commit comment says: it adds the option to use Temporal types instead of Date for typescript-fetch. I've manually tried it on an OpenAPI YAML file having date and date-time parameters/attributes in a URL path, in URL query parameters, and in request/response (JSON) bodies. Everything seems to work well.

Rationale for the changes:
* JavaScript's Date is suitable to be used as the data type for OpenAPI's "date-time". However, it is notoriously unpleasant to work with in applications needing to work with time-related values across different timezones (among other things). It's also the reason why projects like https://momentjs.com/ gained so much popularity in the past. The new JavaScript Temporal API tries to solve all those Date's pains.
* Currently, typescript-fetch uses JavaScript's Date even for OpenAPI's "date" (i.e. for a date without time or timezone). The workaround is to create a Date instance at zero hours at Zulu timezone. Again, it's very easy to make a mistake when working with it. Temporal API has PlainDate, which corresponds to OpenAPI's "date" exactly.

I haven't found many existing unit tests regarding dates for typescript-fetch; in fact, I've found just a single one. So I duplicated it for the Temporal variant. I don't feel confident to create new tests covering other situations (both for Date and for Temporal).

Tagging: @TiFu @taxpon @sebastianhaas @kenisteward @Vrolijkx @macjohnny @topce @akehir @petejohansonxo @amakhrov @davidgamero @mkusaka @joscha @KannaKim.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional Temporal support to `typescript-fetch`. Previously date/date-time fields were generated as `Date`; with `temporal: true`, date-time maps to `Temporal.Instant` and date maps to `Temporal.PlainDate`, with matching serialization and querystring handling. Default behavior is unchanged.

- Detects the `temporal` option as a boolean and gates type mapping and template branches accordingly; `Temporal.Instant`/`Temporal.PlainDate` are registered as primitives.
- Path, query, and form params stringify Temporal via `.toString()` and `Date` via `.toISOString()` (date uses `.substring(0,10)`), including arrays and `oneOf`.
- Runtime querystring encodes `Temporal.Instant`/`Temporal.PlainDate` via `.toString()`.
- Models and `oneOf` parse Temporal via `Temporal.Instant.from(...)`/`Temporal.PlainDate.from(...)` and serialize with `.toString()`, with null-guards; tests added for required Temporal fields.

- No changes for existing users unless `temporal` is enabled.
- If enabling `temporal`, ensure the runtime provides Temporal or include a polyfill.

<sup>Written for commit 0686a0e9b5fb0d82111bf7e29f6dd1993728582a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24714?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

