### PR TITLE
[BUG][Java][Spring] Generated code fails Error Prone UnnecessaryFinal bug pattern

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-http-interface/httpInterfacesConfiguration.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-http-interface/httpInterfacesConfiguration.mustache
@@ -26,7 +26,7 @@ public abstract class HttpInterfacesAbstractConfigurator {
 
     private final {{#reactive}}WebClient{{/reactive}}{{^reactive}}RestClient{{/reactive}} client;
 
-    public HttpInterfacesAbstractConfigurator(final {{#reactive}}WebClient{{/reactive}}{{^reactive}}RestClient{{/reactive}} client) {
+    public HttpInterfacesAbstractConfigurator({{#reactive}}WebClient{{/reactive}}{{^reactive}}RestClient{{/reactive}} client) {
         this.client = client;
     }
 

--- a/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-http-interface/httpServiceProxyFactoryInterfacesConfigurator.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-http-interface/httpServiceProxyFactoryInterfacesConfigurator.mustache
@@ -18,7 +18,7 @@ public abstract class HttpInterfacesAbstractConfigurator {
 
     private final HttpServiceProxyFactory factory;
 
-    public HttpInterfacesAbstractConfigurator(final HttpServiceProxyFactory factory) {
+    public HttpInterfacesAbstractConfigurator(HttpServiceProxyFactory factory) {
         this.factory = factory;
     }
 

--- a/samples/client/petstore/spring-http-interface-bean-validation/src/main/java/org/openapitools/configuration/HttpInterfacesAbstractConfigurator.java
+++ b/samples/client/petstore/spring-http-interface-bean-validation/src/main/java/org/openapitools/configuration/HttpInterfacesAbstractConfigurator.java
@@ -21,7 +21,7 @@ public abstract class HttpInterfacesAbstractConfigurator {
 
     private final RestClient client;
 
-    public HttpInterfacesAbstractConfigurator(final RestClient client) {
+    public HttpInterfacesAbstractConfigurator(RestClient client) {
         this.client = client;
     }
 

--- a/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/configuration/HttpInterfacesAbstractConfigurator.java
+++ b/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/configuration/HttpInterfacesAbstractConfigurator.java
@@ -21,7 +21,7 @@ public abstract class HttpInterfacesAbstractConfigurator {
 
     private final RestClient client;
 
-    public HttpInterfacesAbstractConfigurator(final RestClient client) {
+    public HttpInterfacesAbstractConfigurator(RestClient client) {
         this.client = client;
     }
 

--- a/samples/client/petstore/spring-http-interface-oauth/src/main/java/org/openapitools/configuration/HttpInterfacesAbstractConfigurator.java
+++ b/samples/client/petstore/spring-http-interface-oauth/src/main/java/org/openapitools/configuration/HttpInterfacesAbstractConfigurator.java
@@ -16,7 +16,7 @@ public abstract class HttpInterfacesAbstractConfigurator {
 
     private final RestClient client;
 
-    public HttpInterfacesAbstractConfigurator(final RestClient client) {
+    public HttpInterfacesAbstractConfigurator(RestClient client) {
         this.client = client;
     }
 

--- a/samples/client/petstore/spring-http-interface-reactive-bean-validation/src/main/java/org/openapitools/configuration/HttpInterfacesAbstractConfigurator.java
+++ b/samples/client/petstore/spring-http-interface-reactive-bean-validation/src/main/java/org/openapitools/configuration/HttpInterfacesAbstractConfigurator.java
@@ -21,7 +21,7 @@ public abstract class HttpInterfacesAbstractConfigurator {
 
     private final WebClient client;
 
-    public HttpInterfacesAbstractConfigurator(final WebClient client) {
+    public HttpInterfacesAbstractConfigurator(WebClient client) {
         this.client = client;
     }
 

--- a/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/configuration/HttpInterfacesAbstractConfigurator.java
+++ b/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/configuration/HttpInterfacesAbstractConfigurator.java
@@ -21,7 +21,7 @@ public abstract class HttpInterfacesAbstractConfigurator {
 
     private final WebClient client;
 
-    public HttpInterfacesAbstractConfigurator(final WebClient client) {
+    public HttpInterfacesAbstractConfigurator(WebClient client) {
         this.client = client;
     }
 

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/configuration/HttpInterfacesAbstractConfigurator.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/configuration/HttpInterfacesAbstractConfigurator.java
@@ -21,7 +21,7 @@ public abstract class HttpInterfacesAbstractConfigurator {
 
     private final WebClient client;
 
-    public HttpInterfacesAbstractConfigurator(final WebClient client) {
+    public HttpInterfacesAbstractConfigurator(WebClient client) {
         this.client = client;
     }
 

--- a/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/configuration/HttpInterfacesAbstractConfigurator.java
+++ b/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/configuration/HttpInterfacesAbstractConfigurator.java
@@ -21,7 +21,7 @@ public abstract class HttpInterfacesAbstractConfigurator {
 
     private final RestClient client;
 
-    public HttpInterfacesAbstractConfigurator(final RestClient client) {
+    public HttpInterfacesAbstractConfigurator(RestClient client) {
         this.client = client;
     }
 

--- a/samples/client/petstore/spring-http-interface-useHttpServiceProxyFactoryInterfacesConfigurator/src/main/java/org/openapitools/configuration/HttpInterfacesAbstractConfigurator.java
+++ b/samples/client/petstore/spring-http-interface-useHttpServiceProxyFactoryInterfacesConfigurator/src/main/java/org/openapitools/configuration/HttpInterfacesAbstractConfigurator.java
@@ -19,7 +19,7 @@ public abstract class HttpInterfacesAbstractConfigurator {
 
     private final HttpServiceProxyFactory factory;
 
-    public HttpInterfacesAbstractConfigurator(final HttpServiceProxyFactory factory) {
+    public HttpInterfacesAbstractConfigurator(HttpServiceProxyFactory factory) {
         this.factory = factory;
     }
 

--- a/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/configuration/HttpInterfacesAbstractConfigurator.java
+++ b/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/configuration/HttpInterfacesAbstractConfigurator.java
@@ -21,7 +21,7 @@ public abstract class HttpInterfacesAbstractConfigurator {
 
     private final RestClient client;
 
-    public HttpInterfacesAbstractConfigurator(final RestClient client) {
+    public HttpInterfacesAbstractConfigurator(RestClient client) {
         this.client = client;
     }
 


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Fixes #24744 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove redundant final modifiers from constructor parameters in generated Spring HTTP interface configurators. This eliminates Error Prone UnnecessaryFinal warnings without changing runtime behavior.

- Update templates `httpInterfacesConfiguration.mustache` and `httpServiceProxyFactoryInterfacesConfigurator.mustache` in the `JavaSpring` `spring-http-interface` library.
- Regenerate affected samples to reflect the change.
- No migration required; output differs only by parameter modifiers and compiles the same.

<sup>Written for commit c7f14f88ded68c1e637bf66836973b82d88b266f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24745?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

