### PR TITLE
[python] write back the fully qualified apiPackage/modelPackage

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientCodegen.java
@@ -475,6 +475,12 @@ public class PythonClientCodegen extends AbstractPythonCodegen implements Codege
 
         modelPackage = this.packageName + "." + modelPackage;
         apiPackage = this.packageName + "." + apiPackage;
+
+        // the template bundles apply additionalProperties on top of the values derived here,
+        // so the fully qualified names must be written back or user-supplied ones would shadow
+        // them and produce imports missing the package prefix (#3285)
+        additionalProperties.put(CodegenConstants.MODEL_PACKAGE, modelPackage);
+        additionalProperties.put(CodegenConstants.API_PACKAGE, apiPackage);
     }
 
     public boolean getUseOneOfDiscriminatorLookup() {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonClientCodegenTest.java
@@ -696,6 +696,34 @@ public class PythonClientCodegenTest {
         assertFileContains(initFilePath, "from openapi_client.models.user import User as User");
     }
 
+    @Test(description = "outputs __init__.py with fully qualified imports when apiPackage is customized")
+    public void testInitFileImportsExportsWithCustomApiPackage() throws IOException {
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/petstore.yaml");
+        final DefaultGenerator defaultGenerator = new DefaultGenerator();
+        final ClientOptInput clientOptInput = new ClientOptInput();
+        clientOptInput.openAPI(openAPI);
+        PythonClientCodegen pythonClientCodegen = new PythonClientCodegen();
+        pythonClientCodegen.setOutputDir(output.getAbsolutePath());
+        pythonClientCodegen.additionalProperties().put(CodegenConstants.PACKAGE_NAME, "my_pkg");
+        pythonClientCodegen.additionalProperties().put(CodegenConstants.API_PACKAGE, "my_api");
+        clientOptInput.config(pythonClientCodegen);
+        defaultGenerator.opts(clientOptInput);
+
+        Map<String, File> files = defaultGenerator.generate().stream().collect(Collectors.toMap(File::getPath, Function.identity()));
+
+        // the api package is nested inside the main package, so its imports must be fully qualified
+        File packageInitFile = files.get(Paths.get(output.getAbsolutePath(), "my_pkg", "__init__.py").toString());
+        assertNotNull(packageInitFile);
+        assertFileContains(packageInitFile.toPath(), "from my_pkg.my_api.pet_api import PetApi as PetApi");
+        assertFileContains(packageInitFile.toPath(), "from my_pkg.models.pet import Pet as Pet");
+
+        File apiInitFile = files.get(Paths.get(output.getAbsolutePath(), "my_pkg", "my_api", "__init__.py").toString());
+        assertNotNull(apiInitFile);
+        assertFileContains(apiInitFile.toPath(), "from my_pkg.my_api.pet_api import PetApi");
+    }
+
     @Test(description = "Verify default license format uses object notation when poetry1 is false")
     public void testLicenseFormatInPyprojectToml() throws IOException {
         File output = Files.createTempDirectory("test").toFile().getCanonicalFile();


### PR DESCRIPTION
Fixes #3285.

With `--api-package my_api` and `packageName=my_pkg`, the generated python client cannot be imported: `my_pkg/__init__.py` contains

```python
from my_api.pet_api import PetApi as PetApi
```

instead of

```python
from my_pkg.my_api.pet_api import PetApi as PetApi
```

The api modules themselves are written to the correct my_pkg/my_api/ folder, and model imports are fine, only the api imports lose the package prefix, so importing the generated package raises `ModuleNotFoundError`.

**_Cause :_**

`PythonClientCodegen.processOpts()` ends with

```java
modelPackage = this.packageName + "." + modelPackage;
apiPackage = this.packageName + "." + apiPackage;
```

but leaves the template-facing copies in additionalProperties untouched. When DefaultGenerator builds the api template bundle it puts the derived values first and then applies additionalProperties on top of them:

```java
operation.put("apiPackage", config.apiPackage());
operation.put("modelPackage", config.modelPackage());
operation.putAll(config.additionalProperties());
```

so the raw user-supplied apiPackage shadows the prefixed one in any template that resolves {{apiPackage}} while iterating {{#apiInfo}}{{#apis}}, which is what exports_api.mustache and exports_package.mustache do. The supporting-file bundle is unaffected because it applies additionalProperties before setting these keys.

**_Fix_**

Write the fully qualified names back to additionalProperties, which is what ~25 other generators already do (AbstractKotlinCodegen, ScalaAkkaClientCodegen, AspNetServerCodegen, ClojureClientCodegen, …).

The underlying cause is the ordering in DefaultGenerator; reordering it there removes the shadowing for every generator, and I verified that doing so also leaves all 798 sample configs byte-identical. I kept this PR scoped to the generator that actually produces broken output, since making additionalProperties lose to the config values is a wider behavioural decision. Happy to switch to the generic fix if you prefer it.

**_Tests_**

Added 
`PythonClientCodegenTest#testInitFileImportsExportsWithCustomApiPackage`
, which fails on master with:

File '.../my_pkg/__init__.py' does not contain line
[from my_pkg.my_api.pet_api import PetApi as PetApi] expected [true] but found [false]

### PR checklist
 
- [ X ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ X ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ X ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@cbornet (2017/09) @tomplus (2018/10) @krjakbrjak (2023/02) @fa0311 (2023/10)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing package prefixes in generated Python `__init__.py` imports when using `packageName` with a custom `apiPackage`. Old behavior: `from my_api.pet_api import PetApi` raised `ModuleNotFoundError`; new behavior: `from my_pkg.my_api.pet_api import PetApi`.

- Writes fully qualified `apiPackage` and `modelPackage` back into `additionalProperties` in `PythonClientCodegen.processOpts` so templates don’t shadow prefixed values.
- Scoped to the Python generator; no change to `DefaultGenerator` ordering.
- Adds `PythonClientCodegenTest#testInitFileImportsExportsWithCustomApiPackage`.

<sup>Written for commit b48c3b2c6c428e518ad8f2cc242485d4a941835f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24739?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

