### PR TITLE
fix(kotlin-client): emit parameter table header before first parameter

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/api_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/api_doc.mustache
@@ -46,10 +46,10 @@ try {
 This endpoint does not need any parameter.
 {{/allParams}}
 {{#allParams}}
-{{#-last}}
+{{#-first}}
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
-{{/-last}}
+{{/-first}}
 | **{{paramName}}** | {{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}{{#isFile}}**{{dataType}}**{{/isFile}}{{^isFile}}{{#generateModelDocs}}[**{{dataType}}**]({{baseType}}.md){{/generateModelDocs}}{{^generateModelDocs}}**{{dataType}}**{{/generateModelDocs}}{{/isFile}}{{/isPrimitiveType}}| {{description}} |{{^required}} [optional]{{/required}}{{#defaultValue}} [default to {{.}}]{{/defaultValue}}{{#allowableValues}} [enum: {{#values}}{{{.}}}{{^-last}}, {{/-last}}{{/values}}]{{/allowableValues}} |
 {{/allParams}}
 

--- a/samples/client/echo_api/kotlin-jvm-okhttp/docs/FormApi.md
+++ b/samples/client/echo_api/kotlin-jvm-okhttp/docs/FormApi.md
@@ -39,10 +39,10 @@ try {
 ```
 
 ### Parameters
-| **integerForm** | **kotlin.Int**|  | [optional] |
-| **booleanForm** | **kotlin.Boolean**|  | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **integerForm** | **kotlin.Int**|  | [optional] |
+| **booleanForm** | **kotlin.Boolean**|  | [optional] |
 | **stringForm** | **kotlin.String**|  | [optional] |
 
 ### Return type
@@ -92,13 +92,13 @@ try {
 ```
 
 ### Parameters
+| Name | Type | Description  | Notes |
+| ------------- | ------------- | ------------- | ------------- |
 | **form1** | **kotlin.String**|  | [optional] |
 | **form2** | **kotlin.Int**|  | [optional] |
 | **form3** | **kotlin.String**|  | [optional] |
 | **form4** | **kotlin.Boolean**|  | [optional] |
 | **id** | **kotlin.Long**|  | [optional] |
-| Name | Type | Description  | Notes |
-| ------------- | ------------- | ------------- | ------------- |
 | **name** | **kotlin.String**|  | [optional] |
 
 ### Return type

--- a/samples/client/echo_api/kotlin-jvm-okhttp/docs/HeaderApi.md
+++ b/samples/client/echo_api/kotlin-jvm-okhttp/docs/HeaderApi.md
@@ -40,12 +40,12 @@ try {
 ```
 
 ### Parameters
+| Name | Type | Description  | Notes |
+| ------------- | ------------- | ------------- | ------------- |
 | **integerHeader** | **kotlin.Int**|  | [optional] |
 | **booleanHeader** | **kotlin.Boolean**|  | [optional] |
 | **stringHeader** | **kotlin.String**|  | [optional] |
 | **enumNonrefStringHeader** | **kotlin.String**|  | [optional] [enum: success, failure, unclassified] |
-| Name | Type | Description  | Notes |
-| ------------- | ------------- | ------------- | ------------- |
 | **enumRefStringHeader** | [**ApiStringEnumRef**](.md)|  | [optional] [enum: success, failure, unclassified] |
 
 ### Return type

--- a/samples/client/echo_api/kotlin-jvm-okhttp/docs/PathApi.md
+++ b/samples/client/echo_api/kotlin-jvm-okhttp/docs/PathApi.md
@@ -39,11 +39,11 @@ try {
 ```
 
 ### Parameters
+| Name | Type | Description  | Notes |
+| ------------- | ------------- | ------------- | ------------- |
 | **pathString** | **kotlin.String**|  | |
 | **pathInteger** | **kotlin.Int**|  | |
 | **enumNonrefStringPath** | **kotlin.String**|  | [enum: success, failure, unclassified] |
-| Name | Type | Description  | Notes |
-| ------------- | ------------- | ------------- | ------------- |
 | **enumRefStringPath** | [**ApiStringEnumRef**](.md)|  | [enum: success, failure, unclassified] |
 
 ### Return type

--- a/samples/client/echo_api/kotlin-jvm-okhttp/docs/QueryApi.md
+++ b/samples/client/echo_api/kotlin-jvm-okhttp/docs/QueryApi.md
@@ -42,9 +42,9 @@ try {
 ```
 
 ### Parameters
-| **enumNonrefStringQuery** | **kotlin.String**|  | [optional] [enum: success, failure, unclassified] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **enumNonrefStringQuery** | **kotlin.String**|  | [optional] [enum: success, failure, unclassified] |
 | **enumRefStringQuery** | [**ApiStringEnumRef**](.md)|  | [optional] [enum: success, failure, unclassified] |
 
 ### Return type
@@ -91,10 +91,10 @@ try {
 ```
 
 ### Parameters
-| **datetimeQuery** | **java.time.OffsetDateTime**|  | [optional] |
-| **dateQuery** | **java.time.LocalDate**|  | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **datetimeQuery** | **java.time.OffsetDateTime**|  | [optional] |
+| **dateQuery** | **java.time.LocalDate**|  | [optional] |
 | **stringQuery** | **kotlin.String**|  | [optional] |
 
 ### Return type
@@ -141,10 +141,10 @@ try {
 ```
 
 ### Parameters
-| **integerQuery** | **kotlin.Int**|  | [optional] |
-| **booleanQuery** | **kotlin.Boolean**|  | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **integerQuery** | **kotlin.Int**|  | [optional] |
+| **booleanQuery** | **kotlin.Boolean**|  | [optional] |
 | **stringQuery** | **kotlin.String**|  | [optional] |
 
 ### Return type

--- a/samples/client/echo_api/kotlin-jvm-spring-3-restclient/docs/FormApi.md
+++ b/samples/client/echo_api/kotlin-jvm-spring-3-restclient/docs/FormApi.md
@@ -39,10 +39,10 @@ try {
 ```
 
 ### Parameters
-| **integerForm** | **kotlin.Int**|  | [optional] |
-| **booleanForm** | **kotlin.Boolean**|  | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **integerForm** | **kotlin.Int**|  | [optional] |
+| **booleanForm** | **kotlin.Boolean**|  | [optional] |
 | **stringForm** | **kotlin.String**|  | [optional] |
 
 ### Return type
@@ -92,13 +92,13 @@ try {
 ```
 
 ### Parameters
+| Name | Type | Description  | Notes |
+| ------------- | ------------- | ------------- | ------------- |
 | **form1** | **kotlin.String**|  | [optional] |
 | **form2** | **kotlin.Int**|  | [optional] |
 | **form3** | **kotlin.String**|  | [optional] |
 | **form4** | **kotlin.Boolean**|  | [optional] |
 | **id** | **kotlin.Long**|  | [optional] |
-| Name | Type | Description  | Notes |
-| ------------- | ------------- | ------------- | ------------- |
 | **name** | **kotlin.String**|  | [optional] |
 
 ### Return type

--- a/samples/client/echo_api/kotlin-jvm-spring-3-restclient/docs/HeaderApi.md
+++ b/samples/client/echo_api/kotlin-jvm-spring-3-restclient/docs/HeaderApi.md
@@ -40,12 +40,12 @@ try {
 ```
 
 ### Parameters
+| Name | Type | Description  | Notes |
+| ------------- | ------------- | ------------- | ------------- |
 | **integerHeader** | **kotlin.Int**|  | [optional] |
 | **booleanHeader** | **kotlin.Boolean**|  | [optional] |
 | **stringHeader** | **kotlin.String**|  | [optional] |
 | **enumNonrefStringHeader** | **kotlin.String**|  | [optional] [enum: success, failure, unclassified] |
-| Name | Type | Description  | Notes |
-| ------------- | ------------- | ------------- | ------------- |
 | **enumRefStringHeader** | [**StringEnumRef**](.md)|  | [optional] [enum: success, failure, unclassified] |
 
 ### Return type

--- a/samples/client/echo_api/kotlin-jvm-spring-3-restclient/docs/PathApi.md
+++ b/samples/client/echo_api/kotlin-jvm-spring-3-restclient/docs/PathApi.md
@@ -39,11 +39,11 @@ try {
 ```
 
 ### Parameters
+| Name | Type | Description  | Notes |
+| ------------- | ------------- | ------------- | ------------- |
 | **pathString** | **kotlin.String**|  | |
 | **pathInteger** | **kotlin.Int**|  | |
 | **enumNonrefStringPath** | **kotlin.String**|  | [enum: success, failure, unclassified] |
-| Name | Type | Description  | Notes |
-| ------------- | ------------- | ------------- | ------------- |
 | **enumRefStringPath** | [**StringEnumRef**](.md)|  | [enum: success, failure, unclassified] |
 
 ### Return type

--- a/samples/client/echo_api/kotlin-jvm-spring-3-restclient/docs/QueryApi.md
+++ b/samples/client/echo_api/kotlin-jvm-spring-3-restclient/docs/QueryApi.md
@@ -42,9 +42,9 @@ try {
 ```
 
 ### Parameters
-| **enumNonrefStringQuery** | **kotlin.String**|  | [optional] [enum: success, failure, unclassified] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **enumNonrefStringQuery** | **kotlin.String**|  | [optional] [enum: success, failure, unclassified] |
 | **enumRefStringQuery** | [**StringEnumRef**](.md)|  | [optional] [enum: success, failure, unclassified] |
 
 ### Return type
@@ -91,10 +91,10 @@ try {
 ```
 
 ### Parameters
-| **datetimeQuery** | **java.time.OffsetDateTime**|  | [optional] |
-| **dateQuery** | **java.time.LocalDate**|  | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **datetimeQuery** | **java.time.OffsetDateTime**|  | [optional] |
+| **dateQuery** | **java.time.LocalDate**|  | [optional] |
 | **stringQuery** | **kotlin.String**|  | [optional] |
 
 ### Return type
@@ -141,10 +141,10 @@ try {
 ```
 
 ### Parameters
-| **integerQuery** | **kotlin.Int**|  | [optional] |
-| **booleanQuery** | **kotlin.Boolean**|  | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **integerQuery** | **kotlin.Int**|  | [optional] |
+| **booleanQuery** | **kotlin.Boolean**|  | [optional] |
 | **stringQuery** | **kotlin.String**|  | [optional] |
 
 ### Return type

--- a/samples/client/echo_api/kotlin-jvm-spring-3-webclient/docs/FormApi.md
+++ b/samples/client/echo_api/kotlin-jvm-spring-3-webclient/docs/FormApi.md
@@ -39,10 +39,10 @@ try {
 ```
 
 ### Parameters
-| **integerForm** | **kotlin.Int**|  | [optional] |
-| **booleanForm** | **kotlin.Boolean**|  | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **integerForm** | **kotlin.Int**|  | [optional] |
+| **booleanForm** | **kotlin.Boolean**|  | [optional] |
 | **stringForm** | **kotlin.String**|  | [optional] |
 
 ### Return type
@@ -92,13 +92,13 @@ try {
 ```
 
 ### Parameters
+| Name | Type | Description  | Notes |
+| ------------- | ------------- | ------------- | ------------- |
 | **form1** | **kotlin.String**|  | [optional] |
 | **form2** | **kotlin.Int**|  | [optional] |
 | **form3** | **kotlin.String**|  | [optional] |
 | **form4** | **kotlin.Boolean**|  | [optional] |
 | **id** | **kotlin.Long**|  | [optional] |
-| Name | Type | Description  | Notes |
-| ------------- | ------------- | ------------- | ------------- |
 | **name** | **kotlin.String**|  | [optional] |
 
 ### Return type

--- a/samples/client/echo_api/kotlin-jvm-spring-3-webclient/docs/HeaderApi.md
+++ b/samples/client/echo_api/kotlin-jvm-spring-3-webclient/docs/HeaderApi.md
@@ -40,12 +40,12 @@ try {
 ```
 
 ### Parameters
+| Name | Type | Description  | Notes |
+| ------------- | ------------- | ------------- | ------------- |
 | **integerHeader** | **kotlin.Int**|  | [optional] |
 | **booleanHeader** | **kotlin.Boolean**|  | [optional] |
 | **stringHeader** | **kotlin.String**|  | [optional] |
 | **enumNonrefStringHeader** | **kotlin.String**|  | [optional] [enum: success, failure, unclassified] |
-| Name | Type | Description  | Notes |
-| ------------- | ------------- | ------------- | ------------- |
 | **enumRefStringHeader** | [**StringEnumRef**](.md)|  | [optional] [enum: success, failure, unclassified] |
 
 ### Return type

--- a/samples/client/echo_api/kotlin-jvm-spring-3-webclient/docs/PathApi.md
+++ b/samples/client/echo_api/kotlin-jvm-spring-3-webclient/docs/PathApi.md
@@ -39,11 +39,11 @@ try {
 ```
 
 ### Parameters
+| Name | Type | Description  | Notes |
+| ------------- | ------------- | ------------- | ------------- |
 | **pathString** | **kotlin.String**|  | |
 | **pathInteger** | **kotlin.Int**|  | |
 | **enumNonrefStringPath** | **kotlin.String**|  | [enum: success, failure, unclassified] |
-| Name | Type | Description  | Notes |
-| ------------- | ------------- | ------------- | ------------- |
 | **enumRefStringPath** | [**StringEnumRef**](.md)|  | [enum: success, failure, unclassified] |
 
 ### Return type

--- a/samples/client/echo_api/kotlin-jvm-spring-3-webclient/docs/QueryApi.md
+++ b/samples/client/echo_api/kotlin-jvm-spring-3-webclient/docs/QueryApi.md
@@ -42,9 +42,9 @@ try {
 ```
 
 ### Parameters
-| **enumNonrefStringQuery** | **kotlin.String**|  | [optional] [enum: success, failure, unclassified] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **enumNonrefStringQuery** | **kotlin.String**|  | [optional] [enum: success, failure, unclassified] |
 | **enumRefStringQuery** | [**StringEnumRef**](.md)|  | [optional] [enum: success, failure, unclassified] |
 
 ### Return type
@@ -91,10 +91,10 @@ try {
 ```
 
 ### Parameters
-| **datetimeQuery** | **java.time.OffsetDateTime**|  | [optional] |
-| **dateQuery** | **java.time.LocalDate**|  | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **datetimeQuery** | **java.time.OffsetDateTime**|  | [optional] |
+| **dateQuery** | **java.time.LocalDate**|  | [optional] |
 | **stringQuery** | **kotlin.String**|  | [optional] |
 
 ### Return type
@@ -141,10 +141,10 @@ try {
 ```
 
 ### Parameters
-| **integerQuery** | **kotlin.Int**|  | [optional] |
-| **booleanQuery** | **kotlin.Boolean**|  | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **integerQuery** | **kotlin.Int**|  | [optional] |
+| **booleanQuery** | **kotlin.Boolean**|  | [optional] |
 | **stringQuery** | **kotlin.String**|  | [optional] |
 
 ### Return type

--- a/samples/client/others/kotlin-jvm-okhttp-non-ascii-headers/docs/PetApi.md
+++ b/samples/client/others/kotlin-jvm-okhttp-non-ascii-headers/docs/PetApi.md
@@ -97,9 +97,9 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| Pet id to delete | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| Pet id to delete | |
 | **apiKey** | **kotlin.String**|  | [optional] |
 
 ### Return type
@@ -364,10 +364,10 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
-| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
+| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | **status** | **kotlin.String**| Updated status of the pet | [optional] |
 
 ### Return type
@@ -422,10 +422,10 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet to update | |
-| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet to update | |
+| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | **file** | **java.io.File**| file to upload | [optional] |
 
 ### Return type

--- a/samples/client/others/kotlin-jvm-okhttp-non-ascii-headers/docs/UserApi.md
+++ b/samples/client/others/kotlin-jvm-okhttp-non-ascii-headers/docs/UserApi.md
@@ -282,9 +282,9 @@ try {
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| The user name for login | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| The user name for login | |
 | **password** | **kotlin.String**| The password for login in clear text | |
 
 ### Return type
@@ -374,9 +374,9 @@ try {
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| name that need to be deleted | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| name that need to be deleted | |
 | **user** | [**User**](User.md)| Updated user object | |
 
 ### Return type

--- a/samples/client/others/kotlin-jvm-okhttp-parameter-tests/docs/DefaultApi.md
+++ b/samples/client/others/kotlin-jvm-okhttp-parameter-tests/docs/DefaultApi.md
@@ -49,6 +49,8 @@ try {
 ```
 
 ### Parameters
+| Name | Type | Description  | Notes |
+| ------------- | ------------- | ------------- | ------------- |
 | **pathDefault** | **kotlin.String**| path default | |
 | **pathNullable** | **kotlin.String**| path_nullable | |
 | **queryDefault** | **kotlin.String**| query default | [optional] [default to &quot;available&quot;] |
@@ -63,8 +65,6 @@ try {
 | **queryNullable** | **kotlin.String**| query nullable | [optional] |
 | **headerNullable** | **kotlin.String**| header nullable | [optional] |
 | **cookieNullable** | **kotlin.String**| cookie_nullable | [optional] |
-| Name | Type | Description  | Notes |
-| ------------- | ------------- | ------------- | ------------- |
 | **dollarQueryDollarDollarSign** | **kotlin.String**| query parameter with dollar sign | [optional] |
 
 ### Return type

--- a/samples/client/petstore/kotlin-allOf-discriminator-kotlinx-serialization/docs/BirdApi.md
+++ b/samples/client/petstore/kotlin-allOf-discriminator-kotlinx-serialization/docs/BirdApi.md
@@ -80,9 +80,9 @@ try {
 ```
 
 ### Parameters
-| **metadata** | [**Bird**](Bird.md)|  | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **metadata** | [**Bird**](Bird.md)|  | |
 | **file** | **java.io.File**|  | |
 
 ### Return type

--- a/samples/client/petstore/kotlin-default-values-jvm-okhttp4/docs/DefaultApi.md
+++ b/samples/client/petstore/kotlin-default-values-jvm-okhttp4/docs/DefaultApi.md
@@ -63,6 +63,8 @@ try {
 ```
 
 ### Parameters
+| Name | Type | Description  | Notes |
+| ------------- | ------------- | ------------- | ------------- |
 | **pi0** | **kotlin.Int**|  | [default to 10] |
 | **pi1** | **kotlin.Int**|  | |
 | **pn0** | **java.math.BigDecimal**|  | [default to 10.0] |
@@ -91,8 +93,6 @@ try {
 | **fn1** | **java.math.BigDecimal**|  | [default to 71.0] |
 | **fn2** | **java.math.BigDecimal**|  | [optional] |
 | **fn3** | **java.math.BigDecimal**|  | |
-| Name | Type | Description  | Notes |
-| ------------- | ------------- | ------------- | ------------- |
 | **fn4** | [**kotlin.collections.List&lt;kotlin.String&gt;**](kotlin.String.md)|  | |
 
 ### Return type

--- a/samples/client/petstore/kotlin-default-values-multiplatform/docs/DefaultApi.md
+++ b/samples/client/petstore/kotlin-default-values-multiplatform/docs/DefaultApi.md
@@ -63,6 +63,8 @@ try {
 ```
 
 ### Parameters
+| Name | Type | Description  | Notes |
+| ------------- | ------------- | ------------- | ------------- |
 | **pi0** | **kotlin.Int**|  | [default to 10] |
 | **pi1** | **kotlin.Int**|  | |
 | **pn0** | **kotlin.Double**|  | [default to 10.0] |
@@ -91,8 +93,6 @@ try {
 | **fn1** | **kotlin.Double**|  | [default to 71.0] |
 | **fn2** | **kotlin.Double**|  | [optional] |
 | **fn3** | **kotlin.Double**|  | |
-| Name | Type | Description  | Notes |
-| ------------- | ------------- | ------------- | ------------- |
 | **fn4** | [**kotlin.collections.List&lt;kotlin.String&gt;**](kotlin.String.md)|  | |
 
 ### Return type

--- a/samples/client/petstore/kotlin-explicit/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-explicit/docs/PetApi.md
@@ -92,9 +92,9 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| Pet id to delete | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| Pet id to delete | |
 | **apiKey** | **kotlin.String**|  | [optional] |
 
 ### Return type
@@ -354,10 +354,10 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
-| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
+| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | **status** | **kotlin.String**| Updated status of the pet | [optional] |
 
 ### Return type
@@ -410,10 +410,10 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet to update | |
-| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet to update | |
+| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | **file** | **java.io.File**| file to upload | [optional] |
 
 ### Return type

--- a/samples/client/petstore/kotlin-explicit/docs/UserApi.md
+++ b/samples/client/petstore/kotlin-explicit/docs/UserApi.md
@@ -262,9 +262,9 @@ try {
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| The user name for login | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| The user name for login | |
 | **password** | **kotlin.String**| The password for login in clear text | |
 
 ### Return type
@@ -349,9 +349,9 @@ try {
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| name that need to be deleted | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| name that need to be deleted | |
 | **body** | [**User**](User.md)| Updated user object | |
 
 ### Return type

--- a/samples/client/petstore/kotlin-gson/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-gson/docs/PetApi.md
@@ -97,9 +97,9 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| Pet id to delete | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| Pet id to delete | |
 | **apiKey** | **kotlin.String**|  | [optional] |
 
 ### Return type
@@ -364,10 +364,10 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
-| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
+| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | **status** | **kotlin.String**| Updated status of the pet | [optional] |
 
 ### Return type
@@ -422,10 +422,10 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet to update | |
-| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet to update | |
+| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | **file** | **java.io.File**| file to upload | [optional] |
 
 ### Return type

--- a/samples/client/petstore/kotlin-gson/docs/UserApi.md
+++ b/samples/client/petstore/kotlin-gson/docs/UserApi.md
@@ -282,9 +282,9 @@ try {
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| The user name for login | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| The user name for login | |
 | **password** | **kotlin.String**| The password for login in clear text | |
 
 ### Return type
@@ -374,9 +374,9 @@ try {
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| name that need to be deleted | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| name that need to be deleted | |
 | **user** | [**User**](User.md)| Updated user object | |
 
 ### Return type

--- a/samples/client/petstore/kotlin-jackson/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-jackson/docs/PetApi.md
@@ -92,9 +92,9 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| Pet id to delete | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| Pet id to delete | |
 | **apiKey** | **kotlin.String**|  | [optional] |
 
 ### Return type
@@ -354,10 +354,10 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
-| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
+| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | **status** | **kotlin.String**| Updated status of the pet | [optional] |
 
 ### Return type
@@ -410,10 +410,10 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet to update | |
-| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet to update | |
+| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | **file** | **java.io.File**| file to upload | [optional] |
 
 ### Return type

--- a/samples/client/petstore/kotlin-jackson/docs/UserApi.md
+++ b/samples/client/petstore/kotlin-jackson/docs/UserApi.md
@@ -262,9 +262,9 @@ try {
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| The user name for login | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| The user name for login | |
 | **password** | **kotlin.String**| The password for login in clear text | |
 
 ### Return type
@@ -349,9 +349,9 @@ try {
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| name that need to be deleted | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| name that need to be deleted | |
 | **body** | [**User**](User.md)| Updated user object | |
 
 ### Return type

--- a/samples/client/petstore/kotlin-jackson3/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-jackson3/docs/PetApi.md
@@ -92,9 +92,9 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| Pet id to delete | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| Pet id to delete | |
 | **apiKey** | **kotlin.String**|  | [optional] |
 
 ### Return type
@@ -354,10 +354,10 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
-| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
+| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | **status** | **kotlin.String**| Updated status of the pet | [optional] |
 
 ### Return type
@@ -410,10 +410,10 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet to update | |
-| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet to update | |
+| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | **file** | **java.io.File**| file to upload | [optional] |
 
 ### Return type

--- a/samples/client/petstore/kotlin-jackson3/docs/UserApi.md
+++ b/samples/client/petstore/kotlin-jackson3/docs/UserApi.md
@@ -262,9 +262,9 @@ try {
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| The user name for login | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| The user name for login | |
 | **password** | **kotlin.String**| The password for login in clear text | |
 
 ### Return type
@@ -349,9 +349,9 @@ try {
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| name that need to be deleted | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| name that need to be deleted | |
 | **body** | [**User**](User.md)| Updated user object | |
 
 ### Return type

--- a/samples/client/petstore/kotlin-json-request-string/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-json-request-string/docs/PetApi.md
@@ -92,9 +92,9 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| Pet id to delete | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| Pet id to delete | |
 | **apiKey** | **kotlin.String**|  | [optional] |
 
 ### Return type
@@ -352,10 +352,10 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
-| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
+| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | **status** | **kotlin.String**| Updated status of the pet | [optional] |
 
 ### Return type
@@ -408,10 +408,10 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet to update | |
-| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet to update | |
+| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | **file** | **java.io.File**| file to upload | [optional] |
 
 ### Return type

--- a/samples/client/petstore/kotlin-json-request-string/docs/UserApi.md
+++ b/samples/client/petstore/kotlin-json-request-string/docs/UserApi.md
@@ -262,9 +262,9 @@ try {
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| The user name for login | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| The user name for login | |
 | **password** | **kotlin.String**| The password for login in clear text | |
 
 ### Return type
@@ -349,9 +349,9 @@ try {
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| name that need to be deleted | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| name that need to be deleted | |
 | **body** | [**User**](User.md)| Updated user object | |
 
 ### Return type

--- a/samples/client/petstore/kotlin-jvm-ktor-gson/docs/FakeApi.md
+++ b/samples/client/petstore/kotlin-jvm-ktor-gson/docs/FakeApi.md
@@ -82,11 +82,11 @@ try {
 ```
 
 ### Parameters
+| Name | Type | Description  | Notes |
+| ------------- | ------------- | ------------- | ------------- |
 | **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
 | **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | **status** | **kotlin.Int**| integer type | [optional] |
-| Name | Type | Description  | Notes |
-| ------------- | ------------- | ------------- | ------------- |
 | **status2** | **java.math.BigDecimal**| number type | [optional] |
 
 ### Return type

--- a/samples/client/petstore/kotlin-jvm-ktor-gson/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-jvm-ktor-gson/docs/PetApi.md
@@ -93,9 +93,9 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| Pet id to delete | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| Pet id to delete | |
 | **apiKey** | **kotlin.String**|  | [optional] |
 
 ### Return type
@@ -344,10 +344,10 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
-| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
+| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | **status** | **kotlin.String**| Updated status of the pet | [optional] |
 
 ### Return type
@@ -398,10 +398,10 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet to update | |
-| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet to update | |
+| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | **file** | **io.ktor.client.request.forms.FormPart&lt;io.ktor.client.request.forms.InputProvider&gt;**| file to upload | [optional] |
 
 ### Return type

--- a/samples/client/petstore/kotlin-jvm-ktor-gson/docs/UserApi.md
+++ b/samples/client/petstore/kotlin-jvm-ktor-gson/docs/UserApi.md
@@ -282,9 +282,9 @@ try {
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| The user name for login | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| The user name for login | |
 | **password** | **kotlin.String**| The password for login in clear text | |
 
 ### Return type
@@ -374,9 +374,9 @@ try {
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| name that need to be deleted | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| name that need to be deleted | |
 | **user** | [**User**](User.md)| Updated user object | |
 
 ### Return type

--- a/samples/client/petstore/kotlin-jvm-ktor-jackson/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-jvm-ktor-jackson/docs/PetApi.md
@@ -88,9 +88,9 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| Pet id to delete | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| Pet id to delete | |
 | **apiKey** | **kotlin.String**|  | [optional] |
 
 ### Return type
@@ -334,10 +334,10 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
-| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
+| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | **status** | **kotlin.String**| Updated status of the pet | [optional] |
 
 ### Return type
@@ -386,10 +386,10 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet to update | |
-| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet to update | |
+| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | **file** | **io.ktor.client.request.forms.FormPart&lt;io.ktor.client.request.forms.InputProvider&gt;**| file to upload | [optional] |
 
 ### Return type

--- a/samples/client/petstore/kotlin-jvm-ktor-jackson/docs/UserApi.md
+++ b/samples/client/petstore/kotlin-jvm-ktor-jackson/docs/UserApi.md
@@ -262,9 +262,9 @@ try {
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| The user name for login | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| The user name for login | |
 | **password** | **kotlin.String**| The password for login in clear text | |
 
 ### Return type
@@ -349,9 +349,9 @@ try {
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| name that need to be deleted | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| name that need to be deleted | |
 | **body** | [**User**](User.md)| Updated user object | |
 
 ### Return type

--- a/samples/client/petstore/kotlin-jvm-ktor-kotlinx_serialization/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-jvm-ktor-kotlinx_serialization/docs/PetApi.md
@@ -93,9 +93,9 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| Pet id to delete | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| Pet id to delete | |
 | **apiKey** | **kotlin.String**|  | [optional] |
 
 ### Return type
@@ -344,10 +344,10 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
-| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
+| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | **status** | **kotlin.String**| Updated status of the pet | [optional] |
 
 ### Return type
@@ -398,10 +398,10 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet to update | |
-| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet to update | |
+| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | **file** | **io.ktor.client.request.forms.FormPart&lt;io.ktor.client.request.forms.InputProvider&gt;**| file to upload | [optional] |
 
 ### Return type

--- a/samples/client/petstore/kotlin-jvm-ktor-kotlinx_serialization/docs/UserApi.md
+++ b/samples/client/petstore/kotlin-jvm-ktor-kotlinx_serialization/docs/UserApi.md
@@ -282,9 +282,9 @@ try {
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| The user name for login | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| The user name for login | |
 | **password** | **kotlin.String**| The password for login in clear text | |
 
 ### Return type
@@ -374,9 +374,9 @@ try {
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| name that need to be deleted | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| name that need to be deleted | |
 | **user** | [**User**](User.md)| Updated user object | |
 
 ### Return type

--- a/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/docs/PetApi.md
@@ -92,9 +92,9 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| Pet id to delete | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| Pet id to delete | |
 | **apiKey** | **kotlin.String**|  | [optional] |
 
 ### Return type
@@ -354,10 +354,10 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
-| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
+| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | **status** | **kotlin.String**| Updated status of the pet | [optional] |
 
 ### Return type
@@ -410,10 +410,10 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet to update | |
-| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet to update | |
+| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | **file** | **java.io.File**| file to upload | [optional] |
 
 ### Return type

--- a/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/docs/UserApi.md
+++ b/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/docs/UserApi.md
@@ -262,9 +262,9 @@ try {
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| The user name for login | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| The user name for login | |
 | **password** | **kotlin.String**| The password for login in clear text | |
 
 ### Return type
@@ -349,9 +349,9 @@ try {
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| name that need to be deleted | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| name that need to be deleted | |
 | **body** | [**User**](User.md)| Updated user object | |
 
 ### Return type

--- a/samples/client/petstore/kotlin-jvm-spring-2-webclient/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-jvm-spring-2-webclient/docs/PetApi.md
@@ -93,9 +93,9 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| Pet id to delete | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| Pet id to delete | |
 | **apiKey** | **kotlin.String**|  | [optional] |
 
 ### Return type
@@ -344,10 +344,10 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
-| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
+| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | **status** | **kotlin.String**| Updated status of the pet | [optional] |
 
 ### Return type
@@ -398,10 +398,10 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet to update | |
-| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet to update | |
+| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | **file** | **java.io.File**| file to upload | [optional] |
 
 ### Return type

--- a/samples/client/petstore/kotlin-jvm-spring-2-webclient/docs/UserApi.md
+++ b/samples/client/petstore/kotlin-jvm-spring-2-webclient/docs/UserApi.md
@@ -282,9 +282,9 @@ try {
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| The user name for login | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| The user name for login | |
 | **password** | **kotlin.String**| The password for login in clear text | |
 
 ### Return type
@@ -374,9 +374,9 @@ try {
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| name that need to be deleted | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| name that need to be deleted | |
 | **user** | [**User**](User.md)| Updated user object | |
 
 ### Return type

--- a/samples/client/petstore/kotlin-jvm-spring-3-restclient/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-jvm-spring-3-restclient/docs/PetApi.md
@@ -93,9 +93,9 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| Pet id to delete | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| Pet id to delete | |
 | **apiKey** | **kotlin.String**|  | [optional] |
 
 ### Return type
@@ -344,10 +344,10 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
-| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
+| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | **status** | **kotlin.String**| Updated status of the pet | [optional] |
 
 ### Return type
@@ -398,10 +398,10 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet to update | |
-| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet to update | |
+| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | **file** | **java.io.File**| file to upload | [optional] |
 
 ### Return type

--- a/samples/client/petstore/kotlin-jvm-spring-3-restclient/docs/UserApi.md
+++ b/samples/client/petstore/kotlin-jvm-spring-3-restclient/docs/UserApi.md
@@ -282,9 +282,9 @@ try {
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| The user name for login | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| The user name for login | |
 | **password** | **kotlin.String**| The password for login in clear text | |
 
 ### Return type
@@ -374,9 +374,9 @@ try {
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| name that need to be deleted | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| name that need to be deleted | |
 | **user** | [**User**](User.md)| Updated user object | |
 
 ### Return type

--- a/samples/client/petstore/kotlin-jvm-spring-3-webclient/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-jvm-spring-3-webclient/docs/PetApi.md
@@ -93,9 +93,9 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| Pet id to delete | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| Pet id to delete | |
 | **apiKey** | **kotlin.String**|  | [optional] |
 
 ### Return type
@@ -344,10 +344,10 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
-| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
+| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | **status** | **kotlin.String**| Updated status of the pet | [optional] |
 
 ### Return type
@@ -398,10 +398,10 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet to update | |
-| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet to update | |
+| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | **file** | **java.io.File**| file to upload | [optional] |
 
 ### Return type

--- a/samples/client/petstore/kotlin-jvm-spring-3-webclient/docs/UserApi.md
+++ b/samples/client/petstore/kotlin-jvm-spring-3-webclient/docs/UserApi.md
@@ -282,9 +282,9 @@ try {
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| The user name for login | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| The user name for login | |
 | **password** | **kotlin.String**| The password for login in clear text | |
 
 ### Return type
@@ -374,9 +374,9 @@ try {
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| name that need to be deleted | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| name that need to be deleted | |
 | **user** | [**User**](User.md)| Updated user object | |
 
 ### Return type

--- a/samples/client/petstore/kotlin-jvm-spring-4-restclient-jackson3/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-jvm-spring-4-restclient-jackson3/docs/PetApi.md
@@ -93,9 +93,9 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| Pet id to delete | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| Pet id to delete | |
 | **apiKey** | **kotlin.String**|  | [optional] |
 
 ### Return type
@@ -344,10 +344,10 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
-| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
+| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | **status** | **kotlin.String**| Updated status of the pet | [optional] |
 
 ### Return type
@@ -398,10 +398,10 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet to update | |
-| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet to update | |
+| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | **file** | **java.io.File**| file to upload | [optional] |
 
 ### Return type

--- a/samples/client/petstore/kotlin-jvm-spring-4-restclient-jackson3/docs/UserApi.md
+++ b/samples/client/petstore/kotlin-jvm-spring-4-restclient-jackson3/docs/UserApi.md
@@ -282,9 +282,9 @@ try {
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| The user name for login | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| The user name for login | |
 | **password** | **kotlin.String**| The password for login in clear text | |
 
 ### Return type
@@ -374,9 +374,9 @@ try {
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| name that need to be deleted | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| name that need to be deleted | |
 | **user** | [**User**](User.md)| Updated user object | |
 
 ### Return type

--- a/samples/client/petstore/kotlin-jvm-vertx-gson/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-jvm-vertx-gson/docs/PetApi.md
@@ -93,9 +93,9 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| Pet id to delete | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| Pet id to delete | |
 | **apiKey** | **kotlin.String**|  | [optional] |
 
 ### Return type
@@ -344,10 +344,10 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
-| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
+| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | **status** | **kotlin.String**| Updated status of the pet | [optional] |
 
 ### Return type
@@ -398,10 +398,10 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet to update | |
-| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet to update | |
+| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | **file** | **java.io.File**| file to upload | [optional] |
 
 ### Return type

--- a/samples/client/petstore/kotlin-jvm-vertx-gson/docs/UserApi.md
+++ b/samples/client/petstore/kotlin-jvm-vertx-gson/docs/UserApi.md
@@ -282,9 +282,9 @@ try {
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| The user name for login | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| The user name for login | |
 | **password** | **kotlin.String**| The password for login in clear text | |
 
 ### Return type
@@ -374,9 +374,9 @@ try {
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| name that need to be deleted | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| name that need to be deleted | |
 | **user** | [**User**](User.md)| Updated user object | |
 
 ### Return type

--- a/samples/client/petstore/kotlin-jvm-vertx-jackson-coroutines/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-jvm-vertx-jackson-coroutines/docs/PetApi.md
@@ -93,9 +93,9 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| Pet id to delete | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| Pet id to delete | |
 | **apiKey** | **kotlin.String**|  | [optional] |
 
 ### Return type
@@ -344,10 +344,10 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
-| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
+| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | **status** | **kotlin.String**| Updated status of the pet | [optional] |
 
 ### Return type
@@ -398,10 +398,10 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet to update | |
-| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet to update | |
+| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | **file** | **java.io.File**| file to upload | [optional] |
 
 ### Return type

--- a/samples/client/petstore/kotlin-jvm-vertx-jackson-coroutines/docs/UserApi.md
+++ b/samples/client/petstore/kotlin-jvm-vertx-jackson-coroutines/docs/UserApi.md
@@ -282,9 +282,9 @@ try {
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| The user name for login | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| The user name for login | |
 | **password** | **kotlin.String**| The password for login in clear text | |
 
 ### Return type
@@ -374,9 +374,9 @@ try {
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| name that need to be deleted | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| name that need to be deleted | |
 | **user** | [**User**](User.md)| Updated user object | |
 
 ### Return type

--- a/samples/client/petstore/kotlin-jvm-vertx-jackson/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-jvm-vertx-jackson/docs/PetApi.md
@@ -93,9 +93,9 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| Pet id to delete | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| Pet id to delete | |
 | **apiKey** | **kotlin.String**|  | [optional] |
 
 ### Return type
@@ -344,10 +344,10 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
-| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
+| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | **status** | **kotlin.String**| Updated status of the pet | [optional] |
 
 ### Return type
@@ -398,10 +398,10 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet to update | |
-| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet to update | |
+| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | **file** | **java.io.File**| file to upload | [optional] |
 
 ### Return type

--- a/samples/client/petstore/kotlin-jvm-vertx-jackson/docs/UserApi.md
+++ b/samples/client/petstore/kotlin-jvm-vertx-jackson/docs/UserApi.md
@@ -282,9 +282,9 @@ try {
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| The user name for login | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| The user name for login | |
 | **password** | **kotlin.String**| The password for login in clear text | |
 
 ### Return type
@@ -374,9 +374,9 @@ try {
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| name that need to be deleted | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| name that need to be deleted | |
 | **user** | [**User**](User.md)| Updated user object | |
 
 ### Return type

--- a/samples/client/petstore/kotlin-jvm-vertx-moshi/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-jvm-vertx-moshi/docs/PetApi.md
@@ -93,9 +93,9 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| Pet id to delete | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| Pet id to delete | |
 | **apiKey** | **kotlin.String**|  | [optional] |
 
 ### Return type
@@ -344,10 +344,10 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
-| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
+| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | **status** | **kotlin.String**| Updated status of the pet | [optional] |
 
 ### Return type
@@ -398,10 +398,10 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet to update | |
-| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet to update | |
+| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | **file** | **java.io.File**| file to upload | [optional] |
 
 ### Return type

--- a/samples/client/petstore/kotlin-jvm-vertx-moshi/docs/UserApi.md
+++ b/samples/client/petstore/kotlin-jvm-vertx-moshi/docs/UserApi.md
@@ -282,9 +282,9 @@ try {
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| The user name for login | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| The user name for login | |
 | **password** | **kotlin.String**| The password for login in clear text | |
 
 ### Return type
@@ -374,9 +374,9 @@ try {
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| name that need to be deleted | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| name that need to be deleted | |
 | **user** | [**User**](User.md)| Updated user object | |
 
 ### Return type

--- a/samples/client/petstore/kotlin-kotlinx-datetime/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-kotlinx-datetime/docs/PetApi.md
@@ -92,9 +92,9 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| Pet id to delete | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| Pet id to delete | |
 | **apiKey** | **kotlin.String**|  | [optional] |
 
 ### Return type
@@ -354,10 +354,10 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
-| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
+| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | **status** | **kotlin.String**| Updated status of the pet | [optional] |
 
 ### Return type
@@ -410,10 +410,10 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet to update | |
-| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet to update | |
+| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | **file** | **java.io.File**| file to upload | [optional] |
 
 ### Return type

--- a/samples/client/petstore/kotlin-kotlinx-datetime/docs/UserApi.md
+++ b/samples/client/petstore/kotlin-kotlinx-datetime/docs/UserApi.md
@@ -262,9 +262,9 @@ try {
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| The user name for login | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| The user name for login | |
 | **password** | **kotlin.String**| The password for login in clear text | |
 
 ### Return type
@@ -349,9 +349,9 @@ try {
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| name that need to be deleted | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| name that need to be deleted | |
 | **body** | [**User**](User.md)| Updated user object | |
 
 ### Return type

--- a/samples/client/petstore/kotlin-modelMutable/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-modelMutable/docs/PetApi.md
@@ -92,9 +92,9 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| Pet id to delete | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| Pet id to delete | |
 | **apiKey** | **kotlin.String**|  | [optional] |
 
 ### Return type
@@ -354,10 +354,10 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
-| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
+| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | **status** | **kotlin.String**| Updated status of the pet | [optional] |
 
 ### Return type
@@ -410,10 +410,10 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet to update | |
-| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet to update | |
+| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | **file** | **java.io.File**| file to upload | [optional] |
 
 ### Return type

--- a/samples/client/petstore/kotlin-modelMutable/docs/UserApi.md
+++ b/samples/client/petstore/kotlin-modelMutable/docs/UserApi.md
@@ -262,9 +262,9 @@ try {
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| The user name for login | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| The user name for login | |
 | **password** | **kotlin.String**| The password for login in clear text | |
 
 ### Return type
@@ -349,9 +349,9 @@ try {
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| name that need to be deleted | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| name that need to be deleted | |
 | **body** | [**User**](User.md)| Updated user object | |
 
 ### Return type

--- a/samples/client/petstore/kotlin-moshi-codegen/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-moshi-codegen/docs/PetApi.md
@@ -92,9 +92,9 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| Pet id to delete | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| Pet id to delete | |
 | **apiKey** | **kotlin.String**|  | [optional] |
 
 ### Return type
@@ -354,10 +354,10 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
-| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
+| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | **status** | **kotlin.String**| Updated status of the pet | [optional] |
 
 ### Return type
@@ -410,10 +410,10 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet to update | |
-| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet to update | |
+| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | **file** | **java.io.File**| file to upload | [optional] |
 
 ### Return type

--- a/samples/client/petstore/kotlin-moshi-codegen/docs/UserApi.md
+++ b/samples/client/petstore/kotlin-moshi-codegen/docs/UserApi.md
@@ -262,9 +262,9 @@ try {
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| The user name for login | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| The user name for login | |
 | **password** | **kotlin.String**| The password for login in clear text | |
 
 ### Return type
@@ -349,9 +349,9 @@ try {
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| name that need to be deleted | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| name that need to be deleted | |
 | **body** | [**User**](User.md)| Updated user object | |
 
 ### Return type

--- a/samples/client/petstore/kotlin-multiplatform-allOf-discriminator/docs/BirdApi.md
+++ b/samples/client/petstore/kotlin-multiplatform-allOf-discriminator/docs/BirdApi.md
@@ -80,9 +80,9 @@ try {
 ```
 
 ### Parameters
-| **metadata** | [**Bird**](Bird.md)|  | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **metadata** | [**Bird**](Bird.md)|  | |
 | **file** | **io.ktor.client.request.forms.FormPart&lt;io.ktor.client.request.forms.InputProvider&gt;**|  | |
 
 ### Return type

--- a/samples/client/petstore/kotlin-multiplatform-kotlinx-datetime/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-multiplatform-kotlinx-datetime/docs/PetApi.md
@@ -88,9 +88,9 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| Pet id to delete | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| Pet id to delete | |
 | **apiKey** | **kotlin.String**|  | [optional] |
 
 ### Return type
@@ -334,10 +334,10 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
-| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
+| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | **status** | **kotlin.String**| Updated status of the pet | [optional] |
 
 ### Return type
@@ -386,10 +386,10 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet to update | |
-| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet to update | |
+| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | **file** | **io.ktor.client.request.forms.FormPart&lt;io.ktor.client.request.forms.InputProvider&gt;**| file to upload | [optional] |
 
 ### Return type

--- a/samples/client/petstore/kotlin-multiplatform-kotlinx-datetime/docs/UserApi.md
+++ b/samples/client/petstore/kotlin-multiplatform-kotlinx-datetime/docs/UserApi.md
@@ -262,9 +262,9 @@ try {
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| The user name for login | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| The user name for login | |
 | **password** | **kotlin.String**| The password for login in clear text | |
 
 ### Return type
@@ -349,9 +349,9 @@ try {
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| name that need to be deleted | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| name that need to be deleted | |
 | **body** | [**User**](User.md)| Updated user object | |
 
 ### Return type

--- a/samples/client/petstore/kotlin-multiplatform/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-multiplatform/docs/PetApi.md
@@ -88,9 +88,9 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| Pet id to delete | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| Pet id to delete | |
 | **apiKey** | **kotlin.String**|  | [optional] |
 
 ### Return type
@@ -334,10 +334,10 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
-| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
+| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | **status** | **kotlin.String**| Updated status of the pet | [optional] |
 
 ### Return type
@@ -386,10 +386,10 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet to update | |
-| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet to update | |
+| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | **file** | **io.ktor.client.request.forms.FormPart&lt;io.ktor.client.request.forms.InputProvider&gt;**| file to upload | [optional] |
 
 ### Return type

--- a/samples/client/petstore/kotlin-multiplatform/docs/UserApi.md
+++ b/samples/client/petstore/kotlin-multiplatform/docs/UserApi.md
@@ -262,9 +262,9 @@ try {
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| The user name for login | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| The user name for login | |
 | **password** | **kotlin.String**| The password for login in clear text | |
 
 ### Return type
@@ -349,9 +349,9 @@ try {
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| name that need to be deleted | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| name that need to be deleted | |
 | **body** | [**User**](User.md)| Updated user object | |
 
 ### Return type

--- a/samples/client/petstore/kotlin-name-parameter-mappings/docs/FakeApi.md
+++ b/samples/client/petstore/kotlin-name-parameter-mappings/docs/FakeApi.md
@@ -37,11 +37,11 @@ try {
 ```
 
 ### Parameters
+| Name | Type | Description  | Notes |
+| ------------- | ------------- | ------------- | ------------- |
 | **underscoreType** | **kotlin.Long**| _type | |
 | **type** | **kotlin.String**| type | |
 | **typeWithUnderscore** | **kotlin.String**| type_ | |
-| Name | Type | Description  | Notes |
-| ------------- | ------------- | ------------- | ------------- |
 | **httpDebugOption** | **kotlin.String**| http debug option (to test parameter naming option) | |
 
 ### Return type

--- a/samples/client/petstore/kotlin-nonpublic/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-nonpublic/docs/PetApi.md
@@ -92,9 +92,9 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| Pet id to delete | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| Pet id to delete | |
 | **apiKey** | **kotlin.String**|  | [optional] |
 
 ### Return type
@@ -354,10 +354,10 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
-| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
+| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | **status** | **kotlin.String**| Updated status of the pet | [optional] |
 
 ### Return type
@@ -410,10 +410,10 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet to update | |
-| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet to update | |
+| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | **file** | **java.io.File**| file to upload | [optional] |
 
 ### Return type

--- a/samples/client/petstore/kotlin-nonpublic/docs/UserApi.md
+++ b/samples/client/petstore/kotlin-nonpublic/docs/UserApi.md
@@ -262,9 +262,9 @@ try {
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| The user name for login | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| The user name for login | |
 | **password** | **kotlin.String**| The password for login in clear text | |
 
 ### Return type
@@ -349,9 +349,9 @@ try {
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| name that need to be deleted | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| name that need to be deleted | |
 | **body** | [**User**](User.md)| Updated user object | |
 
 ### Return type

--- a/samples/client/petstore/kotlin-nullable/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-nullable/docs/PetApi.md
@@ -92,9 +92,9 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| Pet id to delete | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| Pet id to delete | |
 | **apiKey** | **kotlin.String**|  | [optional] |
 
 ### Return type
@@ -354,10 +354,10 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
-| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
+| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | **status** | **kotlin.String**| Updated status of the pet | [optional] |
 
 ### Return type
@@ -410,10 +410,10 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet to update | |
-| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet to update | |
+| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | **file** | **java.io.File**| file to upload | [optional] |
 
 ### Return type

--- a/samples/client/petstore/kotlin-nullable/docs/UserApi.md
+++ b/samples/client/petstore/kotlin-nullable/docs/UserApi.md
@@ -262,9 +262,9 @@ try {
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| The user name for login | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| The user name for login | |
 | **password** | **kotlin.String**| The password for login in clear text | |
 
 ### Return type
@@ -349,9 +349,9 @@ try {
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| name that need to be deleted | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| name that need to be deleted | |
 | **body** | [**User**](User.md)| Updated user object | |
 
 ### Return type

--- a/samples/client/petstore/kotlin-string/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-string/docs/PetApi.md
@@ -92,9 +92,9 @@ try {
 ```
 
 ### Parameters
-| **apiKey** | **kotlin.String**|  | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **apiKey** | **kotlin.String**|  | [optional] |
 | **petId** | **kotlin.Long**| Pet id to delete | |
 
 ### Return type
@@ -354,10 +354,10 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
-| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
+| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | **status** | **kotlin.String**| Updated status of the pet | [optional] |
 
 ### Return type
@@ -410,10 +410,10 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet to update | |
-| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet to update | |
+| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | **file** | **kotlin.ByteArray**| file to upload | [optional] |
 
 ### Return type

--- a/samples/client/petstore/kotlin-string/docs/UserApi.md
+++ b/samples/client/petstore/kotlin-string/docs/UserApi.md
@@ -262,9 +262,9 @@ try {
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| The user name for login | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| The user name for login | |
 | **password** | **kotlin.String**| The password for login in clear text | |
 
 ### Return type
@@ -349,9 +349,9 @@ try {
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| name that need to be deleted | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| name that need to be deleted | |
 | **body** | [**User**](User.md)| Updated user object | |
 
 ### Return type

--- a/samples/client/petstore/kotlin-threetenbp/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-threetenbp/docs/PetApi.md
@@ -92,9 +92,9 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| Pet id to delete | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| Pet id to delete | |
 | **apiKey** | **kotlin.String**|  | [optional] |
 
 ### Return type
@@ -354,10 +354,10 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
-| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
+| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | **status** | **kotlin.String**| Updated status of the pet | [optional] |
 
 ### Return type
@@ -410,10 +410,10 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet to update | |
-| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet to update | |
+| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | **file** | **java.io.File**| file to upload | [optional] |
 
 ### Return type

--- a/samples/client/petstore/kotlin-threetenbp/docs/UserApi.md
+++ b/samples/client/petstore/kotlin-threetenbp/docs/UserApi.md
@@ -262,9 +262,9 @@ try {
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| The user name for login | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| The user name for login | |
 | **password** | **kotlin.String**| The password for login in clear text | |
 
 ### Return type
@@ -349,9 +349,9 @@ try {
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| name that need to be deleted | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| name that need to be deleted | |
 | **body** | [**User**](User.md)| Updated user object | |
 
 ### Return type

--- a/samples/client/petstore/kotlin/docs/PetApi.md
+++ b/samples/client/petstore/kotlin/docs/PetApi.md
@@ -92,9 +92,9 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| Pet id to delete | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| Pet id to delete | |
 | **apiKey** | **kotlin.String**|  | [optional] |
 
 ### Return type
@@ -354,10 +354,10 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
-| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
+| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | **status** | **kotlin.String**| Updated status of the pet | [optional] |
 
 ### Return type
@@ -410,10 +410,10 @@ try {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet to update | |
-| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet to update | |
+| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | **file** | **java.io.File**| file to upload | [optional] |
 
 ### Return type

--- a/samples/client/petstore/kotlin/docs/UserApi.md
+++ b/samples/client/petstore/kotlin/docs/UserApi.md
@@ -262,9 +262,9 @@ try {
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| The user name for login | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| The user name for login | |
 | **password** | **kotlin.String**| The password for login in clear text | |
 
 ### Return type
@@ -349,9 +349,9 @@ try {
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| name that need to be deleted | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| name that need to be deleted | |
 | **body** | [**User**](User.md)| Updated user object | |
 
 ### Return type


### PR DESCRIPTION
Problem

kotlin-client/api_doc.mustache emits the parameter table header inside {{#-last}}, so for any operation with two or more parameters the header lands immediately before the final parameter. Every preceding row falls outside the table and GitHub renders it as stray text. Single-parameter operations work by accident, since -first and -last coincide.

Visible on master today — samples/client/petstore/kotlin/docs/PetApi.md lines 94–98 (deletePet), plus two other malformed tables in that same file.

Fix

{{#-last}} → {{#-first}} on the header block.

Samples

Regenerated bin/configs/kotlin*.yaml. 76 files, 249 insertions / 249 deletions — every change is a parameter row moving from above the header to below the separator. No non-doc output affected.

Note

typescript-fetch/api_doc.mustache has the same bug. Every other generator I checked emits the header outside the loop. Left out of this PR to keep it scoped to kotlin-client.
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes malformed Markdown parameter tables in Kotlin client API docs by emitting the header before the first parameter. Previously the header appeared before the last parameter, leaving earlier rows outside the table; now all rows render inside the table.

- Change `{{#-last}}` to `{{#-first}}` for the header block in `modules/openapi-generator/src/main/resources/kotlin-client/api_doc.mustache`.
- Regenerates Kotlin samples; diffs are docs-only (rows moved under the header). No generator behavior or non-doc outputs changed.
- Single-parameter operations are unchanged; multi-parameter tables now render correctly on GitHub.
- Related bug exists in `typescript-fetch/api_doc.mustache`; excluded to keep scope focused.

<sup>Written for commit 3e6c797c3d7bb4e24e05bf6aaac95cac922f9f5c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24742?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

