### PR TITLE
[FIX][KOTLIN][SPRING] mark @param:JsonProperty as required in generated models when required in open api spec

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-spring/dataClassReqVar.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/dataClassReqVar.mustache
@@ -5,5 +5,5 @@
     @field:JsonInclude(JsonInclude.Include.{{{vendorExtensions.x-jackson-json-include-policy}}}){{/vendorExtensions.x-jackson-json-include-policy}}{{#vendorExtensions.x-has-json-setter-nulls-skip}}
     @field:JsonSetter(nulls = Nulls.SKIP){{/vendorExtensions.x-has-json-setter-nulls-skip}}{{#vendorExtensions.x-has-json-setter-nulls-fail}}
     @field:JsonSetter(nulls = Nulls.FAIL){{/vendorExtensions.x-has-json-setter-nulls-fail}}
-    @param:JsonProperty("{{{baseName}}}")
+    @param:JsonProperty("{{{baseName}}}", required = true)
     @get:JsonProperty("{{{baseName}}}", required = true){{#isInherited}} override{{/isInherited}} {{>modelMutable}} {{{name}}}: {{#isEnum}}{{#isArray}}{{baseType}}<{{/isArray}}{{classname}}.{{{nameInPascalCase}}}{{#isArray}}>{{/isArray}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{#isNullable}}?{{/isNullable}}{{#defaultValue}} = {{^isNumber}}{{{defaultValue}}}{{/isNumber}}{{#isNumber}}{{{dataType}}}("{{{defaultValue}}}"){{/isNumber}}{{/defaultValue}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/spring/KotlinSpringServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/spring/KotlinSpringServerCodegenTest.java
@@ -7526,7 +7526,25 @@ public class KotlinSpringServerCodegenTest {
         assertThat(itemFile).isNotNull();
         assertFileContains(
                 itemFile.toPath(),
-                "@param:JsonProperty(\"snake_case_value\")\n    @get:JsonProperty(\"snake_case_value\", required = true) val mappedValue"
+                "@param:JsonProperty(\"snake_case_value\", required = true)\n    @get:JsonProperty(\"snake_case_value\", required = true) val mappedValue"
+        );
+    }
+
+    @Test(description = "required vars: @param:JsonProperty must be marked required to keep missing-property failures")
+    public void requiredParamJsonPropertyAnnotationIsMarkedRequired() throws IOException {
+        Map<String, File> files = generateFromContract(
+                "src/test/resources/3_0/kotlin/param-json-property.yaml"
+        );
+
+        File itemFile = files.get("Item.kt");
+        assertThat(itemFile).isNotNull();
+        assertFileContains(
+                itemFile.toPath(),
+                "@param:JsonProperty(\"snake_case_value\", required = true)\n    @get:JsonProperty(\"snake_case_value\", required = true) val snakeCaseValue"
+        );
+        assertFileContains(
+                itemFile.toPath(),
+                "@param:JsonProperty(\"2nd_field\")\n    @get:JsonProperty(\"2nd_field\") val `2ndField`"
         );
     }
 

--- a/samples/server/others/kotlin-springboot/oneOf-discriminator-const/src/main/kotlin/org/openapitools/model/Cat.kt
+++ b/samples/server/others/kotlin-springboot/oneOf-discriminator-const/src/main/kotlin/org/openapitools/model/Cat.kt
@@ -26,11 +26,11 @@ import jakarta.validation.Valid
 data class Cat(
 
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("huntingSkill")
+    @param:JsonProperty("huntingSkill", required = true)
     @get:JsonProperty("huntingSkill", required = true) val huntingSkill: Cat.HuntingSkill,
 
     @field:Valid
-    @param:JsonProperty("petType")
+    @param:JsonProperty("petType", required = true)
     @get:JsonProperty("petType", required = true) override val petType: kotlin.String = "cat"
 ) : Pet {
 

--- a/samples/server/others/kotlin-springboot/oneOf-discriminator-const/src/main/kotlin/org/openapitools/model/Dog.kt
+++ b/samples/server/others/kotlin-springboot/oneOf-discriminator-const/src/main/kotlin/org/openapitools/model/Dog.kt
@@ -27,12 +27,12 @@ data class Dog(
 
     @field:Valid
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("petType")
+    @param:JsonProperty("petType", required = true)
     @get:JsonProperty("petType", required = true) override val petType: kotlin.String = "dog",
 
     @get:Min(value=0)
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("packSize")
+    @param:JsonProperty("packSize", required = true)
     @get:JsonProperty("packSize", required = true) val packSize: kotlin.Int = 0
 ) : Pet {
 

--- a/samples/server/others/kotlin-springboot/oneOf-discriminator/src/main/kotlin/org/openapitools/model/Bird.kt
+++ b/samples/server/others/kotlin-springboot/oneOf-discriminator/src/main/kotlin/org/openapitools/model/Bird.kt
@@ -28,11 +28,11 @@ import jakarta.validation.Valid
 data class Bird(
 
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("discriminator")
+    @param:JsonProperty("discriminator", required = true)
     @get:JsonProperty("discriminator", required = true) override val discriminator: kotlin.String = "BIRD",
 
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("another_discriminator")
+    @param:JsonProperty("another_discriminator", required = true)
     @get:JsonProperty("another_discriminator", required = true) override val anotherDiscriminator: kotlin.String = "ANOTHER_BIRD",
 
     @field:JsonInclude(JsonInclude.Include.NON_NULL)

--- a/samples/server/others/kotlin-springboot/oneOf-discriminator/src/main/kotlin/org/openapitools/model/Robobird.kt
+++ b/samples/server/others/kotlin-springboot/oneOf-discriminator/src/main/kotlin/org/openapitools/model/Robobird.kt
@@ -28,11 +28,11 @@ import jakarta.validation.Valid
 data class Robobird(
 
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("discriminator")
+    @param:JsonProperty("discriminator", required = true)
     @get:JsonProperty("discriminator", required = true) override val discriminator: kotlin.String = "ROBOBIRD",
 
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("another_discriminator")
+    @param:JsonProperty("another_discriminator", required = true)
     @get:JsonProperty("another_discriminator", required = true) override val anotherDiscriminator: kotlin.String = "ANOTHER_ROBOBIRD",
 
     @field:JsonInclude(JsonInclude.Include.NON_NULL)

--- a/samples/server/others/kotlin-springboot/oneOf-enum-discriminator/src/main/kotlin/org/openapitools/model/Car.kt
+++ b/samples/server/others/kotlin-springboot/oneOf-enum-discriminator/src/main/kotlin/org/openapitools/model/Car.kt
@@ -28,11 +28,11 @@ data class Car(
 
     @field:Valid
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("vehicleType")
+    @param:JsonProperty("vehicleType", required = true)
     @get:JsonProperty("vehicleType", required = true) override val vehicleType: VehicleType = VehicleType.CAR,
 
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("numDoors")
+    @param:JsonProperty("numDoors", required = true)
     @get:JsonProperty("numDoors", required = true) val numDoors: kotlin.Int
 ) : Vehicle {
 

--- a/samples/server/others/kotlin-springboot/oneOf-enum-discriminator/src/main/kotlin/org/openapitools/model/Truck.kt
+++ b/samples/server/others/kotlin-springboot/oneOf-enum-discriminator/src/main/kotlin/org/openapitools/model/Truck.kt
@@ -28,11 +28,11 @@ data class Truck(
 
     @field:Valid
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("vehicleType")
+    @param:JsonProperty("vehicleType", required = true)
     @get:JsonProperty("vehicleType", required = true) override val vehicleType: VehicleType = VehicleType.TRUCK,
 
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("payloadCapacity")
+    @param:JsonProperty("payloadCapacity", required = true)
     @get:JsonProperty("payloadCapacity", required = true) val payloadCapacity: java.math.BigDecimal
 ) : Vehicle {
 

--- a/samples/server/petstore/kotlin-spring-cloud-4/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-spring-cloud-4/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -27,10 +27,10 @@ import jakarta.validation.Valid
  */
 data class Pet(
 
-    @param:JsonProperty("name")
+    @param:JsonProperty("name", required = true)
     @get:JsonProperty("name", required = true) val name: kotlin.String,
 
-    @param:JsonProperty("photoUrls")
+    @param:JsonProperty("photoUrls", required = true)
     @get:JsonProperty("photoUrls", required = true) val photoUrls: kotlin.collections.List<kotlin.String>,
 
     @param:JsonProperty("id")

--- a/samples/server/petstore/kotlin-spring-cloud/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-spring-cloud/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -31,11 +31,11 @@ import javax.validation.Valid
 data class Pet(
 
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("name")
+    @param:JsonProperty("name", required = true)
     @get:JsonProperty("name", required = true) val name: kotlin.String,
 
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("photoUrls")
+    @param:JsonProperty("photoUrls", required = true)
     @get:JsonProperty("photoUrls", required = true) val photoUrls: kotlin.collections.List<kotlin.String>,
 
     @field:JsonInclude(JsonInclude.Include.NON_NULL)

--- a/samples/server/petstore/kotlin-spring-declarative-interface-bean-validation/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-spring-declarative-interface-bean-validation/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -33,12 +33,12 @@ data class Pet(
 
     @Schema(example = "doggie", required = true, description = "")
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("name")
+    @param:JsonProperty("name", required = true)
     @get:JsonProperty("name", required = true) val name: kotlin.String,
 
     @Schema(required = true, description = "")
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("photoUrls")
+    @param:JsonProperty("photoUrls", required = true)
     @get:JsonProperty("photoUrls", required = true) val photoUrls: kotlin.collections.List<kotlin.String>,
 
     @Schema(description = "")

--- a/samples/server/petstore/kotlin-spring-declarative-interface-reactive-coroutines/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-spring-declarative-interface-reactive-coroutines/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -33,12 +33,12 @@ data class Pet(
 
     @Schema(example = "doggie", required = true, description = "")
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("name")
+    @param:JsonProperty("name", required = true)
     @get:JsonProperty("name", required = true) val name: kotlin.String,
 
     @Schema(required = true, description = "")
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("photoUrls")
+    @param:JsonProperty("photoUrls", required = true)
     @get:JsonProperty("photoUrls", required = true) val photoUrls: kotlin.collections.List<kotlin.String>,
 
     @Schema(description = "")

--- a/samples/server/petstore/kotlin-spring-declarative-interface-reactive-reactor-wrapped/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-spring-declarative-interface-reactive-reactor-wrapped/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -33,12 +33,12 @@ data class Pet(
 
     @Schema(example = "doggie", required = true, description = "")
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("name")
+    @param:JsonProperty("name", required = true)
     @get:JsonProperty("name", required = true) val name: kotlin.String,
 
     @Schema(required = true, description = "")
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("photoUrls")
+    @param:JsonProperty("photoUrls", required = true)
     @get:JsonProperty("photoUrls", required = true) val photoUrls: kotlin.collections.List<kotlin.String>,
 
     @Schema(description = "")

--- a/samples/server/petstore/kotlin-spring-declarative-interface-wrapped/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-spring-declarative-interface-wrapped/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -33,12 +33,12 @@ data class Pet(
 
     @Schema(example = "doggie", required = true, description = "")
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("name")
+    @param:JsonProperty("name", required = true)
     @get:JsonProperty("name", required = true) val name: kotlin.String,
 
     @Schema(required = true, description = "")
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("photoUrls")
+    @param:JsonProperty("photoUrls", required = true)
     @get:JsonProperty("photoUrls", required = true) val photoUrls: kotlin.collections.List<kotlin.String>,
 
     @Schema(description = "")

--- a/samples/server/petstore/kotlin-spring-declarative-interface/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-spring-declarative-interface/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -33,12 +33,12 @@ data class Pet(
 
     @Schema(example = "doggie", required = true, description = "")
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("name")
+    @param:JsonProperty("name", required = true)
     @get:JsonProperty("name", required = true) val name: kotlin.String,
 
     @Schema(required = true, description = "")
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("photoUrls")
+    @param:JsonProperty("photoUrls", required = true)
     @get:JsonProperty("photoUrls", required = true) val photoUrls: kotlin.collections.List<kotlin.String>,
 
     @Schema(description = "")

--- a/samples/server/petstore/kotlin-spring-default/src/main/kotlin/org/openapitools/model/AnyOfUserOrPet.kt
+++ b/samples/server/petstore/kotlin-spring-default/src/main/kotlin/org/openapitools/model/AnyOfUserOrPet.kt
@@ -42,17 +42,17 @@ data class AnyOfUserOrPet(
 
     @Schema(required = true, description = "")
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("username")
+    @param:JsonProperty("username", required = true)
     @get:JsonProperty("username", required = true) val username: kotlin.String,
 
     @Schema(example = "doggie", required = true, description = "")
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("name")
+    @param:JsonProperty("name", required = true)
     @get:JsonProperty("name", required = true) val name: kotlin.String,
 
     @Schema(required = true, description = "")
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("photoUrls")
+    @param:JsonProperty("photoUrls", required = true)
     @get:JsonProperty("photoUrls", required = true) val photoUrls: kotlin.collections.List<kotlin.String>,
 
     @Schema(description = "")

--- a/samples/server/petstore/kotlin-spring-default/src/main/kotlin/org/openapitools/model/AnyOfUserOrPetOrArrayString.kt
+++ b/samples/server/petstore/kotlin-spring-default/src/main/kotlin/org/openapitools/model/AnyOfUserOrPetOrArrayString.kt
@@ -42,17 +42,17 @@ data class AnyOfUserOrPetOrArrayString(
 
     @Schema(required = true, description = "")
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("username")
+    @param:JsonProperty("username", required = true)
     @get:JsonProperty("username", required = true) val username: kotlin.String,
 
     @Schema(example = "doggie", required = true, description = "")
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("name")
+    @param:JsonProperty("name", required = true)
     @get:JsonProperty("name", required = true) val name: kotlin.String,
 
     @Schema(required = true, description = "")
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("photoUrls")
+    @param:JsonProperty("photoUrls", required = true)
     @get:JsonProperty("photoUrls", required = true) val photoUrls: kotlin.collections.List<kotlin.String>,
 
     @Schema(description = "")

--- a/samples/server/petstore/kotlin-spring-default/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-spring-default/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -33,12 +33,12 @@ data class Pet(
 
     @Schema(example = "doggie", required = true, description = "")
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("name")
+    @param:JsonProperty("name", required = true)
     @get:JsonProperty("name", required = true) val name: kotlin.String,
 
     @Schema(required = true, description = "")
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("photoUrls")
+    @param:JsonProperty("photoUrls", required = true)
     @get:JsonProperty("photoUrls", required = true) val photoUrls: kotlin.collections.List<kotlin.String>,
 
     @Schema(description = "")

--- a/samples/server/petstore/kotlin-spring-default/src/main/kotlin/org/openapitools/model/User.kt
+++ b/samples/server/petstore/kotlin-spring-default/src/main/kotlin/org/openapitools/model/User.kt
@@ -33,7 +33,7 @@ data class User(
 
     @Schema(required = true, description = "")
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("username")
+    @param:JsonProperty("username", required = true)
     @get:JsonProperty("username", required = true) val username: kotlin.String,
 
     @Schema(description = "")

--- a/samples/server/petstore/kotlin-spring-sealed-interfaces/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-spring-sealed-interfaces/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -34,11 +34,11 @@ import jakarta.validation.Valid
 data class Pet(
 
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("name")
+    @param:JsonProperty("name", required = true)
     @get:JsonProperty("name", required = true) val name: kotlin.String,
 
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("photoUrls")
+    @param:JsonProperty("photoUrls", required = true)
     @get:JsonProperty("photoUrls", required = true) val photoUrls: kotlin.collections.List<kotlin.String>,
 
     @field:JsonInclude(JsonInclude.Include.NON_NULL)

--- a/samples/server/petstore/kotlin-springboot-3-no-response-entity/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-springboot-3-no-response-entity/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -31,11 +31,11 @@ import jakarta.validation.Valid
 data class Pet(
 
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("name")
+    @param:JsonProperty("name", required = true)
     @get:JsonProperty("name", required = true) val name: kotlin.String,
 
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("photoUrls")
+    @param:JsonProperty("photoUrls", required = true)
     @get:JsonProperty("photoUrls", required = true) val photoUrls: kotlin.collections.List<kotlin.String>,
 
     @field:JsonInclude(JsonInclude.Include.NON_NULL)

--- a/samples/server/petstore/kotlin-springboot-3/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-springboot-3/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -31,11 +31,11 @@ import jakarta.validation.Valid
 data class Pet(
 
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("name")
+    @param:JsonProperty("name", required = true)
     @get:JsonProperty("name", required = true) val name: kotlin.String,
 
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("photoUrls")
+    @param:JsonProperty("photoUrls", required = true)
     @get:JsonProperty("photoUrls", required = true) val photoUrls: kotlin.collections.List<kotlin.String>,
 
     @field:JsonSetter(nulls = Nulls.SKIP)

--- a/samples/server/petstore/kotlin-springboot-4/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-springboot-4/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -31,11 +31,11 @@ import jakarta.validation.Valid
 data class Pet(
 
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("name")
+    @param:JsonProperty("name", required = true)
     @get:JsonProperty("name", required = true) val name: kotlin.String,
 
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("photoUrls")
+    @param:JsonProperty("photoUrls", required = true)
     @get:JsonProperty("photoUrls", required = true) val photoUrls: kotlin.collections.List<kotlin.String>,
 
     @field:JsonInclude(JsonInclude.Include.NON_NULL)

--- a/samples/server/petstore/kotlin-springboot-additionalproperties/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-springboot-additionalproperties/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -31,11 +31,11 @@ import jakarta.validation.Valid
 data class Pet(
 
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("name")
+    @param:JsonProperty("name", required = true)
     @get:JsonProperty("name", required = true) val name: kotlin.String,
 
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("photoUrls")
+    @param:JsonProperty("photoUrls", required = true)
     @get:JsonProperty("photoUrls", required = true) val photoUrls: kotlin.collections.List<kotlin.String>,
 
     @field:JsonInclude(JsonInclude.Include.NON_NULL)

--- a/samples/server/petstore/kotlin-springboot-bigdecimal-default/src/main/kotlin/org/openapitools/model/Apa.kt
+++ b/samples/server/petstore/kotlin-springboot-bigdecimal-default/src/main/kotlin/org/openapitools/model/Apa.kt
@@ -29,12 +29,12 @@ data class Apa(
 
     @Schema(required = true, description = "")
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("bepa")
+    @param:JsonProperty("bepa", required = true)
     @get:JsonProperty("bepa", required = true) val bepa: java.math.BigDecimal = java.math.BigDecimal("0"),
 
     @Schema(required = true, description = "")
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("cepa")
+    @param:JsonProperty("cepa", required = true)
     @get:JsonProperty("cepa", required = true) val cepa: java.math.BigDecimal = java.math.BigDecimal("6.28318"),
 
     @Schema(description = "")

--- a/samples/server/petstore/kotlin-springboot-delegate-nodefaults/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-springboot-delegate-nodefaults/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -33,12 +33,12 @@ data class Pet(
 
     @Schema(example = "doggie", required = true, description = "")
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("name")
+    @param:JsonProperty("name", required = true)
     @get:JsonProperty("name", required = true) val name: kotlin.String,
 
     @Schema(required = true, description = "")
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("photoUrls")
+    @param:JsonProperty("photoUrls", required = true)
     @get:JsonProperty("photoUrls", required = true) val photoUrls: kotlin.collections.List<kotlin.String>,
 
     @Schema(description = "")

--- a/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -33,12 +33,12 @@ data class Pet(
 
     @Schema(example = "doggie", required = true, description = "")
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("name")
+    @param:JsonProperty("name", required = true)
     @get:JsonProperty("name", required = true) val name: kotlin.String,
 
     @Schema(required = true, description = "")
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("photoUrls")
+    @param:JsonProperty("photoUrls", required = true)
     @get:JsonProperty("photoUrls", required = true) val photoUrls: kotlin.collections.List<kotlin.String>,
 
     @Schema(description = "")

--- a/samples/server/petstore/kotlin-springboot-include-http-request-context-delegate/src/main/kotlin/org/openapitools/model/Cat.kt
+++ b/samples/server/petstore/kotlin-springboot-include-http-request-context-delegate/src/main/kotlin/org/openapitools/model/Cat.kt
@@ -38,17 +38,17 @@ data class Cat(
 
     @ApiModelProperty(required = true, value = "")
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("name")
+    @param:JsonProperty("name", required = true)
     @get:JsonProperty("name", required = true) override val name: kotlin.String,
 
     @ApiModelProperty(required = true, value = "")
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("photoUrls")
+    @param:JsonProperty("photoUrls", required = true)
     @get:JsonProperty("photoUrls", required = true) override val photoUrls: kotlin.collections.List<kotlin.String>,
 
     @ApiModelProperty(required = true, value = "")
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("petType")
+    @param:JsonProperty("petType", required = true)
     @get:JsonProperty("petType", required = true) override val petType: kotlin.String,
 
     @ApiModelProperty(value = "")

--- a/samples/server/petstore/kotlin-springboot-include-http-request-context-delegate/src/main/kotlin/org/openapitools/model/Dog.kt
+++ b/samples/server/petstore/kotlin-springboot-include-http-request-context-delegate/src/main/kotlin/org/openapitools/model/Dog.kt
@@ -39,32 +39,32 @@ data class Dog(
 
     @ApiModelProperty(required = true, value = "")
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("bark")
+    @param:JsonProperty("bark", required = true)
     @get:JsonProperty("bark", required = true) val bark: kotlin.Boolean,
 
     @ApiModelProperty(required = true, value = "")
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("breed")
+    @param:JsonProperty("breed", required = true)
     @get:JsonProperty("breed", required = true) val breed: Dog.Breed,
 
     @ApiModelProperty(required = true, value = "Whether the dog enjoys fetching")
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("likesFetch")
+    @param:JsonProperty("likesFetch", required = true)
     @get:JsonProperty("likesFetch", required = true) override val likesFetch: kotlin.Boolean,
 
     @ApiModelProperty(required = true, value = "")
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("name")
+    @param:JsonProperty("name", required = true)
     @get:JsonProperty("name", required = true) override val name: kotlin.String,
 
     @ApiModelProperty(required = true, value = "")
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("photoUrls")
+    @param:JsonProperty("photoUrls", required = true)
     @get:JsonProperty("photoUrls", required = true) override val photoUrls: kotlin.collections.List<kotlin.String>,
 
     @ApiModelProperty(required = true, value = "")
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("petType")
+    @param:JsonProperty("petType", required = true)
     @get:JsonProperty("petType", required = true) override val petType: kotlin.String,
 
     @ApiModelProperty(value = "")

--- a/samples/server/petstore/kotlin-springboot-integer-enum/src/main/kotlin/org/openapitools/model/ApiError.kt
+++ b/samples/server/petstore/kotlin-springboot-integer-enum/src/main/kotlin/org/openapitools/model/ApiError.kt
@@ -27,7 +27,7 @@ import jakarta.validation.Valid
 data class ApiError(
 
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("errorCode")
+    @param:JsonProperty("errorCode", required = true)
     @get:JsonProperty("errorCode", required = true) val errorCode: ApiError.ErrorCode,
 
     @field:Valid

--- a/samples/server/petstore/kotlin-springboot-modelMutable/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-springboot-modelMutable/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -33,12 +33,12 @@ data class Pet(
 
     @Schema(example = "doggie", required = true, description = "")
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("name")
+    @param:JsonProperty("name", required = true)
     @get:JsonProperty("name", required = true) var name: kotlin.String,
 
     @Schema(required = true, description = "")
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("photoUrls")
+    @param:JsonProperty("photoUrls", required = true)
     @get:JsonProperty("photoUrls", required = true) var photoUrls: kotlin.collections.MutableList<kotlin.String>,
 
     @Schema(description = "")

--- a/samples/server/petstore/kotlin-springboot-no-response-entity-delegate/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-springboot-no-response-entity-delegate/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -31,11 +31,11 @@ import javax.validation.Valid
 data class Pet(
 
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("name")
+    @param:JsonProperty("name", required = true)
     @get:JsonProperty("name", required = true) val name: kotlin.String,
 
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("photoUrls")
+    @param:JsonProperty("photoUrls", required = true)
     @get:JsonProperty("photoUrls", required = true) val photoUrls: kotlin.collections.List<kotlin.String>,
 
     @field:JsonInclude(JsonInclude.Include.NON_NULL)

--- a/samples/server/petstore/kotlin-springboot-no-response-entity/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-springboot-no-response-entity/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -31,11 +31,11 @@ import javax.validation.Valid
 data class Pet(
 
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("name")
+    @param:JsonProperty("name", required = true)
     @get:JsonProperty("name", required = true) val name: kotlin.String,
 
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("photoUrls")
+    @param:JsonProperty("photoUrls", required = true)
     @get:JsonProperty("photoUrls", required = true) val photoUrls: kotlin.collections.List<kotlin.String>,
 
     @field:JsonInclude(JsonInclude.Include.NON_NULL)

--- a/samples/server/petstore/kotlin-springboot-paged-model/src/main/kotlin/org/openapitools/model/PageMeta.kt
+++ b/samples/server/petstore/kotlin-springboot-paged-model/src/main/kotlin/org/openapitools/model/PageMeta.kt
@@ -23,19 +23,19 @@ import jakarta.validation.Valid
 data class PageMeta(
 
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("size")
+    @param:JsonProperty("size", required = true)
     @get:JsonProperty("size", required = true) val propertySize: kotlin.Long,
 
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("number")
+    @param:JsonProperty("number", required = true)
     @get:JsonProperty("number", required = true) val number: kotlin.Long,
 
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("totalElements")
+    @param:JsonProperty("totalElements", required = true)
     @get:JsonProperty("totalElements", required = true) val totalElements: kotlin.Long,
 
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("totalPages")
+    @param:JsonProperty("totalPages", required = true)
     @get:JsonProperty("totalPages", required = true) val totalPages: kotlin.Long
 ) : java.io.Serializable {
 

--- a/samples/server/petstore/kotlin-springboot-paged-model/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-springboot-paged-model/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -24,7 +24,7 @@ import jakarta.validation.Valid
 data class Pet(
 
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("name")
+    @param:JsonProperty("name", required = true)
     @get:JsonProperty("name", required = true) val name: kotlin.String,
 
     @field:JsonInclude(JsonInclude.Include.NON_NULL)

--- a/samples/server/petstore/kotlin-springboot-reactive-without-flow/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-springboot-reactive-without-flow/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -33,12 +33,12 @@ data class Pet(
 
     @Schema(example = "doggie", required = true, description = "")
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("name")
+    @param:JsonProperty("name", required = true)
     @get:JsonProperty("name", required = true) val name: kotlin.String,
 
     @Schema(required = true, description = "")
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("photoUrls")
+    @param:JsonProperty("photoUrls", required = true)
     @get:JsonProperty("photoUrls", required = true) val photoUrls: kotlin.collections.List<kotlin.String>,
 
     @Schema(description = "")

--- a/samples/server/petstore/kotlin-springboot-reactive/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-springboot-reactive/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -33,12 +33,12 @@ data class Pet(
 
     @Schema(example = "doggie", required = true, description = "")
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("name")
+    @param:JsonProperty("name", required = true)
     @get:JsonProperty("name", required = true) val name: kotlin.String,
 
     @Schema(required = true, description = "")
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("photoUrls")
+    @param:JsonProperty("photoUrls", required = true)
     @get:JsonProperty("photoUrls", required = true) val photoUrls: kotlin.collections.List<kotlin.String>,
 
     @Schema(description = "")

--- a/samples/server/petstore/kotlin-springboot-request-cookie/src/main/kotlin/org/openapitools/model/Cat.kt
+++ b/samples/server/petstore/kotlin-springboot-request-cookie/src/main/kotlin/org/openapitools/model/Cat.kt
@@ -27,7 +27,7 @@ data class Cat(
 
     @Schema(required = true, description = "")
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("className")
+    @param:JsonProperty("className", required = true)
     @get:JsonProperty("className", required = true) override val className: kotlin.String,
 
     @Schema(description = "")

--- a/samples/server/petstore/kotlin-springboot-request-cookie/src/main/kotlin/org/openapitools/model/Category.kt
+++ b/samples/server/petstore/kotlin-springboot-request-cookie/src/main/kotlin/org/openapitools/model/Category.kt
@@ -25,7 +25,7 @@ data class Category(
 
     @Schema(required = true, description = "")
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("name")
+    @param:JsonProperty("name", required = true)
     @get:JsonProperty("name", required = true) val name: kotlin.String = "default-name",
 
     @Schema(description = "")

--- a/samples/server/petstore/kotlin-springboot-request-cookie/src/main/kotlin/org/openapitools/model/Dog.kt
+++ b/samples/server/petstore/kotlin-springboot-request-cookie/src/main/kotlin/org/openapitools/model/Dog.kt
@@ -27,7 +27,7 @@ data class Dog(
 
     @Schema(required = true, description = "")
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("className")
+    @param:JsonProperty("className", required = true)
     @get:JsonProperty("className", required = true) override val className: kotlin.String,
 
     @Schema(description = "")

--- a/samples/server/petstore/kotlin-springboot-request-cookie/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-springboot-request-cookie/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -33,12 +33,12 @@ data class Pet(
 
     @Schema(example = "doggie", required = true, description = "")
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("name")
+    @param:JsonProperty("name", required = true)
     @get:JsonProperty("name", required = true) val name: kotlin.String,
 
     @Schema(required = true, description = "")
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("photoUrls")
+    @param:JsonProperty("photoUrls", required = true)
     @get:JsonProperty("photoUrls", required = true) val photoUrls: kotlin.collections.Set<kotlin.String>,
 
     @Schema(description = "")

--- a/samples/server/petstore/kotlin-springboot-sort-validation/src/main/kotlin/org/openapitools/model/NullableModel.kt
+++ b/samples/server/petstore/kotlin-springboot-sort-validation/src/main/kotlin/org/openapitools/model/NullableModel.kt
@@ -26,11 +26,11 @@ import jakarta.validation.Valid
 data class NullableModel(
 
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("requiredNonNullable")
+    @param:JsonProperty("requiredNonNullable", required = true)
     @get:JsonProperty("requiredNonNullable", required = true) val requiredNonNullable: kotlin.String,
 
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("requiredNullable")
+    @param:JsonProperty("requiredNullable", required = true)
     @get:JsonProperty("requiredNullable", required = true) val requiredNullable: kotlin.String?,
 
     @field:JsonInclude(JsonInclude.Include.NON_NULL)

--- a/samples/server/petstore/kotlin-springboot-sort-validation/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-springboot-sort-validation/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -24,7 +24,7 @@ import jakarta.validation.Valid
 data class Pet(
 
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("name")
+    @param:JsonProperty("name", required = true)
     @get:JsonProperty("name", required = true) val name: kotlin.String,
 
     @field:JsonInclude(JsonInclude.Include.NON_NULL)

--- a/samples/server/petstore/kotlin-springboot-source-swagger1/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-springboot-source-swagger1/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -33,12 +33,12 @@ data class Pet(
 
     @ApiModelProperty(example = "doggie", required = true, value = "")
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("name")
+    @param:JsonProperty("name", required = true)
     @get:JsonProperty("name", required = true) val name: kotlin.String,
 
     @ApiModelProperty(required = true, value = "")
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("photoUrls")
+    @param:JsonProperty("photoUrls", required = true)
     @get:JsonProperty("photoUrls", required = true) val photoUrls: kotlin.collections.List<kotlin.String>,
 
     @ApiModelProperty(value = "")

--- a/samples/server/petstore/kotlin-springboot-source-swagger2/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-springboot-source-swagger2/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -33,12 +33,12 @@ data class Pet(
 
     @Schema(example = "doggie", required = true, description = "")
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("name")
+    @param:JsonProperty("name", required = true)
     @get:JsonProperty("name", required = true) val name: kotlin.String,
 
     @Schema(required = true, description = "")
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("photoUrls")
+    @param:JsonProperty("photoUrls", required = true)
     @get:JsonProperty("photoUrls", required = true) val photoUrls: kotlin.collections.List<kotlin.String>,
 
     @Schema(description = "")

--- a/samples/server/petstore/kotlin-springboot-x-kotlin-implements/src/main/kotlin/org/openapitools/model/Cat.kt
+++ b/samples/server/petstore/kotlin-springboot-x-kotlin-implements/src/main/kotlin/org/openapitools/model/Cat.kt
@@ -38,17 +38,17 @@ data class Cat(
 
     @ApiModelProperty(required = true, value = "")
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("name")
+    @param:JsonProperty("name", required = true)
     @get:JsonProperty("name", required = true) override val name: kotlin.String,
 
     @ApiModelProperty(required = true, value = "")
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("photoUrls")
+    @param:JsonProperty("photoUrls", required = true)
     @get:JsonProperty("photoUrls", required = true) override val photoUrls: kotlin.collections.List<kotlin.String>,
 
     @ApiModelProperty(required = true, value = "")
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("petType")
+    @param:JsonProperty("petType", required = true)
     @get:JsonProperty("petType", required = true) override val petType: kotlin.String,
 
     @ApiModelProperty(value = "")

--- a/samples/server/petstore/kotlin-springboot-x-kotlin-implements/src/main/kotlin/org/openapitools/model/Dog.kt
+++ b/samples/server/petstore/kotlin-springboot-x-kotlin-implements/src/main/kotlin/org/openapitools/model/Dog.kt
@@ -39,32 +39,32 @@ data class Dog(
 
     @ApiModelProperty(required = true, value = "")
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("bark")
+    @param:JsonProperty("bark", required = true)
     @get:JsonProperty("bark", required = true) override val bark: kotlin.Boolean,
 
     @ApiModelProperty(required = true, value = "")
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("breed")
+    @param:JsonProperty("breed", required = true)
     @get:JsonProperty("breed", required = true) override val breed: Dog.Breed,
 
     @ApiModelProperty(required = true, value = "Whether the dog enjoys fetching")
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("likesFetch")
+    @param:JsonProperty("likesFetch", required = true)
     @get:JsonProperty("likesFetch", required = true) override val likesFetch: kotlin.Boolean,
 
     @ApiModelProperty(required = true, value = "")
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("name")
+    @param:JsonProperty("name", required = true)
     @get:JsonProperty("name", required = true) override val name: kotlin.String,
 
     @ApiModelProperty(required = true, value = "")
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("photoUrls")
+    @param:JsonProperty("photoUrls", required = true)
     @get:JsonProperty("photoUrls", required = true) override val photoUrls: kotlin.collections.List<kotlin.String>,
 
     @ApiModelProperty(required = true, value = "")
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("petType")
+    @param:JsonProperty("petType", required = true)
     @get:JsonProperty("petType", required = true) override val petType: kotlin.String,
 
     @ApiModelProperty(value = "")

--- a/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -32,11 +32,11 @@ import javax.validation.Valid
 data class Pet(
 
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("name")
+    @param:JsonProperty("name", required = true)
     @get:JsonProperty("name", required = true) val name: kotlin.String,
 
     @field:JsonInclude(JsonInclude.Include.ALWAYS)
-    @param:JsonProperty("photoUrls")
+    @param:JsonProperty("photoUrls", required = true)
     @get:JsonProperty("photoUrls", required = true) val photoUrls: kotlin.collections.List<kotlin.String>,
 
     @field:JsonInclude(JsonInclude.Include.NON_EMPTY)


### PR DESCRIPTION
Fixes a kotlin-spring regression introduced in v7.24.0 (by #24036), where required primitive properties could be silently defaulted when missing in request JSON.

### Related issue

Fixes #24753

### What changed

- Updated required kotlin-spring model vars to emit:
  - `@param:JsonProperty("...", required = true)`
- Added/updated kotlin-spring generator tests to assert:
  - required vars use `@param:JsonProperty(..., required = true)`
  - optional vars still use plain `@param:JsonProperty("...")`

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@karismann (2019/03) @Zomzog (2019/04) @andrewemery (2019/10) @4brunu (2019/11) @yutaka0m (2020/03) @stefankoppier (2022/06) @e5l (2024/10)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores required-property validation in generated Kotlin Spring models. Previously (since v7.24.0), missing required primitives could be silently defaulted because constructor params used plain @param:JsonProperty; now required vars emit @param:JsonProperty(..., required = true) so Jackson fails on missing fields.

- Behavior: required vars add `required = true` on `@param:JsonProperty`; optional vars remain unchanged. Aligns with existing `@get:JsonProperty(..., required = true)`.
- Diff hotspots: `dataClassReqVar.mustache` template updated; tests added to assert required/optional behavior; samples regenerated.
- Migration: regenerate `kotlin-spring` server models to restore missing-field failures. No runtime/config changes.

<sup>Written for commit 0ad8aff2d58e89fa24bd5aa212d9b2b71a4247c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24754?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

