### PR TITLE
fix(kotlin-client): emit parameter table header before first parameter

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-retrofit2/api_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-retrofit2/api_doc.mustache
@@ -52,10 +52,10 @@ launch(Dispatchers.IO) {
 This endpoint does not need any parameter.
 {{/allParams}}
 {{#allParams}}
-{{#-last}}
+{{#-first}}
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
-{{/-last}}
+{{/-first}}
 | **{{paramName}}** | {{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}{{#isFile}}**{{dataType}}**{{/isFile}}{{^isFile}}{{#generateModelDocs}}[**{{dataType}}**]({{baseType}}.md){{/generateModelDocs}}{{^generateModelDocs}}**{{dataType}}**{{/generateModelDocs}}{{/isFile}}{{/isPrimitiveType}}| {{description}} |{{^required}} [optional]{{/required}}{{#defaultValue}} [default to {{.}}]{{/defaultValue}}{{#allowableValues}} [enum: {{#values}}{{{.}}}{{^-last}}, {{/-last}}{{/values}}]{{/allowableValues}} |
 {{/allParams}}
 

--- a/samples/client/echo_api/kotlin-model-prefix-type-mappings/docs/FormApi.md
+++ b/samples/client/echo_api/kotlin-model-prefix-type-mappings/docs/FormApi.md
@@ -32,10 +32,10 @@ launch(Dispatchers.IO) {
 ```
 
 ### Parameters
-| **integerForm** | **kotlin.Int**|  | [optional] |
-| **booleanForm** | **kotlin.Boolean**|  | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **integerForm** | **kotlin.Int**|  | [optional] |
+| **booleanForm** | **kotlin.Boolean**|  | [optional] |
 | **stringForm** | **kotlin.String**|  | [optional] |
 
 ### Return type
@@ -78,13 +78,13 @@ launch(Dispatchers.IO) {
 ```
 
 ### Parameters
+| Name | Type | Description  | Notes |
+| ------------- | ------------- | ------------- | ------------- |
 | **form1** | **kotlin.String**|  | [optional] |
 | **form2** | **kotlin.Int**|  | [optional] |
 | **form3** | **kotlin.String**|  | [optional] |
 | **form4** | **kotlin.Boolean**|  | [optional] |
 | **id** | **kotlin.Long**|  | [optional] |
-| Name | Type | Description  | Notes |
-| ------------- | ------------- | ------------- | ------------- |
 | **name** | **kotlin.String**|  | [optional] |
 
 ### Return type

--- a/samples/client/echo_api/kotlin-model-prefix-type-mappings/docs/HeaderApi.md
+++ b/samples/client/echo_api/kotlin-model-prefix-type-mappings/docs/HeaderApi.md
@@ -33,12 +33,12 @@ launch(Dispatchers.IO) {
 ```
 
 ### Parameters
+| Name | Type | Description  | Notes |
+| ------------- | ------------- | ------------- | ------------- |
 | **integerHeader** | **kotlin.Int**|  | [optional] |
 | **booleanHeader** | **kotlin.Boolean**|  | [optional] |
 | **stringHeader** | **kotlin.String**|  | [optional] |
 | **enumNonrefStringHeader** | **kotlin.String**|  | [optional] [enum: success, failure, unclassified] |
-| Name | Type | Description  | Notes |
-| ------------- | ------------- | ------------- | ------------- |
 | **enumRefStringHeader** | [**ApiStringEnumRef**](.md)|  | [optional] [enum: success, failure, unclassified] |
 
 ### Return type

--- a/samples/client/echo_api/kotlin-model-prefix-type-mappings/docs/PathApi.md
+++ b/samples/client/echo_api/kotlin-model-prefix-type-mappings/docs/PathApi.md
@@ -32,11 +32,11 @@ launch(Dispatchers.IO) {
 ```
 
 ### Parameters
+| Name | Type | Description  | Notes |
+| ------------- | ------------- | ------------- | ------------- |
 | **pathString** | **kotlin.String**|  | |
 | **pathInteger** | **kotlin.Int**|  | |
 | **enumNonrefStringPath** | **kotlin.String**|  | [enum: success, failure, unclassified] |
-| Name | Type | Description  | Notes |
-| ------------- | ------------- | ------------- | ------------- |
 | **enumRefStringPath** | [**ApiStringEnumRef**](.md)|  | [enum: success, failure, unclassified] |
 
 ### Return type

--- a/samples/client/echo_api/kotlin-model-prefix-type-mappings/docs/QueryApi.md
+++ b/samples/client/echo_api/kotlin-model-prefix-type-mappings/docs/QueryApi.md
@@ -35,9 +35,9 @@ launch(Dispatchers.IO) {
 ```
 
 ### Parameters
-| **enumNonrefStringQuery** | **kotlin.String**|  | [optional] [enum: success, failure, unclassified] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **enumNonrefStringQuery** | **kotlin.String**|  | [optional] [enum: success, failure, unclassified] |
 | **enumRefStringQuery** | [**ApiStringEnumRef**](.md)|  | [optional] [enum: success, failure, unclassified] |
 
 ### Return type
@@ -77,10 +77,10 @@ launch(Dispatchers.IO) {
 ```
 
 ### Parameters
-| **datetimeQuery** | **java.time.OffsetDateTime**|  | [optional] |
-| **dateQuery** | **java.time.LocalDate**|  | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **datetimeQuery** | **java.time.OffsetDateTime**|  | [optional] |
+| **dateQuery** | **java.time.LocalDate**|  | [optional] |
 | **stringQuery** | **kotlin.String**|  | [optional] |
 
 ### Return type
@@ -120,10 +120,10 @@ launch(Dispatchers.IO) {
 ```
 
 ### Parameters
-| **integerQuery** | **kotlin.Int**|  | [optional] |
-| **booleanQuery** | **kotlin.Boolean**|  | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **integerQuery** | **kotlin.Int**|  | [optional] |
+| **booleanQuery** | **kotlin.Boolean**|  | [optional] |
 | **stringQuery** | **kotlin.String**|  | [optional] |
 
 ### Return type

--- a/samples/client/petstore/kotlin-default-values-jvm-retrofit2/docs/DefaultApi.md
+++ b/samples/client/petstore/kotlin-default-values-jvm-retrofit2/docs/DefaultApi.md
@@ -55,6 +55,8 @@ webService.test(pi0, pi1, pn0, pn1, qi0, qi1, qi2, qi3, qn0, qn1, qn2, qn3, hi0,
 ```
 
 ### Parameters
+| Name | Type | Description  | Notes |
+| ------------- | ------------- | ------------- | ------------- |
 | **pi0** | **kotlin.Int**|  | [default to 10] |
 | **pi1** | **kotlin.Int**|  | |
 | **pn0** | **java.math.BigDecimal**|  | [default to 10.0] |
@@ -83,8 +85,6 @@ webService.test(pi0, pi1, pn0, pn1, qi0, qi1, qi2, qi3, qn0, qn1, qn2, qn3, hi0,
 | **fn1** | **java.math.BigDecimal**|  | [default to 71.0] |
 | **fn2** | **java.math.BigDecimal**|  | [optional] |
 | **fn3** | **java.math.BigDecimal**|  | |
-| Name | Type | Description  | Notes |
-| ------------- | ------------- | ------------- | ------------- |
 | **fn4** | [**kotlin.collections.List&lt;kotlin.String&gt;**](kotlin.String.md)|  | |
 
 ### Return type

--- a/samples/client/petstore/kotlin-jvm-jackson/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-jvm-jackson/docs/PetApi.md
@@ -72,9 +72,9 @@ webService.deletePet(petId, apiKey)
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| Pet id to delete | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| Pet id to delete | |
 | **apiKey** | **kotlin.String**|  | [optional] |
 
 ### Return type
@@ -260,10 +260,10 @@ webService.updatePetWithForm(petId, name, status)
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
-| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
+| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | **status** | **kotlin.String**| Updated status of the pet | [optional] |
 
 ### Return type
@@ -301,10 +301,10 @@ val result : ModelApiResponse = webService.uploadFile(petId, additionalMetadata,
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet to update | |
-| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet to update | |
+| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | **file** | **java.io.File**| file to upload | [optional] |
 
 ### Return type

--- a/samples/client/petstore/kotlin-jvm-jackson/docs/UserApi.md
+++ b/samples/client/petstore/kotlin-jvm-jackson/docs/UserApi.md
@@ -220,9 +220,9 @@ val result : kotlin.String = webService.loginUser(username, password)
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| The user name for login | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| The user name for login | |
 | **password** | **kotlin.String**| The password for login in clear text | |
 
 ### Return type
@@ -293,9 +293,9 @@ webService.updateUser(username, user)
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| name that need to be deleted | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| name that need to be deleted | |
 | **user** | [**User**](User.md)| Updated user object | |
 
 ### Return type

--- a/samples/client/petstore/kotlin-jvm-retrofit2-coroutines/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-jvm-retrofit2-coroutines/docs/PetApi.md
@@ -76,9 +76,9 @@ launch(Dispatchers.IO) {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| Pet id to delete | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| Pet id to delete | |
 | **apiKey** | **kotlin.String**|  | [optional] |
 
 ### Return type
@@ -274,10 +274,10 @@ launch(Dispatchers.IO) {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
-| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
+| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | **status** | **kotlin.String**| Updated status of the pet | [optional] |
 
 ### Return type
@@ -317,10 +317,10 @@ launch(Dispatchers.IO) {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet to update | |
-| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet to update | |
+| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | **file** | **java.io.File**| file to upload | [optional] |
 
 ### Return type

--- a/samples/client/petstore/kotlin-jvm-retrofit2-coroutines/docs/UserApi.md
+++ b/samples/client/petstore/kotlin-jvm-retrofit2-coroutines/docs/UserApi.md
@@ -232,9 +232,9 @@ launch(Dispatchers.IO) {
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| The user name for login | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| The user name for login | |
 | **password** | **kotlin.String**| The password for login in clear text | |
 
 ### Return type
@@ -309,9 +309,9 @@ launch(Dispatchers.IO) {
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| name that need to be deleted | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| name that need to be deleted | |
 | **user** | [**User**](User.md)| Updated user object | |
 
 ### Return type

--- a/samples/client/petstore/kotlin-model-prefix-type-mappings/docs/FakeApi.md
+++ b/samples/client/petstore/kotlin-model-prefix-type-mappings/docs/FakeApi.md
@@ -70,11 +70,11 @@ launch(Dispatchers.IO) {
 ```
 
 ### Parameters
+| Name | Type | Description  | Notes |
+| ------------- | ------------- | ------------- | ------------- |
 | **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
 | **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | **status** | **kotlin.Int**| integer type | [optional] |
-| Name | Type | Description  | Notes |
-| ------------- | ------------- | ------------- | ------------- |
 | **status2** | **java.math.BigDecimal**| number type | [optional] |
 
 ### Return type

--- a/samples/client/petstore/kotlin-model-prefix-type-mappings/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-model-prefix-type-mappings/docs/PetApi.md
@@ -76,9 +76,9 @@ launch(Dispatchers.IO) {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| Pet id to delete | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| Pet id to delete | |
 | **apiKey** | **kotlin.String**|  | [optional] |
 
 ### Return type
@@ -274,10 +274,10 @@ launch(Dispatchers.IO) {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
-| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
+| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | **status** | **kotlin.String**| Updated status of the pet | [optional] |
 
 ### Return type
@@ -317,10 +317,10 @@ launch(Dispatchers.IO) {
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet to update | |
-| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet to update | |
+| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | **file** | **RequestBody**| file to upload | [optional] |
 
 ### Return type

--- a/samples/client/petstore/kotlin-model-prefix-type-mappings/docs/UserApi.md
+++ b/samples/client/petstore/kotlin-model-prefix-type-mappings/docs/UserApi.md
@@ -232,9 +232,9 @@ launch(Dispatchers.IO) {
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| The user name for login | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| The user name for login | |
 | **password** | **kotlin.String**| The password for login in clear text | |
 
 ### Return type
@@ -309,9 +309,9 @@ launch(Dispatchers.IO) {
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| name that need to be deleted | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| name that need to be deleted | |
 | **apiUser** | [**ApiUser**](ApiUser.md)| Updated user object | |
 
 ### Return type

--- a/samples/client/petstore/kotlin-retrofit2-jackson/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-retrofit2-jackson/docs/PetApi.md
@@ -72,9 +72,9 @@ webService.deletePet(petId, apiKey)
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| Pet id to delete | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| Pet id to delete | |
 | **apiKey** | **kotlin.String**|  | [optional] |
 
 ### Return type
@@ -260,10 +260,10 @@ webService.updatePetWithForm(petId, name, status)
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
-| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
+| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | **status** | **kotlin.String**| Updated status of the pet | [optional] |
 
 ### Return type
@@ -301,10 +301,10 @@ val result : ModelApiResponse = webService.uploadFile(petId, additionalMetadata,
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet to update | |
-| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet to update | |
+| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | **file** | **java.io.File**| file to upload | [optional] |
 
 ### Return type

--- a/samples/client/petstore/kotlin-retrofit2-jackson/docs/UserApi.md
+++ b/samples/client/petstore/kotlin-retrofit2-jackson/docs/UserApi.md
@@ -220,9 +220,9 @@ val result : kotlin.String = webService.loginUser(username, password)
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| The user name for login | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| The user name for login | |
 | **password** | **kotlin.String**| The password for login in clear text | |
 
 ### Return type
@@ -293,9 +293,9 @@ webService.updateUser(username, user)
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| name that need to be deleted | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| name that need to be deleted | |
 | **user** | [**User**](User.md)| Updated user object | |
 
 ### Return type

--- a/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/docs/PetApi.md
@@ -68,9 +68,9 @@ webService.deletePet(petId, apiKey)
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| Pet id to delete | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| Pet id to delete | |
 | **apiKey** | **kotlin.String**|  | [optional] |
 
 ### Return type
@@ -252,10 +252,10 @@ webService.updatePetWithForm(petId, name, status)
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
-| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
+| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | **status** | **kotlin.String**| Updated status of the pet | [optional] |
 
 ### Return type
@@ -291,10 +291,10 @@ val result : ModelApiResponse = webService.uploadFile(petId, additionalMetadata,
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet to update | |
-| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet to update | |
+| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | **file** | **java.io.File**| file to upload | [optional] |
 
 ### Return type

--- a/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/docs/UserApi.md
+++ b/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/docs/UserApi.md
@@ -212,9 +212,9 @@ val result : kotlin.String = webService.loginUser(username, password)
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| The user name for login | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| The user name for login | |
 | **password** | **kotlin.String**| The password for login in clear text | |
 
 ### Return type
@@ -283,9 +283,9 @@ webService.updateUser(username, body)
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| name that need to be deleted | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| name that need to be deleted | |
 | **body** | [**User**](User.md)| Updated user object | |
 
 ### Return type

--- a/samples/client/petstore/kotlin-retrofit2-rx3/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-retrofit2-rx3/docs/PetApi.md
@@ -68,9 +68,9 @@ webService.deletePet(petId, apiKey)
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| Pet id to delete | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| Pet id to delete | |
 | **apiKey** | **kotlin.String**|  | [optional] |
 
 ### Return type
@@ -252,10 +252,10 @@ webService.updatePetWithForm(petId, name, status)
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
-| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
+| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | **status** | **kotlin.String**| Updated status of the pet | [optional] |
 
 ### Return type
@@ -291,10 +291,10 @@ val result : ModelApiResponse = webService.uploadFile(petId, additionalMetadata,
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet to update | |
-| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet to update | |
+| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | **file** | **java.io.File**| file to upload | [optional] |
 
 ### Return type

--- a/samples/client/petstore/kotlin-retrofit2-rx3/docs/UserApi.md
+++ b/samples/client/petstore/kotlin-retrofit2-rx3/docs/UserApi.md
@@ -212,9 +212,9 @@ val result : kotlin.String = webService.loginUser(username, password)
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| The user name for login | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| The user name for login | |
 | **password** | **kotlin.String**| The password for login in clear text | |
 
 ### Return type
@@ -283,9 +283,9 @@ webService.updateUser(username, body)
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| name that need to be deleted | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| name that need to be deleted | |
 | **body** | [**User**](User.md)| Updated user object | |
 
 ### Return type

--- a/samples/client/petstore/kotlin-retrofit2/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-retrofit2/docs/PetApi.md
@@ -68,9 +68,9 @@ webService.deletePet(petId, apiKey)
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| Pet id to delete | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| Pet id to delete | |
 | **apiKey** | **kotlin.String**|  | [optional] |
 
 ### Return type
@@ -252,10 +252,10 @@ webService.updatePetWithForm(petId, name, status)
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
-| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet that needs to be updated | |
+| **name** | **kotlin.String**| Updated name of the pet | [optional] |
 | **status** | **kotlin.String**| Updated status of the pet | [optional] |
 
 ### Return type
@@ -291,10 +291,10 @@ val result : ModelApiResponse = webService.uploadFile(petId, additionalMetadata,
 ```
 
 ### Parameters
-| **petId** | **kotlin.Long**| ID of pet to update | |
-| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **petId** | **kotlin.Long**| ID of pet to update | |
+| **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] |
 | **file** | **java.io.File**| file to upload | [optional] |
 
 ### Return type

--- a/samples/client/petstore/kotlin-retrofit2/docs/UserApi.md
+++ b/samples/client/petstore/kotlin-retrofit2/docs/UserApi.md
@@ -212,9 +212,9 @@ val result : kotlin.String = webService.loginUser(username, password)
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| The user name for login | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| The user name for login | |
 | **password** | **kotlin.String**| The password for login in clear text | |
 
 ### Return type
@@ -283,9 +283,9 @@ webService.updateUser(username, body)
 ```
 
 ### Parameters
-| **username** | **kotlin.String**| name that need to be deleted | |
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **username** | **kotlin.String**| name that need to be deleted | |
 | **body** | [**User**](User.md)| Updated user object | |
 
 ### Return type


### PR DESCRIPTION
Problem

Follow-up to #24742. That PR fixed kotlin-client/api_doc.mustache, but the jvm-retrofit2 library ships its own copy, which still emits the parameter table header inside {{#-last}}. For operations with two or more parameters the header lands before the final parameter and every preceding row falls outside the table.

Visible on master today — samples/client/petstore/kotlin-jvm-retrofit2-coroutines/docs/PetApi.md (deletePet): the petId row sits above the header.

Fix

{{#-last}} → {{#-first}} on the header block, matching #24742.

Samples

Regenerated bin/configs/kotlin*.yaml. 21 files, 68 insertions / 68 deletions — every change is a parameter row moving below the header. No non-doc output affected.

I checked every api_doc.mustache in the tree structurally; this was the last one with the header nested inside the row loop.
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Kotlin `jvm-retrofit2` API docs to emit the parameter table header before the first parameter. Previously the header rendered on the last parameter, leaving earlier rows outside the table; now the header renders on the first parameter and all rows appear inside the table.

**Review notes**
- Updates `modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-retrofit2/api_doc.mustache`: switch `{{#-last}}` to `{{#-first}}` for the header block.
- Regenerates samples via `bin/configs/kotlin*.yaml`; diffs move parameter rows below the header (e.g., `samples/client/petstore/kotlin-jvm-retrofit2-coroutines/docs/PetApi.md`).
- Documentation-only change; no generator or runtime behavior changes. No migration actions.

<sup>Written for commit 09c6500a2fbbd1588a939c6b4b4216c7ce28d31a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24756?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

