### PR TITLE
Madhus1218 fix csharp generichost oneof serialization

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/JsonConverter.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/JsonConverter.mustache
@@ -397,14 +397,16 @@
             {{#composedSchemas}}
             {{#oneOf}}
             {{^vendorExtensions.x-duplicated-data-type}}
-            {{^isPrimitiveType}}
+            {{#isModel}}
+            {{^isContainer}}
             if ({{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}.{{name}} != null)
             {
-                {{baseType}}JsonConverter {{#lambda.camelcase_sanitize_param}}{{baseType}}JsonConverter{{/lambda.camelcase_sanitize_param}} = ({{baseType}}JsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert({{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}.{{name}}.GetType()));
+                {{baseType}}JsonConverter {{#lambda.camelcase_sanitize_param}}{{baseType}}JsonConverter{{/lambda.camelcase_sanitize_param}} = new {{baseType}}JsonConverter();
                 {{#lambda.camelcase_sanitize_param}}{{baseType}}JsonConverter{{/lambda.camelcase_sanitize_param}}.WriteProperties(writer, {{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}.{{name}}, jsonSerializerOptions);
             }
 
-            {{/isPrimitiveType}}
+            {{/isContainer}}
+            {{/isModel}}
             {{/vendorExtensions.x-duplicated-data-type}}
             {{/oneOf}}
             {{/composedSchemas}}

--- a/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/JsonConverter.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/JsonConverter.mustache
@@ -376,7 +376,39 @@
 
             {{/children}}
             {{/discriminator}}
+            {{^model.discriminator}}
+            {{#composedSchemas}}
+            {{#oneOf}}
+            {{^vendorExtensions.x-duplicated-data-type}}
+            {{#isPrimitiveType}}
+            if ({{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}.{{name}} != null)
+            {
+                JsonSerializer.Serialize(writer, {{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}.{{name}}, jsonSerializerOptions);
+                return;
+            }
+
+            {{/isPrimitiveType}}
+            {{/vendorExtensions.x-duplicated-data-type}}
+            {{/oneOf}}
+            {{/composedSchemas}}
+            {{/model.discriminator}}
             writer.WriteStartObject();
+            {{^model.discriminator}}
+            {{#composedSchemas}}
+            {{#oneOf}}
+            {{^vendorExtensions.x-duplicated-data-type}}
+            {{^isPrimitiveType}}
+            if ({{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}.{{name}} != null)
+            {
+                {{baseType}}JsonConverter {{#lambda.camelcase_sanitize_param}}{{baseType}}JsonConverter{{/lambda.camelcase_sanitize_param}} = ({{baseType}}JsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert({{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}.{{name}}.GetType()));
+                {{#lambda.camelcase_sanitize_param}}{{baseType}}JsonConverter{{/lambda.camelcase_sanitize_param}}.WriteProperties(writer, {{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}.{{name}}, jsonSerializerOptions);
+            }
+
+            {{/isPrimitiveType}}
+            {{/vendorExtensions.x-duplicated-data-type}}
+            {{/oneOf}}
+            {{/composedSchemas}}
+            {{/model.discriminator}}
 
             {{#model.discriminator}}
             {{#model.hasDiscriminatorWithNonEmptyMapping}}

--- a/samples/client/petstore/csharp/generichost/latest/AnnotatedEnum/src/Org.OpenAPITools/Model/OneOfNullableTest.cs
+++ b/samples/client/petstore/csharp/generichost/latest/AnnotatedEnum/src/Org.OpenAPITools/Model/OneOfNullableTest.cs
@@ -179,6 +179,18 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public override void Write(Utf8JsonWriter writer, OneOfNullableTest oneOfNullableTest, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (oneOfNullableTest.Int != null)
+            {
+                JsonSerializer.Serialize(writer, oneOfNullableTest.Int, jsonSerializerOptions);
+                return;
+            }
+
+            if (oneOfNullableTest.String != null)
+            {
+                JsonSerializer.Serialize(writer, oneOfNullableTest.String, jsonSerializerOptions);
+                return;
+            }
+
             writer.WriteStartObject();
 
             WriteProperties(writer, oneOfNullableTest, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/latest/AnnotatedEnum/src/Org.OpenAPITools/Model/ParentWithPluralOneOfPropertyNumber.cs
+++ b/samples/client/petstore/csharp/generichost/latest/AnnotatedEnum/src/Org.OpenAPITools/Model/ParentWithPluralOneOfPropertyNumber.cs
@@ -178,6 +178,18 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public override void Write(Utf8JsonWriter writer, ParentWithPluralOneOfPropertyNumber parentWithPluralOneOfPropertyNumber, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (parentWithPluralOneOfPropertyNumber.Number != null)
+            {
+                JsonSerializer.Serialize(writer, parentWithPluralOneOfPropertyNumber.Number, jsonSerializerOptions);
+                return;
+            }
+
+            if (parentWithPluralOneOfPropertyNumber.Number2 != null)
+            {
+                JsonSerializer.Serialize(writer, parentWithPluralOneOfPropertyNumber.Number2, jsonSerializerOptions);
+                return;
+            }
+
             writer.WriteStartObject();
 
             WriteProperties(writer, parentWithPluralOneOfPropertyNumber, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/latest/OneOfList/src/Org.OpenAPITools/Model/OneOfArrayRequest.cs
+++ b/samples/client/petstore/csharp/generichost/latest/OneOfList/src/Org.OpenAPITools/Model/OneOfArrayRequest.cs
@@ -178,6 +178,12 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public override void Write(Utf8JsonWriter writer, OneOfArrayRequest oneOfArrayRequest, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (oneOfArrayRequest.List != null)
+            {
+                JsonSerializer.Serialize(writer, oneOfArrayRequest.List, jsonSerializerOptions);
+                return;
+            }
+
             writer.WriteStartObject();
 
             WriteProperties(writer, oneOfArrayRequest, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Fruit.cs
@@ -205,6 +205,17 @@ namespace Org.OpenAPITools.Model
         public override void Write(Utf8JsonWriter writer, Fruit fruit, JsonSerializerOptions jsonSerializerOptions)
         {
             writer.WriteStartObject();
+            if (fruit.Apple != null)
+            {
+                AppleJsonConverter appleJsonConverter = new AppleJsonConverter();
+                appleJsonConverter.WriteProperties(writer, fruit.Apple, jsonSerializerOptions);
+            }
+
+            if (fruit.Banana != null)
+            {
+                BananaJsonConverter bananaJsonConverter = new BananaJsonConverter();
+                bananaJsonConverter.WriteProperties(writer, fruit.Banana, jsonSerializerOptions);
+            }
 
             WriteProperties(writer, fruit, jsonSerializerOptions);
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/FruitReq.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/FruitReq.cs
@@ -179,6 +179,17 @@ namespace Org.OpenAPITools.Model
         public override void Write(Utf8JsonWriter writer, FruitReq fruitReq, JsonSerializerOptions jsonSerializerOptions)
         {
             writer.WriteStartObject();
+            if (fruitReq.AppleReq != null)
+            {
+                AppleReqJsonConverter appleReqJsonConverter = new AppleReqJsonConverter();
+                appleReqJsonConverter.WriteProperties(writer, fruitReq.AppleReq, jsonSerializerOptions);
+            }
+
+            if (fruitReq.BananaReq != null)
+            {
+                BananaReqJsonConverter bananaReqJsonConverter = new BananaReqJsonConverter();
+                bananaReqJsonConverter.WriteProperties(writer, fruitReq.BananaReq, jsonSerializerOptions);
+            }
 
             WriteProperties(writer, fruitReq, jsonSerializerOptions);
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
@@ -244,7 +244,36 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public override void Write(Utf8JsonWriter writer, MixedOneOfContent mixedOneOfContent, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (mixedOneOfContent.String != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.String, jsonSerializerOptions);
+                return;
+            }
+
+            if (mixedOneOfContent.Bool != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.Bool, jsonSerializerOptions);
+                return;
+            }
+
+            if (mixedOneOfContent.Int != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.Int, jsonSerializerOptions);
+                return;
+            }
+
+            if (mixedOneOfContent.Decimal != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.Decimal, jsonSerializerOptions);
+                return;
+            }
+
             writer.WriteStartObject();
+            if (mixedOneOfContent.MixedSubId != null)
+            {
+                MixedSubIdJsonConverter mixedSubIdJsonConverter = new MixedSubIdJsonConverter();
+                mixedSubIdJsonConverter.WriteProperties(writer, mixedOneOfContent.MixedSubId, jsonSerializerOptions);
+            }
 
             WriteProperties(writer, mixedOneOfContent, jsonSerializerOptions);
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/OneOfString.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/OneOfString.cs
@@ -140,6 +140,12 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public override void Write(Utf8JsonWriter writer, OneOfString oneOfString, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (oneOfString.String != null)
+            {
+                JsonSerializer.Serialize(writer, oneOfString.String, jsonSerializerOptions);
+                return;
+            }
+
             writer.WriteStartObject();
 
             WriteProperties(writer, oneOfString, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
@@ -222,6 +222,30 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public override void Write(Utf8JsonWriter writer, PolymorphicProperty polymorphicProperty, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (polymorphicProperty.Bool != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.Bool, jsonSerializerOptions);
+                return;
+            }
+
+            if (polymorphicProperty.String != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.String, jsonSerializerOptions);
+                return;
+            }
+
+            if (polymorphicProperty.Object != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.Object, jsonSerializerOptions);
+                return;
+            }
+
+            if (polymorphicProperty.List != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.List, jsonSerializerOptions);
+                return;
+            }
+
             writer.WriteStartObject();
 
             WriteProperties(writer, polymorphicProperty, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Fruit.cs
@@ -204,6 +204,17 @@ namespace Org.OpenAPITools.Model
         public override void Write(Utf8JsonWriter writer, Fruit fruit, JsonSerializerOptions jsonSerializerOptions)
         {
             writer.WriteStartObject();
+            if (fruit.Apple != null)
+            {
+                AppleJsonConverter appleJsonConverter = new AppleJsonConverter();
+                appleJsonConverter.WriteProperties(writer, fruit.Apple, jsonSerializerOptions);
+            }
+
+            if (fruit.Banana != null)
+            {
+                BananaJsonConverter bananaJsonConverter = new BananaJsonConverter();
+                bananaJsonConverter.WriteProperties(writer, fruit.Banana, jsonSerializerOptions);
+            }
 
             WriteProperties(writer, fruit, jsonSerializerOptions);
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/FruitReq.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/FruitReq.cs
@@ -178,6 +178,17 @@ namespace Org.OpenAPITools.Model
         public override void Write(Utf8JsonWriter writer, FruitReq fruitReq, JsonSerializerOptions jsonSerializerOptions)
         {
             writer.WriteStartObject();
+            if (fruitReq.AppleReq != null)
+            {
+                AppleReqJsonConverter appleReqJsonConverter = new AppleReqJsonConverter();
+                appleReqJsonConverter.WriteProperties(writer, fruitReq.AppleReq, jsonSerializerOptions);
+            }
+
+            if (fruitReq.BananaReq != null)
+            {
+                BananaReqJsonConverter bananaReqJsonConverter = new BananaReqJsonConverter();
+                bananaReqJsonConverter.WriteProperties(writer, fruitReq.BananaReq, jsonSerializerOptions);
+            }
 
             WriteProperties(writer, fruitReq, jsonSerializerOptions);
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
@@ -250,7 +250,36 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public override void Write(Utf8JsonWriter writer, MixedOneOfContent mixedOneOfContent, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (mixedOneOfContent.String != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.String, jsonSerializerOptions);
+                return;
+            }
+
+            if (mixedOneOfContent.Bool != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.Bool, jsonSerializerOptions);
+                return;
+            }
+
+            if (mixedOneOfContent.Int != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.Int, jsonSerializerOptions);
+                return;
+            }
+
+            if (mixedOneOfContent.Decimal != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.Decimal, jsonSerializerOptions);
+                return;
+            }
+
             writer.WriteStartObject();
+            if (mixedOneOfContent.MixedSubId != null)
+            {
+                MixedSubIdJsonConverter mixedSubIdJsonConverter = new MixedSubIdJsonConverter();
+                mixedSubIdJsonConverter.WriteProperties(writer, mixedOneOfContent.MixedSubId, jsonSerializerOptions);
+            }
 
             WriteProperties(writer, mixedOneOfContent, jsonSerializerOptions);
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/OneOfString.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/OneOfString.cs
@@ -146,6 +146,12 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public override void Write(Utf8JsonWriter writer, OneOfString oneOfString, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (oneOfString.String != null)
+            {
+                JsonSerializer.Serialize(writer, oneOfString.String, jsonSerializerOptions);
+                return;
+            }
+
             writer.WriteStartObject();
 
             WriteProperties(writer, oneOfString, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
@@ -228,6 +228,30 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public override void Write(Utf8JsonWriter writer, PolymorphicProperty polymorphicProperty, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (polymorphicProperty.Bool != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.Bool, jsonSerializerOptions);
+                return;
+            }
+
+            if (polymorphicProperty.String != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.String, jsonSerializerOptions);
+                return;
+            }
+
+            if (polymorphicProperty.Object != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.Object, jsonSerializerOptions);
+                return;
+            }
+
+            if (polymorphicProperty.List != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.List, jsonSerializerOptions);
+                return;
+            }
+
             writer.WriteStartObject();
 
             WriteProperties(writer, polymorphicProperty, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Fruit.cs
@@ -206,6 +206,17 @@ namespace Org.OpenAPITools.Model
         public override void Write(Utf8JsonWriter writer, Fruit fruit, JsonSerializerOptions jsonSerializerOptions)
         {
             writer.WriteStartObject();
+            if (fruit.Apple != null)
+            {
+                AppleJsonConverter appleJsonConverter = new AppleJsonConverter();
+                appleJsonConverter.WriteProperties(writer, fruit.Apple, jsonSerializerOptions);
+            }
+
+            if (fruit.Banana != null)
+            {
+                BananaJsonConverter bananaJsonConverter = new BananaJsonConverter();
+                bananaJsonConverter.WriteProperties(writer, fruit.Banana, jsonSerializerOptions);
+            }
 
             WriteProperties(writer, fruit, jsonSerializerOptions);
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/FruitReq.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/FruitReq.cs
@@ -180,6 +180,17 @@ namespace Org.OpenAPITools.Model
         public override void Write(Utf8JsonWriter writer, FruitReq fruitReq, JsonSerializerOptions jsonSerializerOptions)
         {
             writer.WriteStartObject();
+            if (fruitReq.AppleReq != null)
+            {
+                AppleReqJsonConverter appleReqJsonConverter = new AppleReqJsonConverter();
+                appleReqJsonConverter.WriteProperties(writer, fruitReq.AppleReq, jsonSerializerOptions);
+            }
+
+            if (fruitReq.BananaReq != null)
+            {
+                BananaReqJsonConverter bananaReqJsonConverter = new BananaReqJsonConverter();
+                bananaReqJsonConverter.WriteProperties(writer, fruitReq.BananaReq, jsonSerializerOptions);
+            }
 
             WriteProperties(writer, fruitReq, jsonSerializerOptions);
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
@@ -252,7 +252,36 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public override void Write(Utf8JsonWriter writer, MixedOneOfContent mixedOneOfContent, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (mixedOneOfContent.String != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.String, jsonSerializerOptions);
+                return;
+            }
+
+            if (mixedOneOfContent.Bool != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.Bool, jsonSerializerOptions);
+                return;
+            }
+
+            if (mixedOneOfContent.Int != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.Int, jsonSerializerOptions);
+                return;
+            }
+
+            if (mixedOneOfContent.Decimal != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.Decimal, jsonSerializerOptions);
+                return;
+            }
+
             writer.WriteStartObject();
+            if (mixedOneOfContent.MixedSubId != null)
+            {
+                MixedSubIdJsonConverter mixedSubIdJsonConverter = new MixedSubIdJsonConverter();
+                mixedSubIdJsonConverter.WriteProperties(writer, mixedOneOfContent.MixedSubId, jsonSerializerOptions);
+            }
 
             WriteProperties(writer, mixedOneOfContent, jsonSerializerOptions);
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/OneOfString.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/OneOfString.cs
@@ -148,6 +148,12 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public override void Write(Utf8JsonWriter writer, OneOfString oneOfString, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (oneOfString.String != null)
+            {
+                JsonSerializer.Serialize(writer, oneOfString.String, jsonSerializerOptions);
+                return;
+            }
+
             writer.WriteStartObject();
 
             WriteProperties(writer, oneOfString, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
@@ -230,6 +230,30 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public override void Write(Utf8JsonWriter writer, PolymorphicProperty polymorphicProperty, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (polymorphicProperty.Bool != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.Bool, jsonSerializerOptions);
+                return;
+            }
+
+            if (polymorphicProperty.String != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.String, jsonSerializerOptions);
+                return;
+            }
+
+            if (polymorphicProperty.Object != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.Object, jsonSerializerOptions);
+                return;
+            }
+
+            if (polymorphicProperty.List != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.List, jsonSerializerOptions);
+                return;
+            }
+
             writer.WriteStartObject();
 
             WriteProperties(writer, polymorphicProperty, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/net10/OneOf/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net10/OneOf/src/Org.OpenAPITools/Model/Fruit.cs
@@ -237,6 +237,23 @@ namespace Org.OpenAPITools.Model
         public override void Write(Utf8JsonWriter writer, Fruit fruit, JsonSerializerOptions jsonSerializerOptions)
         {
             writer.WriteStartObject();
+            if (fruit.Apple != null)
+            {
+                AppleJsonConverter appleJsonConverter = new AppleJsonConverter();
+                appleJsonConverter.WriteProperties(writer, fruit.Apple, jsonSerializerOptions);
+            }
+
+            if (fruit.Banana != null)
+            {
+                BananaJsonConverter bananaJsonConverter = new BananaJsonConverter();
+                bananaJsonConverter.WriteProperties(writer, fruit.Banana, jsonSerializerOptions);
+            }
+
+            if (fruit.Orange != null)
+            {
+                OrangeJsonConverter orangeJsonConverter = new OrangeJsonConverter();
+                orangeJsonConverter.WriteProperties(writer, fruit.Orange, jsonSerializerOptions);
+            }
 
             WriteProperties(writer, fruit, jsonSerializerOptions);
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
@@ -204,6 +204,17 @@ namespace Org.OpenAPITools.Model
         public override void Write(Utf8JsonWriter writer, Fruit fruit, JsonSerializerOptions jsonSerializerOptions)
         {
             writer.WriteStartObject();
+            if (fruit.Apple != null)
+            {
+                AppleJsonConverter appleJsonConverter = new AppleJsonConverter();
+                appleJsonConverter.WriteProperties(writer, fruit.Apple, jsonSerializerOptions);
+            }
+
+            if (fruit.Banana != null)
+            {
+                BananaJsonConverter bananaJsonConverter = new BananaJsonConverter();
+                bananaJsonConverter.WriteProperties(writer, fruit.Banana, jsonSerializerOptions);
+            }
 
             WriteProperties(writer, fruit, jsonSerializerOptions);
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/FruitReq.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/FruitReq.cs
@@ -178,6 +178,17 @@ namespace Org.OpenAPITools.Model
         public override void Write(Utf8JsonWriter writer, FruitReq fruitReq, JsonSerializerOptions jsonSerializerOptions)
         {
             writer.WriteStartObject();
+            if (fruitReq.AppleReq != null)
+            {
+                AppleReqJsonConverter appleReqJsonConverter = new AppleReqJsonConverter();
+                appleReqJsonConverter.WriteProperties(writer, fruitReq.AppleReq, jsonSerializerOptions);
+            }
+
+            if (fruitReq.BananaReq != null)
+            {
+                BananaReqJsonConverter bananaReqJsonConverter = new BananaReqJsonConverter();
+                bananaReqJsonConverter.WriteProperties(writer, fruitReq.BananaReq, jsonSerializerOptions);
+            }
 
             WriteProperties(writer, fruitReq, jsonSerializerOptions);
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
@@ -250,7 +250,36 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public override void Write(Utf8JsonWriter writer, MixedOneOfContent mixedOneOfContent, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (mixedOneOfContent.String != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.String, jsonSerializerOptions);
+                return;
+            }
+
+            if (mixedOneOfContent.Bool != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.Bool, jsonSerializerOptions);
+                return;
+            }
+
+            if (mixedOneOfContent.Int != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.Int, jsonSerializerOptions);
+                return;
+            }
+
+            if (mixedOneOfContent.Decimal != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.Decimal, jsonSerializerOptions);
+                return;
+            }
+
             writer.WriteStartObject();
+            if (mixedOneOfContent.MixedSubId != null)
+            {
+                MixedSubIdJsonConverter mixedSubIdJsonConverter = new MixedSubIdJsonConverter();
+                mixedSubIdJsonConverter.WriteProperties(writer, mixedOneOfContent.MixedSubId, jsonSerializerOptions);
+            }
 
             WriteProperties(writer, mixedOneOfContent, jsonSerializerOptions);
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/OneOfString.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/OneOfString.cs
@@ -146,6 +146,12 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public override void Write(Utf8JsonWriter writer, OneOfString oneOfString, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (oneOfString.String != null)
+            {
+                JsonSerializer.Serialize(writer, oneOfString.String, jsonSerializerOptions);
+                return;
+            }
+
             writer.WriteStartObject();
 
             WriteProperties(writer, oneOfString, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
@@ -228,6 +228,30 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public override void Write(Utf8JsonWriter writer, PolymorphicProperty polymorphicProperty, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (polymorphicProperty.Bool != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.Bool, jsonSerializerOptions);
+                return;
+            }
+
+            if (polymorphicProperty.String != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.String, jsonSerializerOptions);
+                return;
+            }
+
+            if (polymorphicProperty.Object != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.Object, jsonSerializerOptions);
+                return;
+            }
+
+            if (polymorphicProperty.List != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.List, jsonSerializerOptions);
+                return;
+            }
+
             writer.WriteStartObject();
 
             WriteProperties(writer, polymorphicProperty, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Fruit.cs
@@ -207,6 +207,17 @@ namespace Org.OpenAPITools.Model
         public override void Write(Utf8JsonWriter writer, Fruit fruit, JsonSerializerOptions jsonSerializerOptions)
         {
             writer.WriteStartObject();
+            if (fruit.Apple != null)
+            {
+                AppleJsonConverter appleJsonConverter = new AppleJsonConverter();
+                appleJsonConverter.WriteProperties(writer, fruit.Apple, jsonSerializerOptions);
+            }
+
+            if (fruit.Banana != null)
+            {
+                BananaJsonConverter bananaJsonConverter = new BananaJsonConverter();
+                bananaJsonConverter.WriteProperties(writer, fruit.Banana, jsonSerializerOptions);
+            }
 
             WriteProperties(writer, fruit, jsonSerializerOptions);
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/FruitReq.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/FruitReq.cs
@@ -181,6 +181,17 @@ namespace Org.OpenAPITools.Model
         public override void Write(Utf8JsonWriter writer, FruitReq fruitReq, JsonSerializerOptions jsonSerializerOptions)
         {
             writer.WriteStartObject();
+            if (fruitReq.AppleReq != null)
+            {
+                AppleReqJsonConverter appleReqJsonConverter = new AppleReqJsonConverter();
+                appleReqJsonConverter.WriteProperties(writer, fruitReq.AppleReq, jsonSerializerOptions);
+            }
+
+            if (fruitReq.BananaReq != null)
+            {
+                BananaReqJsonConverter bananaReqJsonConverter = new BananaReqJsonConverter();
+                bananaReqJsonConverter.WriteProperties(writer, fruitReq.BananaReq, jsonSerializerOptions);
+            }
 
             WriteProperties(writer, fruitReq, jsonSerializerOptions);
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
@@ -253,7 +253,36 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public override void Write(Utf8JsonWriter writer, MixedOneOfContent mixedOneOfContent, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (mixedOneOfContent.String != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.String, jsonSerializerOptions);
+                return;
+            }
+
+            if (mixedOneOfContent.Bool != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.Bool, jsonSerializerOptions);
+                return;
+            }
+
+            if (mixedOneOfContent.Int != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.Int, jsonSerializerOptions);
+                return;
+            }
+
+            if (mixedOneOfContent.Decimal != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.Decimal, jsonSerializerOptions);
+                return;
+            }
+
             writer.WriteStartObject();
+            if (mixedOneOfContent.MixedSubId != null)
+            {
+                MixedSubIdJsonConverter mixedSubIdJsonConverter = new MixedSubIdJsonConverter();
+                mixedSubIdJsonConverter.WriteProperties(writer, mixedOneOfContent.MixedSubId, jsonSerializerOptions);
+            }
 
             WriteProperties(writer, mixedOneOfContent, jsonSerializerOptions);
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/OneOfString.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/OneOfString.cs
@@ -149,6 +149,12 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public override void Write(Utf8JsonWriter writer, OneOfString oneOfString, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (oneOfString.String != null)
+            {
+                JsonSerializer.Serialize(writer, oneOfString.String, jsonSerializerOptions);
+                return;
+            }
+
             writer.WriteStartObject();
 
             WriteProperties(writer, oneOfString, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
@@ -231,6 +231,30 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public override void Write(Utf8JsonWriter writer, PolymorphicProperty polymorphicProperty, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (polymorphicProperty.Bool != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.Bool, jsonSerializerOptions);
+                return;
+            }
+
+            if (polymorphicProperty.String != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.String, jsonSerializerOptions);
+                return;
+            }
+
+            if (polymorphicProperty.Object != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.Object, jsonSerializerOptions);
+                return;
+            }
+
+            if (polymorphicProperty.List != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.List, jsonSerializerOptions);
+                return;
+            }
+
             writer.WriteStartObject();
 
             WriteProperties(writer, polymorphicProperty, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Fruit.cs
@@ -204,6 +204,17 @@ namespace Org.OpenAPITools.Model
         public override void Write(Utf8JsonWriter writer, Fruit fruit, JsonSerializerOptions jsonSerializerOptions)
         {
             writer.WriteStartObject();
+            if (fruit.Apple != null)
+            {
+                AppleJsonConverter appleJsonConverter = new AppleJsonConverter();
+                appleJsonConverter.WriteProperties(writer, fruit.Apple, jsonSerializerOptions);
+            }
+
+            if (fruit.Banana != null)
+            {
+                BananaJsonConverter bananaJsonConverter = new BananaJsonConverter();
+                bananaJsonConverter.WriteProperties(writer, fruit.Banana, jsonSerializerOptions);
+            }
 
             WriteProperties(writer, fruit, jsonSerializerOptions);
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/FruitReq.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/FruitReq.cs
@@ -178,6 +178,17 @@ namespace Org.OpenAPITools.Model
         public override void Write(Utf8JsonWriter writer, FruitReq fruitReq, JsonSerializerOptions jsonSerializerOptions)
         {
             writer.WriteStartObject();
+            if (fruitReq.AppleReq != null)
+            {
+                AppleReqJsonConverter appleReqJsonConverter = new AppleReqJsonConverter();
+                appleReqJsonConverter.WriteProperties(writer, fruitReq.AppleReq, jsonSerializerOptions);
+            }
+
+            if (fruitReq.BananaReq != null)
+            {
+                BananaReqJsonConverter bananaReqJsonConverter = new BananaReqJsonConverter();
+                bananaReqJsonConverter.WriteProperties(writer, fruitReq.BananaReq, jsonSerializerOptions);
+            }
 
             WriteProperties(writer, fruitReq, jsonSerializerOptions);
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
@@ -250,7 +250,36 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public override void Write(Utf8JsonWriter writer, MixedOneOfContent mixedOneOfContent, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (mixedOneOfContent.String != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.String, jsonSerializerOptions);
+                return;
+            }
+
+            if (mixedOneOfContent.Bool != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.Bool, jsonSerializerOptions);
+                return;
+            }
+
+            if (mixedOneOfContent.Int != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.Int, jsonSerializerOptions);
+                return;
+            }
+
+            if (mixedOneOfContent.Decimal != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.Decimal, jsonSerializerOptions);
+                return;
+            }
+
             writer.WriteStartObject();
+            if (mixedOneOfContent.MixedSubId != null)
+            {
+                MixedSubIdJsonConverter mixedSubIdJsonConverter = new MixedSubIdJsonConverter();
+                mixedSubIdJsonConverter.WriteProperties(writer, mixedOneOfContent.MixedSubId, jsonSerializerOptions);
+            }
 
             WriteProperties(writer, mixedOneOfContent, jsonSerializerOptions);
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/OneOfString.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/OneOfString.cs
@@ -146,6 +146,12 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public override void Write(Utf8JsonWriter writer, OneOfString oneOfString, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (oneOfString.String != null)
+            {
+                JsonSerializer.Serialize(writer, oneOfString.String, jsonSerializerOptions);
+                return;
+            }
+
             writer.WriteStartObject();
 
             WriteProperties(writer, oneOfString, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
@@ -228,6 +228,30 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public override void Write(Utf8JsonWriter writer, PolymorphicProperty polymorphicProperty, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (polymorphicProperty.Bool != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.Bool, jsonSerializerOptions);
+                return;
+            }
+
+            if (polymorphicProperty.String != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.String, jsonSerializerOptions);
+                return;
+            }
+
+            if (polymorphicProperty.Object != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.Object, jsonSerializerOptions);
+                return;
+            }
+
+            if (polymorphicProperty.List != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.List, jsonSerializerOptions);
+                return;
+            }
+
             writer.WriteStartObject();
 
             WriteProperties(writer, polymorphicProperty, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/net4.7/OneOf/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/OneOf/src/Org.OpenAPITools/Model/Fruit.cs
@@ -235,6 +235,23 @@ namespace Org.OpenAPITools.Model
         public override void Write(Utf8JsonWriter writer, Fruit fruit, JsonSerializerOptions jsonSerializerOptions)
         {
             writer.WriteStartObject();
+            if (fruit.Apple != null)
+            {
+                AppleJsonConverter appleJsonConverter = new AppleJsonConverter();
+                appleJsonConverter.WriteProperties(writer, fruit.Apple, jsonSerializerOptions);
+            }
+
+            if (fruit.Banana != null)
+            {
+                BananaJsonConverter bananaJsonConverter = new BananaJsonConverter();
+                bananaJsonConverter.WriteProperties(writer, fruit.Banana, jsonSerializerOptions);
+            }
+
+            if (fruit.Orange != null)
+            {
+                OrangeJsonConverter orangeJsonConverter = new OrangeJsonConverter();
+                orangeJsonConverter.WriteProperties(writer, fruit.Orange, jsonSerializerOptions);
+            }
 
             WriteProperties(writer, fruit, jsonSerializerOptions);
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
@@ -204,6 +204,17 @@ namespace Org.OpenAPITools.Model
         public override void Write(Utf8JsonWriter writer, Fruit fruit, JsonSerializerOptions jsonSerializerOptions)
         {
             writer.WriteStartObject();
+            if (fruit.Apple != null)
+            {
+                AppleJsonConverter appleJsonConverter = new AppleJsonConverter();
+                appleJsonConverter.WriteProperties(writer, fruit.Apple, jsonSerializerOptions);
+            }
+
+            if (fruit.Banana != null)
+            {
+                BananaJsonConverter bananaJsonConverter = new BananaJsonConverter();
+                bananaJsonConverter.WriteProperties(writer, fruit.Banana, jsonSerializerOptions);
+            }
 
             WriteProperties(writer, fruit, jsonSerializerOptions);
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/FruitReq.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/FruitReq.cs
@@ -178,6 +178,17 @@ namespace Org.OpenAPITools.Model
         public override void Write(Utf8JsonWriter writer, FruitReq fruitReq, JsonSerializerOptions jsonSerializerOptions)
         {
             writer.WriteStartObject();
+            if (fruitReq.AppleReq != null)
+            {
+                AppleReqJsonConverter appleReqJsonConverter = new AppleReqJsonConverter();
+                appleReqJsonConverter.WriteProperties(writer, fruitReq.AppleReq, jsonSerializerOptions);
+            }
+
+            if (fruitReq.BananaReq != null)
+            {
+                BananaReqJsonConverter bananaReqJsonConverter = new BananaReqJsonConverter();
+                bananaReqJsonConverter.WriteProperties(writer, fruitReq.BananaReq, jsonSerializerOptions);
+            }
 
             WriteProperties(writer, fruitReq, jsonSerializerOptions);
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
@@ -250,7 +250,36 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public override void Write(Utf8JsonWriter writer, MixedOneOfContent mixedOneOfContent, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (mixedOneOfContent.String != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.String, jsonSerializerOptions);
+                return;
+            }
+
+            if (mixedOneOfContent.Bool != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.Bool, jsonSerializerOptions);
+                return;
+            }
+
+            if (mixedOneOfContent.Int != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.Int, jsonSerializerOptions);
+                return;
+            }
+
+            if (mixedOneOfContent.Decimal != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.Decimal, jsonSerializerOptions);
+                return;
+            }
+
             writer.WriteStartObject();
+            if (mixedOneOfContent.MixedSubId != null)
+            {
+                MixedSubIdJsonConverter mixedSubIdJsonConverter = new MixedSubIdJsonConverter();
+                mixedSubIdJsonConverter.WriteProperties(writer, mixedOneOfContent.MixedSubId, jsonSerializerOptions);
+            }
 
             WriteProperties(writer, mixedOneOfContent, jsonSerializerOptions);
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/OneOfString.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/OneOfString.cs
@@ -146,6 +146,12 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public override void Write(Utf8JsonWriter writer, OneOfString oneOfString, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (oneOfString.String != null)
+            {
+                JsonSerializer.Serialize(writer, oneOfString.String, jsonSerializerOptions);
+                return;
+            }
+
             writer.WriteStartObject();
 
             WriteProperties(writer, oneOfString, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
@@ -228,6 +228,30 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public override void Write(Utf8JsonWriter writer, PolymorphicProperty polymorphicProperty, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (polymorphicProperty.Bool != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.Bool, jsonSerializerOptions);
+                return;
+            }
+
+            if (polymorphicProperty.String != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.String, jsonSerializerOptions);
+                return;
+            }
+
+            if (polymorphicProperty.Object != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.Object, jsonSerializerOptions);
+                return;
+            }
+
+            if (polymorphicProperty.List != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.List, jsonSerializerOptions);
+                return;
+            }
+
             writer.WriteStartObject();
 
             WriteProperties(writer, polymorphicProperty, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Fruit.cs
@@ -204,6 +204,17 @@ namespace Org.OpenAPITools.Model
         public override void Write(Utf8JsonWriter writer, Fruit fruit, JsonSerializerOptions jsonSerializerOptions)
         {
             writer.WriteStartObject();
+            if (fruit.Apple != null)
+            {
+                AppleJsonConverter appleJsonConverter = new AppleJsonConverter();
+                appleJsonConverter.WriteProperties(writer, fruit.Apple, jsonSerializerOptions);
+            }
+
+            if (fruit.Banana != null)
+            {
+                BananaJsonConverter bananaJsonConverter = new BananaJsonConverter();
+                bananaJsonConverter.WriteProperties(writer, fruit.Banana, jsonSerializerOptions);
+            }
 
             WriteProperties(writer, fruit, jsonSerializerOptions);
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/FruitReq.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/FruitReq.cs
@@ -178,6 +178,17 @@ namespace Org.OpenAPITools.Model
         public override void Write(Utf8JsonWriter writer, FruitReq fruitReq, JsonSerializerOptions jsonSerializerOptions)
         {
             writer.WriteStartObject();
+            if (fruitReq.AppleReq != null)
+            {
+                AppleReqJsonConverter appleReqJsonConverter = new AppleReqJsonConverter();
+                appleReqJsonConverter.WriteProperties(writer, fruitReq.AppleReq, jsonSerializerOptions);
+            }
+
+            if (fruitReq.BananaReq != null)
+            {
+                BananaReqJsonConverter bananaReqJsonConverter = new BananaReqJsonConverter();
+                bananaReqJsonConverter.WriteProperties(writer, fruitReq.BananaReq, jsonSerializerOptions);
+            }
 
             WriteProperties(writer, fruitReq, jsonSerializerOptions);
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
@@ -250,7 +250,36 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public override void Write(Utf8JsonWriter writer, MixedOneOfContent mixedOneOfContent, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (mixedOneOfContent.String != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.String, jsonSerializerOptions);
+                return;
+            }
+
+            if (mixedOneOfContent.Bool != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.Bool, jsonSerializerOptions);
+                return;
+            }
+
+            if (mixedOneOfContent.Int != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.Int, jsonSerializerOptions);
+                return;
+            }
+
+            if (mixedOneOfContent.Decimal != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.Decimal, jsonSerializerOptions);
+                return;
+            }
+
             writer.WriteStartObject();
+            if (mixedOneOfContent.MixedSubId != null)
+            {
+                MixedSubIdJsonConverter mixedSubIdJsonConverter = new MixedSubIdJsonConverter();
+                mixedSubIdJsonConverter.WriteProperties(writer, mixedOneOfContent.MixedSubId, jsonSerializerOptions);
+            }
 
             WriteProperties(writer, mixedOneOfContent, jsonSerializerOptions);
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/OneOfString.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/OneOfString.cs
@@ -146,6 +146,12 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public override void Write(Utf8JsonWriter writer, OneOfString oneOfString, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (oneOfString.String != null)
+            {
+                JsonSerializer.Serialize(writer, oneOfString.String, jsonSerializerOptions);
+                return;
+            }
+
             writer.WriteStartObject();
 
             WriteProperties(writer, oneOfString, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
@@ -228,6 +228,30 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public override void Write(Utf8JsonWriter writer, PolymorphicProperty polymorphicProperty, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (polymorphicProperty.Bool != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.Bool, jsonSerializerOptions);
+                return;
+            }
+
+            if (polymorphicProperty.String != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.String, jsonSerializerOptions);
+                return;
+            }
+
+            if (polymorphicProperty.Object != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.Object, jsonSerializerOptions);
+                return;
+            }
+
+            if (polymorphicProperty.List != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.List, jsonSerializerOptions);
+                return;
+            }
+
             writer.WriteStartObject();
 
             WriteProperties(writer, polymorphicProperty, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/net4.8/OneOf/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/OneOf/src/Org.OpenAPITools/Model/Fruit.cs
@@ -235,6 +235,23 @@ namespace Org.OpenAPITools.Model
         public override void Write(Utf8JsonWriter writer, Fruit fruit, JsonSerializerOptions jsonSerializerOptions)
         {
             writer.WriteStartObject();
+            if (fruit.Apple != null)
+            {
+                AppleJsonConverter appleJsonConverter = new AppleJsonConverter();
+                appleJsonConverter.WriteProperties(writer, fruit.Apple, jsonSerializerOptions);
+            }
+
+            if (fruit.Banana != null)
+            {
+                BananaJsonConverter bananaJsonConverter = new BananaJsonConverter();
+                bananaJsonConverter.WriteProperties(writer, fruit.Banana, jsonSerializerOptions);
+            }
+
+            if (fruit.Orange != null)
+            {
+                OrangeJsonConverter orangeJsonConverter = new OrangeJsonConverter();
+                orangeJsonConverter.WriteProperties(writer, fruit.Orange, jsonSerializerOptions);
+            }
 
             WriteProperties(writer, fruit, jsonSerializerOptions);
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
@@ -204,6 +204,17 @@ namespace Org.OpenAPITools.Model
         public override void Write(Utf8JsonWriter writer, Fruit fruit, JsonSerializerOptions jsonSerializerOptions)
         {
             writer.WriteStartObject();
+            if (fruit.Apple != null)
+            {
+                AppleJsonConverter appleJsonConverter = new AppleJsonConverter();
+                appleJsonConverter.WriteProperties(writer, fruit.Apple, jsonSerializerOptions);
+            }
+
+            if (fruit.Banana != null)
+            {
+                BananaJsonConverter bananaJsonConverter = new BananaJsonConverter();
+                bananaJsonConverter.WriteProperties(writer, fruit.Banana, jsonSerializerOptions);
+            }
 
             WriteProperties(writer, fruit, jsonSerializerOptions);
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/FruitReq.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/FruitReq.cs
@@ -178,6 +178,17 @@ namespace Org.OpenAPITools.Model
         public override void Write(Utf8JsonWriter writer, FruitReq fruitReq, JsonSerializerOptions jsonSerializerOptions)
         {
             writer.WriteStartObject();
+            if (fruitReq.AppleReq != null)
+            {
+                AppleReqJsonConverter appleReqJsonConverter = new AppleReqJsonConverter();
+                appleReqJsonConverter.WriteProperties(writer, fruitReq.AppleReq, jsonSerializerOptions);
+            }
+
+            if (fruitReq.BananaReq != null)
+            {
+                BananaReqJsonConverter bananaReqJsonConverter = new BananaReqJsonConverter();
+                bananaReqJsonConverter.WriteProperties(writer, fruitReq.BananaReq, jsonSerializerOptions);
+            }
 
             WriteProperties(writer, fruitReq, jsonSerializerOptions);
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
@@ -250,7 +250,36 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public override void Write(Utf8JsonWriter writer, MixedOneOfContent mixedOneOfContent, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (mixedOneOfContent.String != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.String, jsonSerializerOptions);
+                return;
+            }
+
+            if (mixedOneOfContent.Bool != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.Bool, jsonSerializerOptions);
+                return;
+            }
+
+            if (mixedOneOfContent.Int != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.Int, jsonSerializerOptions);
+                return;
+            }
+
+            if (mixedOneOfContent.Decimal != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.Decimal, jsonSerializerOptions);
+                return;
+            }
+
             writer.WriteStartObject();
+            if (mixedOneOfContent.MixedSubId != null)
+            {
+                MixedSubIdJsonConverter mixedSubIdJsonConverter = new MixedSubIdJsonConverter();
+                mixedSubIdJsonConverter.WriteProperties(writer, mixedOneOfContent.MixedSubId, jsonSerializerOptions);
+            }
 
             WriteProperties(writer, mixedOneOfContent, jsonSerializerOptions);
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/OneOfString.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/OneOfString.cs
@@ -146,6 +146,12 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public override void Write(Utf8JsonWriter writer, OneOfString oneOfString, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (oneOfString.String != null)
+            {
+                JsonSerializer.Serialize(writer, oneOfString.String, jsonSerializerOptions);
+                return;
+            }
+
             writer.WriteStartObject();
 
             WriteProperties(writer, oneOfString, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
@@ -228,6 +228,30 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public override void Write(Utf8JsonWriter writer, PolymorphicProperty polymorphicProperty, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (polymorphicProperty.Bool != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.Bool, jsonSerializerOptions);
+                return;
+            }
+
+            if (polymorphicProperty.String != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.String, jsonSerializerOptions);
+                return;
+            }
+
+            if (polymorphicProperty.Object != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.Object, jsonSerializerOptions);
+                return;
+            }
+
+            if (polymorphicProperty.List != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.List, jsonSerializerOptions);
+                return;
+            }
+
             writer.WriteStartObject();
 
             WriteProperties(writer, polymorphicProperty, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Fruit.cs
@@ -204,6 +204,17 @@ namespace Org.OpenAPITools.Model
         public override void Write(Utf8JsonWriter writer, Fruit fruit, JsonSerializerOptions jsonSerializerOptions)
         {
             writer.WriteStartObject();
+            if (fruit.Apple != null)
+            {
+                AppleJsonConverter appleJsonConverter = new AppleJsonConverter();
+                appleJsonConverter.WriteProperties(writer, fruit.Apple, jsonSerializerOptions);
+            }
+
+            if (fruit.Banana != null)
+            {
+                BananaJsonConverter bananaJsonConverter = new BananaJsonConverter();
+                bananaJsonConverter.WriteProperties(writer, fruit.Banana, jsonSerializerOptions);
+            }
 
             WriteProperties(writer, fruit, jsonSerializerOptions);
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/FruitReq.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/FruitReq.cs
@@ -178,6 +178,17 @@ namespace Org.OpenAPITools.Model
         public override void Write(Utf8JsonWriter writer, FruitReq fruitReq, JsonSerializerOptions jsonSerializerOptions)
         {
             writer.WriteStartObject();
+            if (fruitReq.AppleReq != null)
+            {
+                AppleReqJsonConverter appleReqJsonConverter = new AppleReqJsonConverter();
+                appleReqJsonConverter.WriteProperties(writer, fruitReq.AppleReq, jsonSerializerOptions);
+            }
+
+            if (fruitReq.BananaReq != null)
+            {
+                BananaReqJsonConverter bananaReqJsonConverter = new BananaReqJsonConverter();
+                bananaReqJsonConverter.WriteProperties(writer, fruitReq.BananaReq, jsonSerializerOptions);
+            }
 
             WriteProperties(writer, fruitReq, jsonSerializerOptions);
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
@@ -250,7 +250,36 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public override void Write(Utf8JsonWriter writer, MixedOneOfContent mixedOneOfContent, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (mixedOneOfContent.String != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.String, jsonSerializerOptions);
+                return;
+            }
+
+            if (mixedOneOfContent.Bool != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.Bool, jsonSerializerOptions);
+                return;
+            }
+
+            if (mixedOneOfContent.Int != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.Int, jsonSerializerOptions);
+                return;
+            }
+
+            if (mixedOneOfContent.Decimal != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.Decimal, jsonSerializerOptions);
+                return;
+            }
+
             writer.WriteStartObject();
+            if (mixedOneOfContent.MixedSubId != null)
+            {
+                MixedSubIdJsonConverter mixedSubIdJsonConverter = new MixedSubIdJsonConverter();
+                mixedSubIdJsonConverter.WriteProperties(writer, mixedOneOfContent.MixedSubId, jsonSerializerOptions);
+            }
 
             WriteProperties(writer, mixedOneOfContent, jsonSerializerOptions);
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/OneOfString.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/OneOfString.cs
@@ -146,6 +146,12 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public override void Write(Utf8JsonWriter writer, OneOfString oneOfString, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (oneOfString.String != null)
+            {
+                JsonSerializer.Serialize(writer, oneOfString.String, jsonSerializerOptions);
+                return;
+            }
+
             writer.WriteStartObject();
 
             WriteProperties(writer, oneOfString, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
@@ -228,6 +228,30 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public override void Write(Utf8JsonWriter writer, PolymorphicProperty polymorphicProperty, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (polymorphicProperty.Bool != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.Bool, jsonSerializerOptions);
+                return;
+            }
+
+            if (polymorphicProperty.String != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.String, jsonSerializerOptions);
+                return;
+            }
+
+            if (polymorphicProperty.Object != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.Object, jsonSerializerOptions);
+                return;
+            }
+
+            if (polymorphicProperty.List != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.List, jsonSerializerOptions);
+                return;
+            }
+
             writer.WriteStartObject();
 
             WriteProperties(writer, polymorphicProperty, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Fruit.cs
@@ -206,6 +206,17 @@ namespace Org.OpenAPITools.Model
         public override void Write(Utf8JsonWriter writer, Fruit fruit, JsonSerializerOptions jsonSerializerOptions)
         {
             writer.WriteStartObject();
+            if (fruit.Apple != null)
+            {
+                AppleJsonConverter appleJsonConverter = new AppleJsonConverter();
+                appleJsonConverter.WriteProperties(writer, fruit.Apple, jsonSerializerOptions);
+            }
+
+            if (fruit.Banana != null)
+            {
+                BananaJsonConverter bananaJsonConverter = new BananaJsonConverter();
+                bananaJsonConverter.WriteProperties(writer, fruit.Banana, jsonSerializerOptions);
+            }
 
             WriteProperties(writer, fruit, jsonSerializerOptions);
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/FruitReq.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/FruitReq.cs
@@ -180,6 +180,17 @@ namespace Org.OpenAPITools.Model
         public override void Write(Utf8JsonWriter writer, FruitReq fruitReq, JsonSerializerOptions jsonSerializerOptions)
         {
             writer.WriteStartObject();
+            if (fruitReq.AppleReq != null)
+            {
+                AppleReqJsonConverter appleReqJsonConverter = new AppleReqJsonConverter();
+                appleReqJsonConverter.WriteProperties(writer, fruitReq.AppleReq, jsonSerializerOptions);
+            }
+
+            if (fruitReq.BananaReq != null)
+            {
+                BananaReqJsonConverter bananaReqJsonConverter = new BananaReqJsonConverter();
+                bananaReqJsonConverter.WriteProperties(writer, fruitReq.BananaReq, jsonSerializerOptions);
+            }
 
             WriteProperties(writer, fruitReq, jsonSerializerOptions);
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
@@ -252,7 +252,36 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public override void Write(Utf8JsonWriter writer, MixedOneOfContent mixedOneOfContent, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (mixedOneOfContent.String != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.String, jsonSerializerOptions);
+                return;
+            }
+
+            if (mixedOneOfContent.Bool != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.Bool, jsonSerializerOptions);
+                return;
+            }
+
+            if (mixedOneOfContent.Int != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.Int, jsonSerializerOptions);
+                return;
+            }
+
+            if (mixedOneOfContent.Decimal != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.Decimal, jsonSerializerOptions);
+                return;
+            }
+
             writer.WriteStartObject();
+            if (mixedOneOfContent.MixedSubId != null)
+            {
+                MixedSubIdJsonConverter mixedSubIdJsonConverter = new MixedSubIdJsonConverter();
+                mixedSubIdJsonConverter.WriteProperties(writer, mixedOneOfContent.MixedSubId, jsonSerializerOptions);
+            }
 
             WriteProperties(writer, mixedOneOfContent, jsonSerializerOptions);
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/OneOfString.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/OneOfString.cs
@@ -148,6 +148,12 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public override void Write(Utf8JsonWriter writer, OneOfString oneOfString, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (oneOfString.String != null)
+            {
+                JsonSerializer.Serialize(writer, oneOfString.String, jsonSerializerOptions);
+                return;
+            }
+
             writer.WriteStartObject();
 
             WriteProperties(writer, oneOfString, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
@@ -230,6 +230,30 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public override void Write(Utf8JsonWriter writer, PolymorphicProperty polymorphicProperty, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (polymorphicProperty.Bool != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.Bool, jsonSerializerOptions);
+                return;
+            }
+
+            if (polymorphicProperty.String != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.String, jsonSerializerOptions);
+                return;
+            }
+
+            if (polymorphicProperty.Object != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.Object, jsonSerializerOptions);
+                return;
+            }
+
+            if (polymorphicProperty.List != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.List, jsonSerializerOptions);
+                return;
+            }
+
             writer.WriteStartObject();
 
             WriteProperties(writer, polymorphicProperty, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/net8/OneOf/.openapi-generator/FILES
+++ b/samples/client/petstore/csharp/generichost/net8/OneOf/.openapi-generator/FILES
@@ -11,6 +11,7 @@ docs/models/Orange.md
 docs/scripts/git_push.ps1
 docs/scripts/git_push.sh
 src/Org.OpenAPITools.Test/Api/DependencyInjectionTests.cs
+src/Org.OpenAPITools.Test/Model/FruitTests.cs
 src/Org.OpenAPITools.Test/Org.OpenAPITools.Test.csproj
 src/Org.OpenAPITools.Test/README.md
 src/Org.OpenAPITools/Api/DefaultApi.cs

--- a/samples/client/petstore/csharp/generichost/net8/OneOf/.openapi-generator/FILES
+++ b/samples/client/petstore/csharp/generichost/net8/OneOf/.openapi-generator/FILES
@@ -11,7 +11,6 @@ docs/models/Orange.md
 docs/scripts/git_push.ps1
 docs/scripts/git_push.sh
 src/Org.OpenAPITools.Test/Api/DependencyInjectionTests.cs
-src/Org.OpenAPITools.Test/Model/FruitTests.cs
 src/Org.OpenAPITools.Test/Org.OpenAPITools.Test.csproj
 src/Org.OpenAPITools.Test/README.md
 src/Org.OpenAPITools/Api/DefaultApi.cs

--- a/samples/client/petstore/csharp/generichost/net8/OneOf/src/Org.OpenAPITools.Test/Model/FruitTests.cs
+++ b/samples/client/petstore/csharp/generichost/net8/OneOf/src/Org.OpenAPITools.Test/Model/FruitTests.cs
@@ -17,6 +17,7 @@ using System.Collections.Generic;
 using Org.OpenAPITools.Model;
 using Org.OpenAPITools.Client;
 using System.Reflection;
+using System.Text.Json;
 
 namespace Org.OpenAPITools.Test.Model
 {
@@ -60,6 +61,41 @@ namespace Org.OpenAPITools.Test.Model
         public void ColorTest()
         {
             // TODO unit test for the property 'Color'
+        }
+
+        [Fact]
+        public void SerializeOneOfReferencedObject()
+        {
+            var options = new JsonSerializerOptions();
+            options.Converters.Add(new AppleJsonConverter());
+            options.Converters.Add(new BananaJsonConverter());
+            options.Converters.Add(new FruitJsonConverter());
+            options.Converters.Add(new OrangeJsonConverter());
+
+            Fruit fruit = new Fruit(new Apple("red"));
+
+            string json = JsonSerializer.Serialize(fruit, options);
+
+            Assert.Equal("{\"kind\":\"red\"}", json);
+        }
+
+        [Fact]
+        public void SerializeOneOfReferencedObjectWithSiblingProperty()
+        {
+            var options = new JsonSerializerOptions();
+            options.Converters.Add(new AppleJsonConverter());
+            options.Converters.Add(new BananaJsonConverter());
+            options.Converters.Add(new FruitJsonConverter());
+            options.Converters.Add(new OrangeJsonConverter());
+
+            Fruit fruit = new Fruit(
+                new Apple("red"),
+                new Option<string?>("green")
+            );
+
+            string json = JsonSerializer.Serialize(fruit, options);
+
+            Assert.Equal("{\"kind\":\"red\",\"color\":\"green\"}", json);
         }
     }
 }

--- a/samples/client/petstore/csharp/generichost/net8/OneOf/src/Org.OpenAPITools.Test/Model/FruitTests.cs
+++ b/samples/client/petstore/csharp/generichost/net8/OneOf/src/Org.OpenAPITools.Test/Model/FruitTests.cs
@@ -17,7 +17,6 @@ using System.Collections.Generic;
 using Org.OpenAPITools.Model;
 using Org.OpenAPITools.Client;
 using System.Reflection;
-using System.Text.Json;
 
 namespace Org.OpenAPITools.Test.Model
 {
@@ -61,41 +60,6 @@ namespace Org.OpenAPITools.Test.Model
         public void ColorTest()
         {
             // TODO unit test for the property 'Color'
-        }
-
-        [Fact]
-        public void SerializeOneOfReferencedObject()
-        {
-            var options = new JsonSerializerOptions();
-            options.Converters.Add(new AppleJsonConverter());
-            options.Converters.Add(new BananaJsonConverter());
-            options.Converters.Add(new FruitJsonConverter());
-            options.Converters.Add(new OrangeJsonConverter());
-
-            Fruit fruit = new Fruit(new Apple("red"));
-
-            string json = JsonSerializer.Serialize(fruit, options);
-
-            Assert.Equal("{\"kind\":\"red\"}", json);
-        }
-
-        [Fact]
-        public void SerializeOneOfReferencedObjectWithSiblingProperty()
-        {
-            var options = new JsonSerializerOptions();
-            options.Converters.Add(new AppleJsonConverter());
-            options.Converters.Add(new BananaJsonConverter());
-            options.Converters.Add(new FruitJsonConverter());
-            options.Converters.Add(new OrangeJsonConverter());
-
-            Fruit fruit = new Fruit(
-                new Apple("red"),
-                new Option<string?>("green")
-            );
-
-            string json = JsonSerializer.Serialize(fruit, options);
-
-            Assert.Equal("{\"kind\":\"red\",\"color\":\"green\"}", json);
         }
     }
 }

--- a/samples/client/petstore/csharp/generichost/net8/OneOf/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net8/OneOf/src/Org.OpenAPITools/Model/Fruit.cs
@@ -239,19 +239,19 @@ namespace Org.OpenAPITools.Model
             writer.WriteStartObject();
             if (fruit.Apple != null)
             {
-                AppleJsonConverter appleJsonConverter = (AppleJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(fruit.Apple.GetType()));
+                AppleJsonConverter appleJsonConverter = new AppleJsonConverter();
                 appleJsonConverter.WriteProperties(writer, fruit.Apple, jsonSerializerOptions);
             }
 
             if (fruit.Banana != null)
             {
-                BananaJsonConverter bananaJsonConverter = (BananaJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(fruit.Banana.GetType()));
+                BananaJsonConverter bananaJsonConverter = new BananaJsonConverter();
                 bananaJsonConverter.WriteProperties(writer, fruit.Banana, jsonSerializerOptions);
             }
 
             if (fruit.Orange != null)
             {
-                OrangeJsonConverter orangeJsonConverter = (OrangeJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(fruit.Orange.GetType()));
+                OrangeJsonConverter orangeJsonConverter = new OrangeJsonConverter();
                 orangeJsonConverter.WriteProperties(writer, fruit.Orange, jsonSerializerOptions);
             }
 

--- a/samples/client/petstore/csharp/generichost/net8/OneOf/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net8/OneOf/src/Org.OpenAPITools/Model/Fruit.cs
@@ -237,6 +237,23 @@ namespace Org.OpenAPITools.Model
         public override void Write(Utf8JsonWriter writer, Fruit fruit, JsonSerializerOptions jsonSerializerOptions)
         {
             writer.WriteStartObject();
+            if (fruit.Apple != null)
+            {
+                AppleJsonConverter appleJsonConverter = (AppleJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(fruit.Apple.GetType()));
+                appleJsonConverter.WriteProperties(writer, fruit.Apple, jsonSerializerOptions);
+            }
+
+            if (fruit.Banana != null)
+            {
+                BananaJsonConverter bananaJsonConverter = (BananaJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(fruit.Banana.GetType()));
+                bananaJsonConverter.WriteProperties(writer, fruit.Banana, jsonSerializerOptions);
+            }
+
+            if (fruit.Orange != null)
+            {
+                OrangeJsonConverter orangeJsonConverter = (OrangeJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(fruit.Orange.GetType()));
+                orangeJsonConverter.WriteProperties(writer, fruit.Orange, jsonSerializerOptions);
+            }
 
             WriteProperties(writer, fruit, jsonSerializerOptions);
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
@@ -204,6 +204,17 @@ namespace Org.OpenAPITools.Model
         public override void Write(Utf8JsonWriter writer, Fruit fruit, JsonSerializerOptions jsonSerializerOptions)
         {
             writer.WriteStartObject();
+            if (fruit.Apple != null)
+            {
+                AppleJsonConverter appleJsonConverter = new AppleJsonConverter();
+                appleJsonConverter.WriteProperties(writer, fruit.Apple, jsonSerializerOptions);
+            }
+
+            if (fruit.Banana != null)
+            {
+                BananaJsonConverter bananaJsonConverter = new BananaJsonConverter();
+                bananaJsonConverter.WriteProperties(writer, fruit.Banana, jsonSerializerOptions);
+            }
 
             WriteProperties(writer, fruit, jsonSerializerOptions);
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/FruitReq.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/FruitReq.cs
@@ -178,6 +178,17 @@ namespace Org.OpenAPITools.Model
         public override void Write(Utf8JsonWriter writer, FruitReq fruitReq, JsonSerializerOptions jsonSerializerOptions)
         {
             writer.WriteStartObject();
+            if (fruitReq.AppleReq != null)
+            {
+                AppleReqJsonConverter appleReqJsonConverter = new AppleReqJsonConverter();
+                appleReqJsonConverter.WriteProperties(writer, fruitReq.AppleReq, jsonSerializerOptions);
+            }
+
+            if (fruitReq.BananaReq != null)
+            {
+                BananaReqJsonConverter bananaReqJsonConverter = new BananaReqJsonConverter();
+                bananaReqJsonConverter.WriteProperties(writer, fruitReq.BananaReq, jsonSerializerOptions);
+            }
 
             WriteProperties(writer, fruitReq, jsonSerializerOptions);
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
@@ -250,7 +250,36 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public override void Write(Utf8JsonWriter writer, MixedOneOfContent mixedOneOfContent, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (mixedOneOfContent.String != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.String, jsonSerializerOptions);
+                return;
+            }
+
+            if (mixedOneOfContent.Bool != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.Bool, jsonSerializerOptions);
+                return;
+            }
+
+            if (mixedOneOfContent.Int != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.Int, jsonSerializerOptions);
+                return;
+            }
+
+            if (mixedOneOfContent.Decimal != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.Decimal, jsonSerializerOptions);
+                return;
+            }
+
             writer.WriteStartObject();
+            if (mixedOneOfContent.MixedSubId != null)
+            {
+                MixedSubIdJsonConverter mixedSubIdJsonConverter = new MixedSubIdJsonConverter();
+                mixedSubIdJsonConverter.WriteProperties(writer, mixedOneOfContent.MixedSubId, jsonSerializerOptions);
+            }
 
             WriteProperties(writer, mixedOneOfContent, jsonSerializerOptions);
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/OneOfString.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/OneOfString.cs
@@ -146,6 +146,12 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public override void Write(Utf8JsonWriter writer, OneOfString oneOfString, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (oneOfString.String != null)
+            {
+                JsonSerializer.Serialize(writer, oneOfString.String, jsonSerializerOptions);
+                return;
+            }
+
             writer.WriteStartObject();
 
             WriteProperties(writer, oneOfString, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
@@ -228,6 +228,30 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public override void Write(Utf8JsonWriter writer, PolymorphicProperty polymorphicProperty, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (polymorphicProperty.Bool != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.Bool, jsonSerializerOptions);
+                return;
+            }
+
+            if (polymorphicProperty.String != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.String, jsonSerializerOptions);
+                return;
+            }
+
+            if (polymorphicProperty.Object != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.Object, jsonSerializerOptions);
+                return;
+            }
+
+            if (polymorphicProperty.List != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.List, jsonSerializerOptions);
+                return;
+            }
+
             writer.WriteStartObject();
 
             WriteProperties(writer, polymorphicProperty, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Fruit.cs
@@ -207,6 +207,17 @@ namespace Org.OpenAPITools.Model
         public override void Write(Utf8JsonWriter writer, Fruit fruit, JsonSerializerOptions jsonSerializerOptions)
         {
             writer.WriteStartObject();
+            if (fruit.Apple != null)
+            {
+                AppleJsonConverter appleJsonConverter = new AppleJsonConverter();
+                appleJsonConverter.WriteProperties(writer, fruit.Apple, jsonSerializerOptions);
+            }
+
+            if (fruit.Banana != null)
+            {
+                BananaJsonConverter bananaJsonConverter = new BananaJsonConverter();
+                bananaJsonConverter.WriteProperties(writer, fruit.Banana, jsonSerializerOptions);
+            }
 
             WriteProperties(writer, fruit, jsonSerializerOptions);
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/FruitReq.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/FruitReq.cs
@@ -181,6 +181,17 @@ namespace Org.OpenAPITools.Model
         public override void Write(Utf8JsonWriter writer, FruitReq fruitReq, JsonSerializerOptions jsonSerializerOptions)
         {
             writer.WriteStartObject();
+            if (fruitReq.AppleReq != null)
+            {
+                AppleReqJsonConverter appleReqJsonConverter = new AppleReqJsonConverter();
+                appleReqJsonConverter.WriteProperties(writer, fruitReq.AppleReq, jsonSerializerOptions);
+            }
+
+            if (fruitReq.BananaReq != null)
+            {
+                BananaReqJsonConverter bananaReqJsonConverter = new BananaReqJsonConverter();
+                bananaReqJsonConverter.WriteProperties(writer, fruitReq.BananaReq, jsonSerializerOptions);
+            }
 
             WriteProperties(writer, fruitReq, jsonSerializerOptions);
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
@@ -253,7 +253,36 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public override void Write(Utf8JsonWriter writer, MixedOneOfContent mixedOneOfContent, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (mixedOneOfContent.String != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.String, jsonSerializerOptions);
+                return;
+            }
+
+            if (mixedOneOfContent.Bool != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.Bool, jsonSerializerOptions);
+                return;
+            }
+
+            if (mixedOneOfContent.Int != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.Int, jsonSerializerOptions);
+                return;
+            }
+
+            if (mixedOneOfContent.Decimal != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.Decimal, jsonSerializerOptions);
+                return;
+            }
+
             writer.WriteStartObject();
+            if (mixedOneOfContent.MixedSubId != null)
+            {
+                MixedSubIdJsonConverter mixedSubIdJsonConverter = new MixedSubIdJsonConverter();
+                mixedSubIdJsonConverter.WriteProperties(writer, mixedOneOfContent.MixedSubId, jsonSerializerOptions);
+            }
 
             WriteProperties(writer, mixedOneOfContent, jsonSerializerOptions);
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/OneOfString.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/OneOfString.cs
@@ -149,6 +149,12 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public override void Write(Utf8JsonWriter writer, OneOfString oneOfString, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (oneOfString.String != null)
+            {
+                JsonSerializer.Serialize(writer, oneOfString.String, jsonSerializerOptions);
+                return;
+            }
+
             writer.WriteStartObject();
 
             WriteProperties(writer, oneOfString, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
@@ -231,6 +231,30 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public override void Write(Utf8JsonWriter writer, PolymorphicProperty polymorphicProperty, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (polymorphicProperty.Bool != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.Bool, jsonSerializerOptions);
+                return;
+            }
+
+            if (polymorphicProperty.String != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.String, jsonSerializerOptions);
+                return;
+            }
+
+            if (polymorphicProperty.Object != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.Object, jsonSerializerOptions);
+                return;
+            }
+
+            if (polymorphicProperty.List != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.List, jsonSerializerOptions);
+                return;
+            }
+
             writer.WriteStartObject();
 
             WriteProperties(writer, polymorphicProperty, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Fruit.cs
@@ -204,6 +204,17 @@ namespace Org.OpenAPITools.Model
         public override void Write(Utf8JsonWriter writer, Fruit fruit, JsonSerializerOptions jsonSerializerOptions)
         {
             writer.WriteStartObject();
+            if (fruit.Apple != null)
+            {
+                AppleJsonConverter appleJsonConverter = new AppleJsonConverter();
+                appleJsonConverter.WriteProperties(writer, fruit.Apple, jsonSerializerOptions);
+            }
+
+            if (fruit.Banana != null)
+            {
+                BananaJsonConverter bananaJsonConverter = new BananaJsonConverter();
+                bananaJsonConverter.WriteProperties(writer, fruit.Banana, jsonSerializerOptions);
+            }
 
             WriteProperties(writer, fruit, jsonSerializerOptions);
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/FruitReq.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/FruitReq.cs
@@ -178,6 +178,17 @@ namespace Org.OpenAPITools.Model
         public override void Write(Utf8JsonWriter writer, FruitReq fruitReq, JsonSerializerOptions jsonSerializerOptions)
         {
             writer.WriteStartObject();
+            if (fruitReq.AppleReq != null)
+            {
+                AppleReqJsonConverter appleReqJsonConverter = new AppleReqJsonConverter();
+                appleReqJsonConverter.WriteProperties(writer, fruitReq.AppleReq, jsonSerializerOptions);
+            }
+
+            if (fruitReq.BananaReq != null)
+            {
+                BananaReqJsonConverter bananaReqJsonConverter = new BananaReqJsonConverter();
+                bananaReqJsonConverter.WriteProperties(writer, fruitReq.BananaReq, jsonSerializerOptions);
+            }
 
             WriteProperties(writer, fruitReq, jsonSerializerOptions);
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
@@ -250,7 +250,36 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public override void Write(Utf8JsonWriter writer, MixedOneOfContent mixedOneOfContent, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (mixedOneOfContent.String != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.String, jsonSerializerOptions);
+                return;
+            }
+
+            if (mixedOneOfContent.Bool != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.Bool, jsonSerializerOptions);
+                return;
+            }
+
+            if (mixedOneOfContent.Int != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.Int, jsonSerializerOptions);
+                return;
+            }
+
+            if (mixedOneOfContent.Decimal != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.Decimal, jsonSerializerOptions);
+                return;
+            }
+
             writer.WriteStartObject();
+            if (mixedOneOfContent.MixedSubId != null)
+            {
+                MixedSubIdJsonConverter mixedSubIdJsonConverter = new MixedSubIdJsonConverter();
+                mixedSubIdJsonConverter.WriteProperties(writer, mixedOneOfContent.MixedSubId, jsonSerializerOptions);
+            }
 
             WriteProperties(writer, mixedOneOfContent, jsonSerializerOptions);
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/OneOfString.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/OneOfString.cs
@@ -146,6 +146,12 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public override void Write(Utf8JsonWriter writer, OneOfString oneOfString, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (oneOfString.String != null)
+            {
+                JsonSerializer.Serialize(writer, oneOfString.String, jsonSerializerOptions);
+                return;
+            }
+
             writer.WriteStartObject();
 
             WriteProperties(writer, oneOfString, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
@@ -228,6 +228,30 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public override void Write(Utf8JsonWriter writer, PolymorphicProperty polymorphicProperty, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (polymorphicProperty.Bool != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.Bool, jsonSerializerOptions);
+                return;
+            }
+
+            if (polymorphicProperty.String != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.String, jsonSerializerOptions);
+                return;
+            }
+
+            if (polymorphicProperty.Object != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.Object, jsonSerializerOptions);
+                return;
+            }
+
+            if (polymorphicProperty.List != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.List, jsonSerializerOptions);
+                return;
+            }
+
             writer.WriteStartObject();
 
             WriteProperties(writer, polymorphicProperty, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Fruit.cs
@@ -206,6 +206,17 @@ namespace Org.OpenAPITools.Model
         public override void Write(Utf8JsonWriter writer, Fruit fruit, JsonSerializerOptions jsonSerializerOptions)
         {
             writer.WriteStartObject();
+            if (fruit.Apple != null)
+            {
+                AppleJsonConverter appleJsonConverter = new AppleJsonConverter();
+                appleJsonConverter.WriteProperties(writer, fruit.Apple, jsonSerializerOptions);
+            }
+
+            if (fruit.Banana != null)
+            {
+                BananaJsonConverter bananaJsonConverter = new BananaJsonConverter();
+                bananaJsonConverter.WriteProperties(writer, fruit.Banana, jsonSerializerOptions);
+            }
 
             WriteProperties(writer, fruit, jsonSerializerOptions);
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/FruitReq.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/FruitReq.cs
@@ -180,6 +180,17 @@ namespace Org.OpenAPITools.Model
         public override void Write(Utf8JsonWriter writer, FruitReq fruitReq, JsonSerializerOptions jsonSerializerOptions)
         {
             writer.WriteStartObject();
+            if (fruitReq.AppleReq != null)
+            {
+                AppleReqJsonConverter appleReqJsonConverter = new AppleReqJsonConverter();
+                appleReqJsonConverter.WriteProperties(writer, fruitReq.AppleReq, jsonSerializerOptions);
+            }
+
+            if (fruitReq.BananaReq != null)
+            {
+                BananaReqJsonConverter bananaReqJsonConverter = new BananaReqJsonConverter();
+                bananaReqJsonConverter.WriteProperties(writer, fruitReq.BananaReq, jsonSerializerOptions);
+            }
 
             WriteProperties(writer, fruitReq, jsonSerializerOptions);
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
@@ -252,7 +252,36 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public override void Write(Utf8JsonWriter writer, MixedOneOfContent mixedOneOfContent, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (mixedOneOfContent.String != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.String, jsonSerializerOptions);
+                return;
+            }
+
+            if (mixedOneOfContent.Bool != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.Bool, jsonSerializerOptions);
+                return;
+            }
+
+            if (mixedOneOfContent.Int != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.Int, jsonSerializerOptions);
+                return;
+            }
+
+            if (mixedOneOfContent.Decimal != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.Decimal, jsonSerializerOptions);
+                return;
+            }
+
             writer.WriteStartObject();
+            if (mixedOneOfContent.MixedSubId != null)
+            {
+                MixedSubIdJsonConverter mixedSubIdJsonConverter = new MixedSubIdJsonConverter();
+                mixedSubIdJsonConverter.WriteProperties(writer, mixedOneOfContent.MixedSubId, jsonSerializerOptions);
+            }
 
             WriteProperties(writer, mixedOneOfContent, jsonSerializerOptions);
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/OneOfString.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/OneOfString.cs
@@ -148,6 +148,12 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public override void Write(Utf8JsonWriter writer, OneOfString oneOfString, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (oneOfString.String != null)
+            {
+                JsonSerializer.Serialize(writer, oneOfString.String, jsonSerializerOptions);
+                return;
+            }
+
             writer.WriteStartObject();
 
             WriteProperties(writer, oneOfString, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
@@ -230,6 +230,30 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public override void Write(Utf8JsonWriter writer, PolymorphicProperty polymorphicProperty, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (polymorphicProperty.Bool != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.Bool, jsonSerializerOptions);
+                return;
+            }
+
+            if (polymorphicProperty.String != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.String, jsonSerializerOptions);
+                return;
+            }
+
+            if (polymorphicProperty.Object != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.Object, jsonSerializerOptions);
+                return;
+            }
+
+            if (polymorphicProperty.List != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.List, jsonSerializerOptions);
+                return;
+            }
+
             writer.WriteStartObject();
 
             WriteProperties(writer, polymorphicProperty, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/net9/OneOf/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net9/OneOf/src/Org.OpenAPITools/Model/Fruit.cs
@@ -237,6 +237,23 @@ namespace Org.OpenAPITools.Model
         public override void Write(Utf8JsonWriter writer, Fruit fruit, JsonSerializerOptions jsonSerializerOptions)
         {
             writer.WriteStartObject();
+            if (fruit.Apple != null)
+            {
+                AppleJsonConverter appleJsonConverter = new AppleJsonConverter();
+                appleJsonConverter.WriteProperties(writer, fruit.Apple, jsonSerializerOptions);
+            }
+
+            if (fruit.Banana != null)
+            {
+                BananaJsonConverter bananaJsonConverter = new BananaJsonConverter();
+                bananaJsonConverter.WriteProperties(writer, fruit.Banana, jsonSerializerOptions);
+            }
+
+            if (fruit.Orange != null)
+            {
+                OrangeJsonConverter orangeJsonConverter = new OrangeJsonConverter();
+                orangeJsonConverter.WriteProperties(writer, fruit.Orange, jsonSerializerOptions);
+            }
 
             WriteProperties(writer, fruit, jsonSerializerOptions);
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
@@ -204,6 +204,17 @@ namespace Org.OpenAPITools.Model
         public override void Write(Utf8JsonWriter writer, Fruit fruit, JsonSerializerOptions jsonSerializerOptions)
         {
             writer.WriteStartObject();
+            if (fruit.Apple != null)
+            {
+                AppleJsonConverter appleJsonConverter = new AppleJsonConverter();
+                appleJsonConverter.WriteProperties(writer, fruit.Apple, jsonSerializerOptions);
+            }
+
+            if (fruit.Banana != null)
+            {
+                BananaJsonConverter bananaJsonConverter = new BananaJsonConverter();
+                bananaJsonConverter.WriteProperties(writer, fruit.Banana, jsonSerializerOptions);
+            }
 
             WriteProperties(writer, fruit, jsonSerializerOptions);
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/FruitReq.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/FruitReq.cs
@@ -178,6 +178,17 @@ namespace Org.OpenAPITools.Model
         public override void Write(Utf8JsonWriter writer, FruitReq fruitReq, JsonSerializerOptions jsonSerializerOptions)
         {
             writer.WriteStartObject();
+            if (fruitReq.AppleReq != null)
+            {
+                AppleReqJsonConverter appleReqJsonConverter = new AppleReqJsonConverter();
+                appleReqJsonConverter.WriteProperties(writer, fruitReq.AppleReq, jsonSerializerOptions);
+            }
+
+            if (fruitReq.BananaReq != null)
+            {
+                BananaReqJsonConverter bananaReqJsonConverter = new BananaReqJsonConverter();
+                bananaReqJsonConverter.WriteProperties(writer, fruitReq.BananaReq, jsonSerializerOptions);
+            }
 
             WriteProperties(writer, fruitReq, jsonSerializerOptions);
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
@@ -250,7 +250,36 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public override void Write(Utf8JsonWriter writer, MixedOneOfContent mixedOneOfContent, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (mixedOneOfContent.String != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.String, jsonSerializerOptions);
+                return;
+            }
+
+            if (mixedOneOfContent.Bool != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.Bool, jsonSerializerOptions);
+                return;
+            }
+
+            if (mixedOneOfContent.Int != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.Int, jsonSerializerOptions);
+                return;
+            }
+
+            if (mixedOneOfContent.Decimal != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.Decimal, jsonSerializerOptions);
+                return;
+            }
+
             writer.WriteStartObject();
+            if (mixedOneOfContent.MixedSubId != null)
+            {
+                MixedSubIdJsonConverter mixedSubIdJsonConverter = new MixedSubIdJsonConverter();
+                mixedSubIdJsonConverter.WriteProperties(writer, mixedOneOfContent.MixedSubId, jsonSerializerOptions);
+            }
 
             WriteProperties(writer, mixedOneOfContent, jsonSerializerOptions);
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/OneOfString.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/OneOfString.cs
@@ -146,6 +146,12 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public override void Write(Utf8JsonWriter writer, OneOfString oneOfString, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (oneOfString.String != null)
+            {
+                JsonSerializer.Serialize(writer, oneOfString.String, jsonSerializerOptions);
+                return;
+            }
+
             writer.WriteStartObject();
 
             WriteProperties(writer, oneOfString, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
@@ -228,6 +228,30 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public override void Write(Utf8JsonWriter writer, PolymorphicProperty polymorphicProperty, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (polymorphicProperty.Bool != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.Bool, jsonSerializerOptions);
+                return;
+            }
+
+            if (polymorphicProperty.String != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.String, jsonSerializerOptions);
+                return;
+            }
+
+            if (polymorphicProperty.Object != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.Object, jsonSerializerOptions);
+                return;
+            }
+
+            if (polymorphicProperty.List != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.List, jsonSerializerOptions);
+                return;
+            }
+
             writer.WriteStartObject();
 
             WriteProperties(writer, polymorphicProperty, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Fruit.cs
@@ -207,6 +207,17 @@ namespace Org.OpenAPITools.Model
         public override void Write(Utf8JsonWriter writer, Fruit fruit, JsonSerializerOptions jsonSerializerOptions)
         {
             writer.WriteStartObject();
+            if (fruit.Apple != null)
+            {
+                AppleJsonConverter appleJsonConverter = new AppleJsonConverter();
+                appleJsonConverter.WriteProperties(writer, fruit.Apple, jsonSerializerOptions);
+            }
+
+            if (fruit.Banana != null)
+            {
+                BananaJsonConverter bananaJsonConverter = new BananaJsonConverter();
+                bananaJsonConverter.WriteProperties(writer, fruit.Banana, jsonSerializerOptions);
+            }
 
             WriteProperties(writer, fruit, jsonSerializerOptions);
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/FruitReq.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/FruitReq.cs
@@ -181,6 +181,17 @@ namespace Org.OpenAPITools.Model
         public override void Write(Utf8JsonWriter writer, FruitReq fruitReq, JsonSerializerOptions jsonSerializerOptions)
         {
             writer.WriteStartObject();
+            if (fruitReq.AppleReq != null)
+            {
+                AppleReqJsonConverter appleReqJsonConverter = new AppleReqJsonConverter();
+                appleReqJsonConverter.WriteProperties(writer, fruitReq.AppleReq, jsonSerializerOptions);
+            }
+
+            if (fruitReq.BananaReq != null)
+            {
+                BananaReqJsonConverter bananaReqJsonConverter = new BananaReqJsonConverter();
+                bananaReqJsonConverter.WriteProperties(writer, fruitReq.BananaReq, jsonSerializerOptions);
+            }
 
             WriteProperties(writer, fruitReq, jsonSerializerOptions);
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
@@ -253,7 +253,36 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public override void Write(Utf8JsonWriter writer, MixedOneOfContent mixedOneOfContent, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (mixedOneOfContent.String != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.String, jsonSerializerOptions);
+                return;
+            }
+
+            if (mixedOneOfContent.Bool != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.Bool, jsonSerializerOptions);
+                return;
+            }
+
+            if (mixedOneOfContent.Int != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.Int, jsonSerializerOptions);
+                return;
+            }
+
+            if (mixedOneOfContent.Decimal != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.Decimal, jsonSerializerOptions);
+                return;
+            }
+
             writer.WriteStartObject();
+            if (mixedOneOfContent.MixedSubId != null)
+            {
+                MixedSubIdJsonConverter mixedSubIdJsonConverter = new MixedSubIdJsonConverter();
+                mixedSubIdJsonConverter.WriteProperties(writer, mixedOneOfContent.MixedSubId, jsonSerializerOptions);
+            }
 
             WriteProperties(writer, mixedOneOfContent, jsonSerializerOptions);
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/OneOfString.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/OneOfString.cs
@@ -149,6 +149,12 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public override void Write(Utf8JsonWriter writer, OneOfString oneOfString, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (oneOfString.String != null)
+            {
+                JsonSerializer.Serialize(writer, oneOfString.String, jsonSerializerOptions);
+                return;
+            }
+
             writer.WriteStartObject();
 
             WriteProperties(writer, oneOfString, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
@@ -231,6 +231,30 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public override void Write(Utf8JsonWriter writer, PolymorphicProperty polymorphicProperty, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (polymorphicProperty.Bool != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.Bool, jsonSerializerOptions);
+                return;
+            }
+
+            if (polymorphicProperty.String != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.String, jsonSerializerOptions);
+                return;
+            }
+
+            if (polymorphicProperty.Object != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.Object, jsonSerializerOptions);
+                return;
+            }
+
+            if (polymorphicProperty.List != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.List, jsonSerializerOptions);
+                return;
+            }
+
             writer.WriteStartObject();
 
             WriteProperties(writer, polymorphicProperty, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
@@ -204,6 +204,17 @@ namespace Org.OpenAPITools.Model
         public override void Write(Utf8JsonWriter writer, Fruit fruit, JsonSerializerOptions jsonSerializerOptions)
         {
             writer.WriteStartObject();
+            if (fruit.Apple != null)
+            {
+                AppleJsonConverter appleJsonConverter = new AppleJsonConverter();
+                appleJsonConverter.WriteProperties(writer, fruit.Apple, jsonSerializerOptions);
+            }
+
+            if (fruit.Banana != null)
+            {
+                BananaJsonConverter bananaJsonConverter = new BananaJsonConverter();
+                bananaJsonConverter.WriteProperties(writer, fruit.Banana, jsonSerializerOptions);
+            }
 
             WriteProperties(writer, fruit, jsonSerializerOptions);
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/FruitReq.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/FruitReq.cs
@@ -178,6 +178,17 @@ namespace Org.OpenAPITools.Model
         public override void Write(Utf8JsonWriter writer, FruitReq fruitReq, JsonSerializerOptions jsonSerializerOptions)
         {
             writer.WriteStartObject();
+            if (fruitReq.AppleReq != null)
+            {
+                AppleReqJsonConverter appleReqJsonConverter = new AppleReqJsonConverter();
+                appleReqJsonConverter.WriteProperties(writer, fruitReq.AppleReq, jsonSerializerOptions);
+            }
+
+            if (fruitReq.BananaReq != null)
+            {
+                BananaReqJsonConverter bananaReqJsonConverter = new BananaReqJsonConverter();
+                bananaReqJsonConverter.WriteProperties(writer, fruitReq.BananaReq, jsonSerializerOptions);
+            }
 
             WriteProperties(writer, fruitReq, jsonSerializerOptions);
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
@@ -250,7 +250,36 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public override void Write(Utf8JsonWriter writer, MixedOneOfContent mixedOneOfContent, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (mixedOneOfContent.String != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.String, jsonSerializerOptions);
+                return;
+            }
+
+            if (mixedOneOfContent.Bool != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.Bool, jsonSerializerOptions);
+                return;
+            }
+
+            if (mixedOneOfContent.Int != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.Int, jsonSerializerOptions);
+                return;
+            }
+
+            if (mixedOneOfContent.Decimal != null)
+            {
+                JsonSerializer.Serialize(writer, mixedOneOfContent.Decimal, jsonSerializerOptions);
+                return;
+            }
+
             writer.WriteStartObject();
+            if (mixedOneOfContent.MixedSubId != null)
+            {
+                MixedSubIdJsonConverter mixedSubIdJsonConverter = new MixedSubIdJsonConverter();
+                mixedSubIdJsonConverter.WriteProperties(writer, mixedOneOfContent.MixedSubId, jsonSerializerOptions);
+            }
 
             WriteProperties(writer, mixedOneOfContent, jsonSerializerOptions);
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/OneOfString.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/OneOfString.cs
@@ -146,6 +146,12 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public override void Write(Utf8JsonWriter writer, OneOfString oneOfString, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (oneOfString.String != null)
+            {
+                JsonSerializer.Serialize(writer, oneOfString.String, jsonSerializerOptions);
+                return;
+            }
+
             writer.WriteStartObject();
 
             WriteProperties(writer, oneOfString, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
@@ -228,6 +228,30 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public override void Write(Utf8JsonWriter writer, PolymorphicProperty polymorphicProperty, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (polymorphicProperty.Bool != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.Bool, jsonSerializerOptions);
+                return;
+            }
+
+            if (polymorphicProperty.String != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.String, jsonSerializerOptions);
+                return;
+            }
+
+            if (polymorphicProperty.Object != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.Object, jsonSerializerOptions);
+                return;
+            }
+
+            if (polymorphicProperty.List != null)
+            {
+                JsonSerializer.Serialize(writer, polymorphicProperty.List, jsonSerializerOptions);
+                return;
+            }
+
             writer.WriteStartObject();
 
             WriteProperties(writer, polymorphicProperty, jsonSerializerOptions);


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes C# `generichost` oneOf serialization when no discriminator. Old behavior wrapped everything in an object; new behavior serializes primitives/arrays as raw values and writes referenced model properties inline. This produces correct JSON; discriminator-based serialization is unchanged.

- Review Focus: `modules/openapi-generator/src/main/resources/csharp/libraries/generichost/JsonConverter.mustache` adds early returns for primitive/array and other non-object `oneOf` cases, and writes the selected referenced-model properties into the object before common properties. Samples were regenerated across all target frameworks to reflect the corrected output.
- Migration: Regenerate C# `generichost` clients. Update consumers/tests that depended on object-wrapped JSON for `oneOf` primitives, arrays/lists, or referenced models.

<sup>Written for commit 33c9825873f5176ef40ca9eaa3652b9e98326e4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24735?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

