### PR TITLE
fix(crystal): support Crystal 1.21

### DIFF
--- a/modules/openapi-generator/src/main/resources/crystal/shard.mustache
+++ b/modules/openapi-generator/src/main/resources/crystal/shard.mustache
@@ -18,6 +18,7 @@ dependencies:
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
+    version: 1.7.0-dev
   spectator:
     gitlab: arctic-fox/spectator
     version: ~> 0.12.0

--- a/samples/client/others/crystal-qdrant/shard.yml
+++ b/samples/client/others/crystal-qdrant/shard.yml
@@ -18,6 +18,7 @@ dependencies:
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
+    version: 1.7.0-dev
   spectator:
     gitlab: arctic-fox/spectator
     version: ~> 0.12.0

--- a/samples/client/petstore/crystal/shard.yml
+++ b/samples/client/petstore/crystal/shard.yml
@@ -18,6 +18,7 @@ dependencies:
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
+    version: 1.7.0-dev
   spectator:
     gitlab: arctic-fox/spectator
     version: ~> 0.12.0


### PR DESCRIPTION
Crystal 1.21 removed `Crystal::Lexer#next_string_array_token` in
[crystal-lang/crystal#16748](https://github.com/crystal-lang/crystal/pull/16748).
Generated Crystal projects leave their Ameba development dependency
unconstrained, so Shards selects the latest stable release, Ameba 1.6.4. That
release still calls the removed lexer method and causes `shards install` to
fail before the generated tests run, as seen in the
[Samples Crystal clients workflow](https://github.com/OpenAPITools/openapi-generator/actions/runs/31674240853).

[crystal-ameba/ameba#823](https://github.com/crystal-ameba/ameba/pull/823)
added Crystal 1.21 compatibility in Ameba 1.7.0-dev. Pin the generated
development dependency to that prerelease until the fix is available in a
stable Ameba release, and regenerate both checked-in Crystal samples from the
updated template.

@cyangle

### Verification

- `./mvnw -pl modules/openapi-generator-cli -am -DskipTests -Dmaven.javadoc.skip=true -Djacoco.skip=true clean package -q`
- `./bin/generate-samples.sh bin/configs/crystal.yaml bin/configs/crystal-qdrant.yaml`
- `./mvnw -pl modules/openapi-generator -am -Dtest=CrystalClientCodegenTest -Dsurefire.failIfNoSpecifiedTests=false test -q`
- `shards install` in the regenerated petstore sample using Crystal 1.21.0; it resolves Ameba 1.7.0-dev successfully

<!-- Please check the completed items below -->
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ```
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files.
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master.
  These must match the expectations made by your contribution.
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`.
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin the generated Crystal projects’ `ameba` dev dependency to `1.7.0-dev` to restore compatibility with Crystal 1.21. Previously, `ameba` was unconstrained and `shards` resolved `1.6.4`, which uses the removed `Crystal::Lexer#next_string_array_token`, causing `shards install` to fail before tests.

- Updates the template `crystal/shard.mustache`; regenerates sample `shard.yml` files accordingly. Only development dependency changes; no runtime impact.
- Temporary pin until a stable `crystal-ameba/ameba` release includes the fix.
- Migration: Crystal clients generated before this change that run on Crystal 1.21+ should set `ameba` to `1.7.0-dev` in their `shard.yml`.

<sup>Written for commit a5847cff5aea35143e160b4ce5ccb9d729e712c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24748?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

