### PR TITLE
fix(spring): preserve original operation ID for pageable

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringPageableScanUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringPageableScanUtils.java
@@ -350,7 +350,9 @@ public class SpringPageableScanUtils {
             Map<String, PageableDefaultsData> pageableDefaultsRegistry,
             AnnotationSyntax syntax) {
 
-        String operationId = codegenOperation.operationId;
+        String operationId = codegenOperation.operationIdOriginal != null
+                ? codegenOperation.operationIdOriginal
+                : codegenOperation.operationId;
         List<String> pageableAnnotations = new ArrayList<>();
 
         if (generatePageableConstraintValidation && useBeanValidation

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
@@ -7888,6 +7888,36 @@ public class SpringCodegenTest {
                 .fileContains("@SortDefault.SortDefaults({@SortDefault(sort = {\"name\"}, direction = Sort.Direction.DESC), @SortDefault(sort = {\"id\"}, direction = Sort.Direction.ASC)})");
     }
 
+    @Test
+    public void pageableAnnotationsUseOriginalOperationId_issue24721() throws IOException {
+        Map<String, Object> props = new HashMap<>();
+        props.put(INTERFACE_ONLY, "true");
+        props.put(SpringCodegen.SKIP_DEFAULT_INTERFACE, "true");
+        props.put(SpringCodegen.USE_TAGS, "true");
+        props.put(SpringCodegen.USE_SPRING_BOOT3, "true");
+        props.put(SpringCodegen.AUTO_X_SPRING_PAGINATED, "true");
+        props.put(SpringCodegen.GENERATE_PAGEABLE_CONSTRAINT_VALIDATION, "true");
+        props.put(SpringCodegen.GENERATE_SORT_VALIDATION, "true");
+
+        Map<String, File> files = generateFromContract(
+                "src/test/resources/3_0/spring/issue_24721.yaml", SPRING_BOOT, props);
+
+        JavaFileAssert.assertThat(files.get("ItemsApi.java"))
+                .assertMethod("listItems")
+                .assertParameter("pageable")
+                .hasType("Pageable")
+                .assertParameterAnnotations()
+                .containsWithName("ValidPageable")
+                .containsWithName("ValidSort")
+                .containsWithName("PageableDefault");
+
+        JavaFileAssert.assertThat(files.get("ItemsApi.java"))
+                .fileContains("@ValidPageable(maxSize = 100, maxPage = 50)")
+                .fileContains("@ValidSort(allowedValues = {\"id,asc\", \"id,desc\", \"name,asc\", \"name,desc\"})")
+                .fileContains("@PageableDefault(page = 0, size = 25)")
+                .fileContains("@SortDefault.SortDefaults({@SortDefault(sort = {\"name\"}, direction = Sort.Direction.DESC)})");
+    }
+
     // -------------------------------------------------------------------------
     // substituteGenericPagedModel tests
     // -------------------------------------------------------------------------

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/languages/SpringPageableScanUtilsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/languages/SpringPageableScanUtilsTest.java
@@ -494,6 +494,31 @@ public class SpringPageableScanUtilsTest {
     }
 
     @Test
+    public void applyPageableAnnotations_usesOriginalOperationIdForRegistryLookup() {
+        CodegenOperation op = minimalOp("listItems");
+        op.operationIdOriginal = "list-items";
+
+        Map<String, SpringPageableScanUtils.PageableConstraintsData> constraintsRegistry =
+                Collections.singletonMap("list-items", new SpringPageableScanUtils.PageableConstraintsData(50, 100, -1, -1));
+        Map<String, List<String>> sortValidationRegistry =
+                Collections.singletonMap("list-items", List.of("id,asc", "name,desc"));
+        Map<String, SpringPageableScanUtils.PageableDefaultsData> defaultsRegistry =
+                Collections.singletonMap("list-items", new SpringPageableScanUtils.PageableDefaultsData(
+                        0, 25, List.of(new SpringPageableScanUtils.SortFieldDefault("name", "DESC"))));
+
+        SpringPageableScanUtils.applyPageableAnnotations(op, true, true, constraintsRegistry,
+                true, sortValidationRegistry, defaultsRegistry,
+                SpringPageableScanUtils.AnnotationSyntax.JAVA);
+
+        List<String> annotations = (List<String>) op.vendorExtensions.get("x-pageable-extra-annotation");
+        assertThat(annotations).containsExactly(
+                "@ValidPageable(maxSize = 100, maxPage = 50)",
+                "@ValidSort(allowedValues = {\"id,asc\", \"name,desc\"})",
+                "@PageableDefault(page = 0, size = 25)",
+                "@SortDefault.SortDefaults({@SortDefault(sort = {\"name\"}, direction = Sort.Direction.DESC)})");
+    }
+
+    @Test
     public void applyPageableAnnotations_noMatchingRegistryEntries_noAnnotationsAdded() {
         CodegenOperation op = minimalOp("someOtherOp");
 

--- a/modules/openapi-generator/src/test/resources/3_0/spring/issue_24721.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/spring/issue_24721.yaml
@@ -1,0 +1,41 @@
+openapi: 3.0.1
+info:
+  title: Issue 24721 Pageable Operation ID Sanitization
+  version: 1.0.0
+paths:
+  /items:
+    get:
+      tags:
+        - items
+      operationId: list-items
+      parameters:
+        - name: page
+          in: query
+          schema:
+            type: integer
+            default: 0
+            maximum: 50
+        - name: size
+          in: query
+          schema:
+            type: integer
+            default: 25
+            maximum: 100
+        - name: sort
+          in: query
+          style: form
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - id,asc
+                - id,desc
+                - name,asc
+                - name,desc
+            default:
+              - name,desc
+      responses:
+        '200':
+          description: Successful response


### PR DESCRIPTION
## Summary

  Fix Spring pageable annotation generation when an OpenAPI `operationId` is normalized during code
  generation.

  For example, `list-items` is normalized to `listItems`, but the pageable registries are populated
  using the original OpenAPI operation ID. The generated operation now uses `operationIdOriginal` for
  registry lookups, with a fallback to the normalized `operationId`.

  ## Changes

  - Use `CodegenOperation.operationIdOriginal` when applying pageable annotations.
  - Preserve the normalized `operationId` as a fallback when no original ID exists.
  - Add an end-to-end regression test for `operationId: list-items`.
  - Add a minimal OpenAPI fixture covering pageable constraints, sort validation, pageable defaults,
  and sort defaults.

  ## Validation

  - `SpringPageableScanUtilsTest`: 27 tests passed.
  - `SpringCodegenTest#pageableAnnotationsUseOriginalOperationId_issue24721`: passed.
  - Full `SpringCodegenTest`: 328 tests passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the original OpenAPI `operationId` when generating Spring pageable annotations to avoid mismatches after normalization. Previously, registries were keyed by the original ID while generation used the normalized ID; lookup now prefers `operationIdOriginal` with a fallback to `operationId`.

- In SpringPageableScanUtils.applyPageableAnnotations, use CodegenOperation.operationIdOriginal when present; otherwise use operationId.
- Adds a unit test covering original-ID registry lookup and an end-to-end test validating `operationId: list-items` generates `listItems` with the expected pageable and sort annotations.
- Adds `3_0/spring/issue_24721.yaml` fixture covering pageable constraints and sort defaults.
- No migration required; only pageable annotation resolution for sanitized operation IDs changes.

<sup>Written for commit 1b1b14e592e99d701f699ddd5ed63f39a1fd3959. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24724?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

