### PR TITLE
[python] re-resolve the environment proxy when the host is assigned

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/python/configuration.mustache
@@ -495,6 +495,9 @@ conf = {{{packageName}}}.Configuration(
 {{^async}}
         # urllib3 does not read proxy environment variables itself:
         # https://github.com/urllib3/urllib3/issues/1785
+        # A proxy taken from the environment is re-resolved when the host is
+        # assigned; see the host setter.
+        self._proxy_from_env = proxy is None
         if proxy is None or no_proxy is None:
             proxies = getproxies()
             if proxy is None:
@@ -502,13 +505,14 @@ conf = {{{packageName}}}.Configuration(
                 proxy = proxies.get(scheme) or proxies.get("all")
             if no_proxy is None:
                 no_proxy = proxies.get("no")
-{{/async}}
-        self.proxy = proxy
-        """Proxy URL
-        """
-{{^async}}
+        self._proxy = proxy
         self.no_proxy = no_proxy
         """Hosts that bypass the proxy
+        """
+{{/async}}
+{{#async}}
+        self.proxy = proxy
+        """Proxy URL
         """
 {{/async}}
         self.proxy_headers = proxy_headers
@@ -991,3 +995,21 @@ conf = {{{packageName}}}.Configuration(
         """Fix base path."""
         self._base_path = value
         self.server_index = None
+{{^async}}
+        if self._proxy_from_env:
+            # the scheme-specific proxy depends on the host, which is
+            # commonly assigned after construction
+            proxies = getproxies()
+            self._proxy = proxies.get(urlparse(value).scheme) or proxies.get("all")
+
+    @property
+    def proxy(self) -> Optional[str]:
+        """Proxy URL
+        """
+        return self._proxy
+
+    @proxy.setter
+    def proxy(self, value: Optional[str]) -> None:
+        self._proxy = value
+        self._proxy_from_env = False
+{{/async}}

--- a/modules/openapi-generator/src/main/resources/python/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/python/configuration.mustache
@@ -501,8 +501,7 @@ conf = {{{packageName}}}.Configuration(
         if proxy is None or no_proxy is None:
             proxies = getproxies()
             if proxy is None:
-                scheme = urlparse(self.host).scheme
-                proxy = proxies.get(scheme) or proxies.get("all")
+                proxy = self._env_proxy(proxies, self.host)
             if no_proxy is None:
                 no_proxy = proxies.get("no")
         self._proxy = proxy
@@ -999,8 +998,12 @@ conf = {{{packageName}}}.Configuration(
         if self._proxy_from_env:
             # the scheme-specific proxy depends on the host, which is
             # commonly assigned after construction
-            proxies = getproxies()
-            self._proxy = proxies.get(urlparse(value).scheme) or proxies.get("all")
+            self._proxy = self._env_proxy(getproxies(), value)
+
+    @staticmethod
+    def _env_proxy(proxies: Dict[str, str], host: str) -> Optional[str]:
+        """Pick the environment proxy that applies to `host`."""
+        return proxies.get(urlparse(host).scheme) or proxies.get("all")
 
     @property
     def proxy(self) -> Optional[str]:

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/configuration.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/configuration.py
@@ -343,8 +343,7 @@ conf = openapi_client.Configuration(
         if proxy is None or no_proxy is None:
             proxies = getproxies()
             if proxy is None:
-                scheme = urlparse(self.host).scheme
-                proxy = proxies.get(scheme) or proxies.get("all")
+                proxy = self._env_proxy(proxies, self.host)
             if no_proxy is None:
                 no_proxy = proxies.get("no")
         self._proxy = proxy
@@ -661,8 +660,12 @@ conf = openapi_client.Configuration(
         if self._proxy_from_env:
             # the scheme-specific proxy depends on the host, which is
             # commonly assigned after construction
-            proxies = getproxies()
-            self._proxy = proxies.get(urlparse(value).scheme) or proxies.get("all")
+            self._proxy = self._env_proxy(getproxies(), value)
+
+    @staticmethod
+    def _env_proxy(proxies: Dict[str, str], host: str) -> Optional[str]:
+        """Pick the environment proxy that applies to `host`."""
+        return proxies.get(urlparse(host).scheme) or proxies.get("all")
 
     @property
     def proxy(self) -> Optional[str]:

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/configuration.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/configuration.py
@@ -337,6 +337,9 @@ conf = openapi_client.Configuration(
 
         # urllib3 does not read proxy environment variables itself:
         # https://github.com/urllib3/urllib3/issues/1785
+        # A proxy taken from the environment is re-resolved when the host is
+        # assigned; see the host setter.
+        self._proxy_from_env = proxy is None
         if proxy is None or no_proxy is None:
             proxies = getproxies()
             if proxy is None:
@@ -344,9 +347,7 @@ conf = openapi_client.Configuration(
                 proxy = proxies.get(scheme) or proxies.get("all")
             if no_proxy is None:
                 no_proxy = proxies.get("no")
-        self.proxy = proxy
-        """Proxy URL
-        """
+        self._proxy = proxy
         self.no_proxy = no_proxy
         """Hosts that bypass the proxy
         """
@@ -657,3 +658,19 @@ conf = openapi_client.Configuration(
         """Fix base path."""
         self._base_path = value
         self.server_index = None
+        if self._proxy_from_env:
+            # the scheme-specific proxy depends on the host, which is
+            # commonly assigned after construction
+            proxies = getproxies()
+            self._proxy = proxies.get(urlparse(value).scheme) or proxies.get("all")
+
+    @property
+    def proxy(self) -> Optional[str]:
+        """Proxy URL
+        """
+        return self._proxy
+
+    @proxy.setter
+    def proxy(self, value: Optional[str]) -> None:
+        self._proxy = value
+        self._proxy_from_env = False

--- a/samples/client/echo_api/python/openapi_client/configuration.py
+++ b/samples/client/echo_api/python/openapi_client/configuration.py
@@ -343,8 +343,7 @@ conf = openapi_client.Configuration(
         if proxy is None or no_proxy is None:
             proxies = getproxies()
             if proxy is None:
-                scheme = urlparse(self.host).scheme
-                proxy = proxies.get(scheme) or proxies.get("all")
+                proxy = self._env_proxy(proxies, self.host)
             if no_proxy is None:
                 no_proxy = proxies.get("no")
         self._proxy = proxy
@@ -661,8 +660,12 @@ conf = openapi_client.Configuration(
         if self._proxy_from_env:
             # the scheme-specific proxy depends on the host, which is
             # commonly assigned after construction
-            proxies = getproxies()
-            self._proxy = proxies.get(urlparse(value).scheme) or proxies.get("all")
+            self._proxy = self._env_proxy(getproxies(), value)
+
+    @staticmethod
+    def _env_proxy(proxies: Dict[str, str], host: str) -> Optional[str]:
+        """Pick the environment proxy that applies to `host`."""
+        return proxies.get(urlparse(host).scheme) or proxies.get("all")
 
     @property
     def proxy(self) -> Optional[str]:

--- a/samples/client/echo_api/python/openapi_client/configuration.py
+++ b/samples/client/echo_api/python/openapi_client/configuration.py
@@ -337,6 +337,9 @@ conf = openapi_client.Configuration(
 
         # urllib3 does not read proxy environment variables itself:
         # https://github.com/urllib3/urllib3/issues/1785
+        # A proxy taken from the environment is re-resolved when the host is
+        # assigned; see the host setter.
+        self._proxy_from_env = proxy is None
         if proxy is None or no_proxy is None:
             proxies = getproxies()
             if proxy is None:
@@ -344,9 +347,7 @@ conf = openapi_client.Configuration(
                 proxy = proxies.get(scheme) or proxies.get("all")
             if no_proxy is None:
                 no_proxy = proxies.get("no")
-        self.proxy = proxy
-        """Proxy URL
-        """
+        self._proxy = proxy
         self.no_proxy = no_proxy
         """Hosts that bypass the proxy
         """
@@ -657,3 +658,19 @@ conf = openapi_client.Configuration(
         """Fix base path."""
         self._base_path = value
         self.server_index = None
+        if self._proxy_from_env:
+            # the scheme-specific proxy depends on the host, which is
+            # commonly assigned after construction
+            proxies = getproxies()
+            self._proxy = proxies.get(urlparse(value).scheme) or proxies.get("all")
+
+    @property
+    def proxy(self) -> Optional[str]:
+        """Proxy URL
+        """
+        return self._proxy
+
+    @proxy.setter
+    def proxy(self, value: Optional[str]) -> None:
+        self._proxy = value
+        self._proxy_from_env = False

--- a/samples/client/others/python-legacy-model-dictionaries/legacy_model_dict_client/configuration.py
+++ b/samples/client/others/python-legacy-model-dictionaries/legacy_model_dict_client/configuration.py
@@ -317,6 +317,9 @@ class Configuration:
 
         # urllib3 does not read proxy environment variables itself:
         # https://github.com/urllib3/urllib3/issues/1785
+        # A proxy taken from the environment is re-resolved when the host is
+        # assigned; see the host setter.
+        self._proxy_from_env = proxy is None
         if proxy is None or no_proxy is None:
             proxies = getproxies()
             if proxy is None:
@@ -324,9 +327,7 @@ class Configuration:
                 proxy = proxies.get(scheme) or proxies.get("all")
             if no_proxy is None:
                 no_proxy = proxies.get("no")
-        self.proxy = proxy
-        """Proxy URL
-        """
+        self._proxy = proxy
         self.no_proxy = no_proxy
         """Hosts that bypass the proxy
         """
@@ -623,3 +624,19 @@ class Configuration:
         """Fix base path."""
         self._base_path = value
         self.server_index = None
+        if self._proxy_from_env:
+            # the scheme-specific proxy depends on the host, which is
+            # commonly assigned after construction
+            proxies = getproxies()
+            self._proxy = proxies.get(urlparse(value).scheme) or proxies.get("all")
+
+    @property
+    def proxy(self) -> Optional[str]:
+        """Proxy URL
+        """
+        return self._proxy
+
+    @proxy.setter
+    def proxy(self, value: Optional[str]) -> None:
+        self._proxy = value
+        self._proxy_from_env = False

--- a/samples/client/others/python-legacy-model-dictionaries/legacy_model_dict_client/configuration.py
+++ b/samples/client/others/python-legacy-model-dictionaries/legacy_model_dict_client/configuration.py
@@ -323,8 +323,7 @@ class Configuration:
         if proxy is None or no_proxy is None:
             proxies = getproxies()
             if proxy is None:
-                scheme = urlparse(self.host).scheme
-                proxy = proxies.get(scheme) or proxies.get("all")
+                proxy = self._env_proxy(proxies, self.host)
             if no_proxy is None:
                 no_proxy = proxies.get("no")
         self._proxy = proxy
@@ -627,8 +626,12 @@ class Configuration:
         if self._proxy_from_env:
             # the scheme-specific proxy depends on the host, which is
             # commonly assigned after construction
-            proxies = getproxies()
-            self._proxy = proxies.get(urlparse(value).scheme) or proxies.get("all")
+            self._proxy = self._env_proxy(getproxies(), value)
+
+    @staticmethod
+    def _env_proxy(proxies: Dict[str, str], host: str) -> Optional[str]:
+        """Pick the environment proxy that applies to `host`."""
+        return proxies.get(urlparse(host).scheme) or proxies.get("all")
 
     @property
     def proxy(self) -> Optional[str]:

--- a/samples/openapi3/client/petstore/python-lazyImports/petstore_api/configuration.py
+++ b/samples/openapi3/client/petstore/python-lazyImports/petstore_api/configuration.py
@@ -407,6 +407,9 @@ conf = petstore_api.Configuration(
 
         # urllib3 does not read proxy environment variables itself:
         # https://github.com/urllib3/urllib3/issues/1785
+        # A proxy taken from the environment is re-resolved when the host is
+        # assigned; see the host setter.
+        self._proxy_from_env = proxy is None
         if proxy is None or no_proxy is None:
             proxies = getproxies()
             if proxy is None:
@@ -414,9 +417,7 @@ conf = petstore_api.Configuration(
                 proxy = proxies.get(scheme) or proxies.get("all")
             if no_proxy is None:
                 no_proxy = proxies.get("no")
-        self.proxy = proxy
-        """Proxy URL
-        """
+        self._proxy = proxy
         self.no_proxy = no_proxy
         """Hosts that bypass the proxy
         """
@@ -805,3 +806,19 @@ conf = petstore_api.Configuration(
         """Fix base path."""
         self._base_path = value
         self.server_index = None
+        if self._proxy_from_env:
+            # the scheme-specific proxy depends on the host, which is
+            # commonly assigned after construction
+            proxies = getproxies()
+            self._proxy = proxies.get(urlparse(value).scheme) or proxies.get("all")
+
+    @property
+    def proxy(self) -> Optional[str]:
+        """Proxy URL
+        """
+        return self._proxy
+
+    @proxy.setter
+    def proxy(self, value: Optional[str]) -> None:
+        self._proxy = value
+        self._proxy_from_env = False

--- a/samples/openapi3/client/petstore/python-lazyImports/petstore_api/configuration.py
+++ b/samples/openapi3/client/petstore/python-lazyImports/petstore_api/configuration.py
@@ -413,8 +413,7 @@ conf = petstore_api.Configuration(
         if proxy is None or no_proxy is None:
             proxies = getproxies()
             if proxy is None:
-                scheme = urlparse(self.host).scheme
-                proxy = proxies.get(scheme) or proxies.get("all")
+                proxy = self._env_proxy(proxies, self.host)
             if no_proxy is None:
                 no_proxy = proxies.get("no")
         self._proxy = proxy
@@ -809,8 +808,12 @@ conf = petstore_api.Configuration(
         if self._proxy_from_env:
             # the scheme-specific proxy depends on the host, which is
             # commonly assigned after construction
-            proxies = getproxies()
-            self._proxy = proxies.get(urlparse(value).scheme) or proxies.get("all")
+            self._proxy = self._env_proxy(getproxies(), value)
+
+    @staticmethod
+    def _env_proxy(proxies: Dict[str, str], host: str) -> Optional[str]:
+        """Pick the environment proxy that applies to `host`."""
+        return proxies.get(urlparse(host).scheme) or proxies.get("all")
 
     @property
     def proxy(self) -> Optional[str]:

--- a/samples/openapi3/client/petstore/python/petstore_api/configuration.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/configuration.py
@@ -413,8 +413,7 @@ conf = petstore_api.Configuration(
         if proxy is None or no_proxy is None:
             proxies = getproxies()
             if proxy is None:
-                scheme = urlparse(self.host).scheme
-                proxy = proxies.get(scheme) or proxies.get("all")
+                proxy = self._env_proxy(proxies, self.host)
             if no_proxy is None:
                 no_proxy = proxies.get("no")
         self._proxy = proxy
@@ -805,8 +804,12 @@ conf = petstore_api.Configuration(
         if self._proxy_from_env:
             # the scheme-specific proxy depends on the host, which is
             # commonly assigned after construction
-            proxies = getproxies()
-            self._proxy = proxies.get(urlparse(value).scheme) or proxies.get("all")
+            self._proxy = self._env_proxy(getproxies(), value)
+
+    @staticmethod
+    def _env_proxy(proxies: Dict[str, str], host: str) -> Optional[str]:
+        """Pick the environment proxy that applies to `host`."""
+        return proxies.get(urlparse(host).scheme) or proxies.get("all")
 
     @property
     def proxy(self) -> Optional[str]:

--- a/samples/openapi3/client/petstore/python/petstore_api/configuration.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/configuration.py
@@ -407,6 +407,9 @@ conf = petstore_api.Configuration(
 
         # urllib3 does not read proxy environment variables itself:
         # https://github.com/urllib3/urllib3/issues/1785
+        # A proxy taken from the environment is re-resolved when the host is
+        # assigned; see the host setter.
+        self._proxy_from_env = proxy is None
         if proxy is None or no_proxy is None:
             proxies = getproxies()
             if proxy is None:
@@ -414,9 +417,7 @@ conf = petstore_api.Configuration(
                 proxy = proxies.get(scheme) or proxies.get("all")
             if no_proxy is None:
                 no_proxy = proxies.get("no")
-        self.proxy = proxy
-        """Proxy URL
-        """
+        self._proxy = proxy
         self.no_proxy = no_proxy
         """Hosts that bypass the proxy
         """
@@ -801,3 +802,19 @@ conf = petstore_api.Configuration(
         """Fix base path."""
         self._base_path = value
         self.server_index = None
+        if self._proxy_from_env:
+            # the scheme-specific proxy depends on the host, which is
+            # commonly assigned after construction
+            proxies = getproxies()
+            self._proxy = proxies.get(urlparse(value).scheme) or proxies.get("all")
+
+    @property
+    def proxy(self) -> Optional[str]:
+        """Proxy URL
+        """
+        return self._proxy
+
+    @proxy.setter
+    def proxy(self, value: Optional[str]) -> None:
+        self._proxy = value
+        self._proxy_from_env = False

--- a/samples/openapi3/client/petstore/python/tests/test_configuration.py
+++ b/samples/openapi3/client/petstore/python/tests/test_configuration.py
@@ -101,6 +101,68 @@ class TestConfiguration(unittest.TestCase):
 
         self.assertEqual(config.proxy, "http://proxy.example")
 
+    def test_proxy_settings_follow_host_assigned_after_construction(self):
+        environment_proxies = {
+            "http": "http://plain-proxy.example",
+            "https": "http://secure-proxy.example",
+        }
+        with patch(
+            "petstore_api.configuration.getproxies",
+            return_value=environment_proxies,
+        ):
+            config = petstore_api.Configuration()
+
+            config.host = "https://api.example"
+            self.assertEqual(config.proxy, "http://secure-proxy.example")
+
+            config.host = "http://api.example"
+            self.assertEqual(config.proxy, "http://plain-proxy.example")
+
+    def test_proxy_settings_resolve_for_a_host_unknown_at_construction(self):
+        # a spec without a server URL leaves the host empty until the caller
+        # assigns one, which is when the scheme first becomes known
+        with patch(
+            "petstore_api.configuration.getproxies",
+            return_value={"https": "http://secure-proxy.example"},
+        ):
+            config = petstore_api.Configuration(host="")
+            self.assertIsNone(config.proxy)
+
+            config.host = "https://api.example"
+            self.assertEqual(config.proxy, "http://secure-proxy.example")
+
+    def test_assigned_proxy_survives_later_host_assignment(self):
+        with patch(
+            "petstore_api.configuration.getproxies",
+            return_value={"https": "http://secure-proxy.example"},
+        ):
+            config = petstore_api.Configuration()
+            config.proxy = "http://assigned-proxy.example"
+            config.host = "https://api.example"
+
+        self.assertEqual(config.proxy, "http://assigned-proxy.example")
+
+    def test_assigned_none_proxy_disables_the_environment(self):
+        with patch(
+            "petstore_api.configuration.getproxies",
+            return_value={"https": "http://secure-proxy.example"},
+        ):
+            config = petstore_api.Configuration()
+            config.proxy = None
+            config.host = "https://api.example"
+
+        self.assertIsNone(config.proxy)
+
+    def test_assigned_host_falls_back_to_the_all_proxy(self):
+        with patch(
+            "petstore_api.configuration.getproxies",
+            return_value={"all": "http://any-proxy.example"},
+        ):
+            config = petstore_api.Configuration()
+            config.host = "https://api.example"
+
+        self.assertEqual(config.proxy, "http://any-proxy.example")
+
     def test_ignore_operation_servers(self):
         self.config.ignore_operation_servers = True
         self.assertTrue(self.config.ignore_operation_servers)


### PR DESCRIPTION
`Configuration.__init__` picks the environment proxy by the scheme of `self.host`:

```python
scheme = urlparse(self.host).scheme
proxy = proxies.get(scheme) or proxies.get("all")
```

`host` is a property, not the constructor argument, and `server_index` falls back to `0` when no `host` is given. For a spec with no server URL that makes `host` an empty string, so `urlparse("").scheme` is `""`, `proxies.get("")` misses, and only the `proxies.get("all")` fallback can match. Clients that construct `Configuration()` and assign the host afterwards never see `HTTP_PROXY` or `HTTPS_PROXY`, and requests go direct with no warning. `ALL_PROXY` is the only variable that works, which is a confusing thing to have to discover.

```console
$ HTTPS_PROXY=http://127.0.0.1:8888 python -c "
from petstore_api import Configuration
c = Configuration(host='')
c.host = 'https://api.example'
print(repr(c.proxy))"
None
```

The host is simply not known at construction time in that pattern, so no reordering inside `__init__` can fix it. This re-resolves the proxy in the `host` setter, which is the point at which the scheme first becomes known.

Construction is unchanged — same code, same order, same result — so nothing that works today behaves differently. The only addition is that assigning a host refreshes a proxy that came from the environment. An explicitly provided proxy is never touched: the property setter clears the "came from the environment" flag, so `config.proxy = X` survives a later `config.host = Y`, and `config.proxy = None` still means no proxy.

I first tried resolving lazily on every read of `proxy`. That also fixes the bug but makes the value re-read the environment on each access, and it broke `test_proxy_settings_default_from_environment`, which constructs inside `patch(getproxies)` and asserts outside it. Re-resolving on host assignment keeps that test passing unmodified, which seemed like the better signal.

Scoped to the urllib3 client with `{{^async}}`, matching the existing guards on the `getproxies`/`urlparse` imports and on `no_proxy`, and consistent with #24082 leaving the async backends to their own proxy handling. Five urllib3 samples change; the httpx and aiohttp samples never had the block.

Tests: the three existing proxy tests pass unmodified, and five are added covering a host assigned after construction (both schemes), a host unknown at construction, an assigned proxy surviving a later host change, an assigned `None`, and the `ALL_PROXY` fallback. `tests/test_configuration.py` is 18 passed; the rest of the petstore suite is unchanged apart from the usual failures that need a live server.

Reported downstream at kubernetes-client/python#2681, where `load_kube_config()` builds the configuration with no host and sets the server afterwards. Verified there by patching the generated file: with `HTTPS_PROXY` set and a kubeconfig pointing at a name that does not resolve, the client goes from `proxy=None` and a DNS failure to a `ProxyManager` and the proxy logging `CONNECT`.

Follows #24082. Related to #20226.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ```
  Commit all changed files.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@cbornet @tomplus @krjakbrjak @fa0311

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-resolves environment proxies when `Configuration.host` is assigned so scheme-specific proxies apply. Previously, assigning `host` after construction skipped `HTTP_PROXY`/`HTTPS_PROXY` and sent requests direct unless `ALL_PROXY` was set; now host assignment refreshes env-derived proxies while explicit proxies remain unchanged.

- Scope: `python` generator for `urllib3` only; `httpx` and `aiohttp` unchanged.
- Implementation: track env-origin proxies with `_proxy_from_env`; store `_proxy` behind a `proxy` property whose setter disables re-resolution; re-resolve in the `host` setter using extracted `_env_proxy(proxies, host)` with `ALL_PROXY` fallback; `no_proxy` handling unchanged.
- Tests: add coverage for host assigned post-construction (both schemes), host unknown at construction, explicit proxy and `None` surviving host changes, and `ALL_PROXY` fallback.
- Migration: none. Clients setting `config.host` after construction now pick up `HTTP_PROXY`/`HTTPS_PROXY`; explicit `config.proxy` still overrides and `None` disables proxies.

<sup>Written for commit 2437d2fdf8f2870a39d3e3dbba5ba494793a07cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24716?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

