### PR TITLE
[go] Add json:"-" tag to AdditionalProperties in model_simple template

### DIFF
--- a/modules/openapi-generator/src/main/resources/go/model_simple.mustache
+++ b/modules/openapi-generator/src/main/resources/go/model_simple.mustache
@@ -23,7 +23,7 @@ type {{classname}} struct {
 	{{name}} {{^required}}{{^isNullable}}{{^isArray}}{{^isFreeFormObject}}*{{/isFreeFormObject}}{{/isArray}}{{/isNullable}}{{/required}}{{{dataType}}}{{{vendorExtensions.x-go-datatag}}}
 {{/vars}}
 {{#isAdditionalPropertiesTrue}}
-	AdditionalProperties map[string]interface{}
+	AdditionalProperties map[string]interface{} `json:"-"`
 {{/isAdditionalPropertiesTrue}}
 }
 


### PR DESCRIPTION
When integrating generated Go models into Kubernetes/Cluster API environments or using strict Go JSON linters/code generators (such as controller-gen), all exported struct fields are required to have an explicit JSON tag.

Without a tag on `AdditionalProperties`, tools fail with errors like:
- encountered struct field "AdditionalProperties" without JSON tag in type "VmDiskBaseRequest"
- encountered struct field "AdditionalProperties" without JSON tag in type "VmPropertiesRequest"

Adding `json:"-"` explicitly marks the field to be ignored by standard JSON tag validation and default marshaling, preventing these errors while keeping `AdditionalProperties` accessible in Go code.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `json:"-"` to the AdditionalProperties field in the Go `model_simple` template to satisfy strict JSON tag requirements and avoid linter/codegen errors. Previously the field had no JSON tag; now it is explicitly ignored by default JSON marshalling and validation, with no change to runtime marshal/unmarshal behavior.

**Review and rollout**
- Touches `modules/openapi-generator/src/main/resources/go/model_simple.mustache`; affects structs with `additionalProperties: true`.
- No wire-format change; custom MarshalJSON/UnmarshalJSON continue to merge AdditionalProperties correctly.
- Regenerate Go outputs; this silences `controller-gen` and similar tools that require explicit JSON tags.

<sup>Written for commit 603e3443ed9de3320f542fc84a5089b350574657. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24726?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

