### PR TITLE
[core] Remove backslash from path

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -4849,6 +4849,8 @@ public class DefaultCodegen implements CodegenConfig {
         } else {
             op.path = path;
         }
+        // remove backslash from path, e.g. /api/v2/GetPetById\\(\\) => /api/v2/GetPetById()
+        op.path = op.path.replace("\\", "");
 
         op.summary = escapeText(operation.getSummary());
         op.unescapedNotes = operation.getDescription();

--- a/modules/openapi-generator/src/test/resources/3_1/java/petstore.yaml
+++ b/modules/openapi-generator/src/test/resources/3_1/java/petstore.yaml
@@ -758,6 +758,13 @@ paths:
                     items:
                       "$ref": "#/components/schemas/myObject"
                   - type: 'null'
+  "/fake/path/backslash/GetPetById\\(\\)":
+    get:
+      tags:
+        - fake
+      responses:
+        '200':
+          description: ''
 externalDocs:
   description: Find out more about Swagger
   url: 'http://swagger.io'

--- a/samples/client/petstore/java/okhttp-gson-3.1/README.md
+++ b/samples/client/petstore/java/okhttp-gson-3.1/README.md
@@ -116,6 +116,7 @@ Class | Method | HTTP request | Description
 *FakeApi* | [**fakeInlineSchemaAnyofPath1Get**](docs/FakeApi.md#fakeInlineSchemaAnyofPath1Get) | **GET** /fake/inline/schema/anyof/path1 | 
 *FakeApi* | [**fakeInlineSchemaAnyofPath2Get**](docs/FakeApi.md#fakeInlineSchemaAnyofPath2Get) | **GET** /fake/inline/schema/anyof/path2 | 
 *FakeApi* | [**fakeInlineSchemaAnyofPath3Get**](docs/FakeApi.md#fakeInlineSchemaAnyofPath3Get) | **GET** /fake/inline/schema/anyof/path3 | 
+*FakeApi* | [**fakePathBackslashGetPetByIdGet**](docs/FakeApi.md#fakePathBackslashGetPetByIdGet) | **GET** /fake/path/backslash/GetPetById() | 
 *FakeApi* | [**op1**](docs/FakeApi.md#op1) | **POST** /fake/api/changeowner | op1
 *FakeApi* | [**op2**](docs/FakeApi.md#op2) | **POST** /fake/api/changename | op2
 *FakeApi* | [**op3**](docs/FakeApi.md#op3) | **POST** /fake/api/query/enum | op3

--- a/samples/client/petstore/java/okhttp-gson-3.1/api/openapi.yaml
+++ b/samples/client/petstore/java/okhttp-gson-3.1/api/openapi.yaml
@@ -834,6 +834,15 @@ paths:
       - fake
       x-accepts:
       - application/json
+  /fake/path/backslash/GetPetById\(\):
+    get:
+      responses:
+        "200":
+          description: ""
+      tags:
+      - fake
+      x-accepts:
+      - application/json
 components:
   parameters:
     ref_to_uuid:

--- a/samples/client/petstore/java/okhttp-gson-3.1/docs/FakeApi.md
+++ b/samples/client/petstore/java/okhttp-gson-3.1/docs/FakeApi.md
@@ -7,6 +7,7 @@ All URIs are relative to *http://petstore.swagger.io/v2*
 | [**fakeInlineSchemaAnyofPath1Get**](FakeApi.md#fakeInlineSchemaAnyofPath1Get) | **GET** /fake/inline/schema/anyof/path1 |  |
 | [**fakeInlineSchemaAnyofPath2Get**](FakeApi.md#fakeInlineSchemaAnyofPath2Get) | **GET** /fake/inline/schema/anyof/path2 |  |
 | [**fakeInlineSchemaAnyofPath3Get**](FakeApi.md#fakeInlineSchemaAnyofPath3Get) | **GET** /fake/inline/schema/anyof/path3 |  |
+| [**fakePathBackslashGetPetByIdGet**](FakeApi.md#fakePathBackslashGetPetByIdGet) | **GET** /fake/path/backslash/GetPetById() |  |
 | [**op1**](FakeApi.md#op1) | **POST** /fake/api/changeowner | op1 |
 | [**op2**](FakeApi.md#op2) | **POST** /fake/api/changename | op2 |
 | [**op3**](FakeApi.md#op3) | **POST** /fake/api/query/enum | op3 |
@@ -180,6 +181,61 @@ No authorization required
 
  - **Content-Type**: Not defined
  - **Accept**: application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** |  |  -  |
+
+<a id="fakePathBackslashGetPetByIdGet"></a>
+# **fakePathBackslashGetPetByIdGet**
+> fakePathBackslashGetPetByIdGet()
+
+
+
+### Example
+```java
+// Import classes:
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
+
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io/v2");
+
+    FakeApi apiInstance = new FakeApi(defaultClient);
+    try {
+      apiInstance.fakePathBackslashGetPetByIdGet();
+    } catch (ApiException e) {
+      System.err.println("Exception when calling FakeApi#fakePathBackslashGetPetByIdGet");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
+}
+```
+
+### Parameters
+This endpoint does not need any parameter.
+
+### Return type
+
+null (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: Not defined
 
 ### HTTP response details
 | Status code | Description | Response headers |

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -427,6 +427,118 @@ public class FakeApi {
         return localVarCall;
     }
     /**
+     * Build call for fakePathBackslashGetPetByIdGet
+     * @param _callback Callback for upload/download progress
+     * @return Call to execute
+     * @throws ApiException If fail to serialize the request body object
+     * @http.response.details
+     <table border="1">
+       <caption>Response Details</caption>
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td>  </td><td>  -  </td></tr>
+     </table>
+     */
+    public okhttp3.Call fakePathBackslashGetPetByIdGetCall(final ApiCallback _callback) throws ApiException {
+        String basePath = null;
+        // Operation Servers
+        String[] localBasePaths = new String[] {  };
+
+        // Determine Base Path to Use
+        if (localCustomBaseUrl != null){
+            basePath = localCustomBaseUrl;
+        } else if ( localBasePaths.length > 0 ) {
+            basePath = localBasePaths[localHostIndex];
+        } else {
+            basePath = null;
+        }
+
+        Object localVarPostBody = null;
+
+        // create path and map variables
+        String localVarPath = "/fake/path/backslash/GetPetById()";
+
+        List<Pair> localVarQueryParams = new ArrayList<Pair>();
+        List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
+        Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+        Map<String, String> localVarCookieParams = new HashMap<String, String>();
+        Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+
+        final String[] localVarAccepts = {
+        };
+        final String localVarAccept = localVarApiClient.selectHeaderAccept(localVarAccepts);
+        if (localVarAccept != null) {
+            localVarHeaderParams.put("Accept", localVarAccept);
+        }
+
+        final String[] localVarContentTypes = {
+        };
+        final String localVarContentType = localVarApiClient.selectHeaderContentType(localVarContentTypes);
+        if (localVarContentType != null) {
+            localVarHeaderParams.put("Content-Type", localVarContentType);
+        }
+
+        String[] localVarAuthNames = new String[] {  };
+        return localVarApiClient.buildCall(basePath, localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+    }
+
+    @SuppressWarnings("rawtypes")
+    private okhttp3.Call fakePathBackslashGetPetByIdGetValidateBeforeCall(final ApiCallback _callback) throws ApiException {
+        return fakePathBackslashGetPetByIdGetCall(_callback);
+
+    }
+
+    /**
+     * 
+     * 
+     * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+     * @http.response.details
+     <table border="1">
+       <caption>Response Details</caption>
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td>  </td><td>  -  </td></tr>
+     </table>
+     */
+    public void fakePathBackslashGetPetByIdGet() throws ApiException {
+        fakePathBackslashGetPetByIdGetWithHttpInfo();
+    }
+
+    /**
+     * 
+     * 
+     * @return ApiResponse&lt;Void&gt;
+     * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+     * @http.response.details
+     <table border="1">
+       <caption>Response Details</caption>
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td>  </td><td>  -  </td></tr>
+     </table>
+     */
+    public ApiResponse<Void> fakePathBackslashGetPetByIdGetWithHttpInfo() throws ApiException {
+        okhttp3.Call localVarCall = fakePathBackslashGetPetByIdGetValidateBeforeCall(null);
+        return localVarApiClient.execute(localVarCall);
+    }
+
+    /**
+     *  (asynchronously)
+     * 
+     * @param _callback The callback to be executed when the API call finishes
+     * @return The request call
+     * @throws ApiException If fail to process the API call, e.g. serializing the request body object
+     * @http.response.details
+     <table border="1">
+       <caption>Response Details</caption>
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td>  </td><td>  -  </td></tr>
+     </table>
+     */
+    public okhttp3.Call fakePathBackslashGetPetByIdGetAsync(final ApiCallback<Void> _callback) throws ApiException {
+
+        okhttp3.Call localVarCall = fakePathBackslashGetPetByIdGetValidateBeforeCall(_callback);
+        localVarApiClient.executeAsync(localVarCall, _callback);
+        return localVarCall;
+    }
+    /**
      * Build call for op1
      * @param _callback Callback for upload/download progress
      * @return Call to execute


### PR DESCRIPTION
fyi @OpenAPITools/generator-core-team 

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalizes generated operation paths by stripping backslashes in `DefaultCodegen`. Previously paths kept backslashes (e.g., /fake/path/backslash/GetPetById\(\)); now they are removed (e.g., /fake/path/backslash/GetPetById()), preventing escaped characters from leaking into generated clients and docs.

- Review notes
  - Implemented in `fromOperation` by setting `op.path = op.path.replace("\\", "")`.
  - Added an OAS 3.1 petstore path with backslashes and updated Java `okhttp-gson-3.1` samples (`README.md`, `docs/FakeApi.md`, `api/openapi.yaml`, `FakeApi.java`) to show the normalized path.

- Migration
  - If your API requires literal backslashes in paths, they will now be removed. Avoid backslashes in OpenAPI paths or customize the generator to preserve them.

<sup>Written for commit 32296f40f3de526fb8c8fb9e21a9673d70bb9340. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24723?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

