### PR TITLE
[python] Deserialize Optional[...] response types

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_client.mustache
@@ -591,6 +591,12 @@ https://github.com/OpenAPITools/openapi-generator/blob/c84b949df1a9ec04ba75989cb
             return None
 
         if isinstance(klass, str):
+            if klass.startswith('Optional['):
+                m = re.match(r'Optional\[(.*)]', klass)
+                assert m is not None, "Malformed Optional type definition"
+                # data is not None here, so the optionality is already resolved
+                return self.__deserialize(data, m.group(1))
+
             if klass.startswith('List['):
                 m = re.match(r'List\[(.*)]', klass)
                 assert m is not None, "Malformed List type definition"

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/api_client.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/api_client.py
@@ -440,6 +440,12 @@ class ApiClient:
             return None
 
         if isinstance(klass, str):
+            if klass.startswith('Optional['):
+                m = re.match(r'Optional\[(.*)]', klass)
+                assert m is not None, "Malformed Optional type definition"
+                # data is not None here, so the optionality is already resolved
+                return self.__deserialize(data, m.group(1))
+
             if klass.startswith('List['):
                 m = re.match(r'List\[(.*)]', klass)
                 assert m is not None, "Malformed List type definition"

--- a/samples/client/echo_api/python/openapi_client/api_client.py
+++ b/samples/client/echo_api/python/openapi_client/api_client.py
@@ -440,6 +440,12 @@ class ApiClient:
             return None
 
         if isinstance(klass, str):
+            if klass.startswith('Optional['):
+                m = re.match(r'Optional\[(.*)]', klass)
+                assert m is not None, "Malformed Optional type definition"
+                # data is not None here, so the optionality is already resolved
+                return self.__deserialize(data, m.group(1))
+
             if klass.startswith('List['):
                 m = re.match(r'List\[(.*)]', klass)
                 assert m is not None, "Malformed List type definition"

--- a/samples/client/others/python-legacy-model-dictionaries/legacy_model_dict_client/api_client.py
+++ b/samples/client/others/python-legacy-model-dictionaries/legacy_model_dict_client/api_client.py
@@ -548,6 +548,12 @@ class ApiClient:
             return None
 
         if isinstance(klass, str):
+            if klass.startswith('Optional['):
+                m = re.match(r'Optional\[(.*)]', klass)
+                assert m is not None, "Malformed Optional type definition"
+                # data is not None here, so the optionality is already resolved
+                return self.__deserialize(data, m.group(1))
+
             if klass.startswith('List['):
                 m = re.match(r'List\[(.*)]', klass)
                 assert m is not None, "Malformed List type definition"

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api_client.py
@@ -439,6 +439,12 @@ class ApiClient:
             return None
 
         if isinstance(klass, str):
+            if klass.startswith('Optional['):
+                m = re.match(r'Optional\[(.*)]', klass)
+                assert m is not None, "Malformed Optional type definition"
+                # data is not None here, so the optionality is already resolved
+                return self.__deserialize(data, m.group(1))
+
             if klass.startswith('List['):
                 m = re.match(r'List\[(.*)]', klass)
                 assert m is not None, "Malformed List type definition"

--- a/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/api_client.py
@@ -442,6 +442,12 @@ class ApiClient:
             return None
 
         if isinstance(klass, str):
+            if klass.startswith('Optional['):
+                m = re.match(r'Optional\[(.*)]', klass)
+                assert m is not None, "Malformed Optional type definition"
+                # data is not None here, so the optionality is already resolved
+                return self.__deserialize(data, m.group(1))
+
             if klass.startswith('List['):
                 m = re.match(r'List\[(.*)]', klass)
                 assert m is not None, "Malformed List type definition"

--- a/samples/openapi3/client/petstore/python-httpx/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-httpx/petstore_api/api_client.py
@@ -442,6 +442,12 @@ class ApiClient:
             return None
 
         if isinstance(klass, str):
+            if klass.startswith('Optional['):
+                m = re.match(r'Optional\[(.*)]', klass)
+                assert m is not None, "Malformed Optional type definition"
+                # data is not None here, so the optionality is already resolved
+                return self.__deserialize(data, m.group(1))
+
             if klass.startswith('List['):
                 m = re.match(r'List\[(.*)]', klass)
                 assert m is not None, "Malformed List type definition"

--- a/samples/openapi3/client/petstore/python-lazyImports/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-lazyImports/petstore_api/api_client.py
@@ -439,6 +439,12 @@ class ApiClient:
             return None
 
         if isinstance(klass, str):
+            if klass.startswith('Optional['):
+                m = re.match(r'Optional\[(.*)]', klass)
+                assert m is not None, "Malformed Optional type definition"
+                # data is not None here, so the optionality is already resolved
+                return self.__deserialize(data, m.group(1))
+
             if klass.startswith('List['):
                 m = re.match(r'List\[(.*)]', klass)
                 assert m is not None, "Malformed List type definition"

--- a/samples/openapi3/client/petstore/python/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api_client.py
@@ -439,6 +439,12 @@ class ApiClient:
             return None
 
         if isinstance(klass, str):
+            if klass.startswith('Optional['):
+                m = re.match(r'Optional\[(.*)]', klass)
+                assert m is not None, "Malformed Optional type definition"
+                # data is not None here, so the optionality is already resolved
+                return self.__deserialize(data, m.group(1))
+
             if klass.startswith('List['):
                 m = re.match(r'List\[(.*)]', klass)
                 assert m is not None, "Malformed List type definition"

--- a/samples/openapi3/client/petstore/python/tests/test_deserialization.py
+++ b/samples/openapi3/client/petstore/python/tests/test_deserialization.py
@@ -251,6 +251,59 @@ class DeserializationTests(unittest.TestCase):
         deserialized = self.deserialize(response, "datetime", 'application/json')
         self.assertIsNone(deserialized)
 
+    def test_deserialize_optional_dict_str_object(self):
+        """ deserialize Dict[str, Optional[object]] """
+        data = {
+            "foo": 1,
+            "bar": None
+        }
+        response = json.dumps(data)
+
+        deserialized = self.deserialize(response, "Dict[str, Optional[object]]", 'application/json')
+        self.assertEqual(deserialized, {"foo": 1, "bar": None})
+
+    def test_deserialize_optional_pet(self):
+        """ deserialize Optional[Pet] """
+        data = {
+            "id": 0,
+            "category": {
+                "id": 0,
+                "name": "string"
+            },
+            "name": "doggie",
+            "photoUrls": [
+                "string"
+            ],
+            "tags": [
+                {
+                    "id": 0,
+                    "name": "string"
+                }
+            ],
+            "status": "available"
+        }
+        response = json.dumps(data)
+
+        deserialized = self.deserialize(response, "Optional[Pet]", 'application/json')
+        self.assertTrue(isinstance(deserialized, petstore_api.Pet))
+        self.assertEqual(deserialized.id, 0)
+        self.assertEqual(deserialized.name, "doggie")
+
+    def test_deserialize_optional_list_of_str(self):
+        """ deserialize Optional[List[str]] """
+        data = ["foo", "bar"]
+        response = json.dumps(data)
+
+        deserialized = self.deserialize(response, "Optional[List[str]]", 'application/json')
+        self.assertEqual(deserialized, ["foo", "bar"])
+
+    def test_deserialize_optional_none(self):
+        """ deserialize Optional[Pet] when the body is null """
+        response = json.dumps(None)
+
+        deserialized = self.deserialize(response, "Optional[Pet]", 'application/json')
+        self.assertIsNone(deserialized)
+
     def test_deserialize_pig(self):
         """ deserialize pig (oneOf) """
         wire_name = """class'"\\Name"""


### PR DESCRIPTION
Fixes #24712

### Problem

`ApiClient.__deserialize` parses only `List[...]`, `Dict[...]` and native type names. The generator fills `_response_types_map` from the response *annotation*, so a nullable response emits `"Dict[str, Optional[object]]"`, which falls through to `getattr(models, "Optional[object]")` and makes every successful response raise `AttributeError`.

### Change

Unwrap `Optional[...]` before the existing rules. `data is None` has already returned above, so the inner type determines the result.

### Verification

- Issue repro spec: `AttributeError` before, `{'a': 1}` after.
- 4 tests added to the python sample; 3 fail on master.
- `pytest tests/`: 155 passed. The 12 failures need the live petstore server, same on master.
- `mvn test -Dtest='Python*Test'`: 102 passed.

/cc @cbornet @tomplus @krjakbrjak @fa0311


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deserializes Python `Optional[...]` response types by unwrapping to the inner type, so nullable responses no longer raise `AttributeError`. Old: `ApiClient.__deserialize` treated `Optional[...]` as a model and failed. New: it detects and unwraps `Optional[...]` before existing `List[...]`/`Dict[...]` rules; `None` still returns `None`. Fixes #24712.

**Review notes**
- Changes are in `modules/openapi-generator/src/main/resources/python/api_client.mustache`; regenerated sample clients mirror the update.
- Adds tests for `Optional[Pet]`, `Optional[List[str]]`, and `Dict[str, Optional[object]]`; local suites pass, petstore live-server failures match `master`.
- No migration actions; generated Python clients now correctly deserialize nullable responses.

<sup>Written for commit 579861f7638f08fd628a48855e8ca7e7560adeda. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24718?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

