### PR TITLE
refactor(typescript-fetch): centralize date type handling in TypeScriptFetchClientCodegen

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
@@ -109,6 +109,9 @@ public class TypeScriptFetchClientCodegen extends AbstractTypeScriptClientCodege
     private static final String X_TYPESCRIPT_FETCH_API_EXAMPLE = "x-typescriptFetchApiExample";
     private static final String X_HAS_DATE_VARS = "x-hasDateVars";
     private static final String BLOB_API_EXAMPLE = "new Blob(['example file content'], { type: 'application/octet-stream' })";
+    private static final String DATE_TYPE = "date";
+    private static final String DATE_TIME_TYPE = "DateTime";
+    private static final String TS_DATE_TYPE = "Date";
 
     protected boolean sagasAndRecords = false;
     @Getter @Setter
@@ -355,11 +358,11 @@ public class TypeScriptFetchClientCodegen extends AbstractTypeScriptClientCodege
         }
 
         if (DATE_LIBRARY_DATE.equals(this.dateLibrary)) {
-            typeMapping.put("date", "Date");
-            typeMapping.put("DateTime", "Date");
+            typeMapping.put(DATE_TYPE, TS_DATE_TYPE);
+            typeMapping.put(DATE_TIME_TYPE, TS_DATE_TYPE);
         } else {
-            typeMapping.put("date", "string");
-            typeMapping.put("DateTime", "string");
+            typeMapping.put(DATE_TYPE, "string");
+            typeMapping.put(DATE_TIME_TYPE, "string");
         }
         additionalProperties.put(DATE_LIBRARY, this.dateLibrary);
         // Mustache cannot compare strings, so expose the selected library as a flag.
@@ -612,7 +615,7 @@ public class TypeScriptFetchClientCodegen extends AbstractTypeScriptClientCodege
      */
     private Set<String> parseImports(CodegenModel cm) {
         Set<String> newImports = new HashSet<>();
-        if (cm.imports.size() > 0) {
+        if (!cm.imports.isEmpty()) {
             for (String name : cm.imports) {
                 if (name.indexOf(" | ") >= 0) {
                     String[] parts = name.split(" \\| ");
@@ -1534,11 +1537,11 @@ public class TypeScriptFetchClientCodegen extends AbstractTypeScriptClientCodege
         }
 
         public boolean isDateType() {
-            return isDate && "Date".equals(dataType);
+            return isDate && TypeScriptFetchClientCodegen.isDateType(dataType);
         }
 
         public boolean isDateTimeType() {
-            return isDateTime && "Date".equals(dataType);
+            return isDateTime && TypeScriptFetchClientCodegen.isDateTimeType(dataType);
         }
 
         public ExtendedCodegenParameter(CodegenParameter cp) {
@@ -1685,11 +1688,11 @@ public class TypeScriptFetchClientCodegen extends AbstractTypeScriptClientCodege
         }
 
         public boolean isDateType() {
-            return isDate && "Date".equals(dataType);
+            return isDate && TypeScriptFetchClientCodegen.isDateType(dataType);
         }
 
         public boolean isDateTimeType() {
-            return isDateTime && "Date".equals(dataType);
+            return isDateTime && TypeScriptFetchClientCodegen.isDateTimeType(dataType);
         }
 
         public ExtendedCodegenProperty(CodegenProperty cp) {
@@ -1973,12 +1976,13 @@ public class TypeScriptFetchClientCodegen extends AbstractTypeScriptClientCodege
         public boolean hasSelfReferencingDiscriminatorMapping(){
             return selfReferencingDiscriminatorMapping != null;
         }
+
         public boolean isDateType() {
-            return isDate && "Date".equals(dataType);
+            return isDate && TypeScriptFetchClientCodegen.isDateType(dataType);
         }
 
         public boolean isDateTimeType() {
-            return isDateTime && "Date".equals(dataType);
+            return isDateTime && TypeScriptFetchClientCodegen.isDateTimeType(dataType);
         }
 
         public ExtendedCodegenModel(CodegenModel cm) {
@@ -2118,5 +2122,13 @@ public class TypeScriptFetchClientCodegen extends AbstractTypeScriptClientCodege
     @Override
     protected String getLicenseNameDefaultValue() {
         return null;
+    }
+
+    private static boolean isDateType(String dataType) {
+        return TS_DATE_TYPE.equals(dataType);
+    }
+
+    private static boolean isDateTimeType(String dataType) {
+        return TS_DATE_TYPE.equals(dataType);
     }
 }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

There are several incentives to support better and consistent date handling for `typescript-fetch` https://github.com/OpenAPITools/openapi-generator/pull/24714, https://github.com/OpenAPITools/openapi-generator/pull/24637. I saw that they had to define the same thing over and over again when they were technically referring to the exact same thing.

I have gathered the definition in a single location so that any further change will be easier to follow and understand.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes date type handling in `TypeScriptFetchClientCodegen` to unify `date`/`DateTime` mapping and type checks. Behavior unchanged: with `dateLibrary=date`, both map to TypeScript `Date`; otherwise both map to `string`.

- Introduces constants `DATE_TYPE`, `DATE_TIME_TYPE`, and `TS_DATE_TYPE`; updates mappings to use them.
- Adds shared helpers `isDateType` and `isDateTimeType`; parameter/property/model checks now delegate to them.
- Minor cleanup: use `isEmpty()` for `cm.imports` in `parseImports`.
- Verify `typescript-fetch` samples produce no generated diffs.

<sup>Written for commit 18b51b2be5d0c2bc349d6707d849f526dfdcaf30. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24715?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

