### PR TITLE
Update kotlin workflow to test new samples

### DIFF
--- a/.github/workflows/samples-kotlin-client.yaml
+++ b/.github/workflows/samples-kotlin-client.yaml
@@ -85,6 +85,8 @@ jobs:
           - samples/client/others/kotlin-oneOf-anyOf-kotlinx-serialization
           - samples/client/others/kotlin-oneOf-anyOf-kotlinx-serialization-nonPublicApi
           - samples/client/others/kotlin-oneOf-anyOf-kotlinx-serialization-explicitApi
+          - samples/client/petstore/kotlin-allOf-special-discriminator-kotlinx-serialization
+          - samples/client/petstore/kotlin-multiplatform-allOf-special-discriminator
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-java@v5.7.0

--- a/samples/client/petstore/kotlin-allOf-special-discriminator-kotlinx-serialization/docs/BirdApi.md
+++ b/samples/client/petstore/kotlin-allOf-special-discriminator-kotlinx-serialization/docs/BirdApi.md
@@ -80,9 +80,9 @@ try {
 ```
 
 ### Parameters
-| **metadata** | [**Bird**](Bird.md)|  | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **metadata** | [**Bird**](Bird.md)|  | |
 | **file** | **java.io.File**|  | |
 
 ### Return type

--- a/samples/client/petstore/kotlin-multiplatform-allOf-special-discriminator/docs/BirdApi.md
+++ b/samples/client/petstore/kotlin-multiplatform-allOf-special-discriminator/docs/BirdApi.md
@@ -80,9 +80,9 @@ try {
 ```
 
 ### Parameters
-| **metadata** | [**Bird**](Bird.md)|  | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **metadata** | [**Bird**](Bird.md)|  | |
 | **file** | **io.ktor.client.request.forms.FormPart&lt;io.ktor.client.request.forms.InputProvider&gt;**|  | |
 
 ### Return type


### PR DESCRIPTION
a follow up pr to https://github.com/OpenAPITools/openapi-generator/pull/24725/

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expands Kotlin samples CI to include two Petstore allOf special-discriminator variants and aligns their docs with current generator output. This increases coverage for `kotlinx-serialization` and multiplatform without changing behavior.

- Adds `samples/client/petstore/kotlin-allOf-special-discriminator-kotlinx-serialization` and `samples/client/petstore/kotlin-multiplatform-allOf-special-discriminator` to the matrix in `.github/workflows/samples-kotlin-client.yaml`.
- Updates `docs/BirdApi.md` in both samples to fix parameter table order; expect a minor CI time increase; no generator or runtime behavior changes.

<sup>Written for commit fdfbd3818780b22c53f05d94d5dfaf9a29d754c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24749?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

