### PR TITLE
[swift5][swift6] Fix AsyncAwait API documentation

### DIFF
--- a/modules/openapi-generator/src/main/resources/swift5/api_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/swift5/api_doc.mustache
@@ -15,10 +15,15 @@ Method | HTTP request | Description
 {{^usePromiseKit}}
 {{^useRxSwift}}
 {{^useVapor}}
+{{^useAsyncAwait}}
     {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} class func {{operationId}}({{#allParams}}{{paramName}}: {{#isEnum}}{{#isContainer}}[{{enumName}}_{{operationId}}]{{/isContainer}}{{^isContainer}}{{enumName}}_{{operationId}}{{/isContainer}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{^required}}? = nil{{/required}}{{^-last}}, {{/-last}}{{/allParams}}{{#hasParams}}, {{/hasParams}}completion: @escaping (_ data: {{{returnType}}}{{^returnType}}Void{{/returnType}}?, _ error: Error?) -> Void)
+{{/useAsyncAwait}}
 {{/useVapor}}
 {{/useRxSwift}}
 {{/usePromiseKit}}
+{{#useAsyncAwait}}
+    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} class func {{operationId}}({{#allParams}}{{paramName}}: {{#isEnum}}{{#isContainer}}[{{enumName}}_{{operationId}}]{{/isContainer}}{{^isContainer}}{{enumName}}_{{operationId}}{{/isContainer}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{^required}}? = nil{{/required}}{{^-last}}, {{/-last}}{{/allParams}}) async throws{{#returnType}} -> {{{returnType}}}{{#isResponseOptional}}?{{/isResponseOptional}}{{/returnType}}
+{{/useAsyncAwait}}
 {{#usePromiseKit}}
     {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} class func {{operationId}}({{#allParams}} {{paramName}}: {{#isEnum}}{{#isContainer}}[{{enumName}}_{{operationId}}]{{/isContainer}}{{^isContainer}}{{enumName}}_{{operationId}}{{/isContainer}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{^required}}? = nil{{/required}}{{^-last}}, {{/-last}}{{/allParams}}) -> Promise<{{{returnType}}}{{^returnType}}Void{{/returnType}}>
 {{/usePromiseKit}}
@@ -45,6 +50,7 @@ import {{{projectName}}}
 {{^usePromiseKit}}
 {{^useRxSwift}}
 {{^useVapor}}
+{{^useAsyncAwait}}
 {{#summary}}
 // {{{.}}}
 {{/summary}}
@@ -58,9 +64,23 @@ import {{{projectName}}}
         dump(response)
     }
 }
+{{/useAsyncAwait}}
 {{/useVapor}}
 {{/useRxSwift}}
 {{/usePromiseKit}}
+{{#useAsyncAwait}}
+{{#summary}}
+// {{{.}}}
+{{/summary}}
+do {
+    {{#returnType}}let response = {{/returnType}}try await {{classname}}.{{{operationId}}}({{#allParams}}{{paramName}}: {{paramName}}{{^-last}}, {{/-last}}{{/allParams}})
+{{#returnType}}
+    dump(response)
+{{/returnType}}
+} catch {
+    print(error)
+}
+{{/useAsyncAwait}}
 {{#usePromiseKit}}
 {{#summary}}
 // {{{.}}}

--- a/modules/openapi-generator/src/main/resources/swift6/api_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/swift6/api_doc.mustache
@@ -15,10 +15,17 @@ Method | HTTP request | Description
 {{^usePromiseKit}}
 {{^useRxSwift}}
 {{^useVapor}}
+{{^useAsyncAwait}}
     {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} class func {{operationId}}({{#allParams}}{{paramName}}: {{#isEnum}}{{#isContainer}}[{{enumName}}_{{operationId}}]{{/isContainer}}{{^isContainer}}{{enumName}}_{{operationId}}{{/isContainer}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{^required}}? = nil{{/required}}{{^-last}}, {{/-last}}{{/allParams}}{{#hasParams}}, {{/hasParams}}completion: @escaping (_ data: {{{returnType}}}{{^returnType}}Void{{/returnType}}?, _ error: Error?) -> Void)
+{{/useAsyncAwait}}
 {{/useVapor}}
 {{/useRxSwift}}
 {{/usePromiseKit}}
+{{^useVapor}}
+{{#useAsyncAwait}}
+    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} {{#apiStaticMethod}}class {{/apiStaticMethod}}func {{operationId}}({{#allParams}}{{paramName}}: {{#isEnum}}{{#isContainer}}[{{enumName}}_{{operationId}}]{{/isContainer}}{{^isContainer}}{{enumName}}_{{operationId}}{{/isContainer}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{^required}}? = nil{{/required}}{{^-last}}, {{/-last}}{{/allParams}}{{#apiStaticMethod}}{{#hasParams}}, {{/hasParams}}apiConfiguration: {{projectName}}APIConfiguration = {{projectName}}APIConfiguration.shared{{/apiStaticMethod}}) async throws(ErrorResponse){{#returnType}} -> {{{returnType}}}{{#isResponseOptional}}?{{/isResponseOptional}}{{/returnType}}
+{{/useAsyncAwait}}
+{{/useVapor}}
 {{#usePromiseKit}}
     {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} class func {{operationId}}({{#allParams}} {{paramName}}: {{#isEnum}}{{#isContainer}}[{{enumName}}_{{operationId}}]{{/isContainer}}{{^isContainer}}{{enumName}}_{{operationId}}{{/isContainer}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{^required}}? = nil{{/required}}{{^-last}}, {{/-last}}{{/allParams}}) -> Promise<{{{returnType}}}{{^returnType}}Void{{/returnType}}>
 {{/usePromiseKit}}
@@ -45,6 +52,7 @@ import {{{projectName}}}
 {{^usePromiseKit}}
 {{^useRxSwift}}
 {{^useVapor}}
+{{^useAsyncAwait}}
 {{#summary}}
 // {{{.}}}
 {{/summary}}
@@ -58,9 +66,25 @@ import {{{projectName}}}
         dump(response)
     }
 }
+{{/useAsyncAwait}}
 {{/useVapor}}
 {{/useRxSwift}}
 {{/usePromiseKit}}
+{{^useVapor}}
+{{#useAsyncAwait}}
+{{#summary}}
+// {{{.}}}
+{{/summary}}
+do {
+    {{#returnType}}let response = {{/returnType}}try await {{classname}}{{^apiStaticMethod}}(){{/apiStaticMethod}}.{{{operationId}}}({{#allParams}}{{paramName}}: {{paramName}}{{^-last}}, {{/-last}}{{/allParams}})
+{{#returnType}}
+    dump(response)
+{{/returnType}}
+} catch {
+    print(error)
+}
+{{/useAsyncAwait}}
+{{/useVapor}}
 {{#usePromiseKit}}
 {{#summary}}
 // {{{.}}}

--- a/samples/client/petstore/swift5/asyncAwaitLibrary/docs/AnotherFakeAPI.md
+++ b/samples/client/petstore/swift5/asyncAwaitLibrary/docs/AnotherFakeAPI.md
@@ -9,7 +9,7 @@ Method | HTTP request | Description
 
 # **call123testSpecialTags**
 ```swift
-    open class func call123testSpecialTags(body: Client, completion: @escaping (_ data: Client?, _ error: Error?) -> Void)
+    open class func call123testSpecialTags(body: Client) async throws -> Client
 ```
 
 To test special tags
@@ -24,15 +24,11 @@ import PetstoreClient
 let body = Client(client: "client_example") // Client | client model
 
 // To test special tags
-AnotherFakeAPI.call123testSpecialTags(body: body) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    let response = try await AnotherFakeAPI.call123testSpecialTags(body: body)
+    dump(response)
+} catch {
+    print(error)
 }
 ```
 

--- a/samples/client/petstore/swift5/asyncAwaitLibrary/docs/FakeAPI.md
+++ b/samples/client/petstore/swift5/asyncAwaitLibrary/docs/FakeAPI.md
@@ -20,7 +20,7 @@ Method | HTTP request | Description
 
 # **fakeOuterBooleanSerialize**
 ```swift
-    open class func fakeOuterBooleanSerialize(body: Bool? = nil, completion: @escaping (_ data: Bool?, _ error: Error?) -> Void)
+    open class func fakeOuterBooleanSerialize(body: Bool? = nil) async throws -> Bool
 ```
 
 
@@ -34,15 +34,11 @@ import PetstoreClient
 
 let body = true // Bool | Input boolean as post body (optional)
 
-FakeAPI.fakeOuterBooleanSerialize(body: body) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    let response = try await FakeAPI.fakeOuterBooleanSerialize(body: body)
+    dump(response)
+} catch {
+    print(error)
 }
 ```
 
@@ -69,7 +65,7 @@ No authorization required
 
 # **fakeOuterCompositeSerialize**
 ```swift
-    open class func fakeOuterCompositeSerialize(body: OuterComposite? = nil, completion: @escaping (_ data: OuterComposite?, _ error: Error?) -> Void)
+    open class func fakeOuterCompositeSerialize(body: OuterComposite? = nil) async throws -> OuterComposite
 ```
 
 
@@ -83,15 +79,11 @@ import PetstoreClient
 
 let body = OuterComposite(myNumber: 123, myString: "myString_example", myBoolean: false) // OuterComposite | Input composite as post body (optional)
 
-FakeAPI.fakeOuterCompositeSerialize(body: body) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    let response = try await FakeAPI.fakeOuterCompositeSerialize(body: body)
+    dump(response)
+} catch {
+    print(error)
 }
 ```
 
@@ -118,7 +110,7 @@ No authorization required
 
 # **fakeOuterNumberSerialize**
 ```swift
-    open class func fakeOuterNumberSerialize(body: Double? = nil, completion: @escaping (_ data: Double?, _ error: Error?) -> Void)
+    open class func fakeOuterNumberSerialize(body: Double? = nil) async throws -> Double
 ```
 
 
@@ -132,15 +124,11 @@ import PetstoreClient
 
 let body = 987 // Double | Input number as post body (optional)
 
-FakeAPI.fakeOuterNumberSerialize(body: body) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    let response = try await FakeAPI.fakeOuterNumberSerialize(body: body)
+    dump(response)
+} catch {
+    print(error)
 }
 ```
 
@@ -167,7 +155,7 @@ No authorization required
 
 # **fakeOuterStringSerialize**
 ```swift
-    open class func fakeOuterStringSerialize(body: String? = nil, completion: @escaping (_ data: String?, _ error: Error?) -> Void)
+    open class func fakeOuterStringSerialize(body: String? = nil) async throws -> String
 ```
 
 
@@ -181,15 +169,11 @@ import PetstoreClient
 
 let body = "body_example" // String | Input string as post body (optional)
 
-FakeAPI.fakeOuterStringSerialize(body: body) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    let response = try await FakeAPI.fakeOuterStringSerialize(body: body)
+    dump(response)
+} catch {
+    print(error)
 }
 ```
 
@@ -216,7 +200,7 @@ No authorization required
 
 # **testBodyWithFileSchema**
 ```swift
-    open class func testBodyWithFileSchema(body: FileSchemaTestClass, completion: @escaping (_ data: Void?, _ error: Error?) -> Void)
+    open class func testBodyWithFileSchema(body: FileSchemaTestClass) async throws
 ```
 
 
@@ -230,15 +214,10 @@ import PetstoreClient
 
 let body = FileSchemaTestClass(file: File(sourceURI: "sourceURI_example"), files: [nil]) // FileSchemaTestClass | 
 
-FakeAPI.testBodyWithFileSchema(body: body) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    try await FakeAPI.testBodyWithFileSchema(body: body)
+} catch {
+    print(error)
 }
 ```
 
@@ -265,7 +244,7 @@ No authorization required
 
 # **testBodyWithQueryParams**
 ```swift
-    open class func testBodyWithQueryParams(query: String, body: User, completion: @escaping (_ data: Void?, _ error: Error?) -> Void)
+    open class func testBodyWithQueryParams(query: String, body: User) async throws
 ```
 
 
@@ -278,15 +257,10 @@ import PetstoreClient
 let query = "query_example" // String | 
 let body = User(id: 123, username: "username_example", firstName: "firstName_example", lastName: "lastName_example", email: "email_example", password: "password_example", phone: "phone_example", userStatus: 123) // User | 
 
-FakeAPI.testBodyWithQueryParams(query: query, body: body) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    try await FakeAPI.testBodyWithQueryParams(query: query, body: body)
+} catch {
+    print(error)
 }
 ```
 
@@ -314,7 +288,7 @@ No authorization required
 
 # **testClientModel**
 ```swift
-    open class func testClientModel(body: Client, completion: @escaping (_ data: Client?, _ error: Error?) -> Void)
+    open class func testClientModel(body: Client) async throws -> Client
 ```
 
 To test \"client\" model
@@ -329,15 +303,11 @@ import PetstoreClient
 let body = Client(client: "client_example") // Client | client model
 
 // To test \"client\" model
-FakeAPI.testClientModel(body: body) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    let response = try await FakeAPI.testClientModel(body: body)
+    dump(response)
+} catch {
+    print(error)
 }
 ```
 
@@ -364,7 +334,7 @@ No authorization required
 
 # **testEndpointParameters**
 ```swift
-    open class func testEndpointParameters(number: Double, double: Double, patternWithoutDelimiter: String, byte: Data, integer: Int? = nil, int32: Int? = nil, int64: Int64? = nil, float: Float? = nil, string: String? = nil, binary: URL? = nil, date: Date? = nil, dateTime: Date? = nil, password: String? = nil, callback: String? = nil, completion: @escaping (_ data: Void?, _ error: Error?) -> Void)
+    open class func testEndpointParameters(number: Double, double: Double, patternWithoutDelimiter: String, byte: Data, integer: Int? = nil, int32: Int? = nil, int64: Int64? = nil, float: Float? = nil, string: String? = nil, binary: URL? = nil, date: Date? = nil, dateTime: Date? = nil, password: String? = nil, callback: String? = nil) async throws
 ```
 
 Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트
@@ -392,15 +362,10 @@ let password = "password_example" // String | None (optional)
 let callback = "callback_example" // String | None (optional)
 
 // Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트
-FakeAPI.testEndpointParameters(number: number, double: double, patternWithoutDelimiter: patternWithoutDelimiter, byte: byte, integer: integer, int32: int32, int64: int64, float: float, string: string, binary: binary, date: date, dateTime: dateTime, password: password, callback: callback) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    try await FakeAPI.testEndpointParameters(number: number, double: double, patternWithoutDelimiter: patternWithoutDelimiter, byte: byte, integer: integer, int32: int32, int64: int64, float: float, string: string, binary: binary, date: date, dateTime: dateTime, password: password, callback: callback)
+} catch {
+    print(error)
 }
 ```
 
@@ -440,7 +405,7 @@ Void (empty response body)
 
 # **testEnumParameters**
 ```swift
-    open class func testEnumParameters(enumHeaderStringArray: [EnumHeaderStringArray_testEnumParameters]? = nil, enumHeaderString: EnumHeaderString_testEnumParameters? = nil, enumQueryStringArray: [EnumQueryStringArray_testEnumParameters]? = nil, enumQueryString: EnumQueryString_testEnumParameters? = nil, enumQueryInteger: EnumQueryInteger_testEnumParameters? = nil, enumQueryDouble: EnumQueryDouble_testEnumParameters? = nil, enumFormStringArray: [EnumFormStringArray_testEnumParameters]? = nil, enumFormString: EnumFormString_testEnumParameters? = nil, completion: @escaping (_ data: Void?, _ error: Error?) -> Void)
+    open class func testEnumParameters(enumHeaderStringArray: [EnumHeaderStringArray_testEnumParameters]? = nil, enumHeaderString: EnumHeaderString_testEnumParameters? = nil, enumQueryStringArray: [EnumQueryStringArray_testEnumParameters]? = nil, enumQueryString: EnumQueryString_testEnumParameters? = nil, enumQueryInteger: EnumQueryInteger_testEnumParameters? = nil, enumQueryDouble: EnumQueryDouble_testEnumParameters? = nil, enumFormStringArray: [EnumFormStringArray_testEnumParameters]? = nil, enumFormString: EnumFormString_testEnumParameters? = nil) async throws
 ```
 
 To test enum parameters
@@ -462,15 +427,10 @@ let enumFormStringArray = ["inner_example"] // [String] | Form parameter enum te
 let enumFormString = "enumFormString_example" // String | Form parameter enum test (string) (optional) (default to .efg)
 
 // To test enum parameters
-FakeAPI.testEnumParameters(enumHeaderStringArray: enumHeaderStringArray, enumHeaderString: enumHeaderString, enumQueryStringArray: enumQueryStringArray, enumQueryString: enumQueryString, enumQueryInteger: enumQueryInteger, enumQueryDouble: enumQueryDouble, enumFormStringArray: enumFormStringArray, enumFormString: enumFormString) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    try await FakeAPI.testEnumParameters(enumHeaderStringArray: enumHeaderStringArray, enumHeaderString: enumHeaderString, enumQueryStringArray: enumQueryStringArray, enumQueryString: enumQueryString, enumQueryInteger: enumQueryInteger, enumQueryDouble: enumQueryDouble, enumFormStringArray: enumFormStringArray, enumFormString: enumFormString)
+} catch {
+    print(error)
 }
 ```
 
@@ -504,7 +464,7 @@ No authorization required
 
 # **testGroupParameters**
 ```swift
-    open class func testGroupParameters(requiredStringGroup: Int, requiredBooleanGroup: Bool, requiredInt64Group: Int64, stringGroup: Int? = nil, booleanGroup: Bool? = nil, int64Group: Int64? = nil, completion: @escaping (_ data: Void?, _ error: Error?) -> Void)
+    open class func testGroupParameters(requiredStringGroup: Int, requiredBooleanGroup: Bool, requiredInt64Group: Int64, stringGroup: Int? = nil, booleanGroup: Bool? = nil, int64Group: Int64? = nil) async throws
 ```
 
 Fake endpoint to test group parameters (optional)
@@ -524,15 +484,10 @@ let booleanGroup = true // Bool | Boolean in group parameters (optional)
 let int64Group = 987 // Int64 | Integer in group parameters (optional)
 
 // Fake endpoint to test group parameters (optional)
-FakeAPI.testGroupParameters(requiredStringGroup: requiredStringGroup, requiredBooleanGroup: requiredBooleanGroup, requiredInt64Group: requiredInt64Group, stringGroup: stringGroup, booleanGroup: booleanGroup, int64Group: int64Group) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    try await FakeAPI.testGroupParameters(requiredStringGroup: requiredStringGroup, requiredBooleanGroup: requiredBooleanGroup, requiredInt64Group: requiredInt64Group, stringGroup: stringGroup, booleanGroup: booleanGroup, int64Group: int64Group)
+} catch {
+    print(error)
 }
 ```
 
@@ -564,7 +519,7 @@ No authorization required
 
 # **testInlineAdditionalProperties**
 ```swift
-    open class func testInlineAdditionalProperties(param: [String: String], completion: @escaping (_ data: Void?, _ error: Error?) -> Void)
+    open class func testInlineAdditionalProperties(param: [String: String]) async throws
 ```
 
 test inline additionalProperties
@@ -577,15 +532,10 @@ import PetstoreClient
 let param = "TODO" // [String: String] | request body
 
 // test inline additionalProperties
-FakeAPI.testInlineAdditionalProperties(param: param) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    try await FakeAPI.testInlineAdditionalProperties(param: param)
+} catch {
+    print(error)
 }
 ```
 
@@ -612,7 +562,7 @@ No authorization required
 
 # **testJsonFormData**
 ```swift
-    open class func testJsonFormData(param: String, param2: String, completion: @escaping (_ data: Void?, _ error: Error?) -> Void)
+    open class func testJsonFormData(param: String, param2: String) async throws
 ```
 
 test json serialization of form data
@@ -626,15 +576,10 @@ let param = "param_example" // String | field1
 let param2 = "param2_example" // String | field2
 
 // test json serialization of form data
-FakeAPI.testJsonFormData(param: param, param2: param2) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    try await FakeAPI.testJsonFormData(param: param, param2: param2)
+} catch {
+    print(error)
 }
 ```
 

--- a/samples/client/petstore/swift5/asyncAwaitLibrary/docs/FakeClassnameTags123API.md
+++ b/samples/client/petstore/swift5/asyncAwaitLibrary/docs/FakeClassnameTags123API.md
@@ -9,7 +9,7 @@ Method | HTTP request | Description
 
 # **testClassname**
 ```swift
-    open class func testClassname(body: Client, completion: @escaping (_ data: Client?, _ error: Error?) -> Void)
+    open class func testClassname(body: Client) async throws -> Client
 ```
 
 To test class name in snake case
@@ -24,15 +24,11 @@ import PetstoreClient
 let body = Client(client: "client_example") // Client | client model
 
 // To test class name in snake case
-FakeClassnameTags123API.testClassname(body: body) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    let response = try await FakeClassnameTags123API.testClassname(body: body)
+    dump(response)
+} catch {
+    print(error)
 }
 ```
 

--- a/samples/client/petstore/swift5/asyncAwaitLibrary/docs/PetAPI.md
+++ b/samples/client/petstore/swift5/asyncAwaitLibrary/docs/PetAPI.md
@@ -17,7 +17,7 @@ Method | HTTP request | Description
 
 # **addPet**
 ```swift
-    open class func addPet(body: Pet, completion: @escaping (_ data: Void?, _ error: Error?) -> Void)
+    open class func addPet(body: Pet) async throws
 ```
 
 Add a new pet to the store
@@ -30,15 +30,10 @@ import PetstoreClient
 let body = Pet(id: 123, category: Category(id: 123, name: "name_example"), name: "name_example", photoUrls: ["photoUrls_example"], tags: [Tag(id: 123, name: "name_example")], status: "status_example") // Pet | Pet object that needs to be added to the store
 
 // Add a new pet to the store
-PetAPI.addPet(body: body) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    try await PetAPI.addPet(body: body)
+} catch {
+    print(error)
 }
 ```
 
@@ -65,7 +60,7 @@ Void (empty response body)
 
 # **deletePet**
 ```swift
-    open class func deletePet(petId: Int64, apiKey: String? = nil, completion: @escaping (_ data: Void?, _ error: Error?) -> Void)
+    open class func deletePet(petId: Int64, apiKey: String? = nil) async throws
 ```
 
 Deletes a pet
@@ -79,15 +74,10 @@ let petId = 987 // Int64 | Pet id to delete
 let apiKey = "apiKey_example" // String |  (optional)
 
 // Deletes a pet
-PetAPI.deletePet(petId: petId, apiKey: apiKey) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    try await PetAPI.deletePet(petId: petId, apiKey: apiKey)
+} catch {
+    print(error)
 }
 ```
 
@@ -115,7 +105,7 @@ Void (empty response body)
 
 # **findPetsByStatus**
 ```swift
-    open class func findPetsByStatus(status: [Status_findPetsByStatus], completion: @escaping (_ data: [Pet]?, _ error: Error?) -> Void)
+    open class func findPetsByStatus(status: [Status_findPetsByStatus]) async throws -> [Pet]
 ```
 
 Finds Pets by status
@@ -130,15 +120,11 @@ import PetstoreClient
 let status = ["status_example"] // [String] | Status values that need to be considered for filter
 
 // Finds Pets by status
-PetAPI.findPetsByStatus(status: status) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    let response = try await PetAPI.findPetsByStatus(status: status)
+    dump(response)
+} catch {
+    print(error)
 }
 ```
 
@@ -165,7 +151,7 @@ Name | Type | Description  | Notes
 
 # **findPetsByTags**
 ```swift
-    open class func findPetsByTags(tags: [String], completion: @escaping (_ data: [Pet]?, _ error: Error?) -> Void)
+    open class func findPetsByTags(tags: [String]) async throws -> [Pet]
 ```
 
 Finds Pets by tags
@@ -180,15 +166,11 @@ import PetstoreClient
 let tags = ["inner_example"] // [String] | Tags to filter by
 
 // Finds Pets by tags
-PetAPI.findPetsByTags(tags: tags) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    let response = try await PetAPI.findPetsByTags(tags: tags)
+    dump(response)
+} catch {
+    print(error)
 }
 ```
 
@@ -215,7 +197,7 @@ Name | Type | Description  | Notes
 
 # **getPetById**
 ```swift
-    open class func getPetById(petId: Int64, completion: @escaping (_ data: Pet?, _ error: Error?) -> Void)
+    open class func getPetById(petId: Int64) async throws -> Pet
 ```
 
 Find pet by ID
@@ -230,15 +212,11 @@ import PetstoreClient
 let petId = 987 // Int64 | ID of pet to return
 
 // Find pet by ID
-PetAPI.getPetById(petId: petId) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    let response = try await PetAPI.getPetById(petId: petId)
+    dump(response)
+} catch {
+    print(error)
 }
 ```
 
@@ -265,7 +243,7 @@ Name | Type | Description  | Notes
 
 # **updatePet**
 ```swift
-    open class func updatePet(body: Pet, completion: @escaping (_ data: Void?, _ error: Error?) -> Void)
+    open class func updatePet(body: Pet) async throws
 ```
 
 Update an existing pet
@@ -278,15 +256,10 @@ import PetstoreClient
 let body = Pet(id: 123, category: Category(id: 123, name: "name_example"), name: "name_example", photoUrls: ["photoUrls_example"], tags: [Tag(id: 123, name: "name_example")], status: "status_example") // Pet | Pet object that needs to be added to the store
 
 // Update an existing pet
-PetAPI.updatePet(body: body) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    try await PetAPI.updatePet(body: body)
+} catch {
+    print(error)
 }
 ```
 
@@ -313,7 +286,7 @@ Void (empty response body)
 
 # **updatePetWithForm**
 ```swift
-    open class func updatePetWithForm(petId: Int64, name: String? = nil, status: String? = nil, completion: @escaping (_ data: Void?, _ error: Error?) -> Void)
+    open class func updatePetWithForm(petId: Int64, name: String? = nil, status: String? = nil) async throws
 ```
 
 Updates a pet in the store with form data
@@ -328,15 +301,10 @@ let name = "name_example" // String | Updated name of the pet (optional)
 let status = "status_example" // String | Updated status of the pet (optional)
 
 // Updates a pet in the store with form data
-PetAPI.updatePetWithForm(petId: petId, name: name, status: status) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    try await PetAPI.updatePetWithForm(petId: petId, name: name, status: status)
+} catch {
+    print(error)
 }
 ```
 
@@ -365,7 +333,7 @@ Void (empty response body)
 
 # **uploadFile**
 ```swift
-    open class func uploadFile(petId: Int64, additionalMetadata: String? = nil, file: URL? = nil, completion: @escaping (_ data: ApiResponse?, _ error: Error?) -> Void)
+    open class func uploadFile(petId: Int64, additionalMetadata: String? = nil, file: URL? = nil) async throws -> ApiResponse
 ```
 
 uploads an image
@@ -380,15 +348,11 @@ let additionalMetadata = "additionalMetadata_example" // String | Additional dat
 let file = URL(string: "https://example.com")! // URL | file to upload (optional)
 
 // uploads an image
-PetAPI.uploadFile(petId: petId, additionalMetadata: additionalMetadata, file: file) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    let response = try await PetAPI.uploadFile(petId: petId, additionalMetadata: additionalMetadata, file: file)
+    dump(response)
+} catch {
+    print(error)
 }
 ```
 
@@ -417,7 +381,7 @@ Name | Type | Description  | Notes
 
 # **uploadFileWithRequiredFile**
 ```swift
-    open class func uploadFileWithRequiredFile(petId: Int64, requiredFile: URL, additionalMetadata: String? = nil, completion: @escaping (_ data: ApiResponse?, _ error: Error?) -> Void)
+    open class func uploadFileWithRequiredFile(petId: Int64, requiredFile: URL, additionalMetadata: String? = nil) async throws -> ApiResponse
 ```
 
 uploads an image (required)
@@ -432,15 +396,11 @@ let requiredFile = URL(string: "https://example.com")! // URL | file to upload
 let additionalMetadata = "additionalMetadata_example" // String | Additional data to pass to server (optional)
 
 // uploads an image (required)
-PetAPI.uploadFileWithRequiredFile(petId: petId, requiredFile: requiredFile, additionalMetadata: additionalMetadata) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    let response = try await PetAPI.uploadFileWithRequiredFile(petId: petId, requiredFile: requiredFile, additionalMetadata: additionalMetadata)
+    dump(response)
+} catch {
+    print(error)
 }
 ```
 

--- a/samples/client/petstore/swift5/asyncAwaitLibrary/docs/StoreAPI.md
+++ b/samples/client/petstore/swift5/asyncAwaitLibrary/docs/StoreAPI.md
@@ -12,7 +12,7 @@ Method | HTTP request | Description
 
 # **deleteOrder**
 ```swift
-    open class func deleteOrder(orderId: String, completion: @escaping (_ data: Void?, _ error: Error?) -> Void)
+    open class func deleteOrder(orderId: String) async throws
 ```
 
 Delete purchase order by ID
@@ -27,15 +27,10 @@ import PetstoreClient
 let orderId = "orderId_example" // String | ID of the order that needs to be deleted
 
 // Delete purchase order by ID
-StoreAPI.deleteOrder(orderId: orderId) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    try await StoreAPI.deleteOrder(orderId: orderId)
+} catch {
+    print(error)
 }
 ```
 
@@ -62,7 +57,7 @@ No authorization required
 
 # **getInventory**
 ```swift
-    open class func getInventory(completion: @escaping (_ data: [String: Int]?, _ error: Error?) -> Void)
+    open class func getInventory() async throws -> [String: Int]
 ```
 
 Returns pet inventories by status
@@ -76,15 +71,11 @@ import PetstoreClient
 
 
 // Returns pet inventories by status
-StoreAPI.getInventory() { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    let response = try await StoreAPI.getInventory()
+    dump(response)
+} catch {
+    print(error)
 }
 ```
 
@@ -108,7 +99,7 @@ This endpoint does not need any parameter.
 
 # **getOrderById**
 ```swift
-    open class func getOrderById(orderId: Int64, completion: @escaping (_ data: Order?, _ error: Error?) -> Void)
+    open class func getOrderById(orderId: Int64) async throws -> Order
 ```
 
 Find purchase order by ID
@@ -123,15 +114,11 @@ import PetstoreClient
 let orderId = 987 // Int64 | ID of pet that needs to be fetched
 
 // Find purchase order by ID
-StoreAPI.getOrderById(orderId: orderId) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    let response = try await StoreAPI.getOrderById(orderId: orderId)
+    dump(response)
+} catch {
+    print(error)
 }
 ```
 
@@ -158,7 +145,7 @@ No authorization required
 
 # **placeOrder**
 ```swift
-    open class func placeOrder(body: Order, completion: @escaping (_ data: Order?, _ error: Error?) -> Void)
+    open class func placeOrder(body: Order) async throws -> Order
 ```
 
 Place an order for a pet
@@ -171,15 +158,11 @@ import PetstoreClient
 let body = Order(id: 123, petId: 123, quantity: 123, shipDate: Date(), status: "status_example", complete: false) // Order | order placed for purchasing the pet
 
 // Place an order for a pet
-StoreAPI.placeOrder(body: body) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    let response = try await StoreAPI.placeOrder(body: body)
+    dump(response)
+} catch {
+    print(error)
 }
 ```
 

--- a/samples/client/petstore/swift5/asyncAwaitLibrary/docs/UserAPI.md
+++ b/samples/client/petstore/swift5/asyncAwaitLibrary/docs/UserAPI.md
@@ -16,7 +16,7 @@ Method | HTTP request | Description
 
 # **createUser**
 ```swift
-    open class func createUser(body: User, completion: @escaping (_ data: Void?, _ error: Error?) -> Void)
+    open class func createUser(body: User) async throws
 ```
 
 Create user
@@ -31,15 +31,10 @@ import PetstoreClient
 let body = User(id: 123, username: "username_example", firstName: "firstName_example", lastName: "lastName_example", email: "email_example", password: "password_example", phone: "phone_example", userStatus: 123) // User | Created user object
 
 // Create user
-UserAPI.createUser(body: body) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    try await UserAPI.createUser(body: body)
+} catch {
+    print(error)
 }
 ```
 
@@ -66,7 +61,7 @@ No authorization required
 
 # **createUsersWithArrayInput**
 ```swift
-    open class func createUsersWithArrayInput(body: [User], completion: @escaping (_ data: Void?, _ error: Error?) -> Void)
+    open class func createUsersWithArrayInput(body: [User]) async throws
 ```
 
 Creates list of users with given input array
@@ -79,15 +74,10 @@ import PetstoreClient
 let body = [User(id: 123, username: "username_example", firstName: "firstName_example", lastName: "lastName_example", email: "email_example", password: "password_example", phone: "phone_example", userStatus: 123)] // [User] | List of user object
 
 // Creates list of users with given input array
-UserAPI.createUsersWithArrayInput(body: body) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    try await UserAPI.createUsersWithArrayInput(body: body)
+} catch {
+    print(error)
 }
 ```
 
@@ -114,7 +104,7 @@ No authorization required
 
 # **createUsersWithListInput**
 ```swift
-    open class func createUsersWithListInput(body: [User], completion: @escaping (_ data: Void?, _ error: Error?) -> Void)
+    open class func createUsersWithListInput(body: [User]) async throws
 ```
 
 Creates list of users with given input array
@@ -127,15 +117,10 @@ import PetstoreClient
 let body = [User(id: 123, username: "username_example", firstName: "firstName_example", lastName: "lastName_example", email: "email_example", password: "password_example", phone: "phone_example", userStatus: 123)] // [User] | List of user object
 
 // Creates list of users with given input array
-UserAPI.createUsersWithListInput(body: body) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    try await UserAPI.createUsersWithListInput(body: body)
+} catch {
+    print(error)
 }
 ```
 
@@ -162,7 +147,7 @@ No authorization required
 
 # **deleteUser**
 ```swift
-    open class func deleteUser(username: String, completion: @escaping (_ data: Void?, _ error: Error?) -> Void)
+    open class func deleteUser(username: String) async throws
 ```
 
 Delete user
@@ -177,15 +162,10 @@ import PetstoreClient
 let username = "username_example" // String | The name that needs to be deleted
 
 // Delete user
-UserAPI.deleteUser(username: username) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    try await UserAPI.deleteUser(username: username)
+} catch {
+    print(error)
 }
 ```
 
@@ -212,7 +192,7 @@ No authorization required
 
 # **getUserByName**
 ```swift
-    open class func getUserByName(username: String, completion: @escaping (_ data: User?, _ error: Error?) -> Void)
+    open class func getUserByName(username: String) async throws -> User
 ```
 
 Get user by user name
@@ -225,15 +205,11 @@ import PetstoreClient
 let username = "username_example" // String | The name that needs to be fetched. Use user1 for testing.
 
 // Get user by user name
-UserAPI.getUserByName(username: username) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    let response = try await UserAPI.getUserByName(username: username)
+    dump(response)
+} catch {
+    print(error)
 }
 ```
 
@@ -260,7 +236,7 @@ No authorization required
 
 # **loginUser**
 ```swift
-    open class func loginUser(username: String, password: String, completion: @escaping (_ data: String?, _ error: Error?) -> Void)
+    open class func loginUser(username: String, password: String) async throws -> String
 ```
 
 Logs user into the system
@@ -274,15 +250,11 @@ let username = "username_example" // String | The user name for login
 let password = "password_example" // String | The password for login in clear text
 
 // Logs user into the system
-UserAPI.loginUser(username: username, password: password) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    let response = try await UserAPI.loginUser(username: username, password: password)
+    dump(response)
+} catch {
+    print(error)
 }
 ```
 
@@ -310,7 +282,7 @@ No authorization required
 
 # **logoutUser**
 ```swift
-    open class func logoutUser(completion: @escaping (_ data: Void?, _ error: Error?) -> Void)
+    open class func logoutUser() async throws
 ```
 
 Logs out current logged in user session
@@ -322,15 +294,10 @@ import PetstoreClient
 
 
 // Logs out current logged in user session
-UserAPI.logoutUser() { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    try await UserAPI.logoutUser()
+} catch {
+    print(error)
 }
 ```
 
@@ -354,7 +321,7 @@ No authorization required
 
 # **updateUser**
 ```swift
-    open class func updateUser(username: String, body: User, completion: @escaping (_ data: Void?, _ error: Error?) -> Void)
+    open class func updateUser(username: String, body: User) async throws
 ```
 
 Updated user
@@ -370,15 +337,10 @@ let username = "username_example" // String | name that need to be deleted
 let body = User(id: 123, username: "username_example", firstName: "firstName_example", lastName: "lastName_example", email: "email_example", password: "password_example", phone: "phone_example", userStatus: 123) // User | Updated user object
 
 // Updated user
-UserAPI.updateUser(username: username, body: body) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    try await UserAPI.updateUser(username: username, body: body)
+} catch {
+    print(error)
 }
 ```
 

--- a/samples/client/petstore/swift6/apiNonStaticMethod/docs/AnotherFakeAPI.md
+++ b/samples/client/petstore/swift6/apiNonStaticMethod/docs/AnotherFakeAPI.md
@@ -9,6 +9,7 @@ Method | HTTP request | Description
 
 # **call123testSpecialTags**
 ```swift
+    open func call123testSpecialTags(body: Client) async throws(ErrorResponse) -> Client
     open class func call123testSpecialTags( body: Client) -> Promise<Client>
     open class func call123testSpecialTags(body: Client) -> Observable<Client>
 ```
@@ -24,6 +25,13 @@ import PetstoreClient
 
 let body = Client(client: "client_example") // Client | client model
 
+// To test special tags
+do {
+    let response = try await AnotherFakeAPI().call123testSpecialTags(body: body)
+    dump(response)
+} catch {
+    print(error)
+}
 // To test special tags
 AnotherFakeAPI.call123testSpecialTags(body: body).then {
          // when the promise is fulfilled

--- a/samples/client/petstore/swift6/apiNonStaticMethod/docs/FakeAPI.md
+++ b/samples/client/petstore/swift6/apiNonStaticMethod/docs/FakeAPI.md
@@ -20,6 +20,7 @@ Method | HTTP request | Description
 
 # **fakeOuterBooleanSerialize**
 ```swift
+    open func fakeOuterBooleanSerialize(body: Bool? = nil) async throws(ErrorResponse) -> Bool
     open class func fakeOuterBooleanSerialize( body: Bool? = nil) -> Promise<Bool>
     open class func fakeOuterBooleanSerialize(body: Bool? = nil) -> Observable<Bool>
 ```
@@ -35,6 +36,12 @@ import PetstoreClient
 
 let body = true // Bool | Input boolean as post body (optional)
 
+do {
+    let response = try await FakeAPI().fakeOuterBooleanSerialize(body: body)
+    dump(response)
+} catch {
+    print(error)
+}
 FakeAPI.fakeOuterBooleanSerialize(body: body).then {
          // when the promise is fulfilled
      }.always {
@@ -68,6 +75,7 @@ No authorization required
 
 # **fakeOuterCompositeSerialize**
 ```swift
+    open func fakeOuterCompositeSerialize(body: OuterComposite? = nil) async throws(ErrorResponse) -> OuterComposite
     open class func fakeOuterCompositeSerialize( body: OuterComposite? = nil) -> Promise<OuterComposite>
     open class func fakeOuterCompositeSerialize(body: OuterComposite? = nil) -> Observable<OuterComposite>
 ```
@@ -83,6 +91,12 @@ import PetstoreClient
 
 let body = OuterComposite(myNumber: 123, myString: "myString_example", myBoolean: false) // OuterComposite | Input composite as post body (optional)
 
+do {
+    let response = try await FakeAPI().fakeOuterCompositeSerialize(body: body)
+    dump(response)
+} catch {
+    print(error)
+}
 FakeAPI.fakeOuterCompositeSerialize(body: body).then {
          // when the promise is fulfilled
      }.always {
@@ -116,6 +130,7 @@ No authorization required
 
 # **fakeOuterNumberSerialize**
 ```swift
+    open func fakeOuterNumberSerialize(body: Double? = nil) async throws(ErrorResponse) -> Double
     open class func fakeOuterNumberSerialize( body: Double? = nil) -> Promise<Double>
     open class func fakeOuterNumberSerialize(body: Double? = nil) -> Observable<Double>
 ```
@@ -131,6 +146,12 @@ import PetstoreClient
 
 let body = 987 // Double | Input number as post body (optional)
 
+do {
+    let response = try await FakeAPI().fakeOuterNumberSerialize(body: body)
+    dump(response)
+} catch {
+    print(error)
+}
 FakeAPI.fakeOuterNumberSerialize(body: body).then {
          // when the promise is fulfilled
      }.always {
@@ -164,6 +185,7 @@ No authorization required
 
 # **fakeOuterStringSerialize**
 ```swift
+    open func fakeOuterStringSerialize(body: String? = nil) async throws(ErrorResponse) -> String
     open class func fakeOuterStringSerialize( body: String? = nil) -> Promise<String>
     open class func fakeOuterStringSerialize(body: String? = nil) -> Observable<String>
 ```
@@ -179,6 +201,12 @@ import PetstoreClient
 
 let body = "body_example" // String | Input string as post body (optional)
 
+do {
+    let response = try await FakeAPI().fakeOuterStringSerialize(body: body)
+    dump(response)
+} catch {
+    print(error)
+}
 FakeAPI.fakeOuterStringSerialize(body: body).then {
          // when the promise is fulfilled
      }.always {
@@ -212,6 +240,7 @@ No authorization required
 
 # **testBodyWithFileSchema**
 ```swift
+    open func testBodyWithFileSchema(body: FileSchemaTestClass) async throws(ErrorResponse)
     open class func testBodyWithFileSchema( body: FileSchemaTestClass) -> Promise<Void>
     open class func testBodyWithFileSchema(body: FileSchemaTestClass) -> Observable<Void>
 ```
@@ -227,6 +256,11 @@ import PetstoreClient
 
 let body = FileSchemaTestClass(file: File(sourceURI: "sourceURI_example"), files: [nil]) // FileSchemaTestClass | 
 
+do {
+    try await FakeAPI().testBodyWithFileSchema(body: body)
+} catch {
+    print(error)
+}
 FakeAPI.testBodyWithFileSchema(body: body).then {
          // when the promise is fulfilled
      }.always {
@@ -260,6 +294,7 @@ No authorization required
 
 # **testBodyWithQueryParams**
 ```swift
+    open func testBodyWithQueryParams(query: String, body: User) async throws(ErrorResponse)
     open class func testBodyWithQueryParams( query: String,  body: User) -> Promise<Void>
     open class func testBodyWithQueryParams(query: String, body: User) -> Observable<Void>
 ```
@@ -274,6 +309,11 @@ import PetstoreClient
 let query = "query_example" // String | 
 let body = User(id: 123, username: "username_example", firstName: "firstName_example", lastName: "lastName_example", email: "email_example", password: "password_example", phone: "phone_example", userStatus: 123) // User | 
 
+do {
+    try await FakeAPI().testBodyWithQueryParams(query: query, body: body)
+} catch {
+    print(error)
+}
 FakeAPI.testBodyWithQueryParams(query: query, body: body).then {
          // when the promise is fulfilled
      }.always {
@@ -308,6 +348,7 @@ No authorization required
 
 # **testClientModel**
 ```swift
+    open func testClientModel(body: Client) async throws(ErrorResponse) -> Client
     open class func testClientModel( body: Client) -> Promise<Client>
     open class func testClientModel(body: Client) -> Observable<Client>
 ```
@@ -323,6 +364,13 @@ import PetstoreClient
 
 let body = Client(client: "client_example") // Client | client model
 
+// To test \"client\" model
+do {
+    let response = try await FakeAPI().testClientModel(body: body)
+    dump(response)
+} catch {
+    print(error)
+}
 // To test \"client\" model
 FakeAPI.testClientModel(body: body).then {
          // when the promise is fulfilled
@@ -357,6 +405,7 @@ No authorization required
 
 # **testEndpointParameters**
 ```swift
+    open func testEndpointParameters(number: Double, double: Double, patternWithoutDelimiter: String, byte: Data, integer: Int? = nil, int32: Int? = nil, int64: Int64? = nil, float: Float? = nil, string: String? = nil, binary: Data? = nil, date: Date? = nil, dateTime: Date? = nil, password: String? = nil, callback: String? = nil) async throws(ErrorResponse)
     open class func testEndpointParameters( number: Double,  double: Double,  patternWithoutDelimiter: String,  byte: Data,  integer: Int? = nil,  int32: Int? = nil,  int64: Int64? = nil,  float: Float? = nil,  string: String? = nil,  binary: Data? = nil,  date: Date? = nil,  dateTime: Date? = nil,  password: String? = nil,  callback: String? = nil) -> Promise<Void>
     open class func testEndpointParameters(number: Double, double: Double, patternWithoutDelimiter: String, byte: Data, integer: Int? = nil, int32: Int? = nil, int64: Int64? = nil, float: Float? = nil, string: String? = nil, binary: Data? = nil, date: Date? = nil, dateTime: Date? = nil, password: String? = nil, callback: String? = nil) -> Observable<Void>
 ```
@@ -385,6 +434,12 @@ let dateTime = Date() // Date | None (optional)
 let password = "password_example" // String | None (optional)
 let callback = "callback_example" // String | None (optional)
 
+// Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트
+do {
+    try await FakeAPI().testEndpointParameters(number: number, double: double, patternWithoutDelimiter: patternWithoutDelimiter, byte: byte, integer: integer, int32: int32, int64: int64, float: float, string: string, binary: binary, date: date, dateTime: dateTime, password: password, callback: callback)
+} catch {
+    print(error)
+}
 // Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트
 FakeAPI.testEndpointParameters(number: number, double: double, patternWithoutDelimiter: patternWithoutDelimiter, byte: byte, integer: integer, int32: int32, int64: int64, float: float, string: string, binary: binary, date: date, dateTime: dateTime, password: password, callback: callback).then {
          // when the promise is fulfilled
@@ -432,6 +487,7 @@ Void (empty response body)
 
 # **testEnumParameters**
 ```swift
+    open func testEnumParameters(enumHeaderStringArray: [EnumHeaderStringArray_testEnumParameters]? = nil, enumHeaderString: EnumHeaderString_testEnumParameters? = nil, enumQueryStringArray: [EnumQueryStringArray_testEnumParameters]? = nil, enumQueryString: EnumQueryString_testEnumParameters? = nil, enumQueryInteger: EnumQueryInteger_testEnumParameters? = nil, enumQueryDouble: EnumQueryDouble_testEnumParameters? = nil, enumFormStringArray: [EnumFormStringArray_testEnumParameters]? = nil, enumFormString: EnumFormString_testEnumParameters? = nil) async throws(ErrorResponse)
     open class func testEnumParameters( enumHeaderStringArray: [EnumHeaderStringArray_testEnumParameters]? = nil,  enumHeaderString: EnumHeaderString_testEnumParameters? = nil,  enumQueryStringArray: [EnumQueryStringArray_testEnumParameters]? = nil,  enumQueryString: EnumQueryString_testEnumParameters? = nil,  enumQueryInteger: EnumQueryInteger_testEnumParameters? = nil,  enumQueryDouble: EnumQueryDouble_testEnumParameters? = nil,  enumFormStringArray: [EnumFormStringArray_testEnumParameters]? = nil,  enumFormString: EnumFormString_testEnumParameters? = nil) -> Promise<Void>
     open class func testEnumParameters(enumHeaderStringArray: [EnumHeaderStringArray_testEnumParameters]? = nil, enumHeaderString: EnumHeaderString_testEnumParameters? = nil, enumQueryStringArray: [EnumQueryStringArray_testEnumParameters]? = nil, enumQueryString: EnumQueryString_testEnumParameters? = nil, enumQueryInteger: EnumQueryInteger_testEnumParameters? = nil, enumQueryDouble: EnumQueryDouble_testEnumParameters? = nil, enumFormStringArray: [EnumFormStringArray_testEnumParameters]? = nil, enumFormString: EnumFormString_testEnumParameters? = nil) -> Observable<Void>
 ```
@@ -454,6 +510,12 @@ let enumQueryDouble = 987 // Double | Query parameter enum test (double) (option
 let enumFormStringArray = ["inner_example"] // [String] | Form parameter enum test (string array) (optional) (default to .dollar)
 let enumFormString = "enumFormString_example" // String | Form parameter enum test (string) (optional) (default to .efg)
 
+// To test enum parameters
+do {
+    try await FakeAPI().testEnumParameters(enumHeaderStringArray: enumHeaderStringArray, enumHeaderString: enumHeaderString, enumQueryStringArray: enumQueryStringArray, enumQueryString: enumQueryString, enumQueryInteger: enumQueryInteger, enumQueryDouble: enumQueryDouble, enumFormStringArray: enumFormStringArray, enumFormString: enumFormString)
+} catch {
+    print(error)
+}
 // To test enum parameters
 FakeAPI.testEnumParameters(enumHeaderStringArray: enumHeaderStringArray, enumHeaderString: enumHeaderString, enumQueryStringArray: enumQueryStringArray, enumQueryString: enumQueryString, enumQueryInteger: enumQueryInteger, enumQueryDouble: enumQueryDouble, enumFormStringArray: enumFormStringArray, enumFormString: enumFormString).then {
          // when the promise is fulfilled
@@ -495,6 +557,7 @@ No authorization required
 
 # **testGroupParameters**
 ```swift
+    open func testGroupParameters(requiredStringGroup: Int, requiredBooleanGroup: Bool, requiredInt64Group: Int64, stringGroup: Int? = nil, booleanGroup: Bool? = nil, int64Group: Int64? = nil) async throws(ErrorResponse)
     open class func testGroupParameters( requiredStringGroup: Int,  requiredBooleanGroup: Bool,  requiredInt64Group: Int64,  stringGroup: Int? = nil,  booleanGroup: Bool? = nil,  int64Group: Int64? = nil) -> Promise<Void>
     open class func testGroupParameters(requiredStringGroup: Int, requiredBooleanGroup: Bool, requiredInt64Group: Int64, stringGroup: Int? = nil, booleanGroup: Bool? = nil, int64Group: Int64? = nil) -> Observable<Void>
 ```
@@ -515,6 +578,12 @@ let stringGroup = 987 // Int | String in group parameters (optional)
 let booleanGroup = true // Bool | Boolean in group parameters (optional)
 let int64Group = 987 // Int64 | Integer in group parameters (optional)
 
+// Fake endpoint to test group parameters (optional)
+do {
+    try await FakeAPI().testGroupParameters(requiredStringGroup: requiredStringGroup, requiredBooleanGroup: requiredBooleanGroup, requiredInt64Group: requiredInt64Group, stringGroup: stringGroup, booleanGroup: booleanGroup, int64Group: int64Group)
+} catch {
+    print(error)
+}
 // Fake endpoint to test group parameters (optional)
 FakeAPI.testGroupParameters(requiredStringGroup: requiredStringGroup, requiredBooleanGroup: requiredBooleanGroup, requiredInt64Group: requiredInt64Group, stringGroup: stringGroup, booleanGroup: booleanGroup, int64Group: int64Group).then {
          // when the promise is fulfilled
@@ -554,6 +623,7 @@ No authorization required
 
 # **testInlineAdditionalProperties**
 ```swift
+    open func testInlineAdditionalProperties(param: [String: String]) async throws(ErrorResponse)
     open class func testInlineAdditionalProperties( param: [String: String]) -> Promise<Void>
     open class func testInlineAdditionalProperties(param: [String: String]) -> Observable<Void>
 ```
@@ -567,6 +637,12 @@ import PetstoreClient
 
 let param = "TODO" // [String: String] | request body
 
+// test inline additionalProperties
+do {
+    try await FakeAPI().testInlineAdditionalProperties(param: param)
+} catch {
+    print(error)
+}
 // test inline additionalProperties
 FakeAPI.testInlineAdditionalProperties(param: param).then {
          // when the promise is fulfilled
@@ -601,6 +677,7 @@ No authorization required
 
 # **testJsonFormData**
 ```swift
+    open func testJsonFormData(param: String, param2: String) async throws(ErrorResponse)
     open class func testJsonFormData( param: String,  param2: String) -> Promise<Void>
     open class func testJsonFormData(param: String, param2: String) -> Observable<Void>
 ```
@@ -615,6 +692,12 @@ import PetstoreClient
 let param = "param_example" // String | field1
 let param2 = "param2_example" // String | field2
 
+// test json serialization of form data
+do {
+    try await FakeAPI().testJsonFormData(param: param, param2: param2)
+} catch {
+    print(error)
+}
 // test json serialization of form data
 FakeAPI.testJsonFormData(param: param, param2: param2).then {
          // when the promise is fulfilled

--- a/samples/client/petstore/swift6/apiNonStaticMethod/docs/FakeClassnameTags123API.md
+++ b/samples/client/petstore/swift6/apiNonStaticMethod/docs/FakeClassnameTags123API.md
@@ -9,6 +9,7 @@ Method | HTTP request | Description
 
 # **testClassname**
 ```swift
+    open func testClassname(body: Client) async throws(ErrorResponse) -> Client
     open class func testClassname( body: Client) -> Promise<Client>
     open class func testClassname(body: Client) -> Observable<Client>
 ```
@@ -24,6 +25,13 @@ import PetstoreClient
 
 let body = Client(client: "client_example") // Client | client model
 
+// To test class name in snake case
+do {
+    let response = try await FakeClassnameTags123API().testClassname(body: body)
+    dump(response)
+} catch {
+    print(error)
+}
 // To test class name in snake case
 FakeClassnameTags123API.testClassname(body: body).then {
          // when the promise is fulfilled

--- a/samples/client/petstore/swift6/apiNonStaticMethod/docs/PetAPI.md
+++ b/samples/client/petstore/swift6/apiNonStaticMethod/docs/PetAPI.md
@@ -17,6 +17,7 @@ Method | HTTP request | Description
 
 # **addPet**
 ```swift
+    open func addPet(body: Pet) async throws(ErrorResponse)
     open class func addPet( body: Pet) -> Promise<Void>
     open class func addPet(body: Pet) -> Observable<Void>
 ```
@@ -30,6 +31,12 @@ import PetstoreClient
 
 let body = Pet(id: 123, category: Category(id: 123, name: "name_example"), name: "name_example", photoUrls: ["photoUrls_example"], tags: [Tag(id: 123, name: "name_example")], status: "status_example") // Pet | Pet object that needs to be added to the store
 
+// Add a new pet to the store
+do {
+    try await PetAPI().addPet(body: body)
+} catch {
+    print(error)
+}
 // Add a new pet to the store
 PetAPI.addPet(body: body).then {
          // when the promise is fulfilled
@@ -64,6 +71,7 @@ Void (empty response body)
 
 # **deletePet**
 ```swift
+    open func deletePet(petId: Int64, apiKey: String? = nil) async throws(ErrorResponse)
     open class func deletePet( petId: Int64,  apiKey: String? = nil) -> Promise<Void>
     open class func deletePet(petId: Int64, apiKey: String? = nil) -> Observable<Void>
 ```
@@ -78,6 +86,12 @@ import PetstoreClient
 let petId = 987 // Int64 | Pet id to delete
 let apiKey = "apiKey_example" // String |  (optional)
 
+// Deletes a pet
+do {
+    try await PetAPI().deletePet(petId: petId, apiKey: apiKey)
+} catch {
+    print(error)
+}
 // Deletes a pet
 PetAPI.deletePet(petId: petId, apiKey: apiKey).then {
          // when the promise is fulfilled
@@ -113,6 +127,7 @@ Void (empty response body)
 
 # **findPetsByStatus**
 ```swift
+    open func findPetsByStatus(status: [Status_findPetsByStatus]) async throws(ErrorResponse) -> [Pet]
     open class func findPetsByStatus( status: [Status_findPetsByStatus]) -> Promise<[Pet]>
     open class func findPetsByStatus(status: [Status_findPetsByStatus]) -> Observable<[Pet]>
 ```
@@ -128,6 +143,13 @@ import PetstoreClient
 
 let status = ["status_example"] // [String] | Status values that need to be considered for filter
 
+// Finds Pets by status
+do {
+    let response = try await PetAPI().findPetsByStatus(status: status)
+    dump(response)
+} catch {
+    print(error)
+}
 // Finds Pets by status
 PetAPI.findPetsByStatus(status: status).then {
          // when the promise is fulfilled
@@ -162,6 +184,7 @@ Name | Type | Description  | Notes
 
 # **findPetsByTags**
 ```swift
+    open func findPetsByTags(tags: [String]) async throws(ErrorResponse) -> [Pet]
     open class func findPetsByTags( tags: [String]) -> Promise<[Pet]>
     open class func findPetsByTags(tags: [String]) -> Observable<[Pet]>
 ```
@@ -177,6 +200,13 @@ import PetstoreClient
 
 let tags = ["inner_example"] // [String] | Tags to filter by
 
+// Finds Pets by tags
+do {
+    let response = try await PetAPI().findPetsByTags(tags: tags)
+    dump(response)
+} catch {
+    print(error)
+}
 // Finds Pets by tags
 PetAPI.findPetsByTags(tags: tags).then {
          // when the promise is fulfilled
@@ -211,6 +241,7 @@ Name | Type | Description  | Notes
 
 # **getPetById**
 ```swift
+    open func getPetById(petId: Int64) async throws(ErrorResponse) -> Pet
     open class func getPetById( petId: Int64) -> Promise<Pet>
     open class func getPetById(petId: Int64) -> Observable<Pet>
 ```
@@ -226,6 +257,13 @@ import PetstoreClient
 
 let petId = 987 // Int64 | ID of pet to return
 
+// Find pet by ID
+do {
+    let response = try await PetAPI().getPetById(petId: petId)
+    dump(response)
+} catch {
+    print(error)
+}
 // Find pet by ID
 PetAPI.getPetById(petId: petId).then {
          // when the promise is fulfilled
@@ -260,6 +298,7 @@ Name | Type | Description  | Notes
 
 # **updatePet**
 ```swift
+    open func updatePet(body: Pet) async throws(ErrorResponse)
     open class func updatePet( body: Pet) -> Promise<Void>
     open class func updatePet(body: Pet) -> Observable<Void>
 ```
@@ -273,6 +312,12 @@ import PetstoreClient
 
 let body = Pet(id: 123, category: Category(id: 123, name: "name_example"), name: "name_example", photoUrls: ["photoUrls_example"], tags: [Tag(id: 123, name: "name_example")], status: "status_example") // Pet | Pet object that needs to be added to the store
 
+// Update an existing pet
+do {
+    try await PetAPI().updatePet(body: body)
+} catch {
+    print(error)
+}
 // Update an existing pet
 PetAPI.updatePet(body: body).then {
          // when the promise is fulfilled
@@ -307,6 +352,7 @@ Void (empty response body)
 
 # **updatePetWithForm**
 ```swift
+    open func updatePetWithForm(petId: Int64, name: String? = nil, status: String? = nil) async throws(ErrorResponse)
     open class func updatePetWithForm( petId: Int64,  name: String? = nil,  status: String? = nil) -> Promise<Void>
     open class func updatePetWithForm(petId: Int64, name: String? = nil, status: String? = nil) -> Observable<Void>
 ```
@@ -322,6 +368,12 @@ let petId = 987 // Int64 | ID of pet that needs to be updated
 let name = "name_example" // String | Updated name of the pet (optional)
 let status = "status_example" // String | Updated status of the pet (optional)
 
+// Updates a pet in the store with form data
+do {
+    try await PetAPI().updatePetWithForm(petId: petId, name: name, status: status)
+} catch {
+    print(error)
+}
 // Updates a pet in the store with form data
 PetAPI.updatePetWithForm(petId: petId, name: name, status: status).then {
          // when the promise is fulfilled
@@ -358,6 +410,7 @@ Void (empty response body)
 
 # **uploadFile**
 ```swift
+    open func uploadFile(petId: Int64, additionalMetadata: String? = nil, file: Data? = nil) async throws(ErrorResponse) -> ApiResponse
     open class func uploadFile( petId: Int64,  additionalMetadata: String? = nil,  file: Data? = nil) -> Promise<ApiResponse>
     open class func uploadFile(petId: Int64, additionalMetadata: String? = nil, file: Data? = nil) -> Observable<ApiResponse>
 ```
@@ -373,6 +426,13 @@ let petId = 987 // Int64 | ID of pet to update
 let additionalMetadata = "additionalMetadata_example" // String | Additional data to pass to server (optional)
 let file = Data([9, 8, 7]) // Data | file to upload (optional)
 
+// uploads an image
+do {
+    let response = try await PetAPI().uploadFile(petId: petId, additionalMetadata: additionalMetadata, file: file)
+    dump(response)
+} catch {
+    print(error)
+}
 // uploads an image
 PetAPI.uploadFile(petId: petId, additionalMetadata: additionalMetadata, file: file).then {
          // when the promise is fulfilled
@@ -409,6 +469,7 @@ Name | Type | Description  | Notes
 
 # **uploadFileWithRequiredFile**
 ```swift
+    open func uploadFileWithRequiredFile(petId: Int64, requiredFile: Data, additionalMetadata: String? = nil) async throws(ErrorResponse) -> ApiResponse
     open class func uploadFileWithRequiredFile( petId: Int64,  requiredFile: Data,  additionalMetadata: String? = nil) -> Promise<ApiResponse>
     open class func uploadFileWithRequiredFile(petId: Int64, requiredFile: Data, additionalMetadata: String? = nil) -> Observable<ApiResponse>
 ```
@@ -424,6 +485,13 @@ let petId = 987 // Int64 | ID of pet to update
 let requiredFile = Data([9, 8, 7]) // Data | file to upload
 let additionalMetadata = "additionalMetadata_example" // String | Additional data to pass to server (optional)
 
+// uploads an image (required)
+do {
+    let response = try await PetAPI().uploadFileWithRequiredFile(petId: petId, requiredFile: requiredFile, additionalMetadata: additionalMetadata)
+    dump(response)
+} catch {
+    print(error)
+}
 // uploads an image (required)
 PetAPI.uploadFileWithRequiredFile(petId: petId, requiredFile: requiredFile, additionalMetadata: additionalMetadata).then {
          // when the promise is fulfilled

--- a/samples/client/petstore/swift6/apiNonStaticMethod/docs/StoreAPI.md
+++ b/samples/client/petstore/swift6/apiNonStaticMethod/docs/StoreAPI.md
@@ -12,6 +12,7 @@ Method | HTTP request | Description
 
 # **deleteOrder**
 ```swift
+    open func deleteOrder(orderId: String) async throws(ErrorResponse)
     open class func deleteOrder( orderId: String) -> Promise<Void>
     open class func deleteOrder(orderId: String) -> Observable<Void>
 ```
@@ -27,6 +28,12 @@ import PetstoreClient
 
 let orderId = "orderId_example" // String | ID of the order that needs to be deleted
 
+// Delete purchase order by ID
+do {
+    try await StoreAPI().deleteOrder(orderId: orderId)
+} catch {
+    print(error)
+}
 // Delete purchase order by ID
 StoreAPI.deleteOrder(orderId: orderId).then {
          // when the promise is fulfilled
@@ -61,6 +68,7 @@ No authorization required
 
 # **getInventory**
 ```swift
+    open func getInventory() async throws(ErrorResponse) -> [String: Int]
     open class func getInventory() -> Promise<[String: Int]>
     open class func getInventory() -> Observable<[String: Int]>
 ```
@@ -75,6 +83,13 @@ Returns a map of status codes to quantities
 import PetstoreClient
 
 
+// Returns pet inventories by status
+do {
+    let response = try await StoreAPI().getInventory()
+    dump(response)
+} catch {
+    print(error)
+}
 // Returns pet inventories by status
 StoreAPI.getInventory().then {
          // when the promise is fulfilled
@@ -106,6 +121,7 @@ This endpoint does not need any parameter.
 
 # **getOrderById**
 ```swift
+    open func getOrderById(orderId: Int64) async throws(ErrorResponse) -> Order
     open class func getOrderById( orderId: Int64) -> Promise<Order>
     open class func getOrderById(orderId: Int64) -> Observable<Order>
 ```
@@ -121,6 +137,13 @@ import PetstoreClient
 
 let orderId = 987 // Int64 | ID of pet that needs to be fetched
 
+// Find purchase order by ID
+do {
+    let response = try await StoreAPI().getOrderById(orderId: orderId)
+    dump(response)
+} catch {
+    print(error)
+}
 // Find purchase order by ID
 StoreAPI.getOrderById(orderId: orderId).then {
          // when the promise is fulfilled
@@ -155,6 +178,7 @@ No authorization required
 
 # **placeOrder**
 ```swift
+    open func placeOrder(body: Order) async throws(ErrorResponse) -> Order
     open class func placeOrder( body: Order) -> Promise<Order>
     open class func placeOrder(body: Order) -> Observable<Order>
 ```
@@ -168,6 +192,13 @@ import PetstoreClient
 
 let body = Order(id: 123, petId: 123, quantity: 123, shipDate: Date(), status: "status_example", complete: false) // Order | order placed for purchasing the pet
 
+// Place an order for a pet
+do {
+    let response = try await StoreAPI().placeOrder(body: body)
+    dump(response)
+} catch {
+    print(error)
+}
 // Place an order for a pet
 StoreAPI.placeOrder(body: body).then {
          // when the promise is fulfilled

--- a/samples/client/petstore/swift6/apiNonStaticMethod/docs/UserAPI.md
+++ b/samples/client/petstore/swift6/apiNonStaticMethod/docs/UserAPI.md
@@ -16,6 +16,7 @@ Method | HTTP request | Description
 
 # **createUser**
 ```swift
+    open func createUser(body: User) async throws(ErrorResponse)
     open class func createUser( body: User) -> Promise<Void>
     open class func createUser(body: User) -> Observable<Void>
 ```
@@ -31,6 +32,12 @@ import PetstoreClient
 
 let body = User(id: 123, username: "username_example", firstName: "firstName_example", lastName: "lastName_example", email: "email_example", password: "password_example", phone: "phone_example", userStatus: 123) // User | Created user object
 
+// Create user
+do {
+    try await UserAPI().createUser(body: body)
+} catch {
+    print(error)
+}
 // Create user
 UserAPI.createUser(body: body).then {
          // when the promise is fulfilled
@@ -65,6 +72,7 @@ No authorization required
 
 # **createUsersWithArrayInput**
 ```swift
+    open func createUsersWithArrayInput(body: [User]) async throws(ErrorResponse)
     open class func createUsersWithArrayInput( body: [User]) -> Promise<Void>
     open class func createUsersWithArrayInput(body: [User]) -> Observable<Void>
 ```
@@ -78,6 +86,12 @@ import PetstoreClient
 
 let body = [User(id: 123, username: "username_example", firstName: "firstName_example", lastName: "lastName_example", email: "email_example", password: "password_example", phone: "phone_example", userStatus: 123)] // [User] | List of user object
 
+// Creates list of users with given input array
+do {
+    try await UserAPI().createUsersWithArrayInput(body: body)
+} catch {
+    print(error)
+}
 // Creates list of users with given input array
 UserAPI.createUsersWithArrayInput(body: body).then {
          // when the promise is fulfilled
@@ -112,6 +126,7 @@ No authorization required
 
 # **createUsersWithListInput**
 ```swift
+    open func createUsersWithListInput(body: [User]) async throws(ErrorResponse)
     open class func createUsersWithListInput( body: [User]) -> Promise<Void>
     open class func createUsersWithListInput(body: [User]) -> Observable<Void>
 ```
@@ -125,6 +140,12 @@ import PetstoreClient
 
 let body = [User(id: 123, username: "username_example", firstName: "firstName_example", lastName: "lastName_example", email: "email_example", password: "password_example", phone: "phone_example", userStatus: 123)] // [User] | List of user object
 
+// Creates list of users with given input array
+do {
+    try await UserAPI().createUsersWithListInput(body: body)
+} catch {
+    print(error)
+}
 // Creates list of users with given input array
 UserAPI.createUsersWithListInput(body: body).then {
          // when the promise is fulfilled
@@ -159,6 +180,7 @@ No authorization required
 
 # **deleteUser**
 ```swift
+    open func deleteUser(username: String) async throws(ErrorResponse)
     open class func deleteUser( username: String) -> Promise<Void>
     open class func deleteUser(username: String) -> Observable<Void>
 ```
@@ -174,6 +196,12 @@ import PetstoreClient
 
 let username = "username_example" // String | The name that needs to be deleted
 
+// Delete user
+do {
+    try await UserAPI().deleteUser(username: username)
+} catch {
+    print(error)
+}
 // Delete user
 UserAPI.deleteUser(username: username).then {
          // when the promise is fulfilled
@@ -208,6 +236,7 @@ No authorization required
 
 # **getUserByName**
 ```swift
+    open func getUserByName(username: String) async throws(ErrorResponse) -> User
     open class func getUserByName( username: String) -> Promise<User>
     open class func getUserByName(username: String) -> Observable<User>
 ```
@@ -221,6 +250,13 @@ import PetstoreClient
 
 let username = "username_example" // String | The name that needs to be fetched. Use user1 for testing.
 
+// Get user by user name
+do {
+    let response = try await UserAPI().getUserByName(username: username)
+    dump(response)
+} catch {
+    print(error)
+}
 // Get user by user name
 UserAPI.getUserByName(username: username).then {
          // when the promise is fulfilled
@@ -255,6 +291,7 @@ No authorization required
 
 # **loginUser**
 ```swift
+    open func loginUser(username: String, password: String) async throws(ErrorResponse) -> String
     open class func loginUser( username: String,  password: String) -> Promise<String>
     open class func loginUser(username: String, password: String) -> Observable<String>
 ```
@@ -269,6 +306,13 @@ import PetstoreClient
 let username = "username_example" // String | The user name for login
 let password = "password_example" // String | The password for login in clear text
 
+// Logs user into the system
+do {
+    let response = try await UserAPI().loginUser(username: username, password: password)
+    dump(response)
+} catch {
+    print(error)
+}
 // Logs user into the system
 UserAPI.loginUser(username: username, password: password).then {
          // when the promise is fulfilled
@@ -304,6 +348,7 @@ No authorization required
 
 # **logoutUser**
 ```swift
+    open func logoutUser() async throws(ErrorResponse)
     open class func logoutUser() -> Promise<Void>
     open class func logoutUser() -> Observable<Void>
 ```
@@ -316,6 +361,12 @@ Logs out current logged in user session
 import PetstoreClient
 
 
+// Logs out current logged in user session
+do {
+    try await UserAPI().logoutUser()
+} catch {
+    print(error)
+}
 // Logs out current logged in user session
 UserAPI.logoutUser().then {
          // when the promise is fulfilled
@@ -347,6 +398,7 @@ No authorization required
 
 # **updateUser**
 ```swift
+    open func updateUser(username: String, body: User) async throws(ErrorResponse)
     open class func updateUser( username: String,  body: User) -> Promise<Void>
     open class func updateUser(username: String, body: User) -> Observable<Void>
 ```
@@ -363,6 +415,12 @@ import PetstoreClient
 let username = "username_example" // String | name that need to be deleted
 let body = User(id: 123, username: "username_example", firstName: "firstName_example", lastName: "lastName_example", email: "email_example", password: "password_example", phone: "phone_example", userStatus: 123) // User | Updated user object
 
+// Updated user
+do {
+    try await UserAPI().updateUser(username: username, body: body)
+} catch {
+    print(error)
+}
 // Updated user
 UserAPI.updateUser(username: username, body: body).then {
          // when the promise is fulfilled

--- a/samples/client/petstore/swift6/asyncAwaitLibrary/docs/AnotherFakeAPI.md
+++ b/samples/client/petstore/swift6/asyncAwaitLibrary/docs/AnotherFakeAPI.md
@@ -9,7 +9,7 @@ Method | HTTP request | Description
 
 # **call123testSpecialTags**
 ```swift
-    open class func call123testSpecialTags(body: Client, completion: @escaping (_ data: Client?, _ error: Error?) -> Void)
+    open class func call123testSpecialTags(body: Client, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse) -> Client
 ```
 
 To test special tags
@@ -24,15 +24,11 @@ import PetstoreClient
 let body = Client(client: "client_example") // Client | client model
 
 // To test special tags
-AnotherFakeAPI.call123testSpecialTags(body: body) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    let response = try await AnotherFakeAPI.call123testSpecialTags(body: body)
+    dump(response)
+} catch {
+    print(error)
 }
 ```
 

--- a/samples/client/petstore/swift6/asyncAwaitLibrary/docs/FakeAPI.md
+++ b/samples/client/petstore/swift6/asyncAwaitLibrary/docs/FakeAPI.md
@@ -20,7 +20,7 @@ Method | HTTP request | Description
 
 # **fakeOuterBooleanSerialize**
 ```swift
-    open class func fakeOuterBooleanSerialize(body: Bool? = nil, completion: @escaping (_ data: Bool?, _ error: Error?) -> Void)
+    open class func fakeOuterBooleanSerialize(body: Bool? = nil, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse) -> Bool
 ```
 
 
@@ -34,15 +34,11 @@ import PetstoreClient
 
 let body = true // Bool | Input boolean as post body (optional)
 
-FakeAPI.fakeOuterBooleanSerialize(body: body) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    let response = try await FakeAPI.fakeOuterBooleanSerialize(body: body)
+    dump(response)
+} catch {
+    print(error)
 }
 ```
 
@@ -69,7 +65,7 @@ No authorization required
 
 # **fakeOuterCompositeSerialize**
 ```swift
-    open class func fakeOuterCompositeSerialize(body: OuterComposite? = nil, completion: @escaping (_ data: OuterComposite?, _ error: Error?) -> Void)
+    open class func fakeOuterCompositeSerialize(body: OuterComposite? = nil, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse) -> OuterComposite
 ```
 
 
@@ -83,15 +79,11 @@ import PetstoreClient
 
 let body = OuterComposite(myNumber: 123, myString: "myString_example", myBoolean: false) // OuterComposite | Input composite as post body (optional)
 
-FakeAPI.fakeOuterCompositeSerialize(body: body) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    let response = try await FakeAPI.fakeOuterCompositeSerialize(body: body)
+    dump(response)
+} catch {
+    print(error)
 }
 ```
 
@@ -118,7 +110,7 @@ No authorization required
 
 # **fakeOuterNumberSerialize**
 ```swift
-    open class func fakeOuterNumberSerialize(body: Double? = nil, completion: @escaping (_ data: Double?, _ error: Error?) -> Void)
+    open class func fakeOuterNumberSerialize(body: Double? = nil, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse) -> Double
 ```
 
 
@@ -132,15 +124,11 @@ import PetstoreClient
 
 let body = 987 // Double | Input number as post body (optional)
 
-FakeAPI.fakeOuterNumberSerialize(body: body) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    let response = try await FakeAPI.fakeOuterNumberSerialize(body: body)
+    dump(response)
+} catch {
+    print(error)
 }
 ```
 
@@ -167,7 +155,7 @@ No authorization required
 
 # **fakeOuterStringSerialize**
 ```swift
-    open class func fakeOuterStringSerialize(body: String? = nil, completion: @escaping (_ data: String?, _ error: Error?) -> Void)
+    open class func fakeOuterStringSerialize(body: String? = nil, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse) -> String
 ```
 
 
@@ -181,15 +169,11 @@ import PetstoreClient
 
 let body = "body_example" // String | Input string as post body (optional)
 
-FakeAPI.fakeOuterStringSerialize(body: body) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    let response = try await FakeAPI.fakeOuterStringSerialize(body: body)
+    dump(response)
+} catch {
+    print(error)
 }
 ```
 
@@ -216,7 +200,7 @@ No authorization required
 
 # **testBodyWithFileSchema**
 ```swift
-    open class func testBodyWithFileSchema(body: FileSchemaTestClass, completion: @escaping (_ data: Void?, _ error: Error?) -> Void)
+    open class func testBodyWithFileSchema(body: FileSchemaTestClass, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse)
 ```
 
 
@@ -230,15 +214,10 @@ import PetstoreClient
 
 let body = FileSchemaTestClass(file: File(sourceURI: "sourceURI_example"), files: [nil]) // FileSchemaTestClass | 
 
-FakeAPI.testBodyWithFileSchema(body: body) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    try await FakeAPI.testBodyWithFileSchema(body: body)
+} catch {
+    print(error)
 }
 ```
 
@@ -265,7 +244,7 @@ No authorization required
 
 # **testBodyWithQueryParams**
 ```swift
-    open class func testBodyWithQueryParams(query: String, body: User, completion: @escaping (_ data: Void?, _ error: Error?) -> Void)
+    open class func testBodyWithQueryParams(query: String, body: User, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse)
 ```
 
 
@@ -278,15 +257,10 @@ import PetstoreClient
 let query = "query_example" // String | 
 let body = User(id: 123, username: "username_example", firstName: "firstName_example", lastName: "lastName_example", email: "email_example", password: "password_example", phone: "phone_example", userStatus: 123) // User | 
 
-FakeAPI.testBodyWithQueryParams(query: query, body: body) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    try await FakeAPI.testBodyWithQueryParams(query: query, body: body)
+} catch {
+    print(error)
 }
 ```
 
@@ -314,7 +288,7 @@ No authorization required
 
 # **testClientModel**
 ```swift
-    open class func testClientModel(body: Client, completion: @escaping (_ data: Client?, _ error: Error?) -> Void)
+    open class func testClientModel(body: Client, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse) -> Client
 ```
 
 To test \"client\" model
@@ -329,15 +303,11 @@ import PetstoreClient
 let body = Client(client: "client_example") // Client | client model
 
 // To test \"client\" model
-FakeAPI.testClientModel(body: body) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    let response = try await FakeAPI.testClientModel(body: body)
+    dump(response)
+} catch {
+    print(error)
 }
 ```
 
@@ -364,7 +334,7 @@ No authorization required
 
 # **testEndpointParameters**
 ```swift
-    open class func testEndpointParameters(number: Double, double: Double, patternWithoutDelimiter: String, byte: Data, integer: Int? = nil, int32: Int? = nil, int64: Int64? = nil, float: Float? = nil, string: String? = nil, binary: URL? = nil, date: Date? = nil, dateTime: Date? = nil, password: String? = nil, callback: String? = nil, completion: @escaping (_ data: Void?, _ error: Error?) -> Void)
+    open class func testEndpointParameters(number: Double, double: Double, patternWithoutDelimiter: String, byte: Data, integer: Int? = nil, int32: Int? = nil, int64: Int64? = nil, float: Float? = nil, string: String? = nil, binary: URL? = nil, date: Date? = nil, dateTime: Date? = nil, password: String? = nil, callback: String? = nil, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse)
 ```
 
 Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트
@@ -392,15 +362,10 @@ let password = "password_example" // String | None (optional)
 let callback = "callback_example" // String | None (optional)
 
 // Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트
-FakeAPI.testEndpointParameters(number: number, double: double, patternWithoutDelimiter: patternWithoutDelimiter, byte: byte, integer: integer, int32: int32, int64: int64, float: float, string: string, binary: binary, date: date, dateTime: dateTime, password: password, callback: callback) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    try await FakeAPI.testEndpointParameters(number: number, double: double, patternWithoutDelimiter: patternWithoutDelimiter, byte: byte, integer: integer, int32: int32, int64: int64, float: float, string: string, binary: binary, date: date, dateTime: dateTime, password: password, callback: callback)
+} catch {
+    print(error)
 }
 ```
 
@@ -440,7 +405,7 @@ Void (empty response body)
 
 # **testEnumParameters**
 ```swift
-    open class func testEnumParameters(enumHeaderStringArray: [EnumHeaderStringArray_testEnumParameters]? = nil, enumHeaderString: EnumHeaderString_testEnumParameters? = nil, enumQueryStringArray: [EnumQueryStringArray_testEnumParameters]? = nil, enumQueryString: EnumQueryString_testEnumParameters? = nil, enumQueryInteger: EnumQueryInteger_testEnumParameters? = nil, enumQueryDouble: EnumQueryDouble_testEnumParameters? = nil, enumFormStringArray: [EnumFormStringArray_testEnumParameters]? = nil, enumFormString: EnumFormString_testEnumParameters? = nil, completion: @escaping (_ data: Void?, _ error: Error?) -> Void)
+    open class func testEnumParameters(enumHeaderStringArray: [EnumHeaderStringArray_testEnumParameters]? = nil, enumHeaderString: EnumHeaderString_testEnumParameters? = nil, enumQueryStringArray: [EnumQueryStringArray_testEnumParameters]? = nil, enumQueryString: EnumQueryString_testEnumParameters? = nil, enumQueryInteger: EnumQueryInteger_testEnumParameters? = nil, enumQueryDouble: EnumQueryDouble_testEnumParameters? = nil, enumFormStringArray: [EnumFormStringArray_testEnumParameters]? = nil, enumFormString: EnumFormString_testEnumParameters? = nil, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse)
 ```
 
 To test enum parameters
@@ -462,15 +427,10 @@ let enumFormStringArray = ["inner_example"] // [String] | Form parameter enum te
 let enumFormString = "enumFormString_example" // String | Form parameter enum test (string) (optional) (default to .efg)
 
 // To test enum parameters
-FakeAPI.testEnumParameters(enumHeaderStringArray: enumHeaderStringArray, enumHeaderString: enumHeaderString, enumQueryStringArray: enumQueryStringArray, enumQueryString: enumQueryString, enumQueryInteger: enumQueryInteger, enumQueryDouble: enumQueryDouble, enumFormStringArray: enumFormStringArray, enumFormString: enumFormString) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    try await FakeAPI.testEnumParameters(enumHeaderStringArray: enumHeaderStringArray, enumHeaderString: enumHeaderString, enumQueryStringArray: enumQueryStringArray, enumQueryString: enumQueryString, enumQueryInteger: enumQueryInteger, enumQueryDouble: enumQueryDouble, enumFormStringArray: enumFormStringArray, enumFormString: enumFormString)
+} catch {
+    print(error)
 }
 ```
 
@@ -504,7 +464,7 @@ No authorization required
 
 # **testGroupParameters**
 ```swift
-    open class func testGroupParameters(requiredStringGroup: Int, requiredBooleanGroup: Bool, requiredInt64Group: Int64, stringGroup: Int? = nil, booleanGroup: Bool? = nil, int64Group: Int64? = nil, completion: @escaping (_ data: Void?, _ error: Error?) -> Void)
+    open class func testGroupParameters(requiredStringGroup: Int, requiredBooleanGroup: Bool, requiredInt64Group: Int64, stringGroup: Int? = nil, booleanGroup: Bool? = nil, int64Group: Int64? = nil, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse)
 ```
 
 Fake endpoint to test group parameters (optional)
@@ -524,15 +484,10 @@ let booleanGroup = true // Bool | Boolean in group parameters (optional)
 let int64Group = 987 // Int64 | Integer in group parameters (optional)
 
 // Fake endpoint to test group parameters (optional)
-FakeAPI.testGroupParameters(requiredStringGroup: requiredStringGroup, requiredBooleanGroup: requiredBooleanGroup, requiredInt64Group: requiredInt64Group, stringGroup: stringGroup, booleanGroup: booleanGroup, int64Group: int64Group) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    try await FakeAPI.testGroupParameters(requiredStringGroup: requiredStringGroup, requiredBooleanGroup: requiredBooleanGroup, requiredInt64Group: requiredInt64Group, stringGroup: stringGroup, booleanGroup: booleanGroup, int64Group: int64Group)
+} catch {
+    print(error)
 }
 ```
 
@@ -564,7 +519,7 @@ No authorization required
 
 # **testInlineAdditionalProperties**
 ```swift
-    open class func testInlineAdditionalProperties(param: [String: String], completion: @escaping (_ data: Void?, _ error: Error?) -> Void)
+    open class func testInlineAdditionalProperties(param: [String: String], apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse)
 ```
 
 test inline additionalProperties
@@ -577,15 +532,10 @@ import PetstoreClient
 let param = "TODO" // [String: String] | request body
 
 // test inline additionalProperties
-FakeAPI.testInlineAdditionalProperties(param: param) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    try await FakeAPI.testInlineAdditionalProperties(param: param)
+} catch {
+    print(error)
 }
 ```
 
@@ -612,7 +562,7 @@ No authorization required
 
 # **testJsonFormData**
 ```swift
-    open class func testJsonFormData(param: String, param2: String, completion: @escaping (_ data: Void?, _ error: Error?) -> Void)
+    open class func testJsonFormData(param: String, param2: String, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse)
 ```
 
 test json serialization of form data
@@ -626,15 +576,10 @@ let param = "param_example" // String | field1
 let param2 = "param2_example" // String | field2
 
 // test json serialization of form data
-FakeAPI.testJsonFormData(param: param, param2: param2) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    try await FakeAPI.testJsonFormData(param: param, param2: param2)
+} catch {
+    print(error)
 }
 ```
 

--- a/samples/client/petstore/swift6/asyncAwaitLibrary/docs/FakeClassnameTags123API.md
+++ b/samples/client/petstore/swift6/asyncAwaitLibrary/docs/FakeClassnameTags123API.md
@@ -9,7 +9,7 @@ Method | HTTP request | Description
 
 # **testClassname**
 ```swift
-    open class func testClassname(body: Client, completion: @escaping (_ data: Client?, _ error: Error?) -> Void)
+    open class func testClassname(body: Client, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse) -> Client
 ```
 
 To test class name in snake case
@@ -24,15 +24,11 @@ import PetstoreClient
 let body = Client(client: "client_example") // Client | client model
 
 // To test class name in snake case
-FakeClassnameTags123API.testClassname(body: body) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    let response = try await FakeClassnameTags123API.testClassname(body: body)
+    dump(response)
+} catch {
+    print(error)
 }
 ```
 

--- a/samples/client/petstore/swift6/asyncAwaitLibrary/docs/PetAPI.md
+++ b/samples/client/petstore/swift6/asyncAwaitLibrary/docs/PetAPI.md
@@ -17,7 +17,7 @@ Method | HTTP request | Description
 
 # **addPet**
 ```swift
-    open class func addPet(body: Pet, completion: @escaping (_ data: Void?, _ error: Error?) -> Void)
+    open class func addPet(body: Pet, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse)
 ```
 
 Add a new pet to the store
@@ -30,15 +30,10 @@ import PetstoreClient
 let body = Pet(id: 123, category: Category(id: 123, name: "name_example"), name: "name_example", photoUrls: ["photoUrls_example"], tags: [Tag(id: 123, name: "name_example")], status: "status_example") // Pet | Pet object that needs to be added to the store
 
 // Add a new pet to the store
-PetAPI.addPet(body: body) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    try await PetAPI.addPet(body: body)
+} catch {
+    print(error)
 }
 ```
 
@@ -65,7 +60,7 @@ Void (empty response body)
 
 # **deletePet**
 ```swift
-    open class func deletePet(petId: Int64, apiKey: String? = nil, completion: @escaping (_ data: Void?, _ error: Error?) -> Void)
+    open class func deletePet(petId: Int64, apiKey: String? = nil, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse)
 ```
 
 Deletes a pet
@@ -79,15 +74,10 @@ let petId = 987 // Int64 | Pet id to delete
 let apiKey = "apiKey_example" // String |  (optional)
 
 // Deletes a pet
-PetAPI.deletePet(petId: petId, apiKey: apiKey) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    try await PetAPI.deletePet(petId: petId, apiKey: apiKey)
+} catch {
+    print(error)
 }
 ```
 
@@ -115,7 +105,7 @@ Void (empty response body)
 
 # **findPetsByStatus**
 ```swift
-    open class func findPetsByStatus(status: [Status_findPetsByStatus], completion: @escaping (_ data: [Pet]?, _ error: Error?) -> Void)
+    open class func findPetsByStatus(status: [Status_findPetsByStatus], apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse) -> [Pet]
 ```
 
 Finds Pets by status
@@ -130,15 +120,11 @@ import PetstoreClient
 let status = ["status_example"] // [String] | Status values that need to be considered for filter
 
 // Finds Pets by status
-PetAPI.findPetsByStatus(status: status) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    let response = try await PetAPI.findPetsByStatus(status: status)
+    dump(response)
+} catch {
+    print(error)
 }
 ```
 
@@ -165,7 +151,7 @@ Name | Type | Description  | Notes
 
 # **findPetsByTags**
 ```swift
-    open class func findPetsByTags(tags: [String], completion: @escaping (_ data: [Pet]?, _ error: Error?) -> Void)
+    open class func findPetsByTags(tags: [String], apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse) -> [Pet]
 ```
 
 Finds Pets by tags
@@ -180,15 +166,11 @@ import PetstoreClient
 let tags = ["inner_example"] // [String] | Tags to filter by
 
 // Finds Pets by tags
-PetAPI.findPetsByTags(tags: tags) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    let response = try await PetAPI.findPetsByTags(tags: tags)
+    dump(response)
+} catch {
+    print(error)
 }
 ```
 
@@ -215,7 +197,7 @@ Name | Type | Description  | Notes
 
 # **getPetById**
 ```swift
-    open class func getPetById(petId: Int64, completion: @escaping (_ data: Pet?, _ error: Error?) -> Void)
+    open class func getPetById(petId: Int64, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse) -> Pet
 ```
 
 Find pet by ID
@@ -230,15 +212,11 @@ import PetstoreClient
 let petId = 987 // Int64 | ID of pet to return
 
 // Find pet by ID
-PetAPI.getPetById(petId: petId) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    let response = try await PetAPI.getPetById(petId: petId)
+    dump(response)
+} catch {
+    print(error)
 }
 ```
 
@@ -265,7 +243,7 @@ Name | Type | Description  | Notes
 
 # **updatePet**
 ```swift
-    open class func updatePet(body: Pet, completion: @escaping (_ data: Void?, _ error: Error?) -> Void)
+    open class func updatePet(body: Pet, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse)
 ```
 
 Update an existing pet
@@ -278,15 +256,10 @@ import PetstoreClient
 let body = Pet(id: 123, category: Category(id: 123, name: "name_example"), name: "name_example", photoUrls: ["photoUrls_example"], tags: [Tag(id: 123, name: "name_example")], status: "status_example") // Pet | Pet object that needs to be added to the store
 
 // Update an existing pet
-PetAPI.updatePet(body: body) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    try await PetAPI.updatePet(body: body)
+} catch {
+    print(error)
 }
 ```
 
@@ -313,7 +286,7 @@ Void (empty response body)
 
 # **updatePetWithForm**
 ```swift
-    open class func updatePetWithForm(petId: Int64, name: String? = nil, status: String? = nil, completion: @escaping (_ data: Void?, _ error: Error?) -> Void)
+    open class func updatePetWithForm(petId: Int64, name: String? = nil, status: String? = nil, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse)
 ```
 
 Updates a pet in the store with form data
@@ -328,15 +301,10 @@ let name = "name_example" // String | Updated name of the pet (optional)
 let status = "status_example" // String | Updated status of the pet (optional)
 
 // Updates a pet in the store with form data
-PetAPI.updatePetWithForm(petId: petId, name: name, status: status) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    try await PetAPI.updatePetWithForm(petId: petId, name: name, status: status)
+} catch {
+    print(error)
 }
 ```
 
@@ -365,7 +333,7 @@ Void (empty response body)
 
 # **uploadFile**
 ```swift
-    open class func uploadFile(petId: Int64, additionalMetadata: String? = nil, file: URL? = nil, completion: @escaping (_ data: ApiResponse?, _ error: Error?) -> Void)
+    open class func uploadFile(petId: Int64, additionalMetadata: String? = nil, file: URL? = nil, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse) -> ApiResponse
 ```
 
 uploads an image
@@ -380,15 +348,11 @@ let additionalMetadata = "additionalMetadata_example" // String | Additional dat
 let file = URL(string: "https://example.com")! // URL | file to upload (optional)
 
 // uploads an image
-PetAPI.uploadFile(petId: petId, additionalMetadata: additionalMetadata, file: file) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    let response = try await PetAPI.uploadFile(petId: petId, additionalMetadata: additionalMetadata, file: file)
+    dump(response)
+} catch {
+    print(error)
 }
 ```
 
@@ -417,7 +381,7 @@ Name | Type | Description  | Notes
 
 # **uploadFileWithRequiredFile**
 ```swift
-    open class func uploadFileWithRequiredFile(petId: Int64, requiredFile: URL, additionalMetadata: String? = nil, completion: @escaping (_ data: ApiResponse?, _ error: Error?) -> Void)
+    open class func uploadFileWithRequiredFile(petId: Int64, requiredFile: URL, additionalMetadata: String? = nil, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse) -> ApiResponse
 ```
 
 uploads an image (required)
@@ -432,15 +396,11 @@ let requiredFile = URL(string: "https://example.com")! // URL | file to upload
 let additionalMetadata = "additionalMetadata_example" // String | Additional data to pass to server (optional)
 
 // uploads an image (required)
-PetAPI.uploadFileWithRequiredFile(petId: petId, requiredFile: requiredFile, additionalMetadata: additionalMetadata) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    let response = try await PetAPI.uploadFileWithRequiredFile(petId: petId, requiredFile: requiredFile, additionalMetadata: additionalMetadata)
+    dump(response)
+} catch {
+    print(error)
 }
 ```
 

--- a/samples/client/petstore/swift6/asyncAwaitLibrary/docs/StoreAPI.md
+++ b/samples/client/petstore/swift6/asyncAwaitLibrary/docs/StoreAPI.md
@@ -12,7 +12,7 @@ Method | HTTP request | Description
 
 # **deleteOrder**
 ```swift
-    open class func deleteOrder(orderId: String, completion: @escaping (_ data: Void?, _ error: Error?) -> Void)
+    open class func deleteOrder(orderId: String, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse)
 ```
 
 Delete purchase order by ID
@@ -27,15 +27,10 @@ import PetstoreClient
 let orderId = "orderId_example" // String | ID of the order that needs to be deleted
 
 // Delete purchase order by ID
-StoreAPI.deleteOrder(orderId: orderId) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    try await StoreAPI.deleteOrder(orderId: orderId)
+} catch {
+    print(error)
 }
 ```
 
@@ -62,7 +57,7 @@ No authorization required
 
 # **getInventory**
 ```swift
-    open class func getInventory(completion: @escaping (_ data: [String: Int]?, _ error: Error?) -> Void)
+    open class func getInventory(apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse) -> [String: Int]
 ```
 
 Returns pet inventories by status
@@ -76,15 +71,11 @@ import PetstoreClient
 
 
 // Returns pet inventories by status
-StoreAPI.getInventory() { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    let response = try await StoreAPI.getInventory()
+    dump(response)
+} catch {
+    print(error)
 }
 ```
 
@@ -108,7 +99,7 @@ This endpoint does not need any parameter.
 
 # **getOrderById**
 ```swift
-    open class func getOrderById(orderId: Int64, completion: @escaping (_ data: Order?, _ error: Error?) -> Void)
+    open class func getOrderById(orderId: Int64, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse) -> Order
 ```
 
 Find purchase order by ID
@@ -123,15 +114,11 @@ import PetstoreClient
 let orderId = 987 // Int64 | ID of pet that needs to be fetched
 
 // Find purchase order by ID
-StoreAPI.getOrderById(orderId: orderId) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    let response = try await StoreAPI.getOrderById(orderId: orderId)
+    dump(response)
+} catch {
+    print(error)
 }
 ```
 
@@ -158,7 +145,7 @@ No authorization required
 
 # **placeOrder**
 ```swift
-    open class func placeOrder(body: Order, completion: @escaping (_ data: Order?, _ error: Error?) -> Void)
+    open class func placeOrder(body: Order, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse) -> Order
 ```
 
 Place an order for a pet
@@ -171,15 +158,11 @@ import PetstoreClient
 let body = Order(id: 123, petId: 123, quantity: 123, shipDate: Date(), status: "status_example", complete: false) // Order | order placed for purchasing the pet
 
 // Place an order for a pet
-StoreAPI.placeOrder(body: body) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    let response = try await StoreAPI.placeOrder(body: body)
+    dump(response)
+} catch {
+    print(error)
 }
 ```
 

--- a/samples/client/petstore/swift6/asyncAwaitLibrary/docs/UserAPI.md
+++ b/samples/client/petstore/swift6/asyncAwaitLibrary/docs/UserAPI.md
@@ -16,7 +16,7 @@ Method | HTTP request | Description
 
 # **createUser**
 ```swift
-    open class func createUser(body: User, completion: @escaping (_ data: Void?, _ error: Error?) -> Void)
+    open class func createUser(body: User, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse)
 ```
 
 Create user
@@ -31,15 +31,10 @@ import PetstoreClient
 let body = User(id: 123, username: "username_example", firstName: "firstName_example", lastName: "lastName_example", email: "email_example", password: "password_example", phone: "phone_example", userStatus: 123) // User | Created user object
 
 // Create user
-UserAPI.createUser(body: body) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    try await UserAPI.createUser(body: body)
+} catch {
+    print(error)
 }
 ```
 
@@ -66,7 +61,7 @@ No authorization required
 
 # **createUsersWithArrayInput**
 ```swift
-    open class func createUsersWithArrayInput(body: [User], completion: @escaping (_ data: Void?, _ error: Error?) -> Void)
+    open class func createUsersWithArrayInput(body: [User], apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse)
 ```
 
 Creates list of users with given input array
@@ -79,15 +74,10 @@ import PetstoreClient
 let body = [User(id: 123, username: "username_example", firstName: "firstName_example", lastName: "lastName_example", email: "email_example", password: "password_example", phone: "phone_example", userStatus: 123)] // [User] | List of user object
 
 // Creates list of users with given input array
-UserAPI.createUsersWithArrayInput(body: body) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    try await UserAPI.createUsersWithArrayInput(body: body)
+} catch {
+    print(error)
 }
 ```
 
@@ -114,7 +104,7 @@ No authorization required
 
 # **createUsersWithListInput**
 ```swift
-    open class func createUsersWithListInput(body: [User], completion: @escaping (_ data: Void?, _ error: Error?) -> Void)
+    open class func createUsersWithListInput(body: [User], apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse)
 ```
 
 Creates list of users with given input array
@@ -127,15 +117,10 @@ import PetstoreClient
 let body = [User(id: 123, username: "username_example", firstName: "firstName_example", lastName: "lastName_example", email: "email_example", password: "password_example", phone: "phone_example", userStatus: 123)] // [User] | List of user object
 
 // Creates list of users with given input array
-UserAPI.createUsersWithListInput(body: body) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    try await UserAPI.createUsersWithListInput(body: body)
+} catch {
+    print(error)
 }
 ```
 
@@ -162,7 +147,7 @@ No authorization required
 
 # **deleteUser**
 ```swift
-    open class func deleteUser(username: String, completion: @escaping (_ data: Void?, _ error: Error?) -> Void)
+    open class func deleteUser(username: String, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse)
 ```
 
 Delete user
@@ -177,15 +162,10 @@ import PetstoreClient
 let username = "username_example" // String | The name that needs to be deleted
 
 // Delete user
-UserAPI.deleteUser(username: username) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    try await UserAPI.deleteUser(username: username)
+} catch {
+    print(error)
 }
 ```
 
@@ -212,7 +192,7 @@ No authorization required
 
 # **getUserByName**
 ```swift
-    open class func getUserByName(username: String, completion: @escaping (_ data: User?, _ error: Error?) -> Void)
+    open class func getUserByName(username: String, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse) -> User
 ```
 
 Get user by user name
@@ -225,15 +205,11 @@ import PetstoreClient
 let username = "username_example" // String | The name that needs to be fetched. Use user1 for testing.
 
 // Get user by user name
-UserAPI.getUserByName(username: username) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    let response = try await UserAPI.getUserByName(username: username)
+    dump(response)
+} catch {
+    print(error)
 }
 ```
 
@@ -260,7 +236,7 @@ No authorization required
 
 # **loginUser**
 ```swift
-    open class func loginUser(username: String, password: String, completion: @escaping (_ data: String?, _ error: Error?) -> Void)
+    open class func loginUser(username: String, password: String, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse) -> String
 ```
 
 Logs user into the system
@@ -274,15 +250,11 @@ let username = "username_example" // String | The user name for login
 let password = "password_example" // String | The password for login in clear text
 
 // Logs user into the system
-UserAPI.loginUser(username: username, password: password) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    let response = try await UserAPI.loginUser(username: username, password: password)
+    dump(response)
+} catch {
+    print(error)
 }
 ```
 
@@ -310,7 +282,7 @@ No authorization required
 
 # **logoutUser**
 ```swift
-    open class func logoutUser(completion: @escaping (_ data: Void?, _ error: Error?) -> Void)
+    open class func logoutUser(apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse)
 ```
 
 Logs out current logged in user session
@@ -322,15 +294,10 @@ import PetstoreClient
 
 
 // Logs out current logged in user session
-UserAPI.logoutUser() { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    try await UserAPI.logoutUser()
+} catch {
+    print(error)
 }
 ```
 
@@ -354,7 +321,7 @@ No authorization required
 
 # **updateUser**
 ```swift
-    open class func updateUser(username: String, body: User, completion: @escaping (_ data: Void?, _ error: Error?) -> Void)
+    open class func updateUser(username: String, body: User, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse)
 ```
 
 Updated user
@@ -370,15 +337,10 @@ let username = "username_example" // String | name that need to be deleted
 let body = User(id: 123, username: "username_example", firstName: "firstName_example", lastName: "lastName_example", email: "email_example", password: "password_example", phone: "phone_example", userStatus: 123) // User | Updated user object
 
 // Updated user
-UserAPI.updateUser(username: username, body: body) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    try await UserAPI.updateUser(username: username, body: body)
+} catch {
+    print(error)
 }
 ```
 

--- a/samples/client/petstore/swift6/default/docs/AnotherFakeAPI.md
+++ b/samples/client/petstore/swift6/default/docs/AnotherFakeAPI.md
@@ -9,7 +9,7 @@ Method | HTTP request | Description
 
 # **call123testSpecialTags**
 ```swift
-    open class func call123testSpecialTags(uuidTest: UUID, body: Client, completion: @escaping (_ data: Client?, _ error: Error?) -> Void)
+    open class func call123testSpecialTags(uuidTest: UUID, body: Client, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse) -> Client
 ```
 
 To test special tags
@@ -25,15 +25,11 @@ let uuidTest = 987 // UUID | to test uuid example value
 let body = Client(client: "client_example") // Client | client model
 
 // To test special tags
-AnotherFakeAPI.call123testSpecialTags(uuidTest: uuidTest, body: body) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    let response = try await AnotherFakeAPI.call123testSpecialTags(uuidTest: uuidTest, body: body)
+    dump(response)
+} catch {
+    print(error)
 }
 ```
 

--- a/samples/client/petstore/swift6/default/docs/FakeAPI.md
+++ b/samples/client/petstore/swift6/default/docs/FakeAPI.md
@@ -22,7 +22,7 @@ Method | HTTP request | Description
 
 # **createXmlItem**
 ```swift
-    open class func createXmlItem(xmlItem: XmlItem, completion: @escaping (_ data: Void?, _ error: Error?) -> Void)
+    open class func createXmlItem(xmlItem: XmlItem, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse)
 ```
 
 creates an XmlItem
@@ -37,15 +37,10 @@ import PetstoreClient
 let xmlItem = XmlItem(attributeString: "attributeString_example", attributeNumber: 123, attributeInteger: 123, attributeBoolean: true, wrappedArray: [123], nameString: "nameString_example", nameNumber: 123, nameInteger: 123, nameBoolean: true, nameArray: [123], nameWrappedArray: [123], prefixString: "prefixString_example", prefixNumber: 123, prefixInteger: 123, prefixBoolean: true, prefixArray: [123], prefixWrappedArray: [123], namespaceString: "namespaceString_example", namespaceNumber: 123, namespaceInteger: 123, namespaceBoolean: true, namespaceArray: [123], namespaceWrappedArray: [123], prefixNsString: "prefixNsString_example", prefixNsNumber: 123, prefixNsInteger: 123, prefixNsBoolean: true, prefixNsArray: [123], prefixNsWrappedArray: [123]) // XmlItem | XmlItem Body
 
 // creates an XmlItem
-FakeAPI.createXmlItem(xmlItem: xmlItem) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    try await FakeAPI.createXmlItem(xmlItem: xmlItem)
+} catch {
+    print(error)
 }
 ```
 
@@ -72,7 +67,7 @@ No authorization required
 
 # **fakeOuterBooleanSerialize**
 ```swift
-    open class func fakeOuterBooleanSerialize(body: Bool? = nil, completion: @escaping (_ data: Bool?, _ error: Error?) -> Void)
+    open class func fakeOuterBooleanSerialize(body: Bool? = nil, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse) -> Bool
 ```
 
 
@@ -86,15 +81,11 @@ import PetstoreClient
 
 let body = true // Bool | Input boolean as post body (optional)
 
-FakeAPI.fakeOuterBooleanSerialize(body: body) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    let response = try await FakeAPI.fakeOuterBooleanSerialize(body: body)
+    dump(response)
+} catch {
+    print(error)
 }
 ```
 
@@ -121,7 +112,7 @@ No authorization required
 
 # **fakeOuterCompositeSerialize**
 ```swift
-    open class func fakeOuterCompositeSerialize(body: OuterComposite? = nil, completion: @escaping (_ data: OuterComposite?, _ error: Error?) -> Void)
+    open class func fakeOuterCompositeSerialize(body: OuterComposite? = nil, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse) -> OuterComposite
 ```
 
 
@@ -135,15 +126,11 @@ import PetstoreClient
 
 let body = OuterComposite(myNumber: 123, myString: "myString_example", myBoolean: false) // OuterComposite | Input composite as post body (optional)
 
-FakeAPI.fakeOuterCompositeSerialize(body: body) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    let response = try await FakeAPI.fakeOuterCompositeSerialize(body: body)
+    dump(response)
+} catch {
+    print(error)
 }
 ```
 
@@ -170,7 +157,7 @@ No authorization required
 
 # **fakeOuterNumberSerialize**
 ```swift
-    open class func fakeOuterNumberSerialize(body: Double? = nil, completion: @escaping (_ data: Double?, _ error: Error?) -> Void)
+    open class func fakeOuterNumberSerialize(body: Double? = nil, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse) -> Double
 ```
 
 
@@ -184,15 +171,11 @@ import PetstoreClient
 
 let body = 987 // Double | Input number as post body (optional)
 
-FakeAPI.fakeOuterNumberSerialize(body: body) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    let response = try await FakeAPI.fakeOuterNumberSerialize(body: body)
+    dump(response)
+} catch {
+    print(error)
 }
 ```
 
@@ -219,7 +202,7 @@ No authorization required
 
 # **fakeOuterStringSerialize**
 ```swift
-    open class func fakeOuterStringSerialize(body: String? = nil, completion: @escaping (_ data: String?, _ error: Error?) -> Void)
+    open class func fakeOuterStringSerialize(body: String? = nil, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse) -> String
 ```
 
 
@@ -233,15 +216,11 @@ import PetstoreClient
 
 let body = "body_example" // String | Input string as post body (optional)
 
-FakeAPI.fakeOuterStringSerialize(body: body) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    let response = try await FakeAPI.fakeOuterStringSerialize(body: body)
+    dump(response)
+} catch {
+    print(error)
 }
 ```
 
@@ -268,7 +247,7 @@ No authorization required
 
 # **testBodyWithFileSchema**
 ```swift
-    open class func testBodyWithFileSchema(body: FileSchemaTestClass, completion: @escaping (_ data: Void?, _ error: Error?) -> Void)
+    open class func testBodyWithFileSchema(body: FileSchemaTestClass, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse)
 ```
 
 
@@ -282,15 +261,10 @@ import PetstoreClient
 
 let body = FileSchemaTestClass(file: File(sourceURI: "sourceURI_example"), files: [nil]) // FileSchemaTestClass | 
 
-FakeAPI.testBodyWithFileSchema(body: body) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    try await FakeAPI.testBodyWithFileSchema(body: body)
+} catch {
+    print(error)
 }
 ```
 
@@ -317,7 +291,7 @@ No authorization required
 
 # **testBodyWithQueryParams**
 ```swift
-    open class func testBodyWithQueryParams(query: String, body: User, completion: @escaping (_ data: Void?, _ error: Error?) -> Void)
+    open class func testBodyWithQueryParams(query: String, body: User, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse)
 ```
 
 
@@ -330,15 +304,10 @@ import PetstoreClient
 let query = "query_example" // String | 
 let body = User(id: 123, username: "username_example", firstName: "firstName_example", lastName: "lastName_example", email: "email_example", password: "password_example", phone: "phone_example", userStatus: 123) // User | 
 
-FakeAPI.testBodyWithQueryParams(query: query, body: body) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    try await FakeAPI.testBodyWithQueryParams(query: query, body: body)
+} catch {
+    print(error)
 }
 ```
 
@@ -366,7 +335,7 @@ No authorization required
 
 # **testClientModel**
 ```swift
-    open class func testClientModel(body: Client, completion: @escaping (_ data: Client?, _ error: Error?) -> Void)
+    open class func testClientModel(body: Client, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse) -> Client
 ```
 
 To test \"client\" model
@@ -381,15 +350,11 @@ import PetstoreClient
 let body = Client(client: "client_example") // Client | client model
 
 // To test \"client\" model
-FakeAPI.testClientModel(body: body) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    let response = try await FakeAPI.testClientModel(body: body)
+    dump(response)
+} catch {
+    print(error)
 }
 ```
 
@@ -416,7 +381,7 @@ No authorization required
 
 # **testEndpointParameters**
 ```swift
-    open class func testEndpointParameters(number: Double, double: Double, patternWithoutDelimiter: String, byte: Data, integer: Int? = nil, int32: Int? = nil, int64: Int64? = nil, float: Float? = nil, string: String? = nil, binary: URL? = nil, date: Date? = nil, dateTime: Date? = nil, password: String? = nil, callback: String? = nil, completion: @escaping (_ data: Void?, _ error: Error?) -> Void)
+    open class func testEndpointParameters(number: Double, double: Double, patternWithoutDelimiter: String, byte: Data, integer: Int? = nil, int32: Int? = nil, int64: Int64? = nil, float: Float? = nil, string: String? = nil, binary: URL? = nil, date: Date? = nil, dateTime: Date? = nil, password: String? = nil, callback: String? = nil, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse)
 ```
 
 Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트
@@ -444,15 +409,10 @@ let password = "password_example" // String | None (optional)
 let callback = "callback_example" // String | None (optional)
 
 // Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트
-FakeAPI.testEndpointParameters(number: number, double: double, patternWithoutDelimiter: patternWithoutDelimiter, byte: byte, integer: integer, int32: int32, int64: int64, float: float, string: string, binary: binary, date: date, dateTime: dateTime, password: password, callback: callback) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    try await FakeAPI.testEndpointParameters(number: number, double: double, patternWithoutDelimiter: patternWithoutDelimiter, byte: byte, integer: integer, int32: int32, int64: int64, float: float, string: string, binary: binary, date: date, dateTime: dateTime, password: password, callback: callback)
+} catch {
+    print(error)
 }
 ```
 
@@ -492,7 +452,7 @@ Void (empty response body)
 
 # **testEnumParameters**
 ```swift
-    open class func testEnumParameters(enumHeaderStringArray: [EnumHeaderStringArray_testEnumParameters]? = nil, enumHeaderString: EnumHeaderString_testEnumParameters? = nil, enumQueryStringArray: [EnumQueryStringArray_testEnumParameters]? = nil, enumQueryString: EnumQueryString_testEnumParameters? = nil, enumQueryInteger: EnumQueryInteger_testEnumParameters? = nil, enumQueryDouble: EnumQueryDouble_testEnumParameters? = nil, enumFormStringArray: [EnumFormStringArray_testEnumParameters]? = nil, enumFormString: EnumFormString_testEnumParameters? = nil, completion: @escaping (_ data: Void?, _ error: Error?) -> Void)
+    open class func testEnumParameters(enumHeaderStringArray: [EnumHeaderStringArray_testEnumParameters]? = nil, enumHeaderString: EnumHeaderString_testEnumParameters? = nil, enumQueryStringArray: [EnumQueryStringArray_testEnumParameters]? = nil, enumQueryString: EnumQueryString_testEnumParameters? = nil, enumQueryInteger: EnumQueryInteger_testEnumParameters? = nil, enumQueryDouble: EnumQueryDouble_testEnumParameters? = nil, enumFormStringArray: [EnumFormStringArray_testEnumParameters]? = nil, enumFormString: EnumFormString_testEnumParameters? = nil, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse)
 ```
 
 To test enum parameters
@@ -514,15 +474,10 @@ let enumFormStringArray = ["inner_example"] // [String] | Form parameter enum te
 let enumFormString = "enumFormString_example" // String | Form parameter enum test (string) (optional) (default to .efg)
 
 // To test enum parameters
-FakeAPI.testEnumParameters(enumHeaderStringArray: enumHeaderStringArray, enumHeaderString: enumHeaderString, enumQueryStringArray: enumQueryStringArray, enumQueryString: enumQueryString, enumQueryInteger: enumQueryInteger, enumQueryDouble: enumQueryDouble, enumFormStringArray: enumFormStringArray, enumFormString: enumFormString) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    try await FakeAPI.testEnumParameters(enumHeaderStringArray: enumHeaderStringArray, enumHeaderString: enumHeaderString, enumQueryStringArray: enumQueryStringArray, enumQueryString: enumQueryString, enumQueryInteger: enumQueryInteger, enumQueryDouble: enumQueryDouble, enumFormStringArray: enumFormStringArray, enumFormString: enumFormString)
+} catch {
+    print(error)
 }
 ```
 
@@ -556,7 +511,7 @@ No authorization required
 
 # **testGroupParameters**
 ```swift
-    open class func testGroupParameters(requiredStringGroup: Int, requiredBooleanGroup: Bool, requiredInt64Group: Int64, stringGroup: Int? = nil, booleanGroup: Bool? = nil, int64Group: Int64? = nil, completion: @escaping (_ data: Void?, _ error: Error?) -> Void)
+    open class func testGroupParameters(requiredStringGroup: Int, requiredBooleanGroup: Bool, requiredInt64Group: Int64, stringGroup: Int? = nil, booleanGroup: Bool? = nil, int64Group: Int64? = nil, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse)
 ```
 
 Fake endpoint to test group parameters (optional)
@@ -576,15 +531,10 @@ let booleanGroup = true // Bool | Boolean in group parameters (optional)
 let int64Group = 987 // Int64 | Integer in group parameters (optional)
 
 // Fake endpoint to test group parameters (optional)
-FakeAPI.testGroupParameters(requiredStringGroup: requiredStringGroup, requiredBooleanGroup: requiredBooleanGroup, requiredInt64Group: requiredInt64Group, stringGroup: stringGroup, booleanGroup: booleanGroup, int64Group: int64Group) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    try await FakeAPI.testGroupParameters(requiredStringGroup: requiredStringGroup, requiredBooleanGroup: requiredBooleanGroup, requiredInt64Group: requiredInt64Group, stringGroup: stringGroup, booleanGroup: booleanGroup, int64Group: int64Group)
+} catch {
+    print(error)
 }
 ```
 
@@ -616,7 +566,7 @@ No authorization required
 
 # **testInlineAdditionalProperties**
 ```swift
-    open class func testInlineAdditionalProperties(param: [String: String], completion: @escaping (_ data: Void?, _ error: Error?) -> Void)
+    open class func testInlineAdditionalProperties(param: [String: String], apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse)
 ```
 
 test inline additionalProperties
@@ -629,15 +579,10 @@ import PetstoreClient
 let param = "TODO" // [String: String] | request body
 
 // test inline additionalProperties
-FakeAPI.testInlineAdditionalProperties(param: param) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    try await FakeAPI.testInlineAdditionalProperties(param: param)
+} catch {
+    print(error)
 }
 ```
 
@@ -664,7 +609,7 @@ No authorization required
 
 # **testJsonFormData**
 ```swift
-    open class func testJsonFormData(param: String, param2: String, completion: @escaping (_ data: Void?, _ error: Error?) -> Void)
+    open class func testJsonFormData(param: String, param2: String, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse)
 ```
 
 test json serialization of form data
@@ -678,15 +623,10 @@ let param = "param_example" // String | field1
 let param2 = "param2_example" // String | field2
 
 // test json serialization of form data
-FakeAPI.testJsonFormData(param: param, param2: param2) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    try await FakeAPI.testJsonFormData(param: param, param2: param2)
+} catch {
+    print(error)
 }
 ```
 
@@ -714,7 +654,7 @@ No authorization required
 
 # **testQueryParameterCollectionFormat**
 ```swift
-    open class func testQueryParameterCollectionFormat(pipe: [String], ioutil: [String], http: [String], url: [String], context: [String], completion: @escaping (_ data: Void?, _ error: Error?) -> Void)
+    open class func testQueryParameterCollectionFormat(pipe: [String], ioutil: [String], http: [String], url: [String], context: [String], apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse)
 ```
 
 
@@ -732,15 +672,10 @@ let http = ["inner_example"] // [String] |
 let url = ["inner_example"] // [String] | 
 let context = ["inner_example"] // [String] | 
 
-FakeAPI.testQueryParameterCollectionFormat(pipe: pipe, ioutil: ioutil, http: http, url: url, context: context) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    try await FakeAPI.testQueryParameterCollectionFormat(pipe: pipe, ioutil: ioutil, http: http, url: url, context: context)
+} catch {
+    print(error)
 }
 ```
 

--- a/samples/client/petstore/swift6/default/docs/FakeClassnameTags123API.md
+++ b/samples/client/petstore/swift6/default/docs/FakeClassnameTags123API.md
@@ -9,7 +9,7 @@ Method | HTTP request | Description
 
 # **testClassname**
 ```swift
-    open class func testClassname(body: Client, completion: @escaping (_ data: Client?, _ error: Error?) -> Void)
+    open class func testClassname(body: Client, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse) -> Client
 ```
 
 To test class name in snake case
@@ -24,15 +24,11 @@ import PetstoreClient
 let body = Client(client: "client_example") // Client | client model
 
 // To test class name in snake case
-FakeClassnameTags123API.testClassname(body: body) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    let response = try await FakeClassnameTags123API.testClassname(body: body)
+    dump(response)
+} catch {
+    print(error)
 }
 ```
 

--- a/samples/client/petstore/swift6/default/docs/PetAPI.md
+++ b/samples/client/petstore/swift6/default/docs/PetAPI.md
@@ -17,7 +17,7 @@ Method | HTTP request | Description
 
 # **addPet**
 ```swift
-    open class func addPet(body: Pet, completion: @escaping (_ data: Void?, _ error: Error?) -> Void)
+    open class func addPet(body: Pet, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse)
 ```
 
 Add a new pet to the store
@@ -30,15 +30,10 @@ import PetstoreClient
 let body = Pet(id: 123, category: Category(id: 123, name: "name_example"), name: "name_example", photoUrls: ["photoUrls_example"], tags: [Tag(id: 123, name: "name_example")], status: "status_example") // Pet | Pet object that needs to be added to the store
 
 // Add a new pet to the store
-PetAPI.addPet(body: body) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    try await PetAPI.addPet(body: body)
+} catch {
+    print(error)
 }
 ```
 
@@ -65,7 +60,7 @@ Void (empty response body)
 
 # **deletePet**
 ```swift
-    open class func deletePet(petId: Int64, apiKey: String? = nil, completion: @escaping (_ data: Void?, _ error: Error?) -> Void)
+    open class func deletePet(petId: Int64, apiKey: String? = nil, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse)
 ```
 
 Deletes a pet
@@ -79,15 +74,10 @@ let petId = 987 // Int64 | Pet id to delete
 let apiKey = "apiKey_example" // String |  (optional)
 
 // Deletes a pet
-PetAPI.deletePet(petId: petId, apiKey: apiKey) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    try await PetAPI.deletePet(petId: petId, apiKey: apiKey)
+} catch {
+    print(error)
 }
 ```
 
@@ -115,7 +105,7 @@ Void (empty response body)
 
 # **findPetsByStatus**
 ```swift
-    open class func findPetsByStatus(status: [Status_findPetsByStatus], completion: @escaping (_ data: [Pet]?, _ error: Error?) -> Void)
+    open class func findPetsByStatus(status: [Status_findPetsByStatus], apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse) -> [Pet]
 ```
 
 Finds Pets by status
@@ -130,15 +120,11 @@ import PetstoreClient
 let status = ["status_example"] // [String] | Status values that need to be considered for filter
 
 // Finds Pets by status
-PetAPI.findPetsByStatus(status: status) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    let response = try await PetAPI.findPetsByStatus(status: status)
+    dump(response)
+} catch {
+    print(error)
 }
 ```
 
@@ -165,7 +151,7 @@ Name | Type | Description  | Notes
 
 # **findPetsByTags**
 ```swift
-    open class func findPetsByTags(tags: Set<String>, completion: @escaping (_ data: Set<Pet>?, _ error: Error?) -> Void)
+    open class func findPetsByTags(tags: Set<String>, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse) -> Set<Pet>
 ```
 
 Finds Pets by tags
@@ -180,15 +166,11 @@ import PetstoreClient
 let tags = ["inner_example"] // Set<String> | Tags to filter by
 
 // Finds Pets by tags
-PetAPI.findPetsByTags(tags: tags) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    let response = try await PetAPI.findPetsByTags(tags: tags)
+    dump(response)
+} catch {
+    print(error)
 }
 ```
 
@@ -215,7 +197,7 @@ Name | Type | Description  | Notes
 
 # **getPetById**
 ```swift
-    open class func getPetById(petId: Int64, completion: @escaping (_ data: Pet?, _ error: Error?) -> Void)
+    open class func getPetById(petId: Int64, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse) -> Pet
 ```
 
 Find pet by ID
@@ -230,15 +212,11 @@ import PetstoreClient
 let petId = 987 // Int64 | ID of pet to return
 
 // Find pet by ID
-PetAPI.getPetById(petId: petId) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    let response = try await PetAPI.getPetById(petId: petId)
+    dump(response)
+} catch {
+    print(error)
 }
 ```
 
@@ -265,7 +243,7 @@ Name | Type | Description  | Notes
 
 # **updatePet**
 ```swift
-    open class func updatePet(body: Pet, completion: @escaping (_ data: Void?, _ error: Error?) -> Void)
+    open class func updatePet(body: Pet, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse)
 ```
 
 Update an existing pet
@@ -278,15 +256,10 @@ import PetstoreClient
 let body = Pet(id: 123, category: Category(id: 123, name: "name_example"), name: "name_example", photoUrls: ["photoUrls_example"], tags: [Tag(id: 123, name: "name_example")], status: "status_example") // Pet | Pet object that needs to be added to the store
 
 // Update an existing pet
-PetAPI.updatePet(body: body) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    try await PetAPI.updatePet(body: body)
+} catch {
+    print(error)
 }
 ```
 
@@ -313,7 +286,7 @@ Void (empty response body)
 
 # **updatePetWithForm**
 ```swift
-    open class func updatePetWithForm(petId: Int64, name: String? = nil, status: String? = nil, completion: @escaping (_ data: Void?, _ error: Error?) -> Void)
+    open class func updatePetWithForm(petId: Int64, name: String? = nil, status: String? = nil, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse)
 ```
 
 Updates a pet in the store with form data
@@ -328,15 +301,10 @@ let name = "name_example" // String | Updated name of the pet (optional)
 let status = "status_example" // String | Updated status of the pet (optional)
 
 // Updates a pet in the store with form data
-PetAPI.updatePetWithForm(petId: petId, name: name, status: status) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    try await PetAPI.updatePetWithForm(petId: petId, name: name, status: status)
+} catch {
+    print(error)
 }
 ```
 
@@ -365,7 +333,7 @@ Void (empty response body)
 
 # **uploadFile**
 ```swift
-    open class func uploadFile(petId: Int64, additionalMetadata: String? = nil, file: URL? = nil, completion: @escaping (_ data: ApiResponse?, _ error: Error?) -> Void)
+    open class func uploadFile(petId: Int64, additionalMetadata: String? = nil, file: URL? = nil, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse) -> ApiResponse
 ```
 
 uploads an image
@@ -380,15 +348,11 @@ let additionalMetadata = "additionalMetadata_example" // String | Additional dat
 let file = URL(string: "https://example.com")! // URL | file to upload (optional)
 
 // uploads an image
-PetAPI.uploadFile(petId: petId, additionalMetadata: additionalMetadata, file: file) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    let response = try await PetAPI.uploadFile(petId: petId, additionalMetadata: additionalMetadata, file: file)
+    dump(response)
+} catch {
+    print(error)
 }
 ```
 
@@ -417,7 +381,7 @@ Name | Type | Description  | Notes
 
 # **uploadFileWithRequiredFile**
 ```swift
-    open class func uploadFileWithRequiredFile(petId: Int64, requiredFile: URL, additionalMetadata: String? = nil, completion: @escaping (_ data: ApiResponse?, _ error: Error?) -> Void)
+    open class func uploadFileWithRequiredFile(petId: Int64, requiredFile: URL, additionalMetadata: String? = nil, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse) -> ApiResponse
 ```
 
 uploads an image (required)
@@ -432,15 +396,11 @@ let requiredFile = URL(string: "https://example.com")! // URL | file to upload
 let additionalMetadata = "additionalMetadata_example" // String | Additional data to pass to server (optional)
 
 // uploads an image (required)
-PetAPI.uploadFileWithRequiredFile(petId: petId, requiredFile: requiredFile, additionalMetadata: additionalMetadata) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    let response = try await PetAPI.uploadFileWithRequiredFile(petId: petId, requiredFile: requiredFile, additionalMetadata: additionalMetadata)
+    dump(response)
+} catch {
+    print(error)
 }
 ```
 

--- a/samples/client/petstore/swift6/default/docs/StoreAPI.md
+++ b/samples/client/petstore/swift6/default/docs/StoreAPI.md
@@ -12,7 +12,7 @@ Method | HTTP request | Description
 
 # **deleteOrder**
 ```swift
-    open class func deleteOrder(orderId: String, completion: @escaping (_ data: Void?, _ error: Error?) -> Void)
+    open class func deleteOrder(orderId: String, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse)
 ```
 
 Delete purchase order by ID
@@ -27,15 +27,10 @@ import PetstoreClient
 let orderId = "orderId_example" // String | ID of the order that needs to be deleted
 
 // Delete purchase order by ID
-StoreAPI.deleteOrder(orderId: orderId) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    try await StoreAPI.deleteOrder(orderId: orderId)
+} catch {
+    print(error)
 }
 ```
 
@@ -62,7 +57,7 @@ No authorization required
 
 # **getInventory**
 ```swift
-    open class func getInventory(completion: @escaping (_ data: [String: Int]?, _ error: Error?) -> Void)
+    open class func getInventory(apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse) -> [String: Int]
 ```
 
 Returns pet inventories by status
@@ -76,15 +71,11 @@ import PetstoreClient
 
 
 // Returns pet inventories by status
-StoreAPI.getInventory() { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    let response = try await StoreAPI.getInventory()
+    dump(response)
+} catch {
+    print(error)
 }
 ```
 
@@ -108,7 +99,7 @@ This endpoint does not need any parameter.
 
 # **getOrderById**
 ```swift
-    open class func getOrderById(orderId: Int64, completion: @escaping (_ data: Order?, _ error: Error?) -> Void)
+    open class func getOrderById(orderId: Int64, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse) -> Order
 ```
 
 Find purchase order by ID
@@ -123,15 +114,11 @@ import PetstoreClient
 let orderId = 987 // Int64 | ID of pet that needs to be fetched
 
 // Find purchase order by ID
-StoreAPI.getOrderById(orderId: orderId) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    let response = try await StoreAPI.getOrderById(orderId: orderId)
+    dump(response)
+} catch {
+    print(error)
 }
 ```
 
@@ -158,7 +145,7 @@ No authorization required
 
 # **placeOrder**
 ```swift
-    open class func placeOrder(body: Order, completion: @escaping (_ data: Order?, _ error: Error?) -> Void)
+    open class func placeOrder(body: Order, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse) -> Order
 ```
 
 Place an order for a pet
@@ -171,15 +158,11 @@ import PetstoreClient
 let body = Order(id: 123, petId: 123, quantity: 123, shipDate: Date(), status: "status_example", complete: false) // Order | order placed for purchasing the pet
 
 // Place an order for a pet
-StoreAPI.placeOrder(body: body) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    let response = try await StoreAPI.placeOrder(body: body)
+    dump(response)
+} catch {
+    print(error)
 }
 ```
 

--- a/samples/client/petstore/swift6/default/docs/UserAPI.md
+++ b/samples/client/petstore/swift6/default/docs/UserAPI.md
@@ -16,7 +16,7 @@ Method | HTTP request | Description
 
 # **createUser**
 ```swift
-    open class func createUser(body: User, completion: @escaping (_ data: Void?, _ error: Error?) -> Void)
+    open class func createUser(body: User, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse)
 ```
 
 Create user
@@ -31,15 +31,10 @@ import PetstoreClient
 let body = User(id: 123, username: "username_example", firstName: "firstName_example", lastName: "lastName_example", email: "email_example", password: "password_example", phone: "phone_example", userStatus: 123) // User | Created user object
 
 // Create user
-UserAPI.createUser(body: body) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    try await UserAPI.createUser(body: body)
+} catch {
+    print(error)
 }
 ```
 
@@ -66,7 +61,7 @@ No authorization required
 
 # **createUsersWithArrayInput**
 ```swift
-    open class func createUsersWithArrayInput(body: [User], completion: @escaping (_ data: Void?, _ error: Error?) -> Void)
+    open class func createUsersWithArrayInput(body: [User], apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse)
 ```
 
 Creates list of users with given input array
@@ -79,15 +74,10 @@ import PetstoreClient
 let body = [User(id: 123, username: "username_example", firstName: "firstName_example", lastName: "lastName_example", email: "email_example", password: "password_example", phone: "phone_example", userStatus: 123)] // [User] | List of user object
 
 // Creates list of users with given input array
-UserAPI.createUsersWithArrayInput(body: body) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    try await UserAPI.createUsersWithArrayInput(body: body)
+} catch {
+    print(error)
 }
 ```
 
@@ -114,7 +104,7 @@ No authorization required
 
 # **createUsersWithListInput**
 ```swift
-    open class func createUsersWithListInput(body: [User], completion: @escaping (_ data: Void?, _ error: Error?) -> Void)
+    open class func createUsersWithListInput(body: [User], apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse)
 ```
 
 Creates list of users with given input array
@@ -127,15 +117,10 @@ import PetstoreClient
 let body = [User(id: 123, username: "username_example", firstName: "firstName_example", lastName: "lastName_example", email: "email_example", password: "password_example", phone: "phone_example", userStatus: 123)] // [User] | List of user object
 
 // Creates list of users with given input array
-UserAPI.createUsersWithListInput(body: body) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    try await UserAPI.createUsersWithListInput(body: body)
+} catch {
+    print(error)
 }
 ```
 
@@ -162,7 +147,7 @@ No authorization required
 
 # **deleteUser**
 ```swift
-    open class func deleteUser(username: String, completion: @escaping (_ data: Void?, _ error: Error?) -> Void)
+    open class func deleteUser(username: String, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse)
 ```
 
 Delete user
@@ -177,15 +162,10 @@ import PetstoreClient
 let username = "username_example" // String | The name that needs to be deleted
 
 // Delete user
-UserAPI.deleteUser(username: username) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    try await UserAPI.deleteUser(username: username)
+} catch {
+    print(error)
 }
 ```
 
@@ -212,7 +192,7 @@ No authorization required
 
 # **getUserByName**
 ```swift
-    open class func getUserByName(username: String, completion: @escaping (_ data: User?, _ error: Error?) -> Void)
+    open class func getUserByName(username: String, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse) -> User
 ```
 
 Get user by user name
@@ -225,15 +205,11 @@ import PetstoreClient
 let username = "username_example" // String | The name that needs to be fetched. Use user1 for testing.
 
 // Get user by user name
-UserAPI.getUserByName(username: username) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    let response = try await UserAPI.getUserByName(username: username)
+    dump(response)
+} catch {
+    print(error)
 }
 ```
 
@@ -260,7 +236,7 @@ No authorization required
 
 # **loginUser**
 ```swift
-    open class func loginUser(username: String, password: String, completion: @escaping (_ data: String?, _ error: Error?) -> Void)
+    open class func loginUser(username: String, password: String, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse) -> String
 ```
 
 Logs user into the system
@@ -274,15 +250,11 @@ let username = "username_example" // String | The user name for login
 let password = "password_example" // String | The password for login in clear text
 
 // Logs user into the system
-UserAPI.loginUser(username: username, password: password) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    let response = try await UserAPI.loginUser(username: username, password: password)
+    dump(response)
+} catch {
+    print(error)
 }
 ```
 
@@ -310,7 +282,7 @@ No authorization required
 
 # **logoutUser**
 ```swift
-    open class func logoutUser(completion: @escaping (_ data: Void?, _ error: Error?) -> Void)
+    open class func logoutUser(apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse)
 ```
 
 Logs out current logged in user session
@@ -322,15 +294,10 @@ import PetstoreClient
 
 
 // Logs out current logged in user session
-UserAPI.logoutUser() { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    try await UserAPI.logoutUser()
+} catch {
+    print(error)
 }
 ```
 
@@ -354,7 +321,7 @@ No authorization required
 
 # **updateUser**
 ```swift
-    open class func updateUser(username: String, body: User, completion: @escaping (_ data: Void?, _ error: Error?) -> Void)
+    open class func updateUser(username: String, body: User, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse)
 ```
 
 Updated user
@@ -370,15 +337,10 @@ let username = "username_example" // String | name that need to be deleted
 let body = User(id: 123, username: "username_example", firstName: "firstName_example", lastName: "lastName_example", email: "email_example", password: "password_example", phone: "phone_example", userStatus: 123) // User | Updated user object
 
 // Updated user
-UserAPI.updateUser(username: username, body: body) { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    try await UserAPI.updateUser(username: username, body: body)
+} catch {
+    print(error)
 }
 ```
 

--- a/samples/client/petstore/swift6/validation/docs/DefaultAPI.md
+++ b/samples/client/petstore/swift6/validation/docs/DefaultAPI.md
@@ -9,7 +9,7 @@ Method | HTTP request | Description
 
 # **rootGet**
 ```swift
-    open class func rootGet(completion: @escaping (_ data: Banana?, _ error: Error?) -> Void)
+    open class func rootGet(apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) async throws(ErrorResponse) -> Banana
 ```
 
 
@@ -20,15 +20,11 @@ Method | HTTP request | Description
 import PetstoreClient
 
 
-DefaultAPI.rootGet() { (response, error) in
-    guard error == nil else {
-        print(error)
-        return
-    }
-
-    if (response) {
-        dump(response)
-    }
+do {
+    let response = try await DefaultAPI.rootGet()
+    dump(response)
+} catch {
+    print(error)
 }
 ```
 


### PR DESCRIPTION
Fixes #24631.

### Summary

Swift 5 and Swift 6 API documentation generated with `responseAs: AsyncAwait` currently shows completion-handler signatures and callback examples even though the generated APIs expose `async throws` methods.

This change:

- adds AsyncAwait-specific signatures and `try await` examples to the Swift 5 and Swift 6 API documentation templates;
- preserves completion-handler documentation for response modes that use it;
- documents Swift 6's typed `throws(ErrorResponse)` and default `apiConfiguration` parameter;
- respects `apiStaticMethod`, including instance calls such as `PetAPI().addPet(...)`;
- keeps Vapor on its library-specific `EventLoopFuture` documentation path; and
- regenerates the affected Swift API documentation samples.

No generated runtime source or public API behavior changes.

### Validation

- Regenerated Swift 5 `asyncAwaitLibrary` samples.
- Regenerated Swift 6 `asyncAwaitLibrary`, `default`, `apiNonStaticMethod`, and `validation` samples.
- Regenerated the Swift 6 Vapor sample and confirmed it produces no tracked changes.
- Ran `Swift5ClientCodegenTest` and `Swift6ClientCodegenTest`: 64 tests, 0 failures, 0 errors, 0 skipped.
- Confirmed AsyncAwait-only docs contain no `completion:` signatures/examples.
- Confirmed non-static AsyncAwait examples use API instances.
- Confirmed `git diff --check` passes.

Direct `swift build` could not start on the local host because the installed Swift compiler and macOS SDK builds do not match. The generator tests and deterministic sample regeneration pass; the draft can use project CI for the remaining platform build signal.

@4brunu @tkqubo — review would be appreciated, particularly for the Swift 6 typed-error/configuration signature and the non-static/Vapor branches.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Run the complete repository build/sample/export sequence from the PR template. Targeted generation and focused generator tests are complete; the full all-generator sequence has not been run locally.
- [x] Mention the relevant Swift technical committee/reviewer contacts.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Swift 5/6 AsyncAwait API docs so they match generated clients. Previously, docs showed completion-handler signatures and callback examples; now they show `async/await` usage (Swift 5: `async throws`; Swift 6: `async throws(ErrorResponse)` with a default `apiConfiguration`).

- Updates `swift5`/`swift6` `api_doc.mustache` to emit AsyncAwait-specific signatures and `try await` examples when `responseAs: AsyncAwait`; preserves completion-handler docs for other response modes.
- For Swift 6, documents `throws(ErrorResponse)` and the default `apiConfiguration` parameter; honors `apiStaticMethod` so instance calls render as `PetAPI().addPet(...)`.
- Keeps `Vapor` docs on the `EventLoopFuture` path; AsyncAwait changes do not apply under `useVapor`.
- Regenerates affected sample docs; no runtime or public API changes. Tests pass. No migration required.

<sup>Written for commit 723207b1244d0f7ee4e16f5550eb01dc039a2b6e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24717?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

