### PR TITLE
Fix nullable query param

### DIFF
--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/api.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/api.mustache
@@ -84,7 +84,7 @@ class {{classname}} {
 
     final _queryParameters = <String, dynamic>{
       {{#queryParams}}
-      {{^required}}{{^isNullable}}if ({{{paramName}}} != null) {{/isNullable}}{{/required}}r'{{baseName}}': {{#includeLibraryTemplate}}api/query_param{{/includeLibraryTemplate}},
+      {{^required}}{{#isNullable}}if ({{{paramName}}} != null) {{/isNullable}}{{/required}}r'{{baseName}}': {{#includeLibraryTemplate}}api/query_param{{/includeLibraryTemplate}},
       {{/queryParams}}
     };{{/hasQueryParams}}{{#hasBodyOrFormParams}}
 

--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/api.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/api.mustache
@@ -84,7 +84,7 @@ class {{classname}} {
 
     final _queryParameters = <String, dynamic>{
       {{#queryParams}}
-      {{^required}}{{#isNullable}}if ({{{paramName}}} != null) {{/isNullable}}{{/required}}r'{{baseName}}': {{#includeLibraryTemplate}}api/query_param{{/includeLibraryTemplate}},
+      {{^required}}if ({{{paramName}}} != null) {{/required}}r'{{baseName}}': {{#includeLibraryTemplate}}api/query_param{{/includeLibraryTemplate}},
       {{/queryParams}}
     };{{/hasQueryParams}}{{#hasBodyOrFormParams}}
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/dart/dio/DartDioClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/dart/dio/DartDioClientCodegenTest.java
@@ -216,7 +216,7 @@ public class DartDioClientCodegenTest {
     }
 
     @Test
-    public void testOptionalNullableQueryParameterIsOmittedWhenNull() throws IOException {
+    public void testQueryParameterNullGuardsFollowRequiredness() throws IOException {
         File output = Files.createTempDirectory("test").toFile();
         output.deleteOnExit();
 
@@ -234,11 +234,28 @@ public class DartDioClientCodegenTest {
 
         TestUtils.assertFileContains(defaultApi,
                 "int? activityId,",
-                "final _queryParameters = <String, dynamic>{",
+                "int? categoryId,",
+                "required int requiredId,",
+                "final _queryParameters = <String, dynamic>{");
+
+        // Optional query parameters use nullable Dart arguments. Null means the
+        // caller omitted the parameter, so the generated request must omit it.
+        TestUtils.assertFileContains(defaultApi,
                 "if (activityId != null)",
-                "r'activity_id': encodeQueryParameter(_serializers, activityId, const FullType(int)),");
+                "r'activity_id': encodeQueryParameter(_serializers, activityId, const FullType(int)),",
+                "if (categoryId != null)",
+                "r'category_id': encodeQueryParameter(_serializers, categoryId, const FullType(int)),");
+
+        // Required query parameters are always emitted. If the schema is
+        // nullable, null is an explicit supplied value rather than omission.
+        TestUtils.assertFileContains(defaultApi,
+                "r'required_id': encodeQueryParameter(_serializers, requiredId, const FullType(int)),",
+                "r'required_nullable_id': encodeQueryParameter(_serializers, requiredNullableId, const FullType(int)),");
         TestUtils.assertFileNotContains(defaultApi,
-                "final _queryParameters = <String, dynamic>{\n      r'activity_id': encodeQueryParameter(_serializers, activityId, const FullType(int)),");
+                "if (requiredId != null)",
+                "if (requiredNullableId != null)",
+                "final _queryParameters = <String, dynamic>{\n      r'activity_id': encodeQueryParameter(_serializers, activityId, const FullType(int)),",
+                "final _queryParameters = <String, dynamic>{\n      r'category_id': encodeQueryParameter(_serializers, categoryId, const FullType(int)),");
     }
 
     /**

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/dart/dio/DartDioClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/dart/dio/DartDioClientCodegenTest.java
@@ -215,6 +215,32 @@ public class DartDioClientCodegenTest {
                 "if (valueDes == null) continue;");
     }
 
+    @Test
+    public void testOptionalNullableQueryParameterIsOmittedWhenNull() throws IOException {
+        File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("dart-dio")
+                .setInputSpec("src/test/resources/3_1/dart-dio/optional_nullable_query_parameter.yaml")
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+        ClientOptInput opts = configurator.toClientOptInput();
+        Generator generator = new DefaultGenerator().opts(opts);
+        List<File> files = generator.generate();
+        files.forEach(File::deleteOnExit);
+
+        Path defaultApi = output.toPath().resolve("lib/src/api/default_api.dart");
+
+        TestUtils.assertFileContains(defaultApi,
+                "int? activityId,",
+                "final _queryParameters = <String, dynamic>{",
+                "if (activityId != null)",
+                "r'activity_id': encodeQueryParameter(_serializers, activityId, const FullType(int)),");
+        TestUtils.assertFileNotContains(defaultApi,
+                "final _queryParameters = <String, dynamic>{\n      r'activity_id': encodeQueryParameter(_serializers, activityId, const FullType(int)),");
+    }
+
     /**
      * Regression test for dart-dio built_value anyOf serialization.
      *

--- a/modules/openapi-generator/src/test/resources/3_1/dart-dio/optional_nullable_query_parameter.yaml
+++ b/modules/openapi-generator/src/test/resources/3_1/dart-dio/optional_nullable_query_parameter.yaml
@@ -15,6 +15,26 @@ paths:
               - type: integer
               - type: "null"
             title: Activity Id
+        - name: category_id
+          in: query
+          required: false
+          schema:
+            type: integer
+            title: Category Id
+        - name: required_id
+          in: query
+          required: true
+          schema:
+            type: integer
+            title: Required Id
+        - name: required_nullable_id
+          in: query
+          required: true
+          schema:
+            anyOf:
+              - type: integer
+              - type: "null"
+            title: Required Nullable Id
       responses:
         "200":
           description: Successful response

--- a/modules/openapi-generator/src/test/resources/3_1/dart-dio/optional_nullable_query_parameter.yaml
+++ b/modules/openapi-generator/src/test/resources/3_1/dart-dio/optional_nullable_query_parameter.yaml
@@ -1,0 +1,20 @@
+openapi: 3.1.0
+info:
+  title: Dart Dio optional nullable query parameter test
+  version: 1.0.0
+paths:
+  /items:
+    get:
+      operationId: getItems
+      parameters:
+        - name: activity_id
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - type: integer
+              - type: "null"
+            title: Activity Id
+      responses:
+        "200":
+          description: Successful response


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Fixes #24736



--

@jaumard (2018/09) @amondnet (2019/12) @sbu-WBT (2020/12) @kuhnroyal (2020/12) @agilob (2020/12) @ahmednfwela (2021/08)


<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `dart-dio` clients omit optional query parameters when the provided value is null. Previously, optional nullable params were emitted as key=null; now guards follow requiredness: optional params are omitted when null, while required params (including nullable) are always sent. Fixes #24736.

- Apply an if (param != null) guard to all non-required query params in `api.mustache`.
- Add an OpenAPI 3.1 fixture and a regression test covering optional vs. required (including nullable) behavior.
- No change to encoding or required parameter handling; regenerate clients.

<sup>Written for commit f95c2e53b3b8283dce287b5ea6ee1cf5243ec35b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24738?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

