### PR TITLE
fix(java-spring): add @Deprecated annotation to fluent setters for deprecated properties

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaSpring/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/pojo.mustache
@@ -154,6 +154,9 @@ public {{>sealed}}class {{classname}}{{#parent}} extends {{{parent}}}{{/parent}}
   {{^lombok.Data}}
 
   {{! begin feature: fluent setter methods }}
+  {{#deprecated}}
+  @Deprecated
+  {{/deprecated}}
   public {{classname}} {{name}}({{#useJspecify}}{{#lambda.jSpecifyNullable}}{{^required}}{{^useOptional}}@Nullable {{/useOptional}}{{#useOptional}}{{#optionalAcceptNullable}}@Nullable {{/optionalAcceptNullable}}{{/useOptional}}{{/required}}{{/lambda.jSpecifyNullable}}{{#lambda.jSpecifyDatatype}}{{{datatypeWithEnum}}}{{/lambda.jSpecifyDatatype}}{{/useJspecify}}{{^useJspecify}}{{>nullableAnnotation_default}}{{{datatypeWithEnum}}}{{/useJspecify}} {{name}}) {
     {{#openApiNullable}}
     this.{{name}} = {{#isNullable}}JsonNullable.of({{/isNullable}}{{#useOptional}}{{^required}}{{^isNullable}}{{^isContainer}}Optional.of{{#optionalAcceptNullable}}Nullable{{/optionalAcceptNullable}}({{/isContainer}}{{/isNullable}}{{/required}}{{/useOptional}}{{name}}{{#isNullable}}){{/isNullable}}{{#useOptional}}{{^required}}{{^isNullable}}{{^isContainer}}){{/isContainer}}{{/isNullable}}{{/required}}{{/useOptional}};
@@ -165,6 +168,9 @@ public {{>sealed}}class {{classname}}{{#parent}} extends {{{parent}}}{{/parent}}
   }
   {{#isArray}}
 
+  {{#deprecated}}
+  @Deprecated
+  {{/deprecated}}
   public {{classname}} add{{nameInPascalCase}}Item({{{items.datatypeWithEnum}}} {{name}}Item) {
     {{#openApiNullable}}
     if (this.{{name}} == null{{#isNullable}} || !this.{{name}}.isPresent(){{/isNullable}}) {
@@ -183,6 +189,9 @@ public {{>sealed}}class {{classname}}{{#parent}} extends {{{parent}}}{{/parent}}
   {{/isArray}}
   {{#isMap}}
 
+  {{#deprecated}}
+  @Deprecated
+  {{/deprecated}}
   public {{classname}} put{{nameInPascalCase}}Item(String key, {{{items.datatypeWithEnum}}} {{name}}Item) {
     {{#openApiNullable}}
     if (this.{{name}} == null{{#isNullable}} || !this.{{name}}.isPresent(){{/isNullable}}) {
@@ -270,19 +279,26 @@ public {{>sealed}}class {{classname}}{{#parent}} extends {{{parent}}}{{/parent}}
 
   {{^lombok.Setter}}
   {{! begin feature: fluent setter methods for inherited properties }}
+  {{#deprecated}}
+  @Deprecated
+  {{/deprecated}}
   public {{classname}} {{name}}({{{datatypeWithEnum}}} {{name}}) {
     super.{{name}}({{name}});
     return this;
   }
   {{#isArray}}
-
+ {{#deprecated}}
+  @Deprecated
+  {{/deprecated}}
   public {{classname}} add{{nameInPascalCase}}Item({{{items.datatypeWithEnum}}} {{name}}Item) {
     super.add{{nameInPascalCase}}Item({{name}}Item);
     return this;
   }
   {{/isArray}}
   {{#isMap}}
-
+ {{#deprecated}}
+  @Deprecated
+  {{/deprecated}}
   public {{classname}} put{{nameInPascalCase}}Item(String key, {{{items.datatypeWithEnum}}} {{name}}Item) {
     super.put{{nameInPascalCase}}Item(key, {{name}}Item);
     return this;

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
@@ -5833,6 +5833,24 @@ public class SpringCodegenTest {
                 .assertMethod("build")
                 .doesNotHaveAnnotation("Deprecated");
     }
+    /**
+     * Regression test for <a href="https://github.com/OpenAPITools/openapi-generator/issues/24704">#24704</a>
+     */
+    @Test
+    public void shouldGenerateDeprecatedAnnotationOnFluentSetter() {
+        final var tempDir = TestUtils.newTempFolder();
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .addAdditionalProperty(GENERATE_BUILDERS, true)
+                .addGlobalProperty(CodegenConstants.MODELS, "Pet")
+                .setInputSpec("src/test/resources/3_0/petstore.yaml")
+                .setGeneratorName("spring")
+                .setOutputDir(tempDir.toString());
+
+        new DefaultGenerator().opts(configurator.toClientOptInput()).generate();
+
+        JavaFileAssert.assertThat(tempDir.resolve("src/main/java/org/openapitools/model/Pet.java"))
+                .assertMethod("status", "StatusEnum").hasAnnotation("Deprecated");
+    }
 
     @Test
     public void shouldAnnotateNonRequiredFieldsAsNullable() throws IOException {

--- a/samples/client/petstore/spring-cloud-deprecated/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/client/petstore/spring-cloud-deprecated/src/main/java/org/openapitools/model/Pet.java
@@ -161,11 +161,13 @@ public class Pet {
     this.name = name;
   }
 
+  @Deprecated
   public Pet photoUrls(List<String> photoUrls) {
     this.photoUrls = photoUrls;
     return this;
   }
 
+  @Deprecated
   public Pet addPhotoUrlsItem(String photoUrlsItem) {
     if (this.photoUrls == null) {
       this.photoUrls = new ArrayList<>();


### PR DESCRIPTION
## Description
Fixes #24704

The `@Deprecated` annotation was correctly generated on getters and standard setters for properties marked `deprecated: true`, but was missing on the corresponding fluent setter methods — for both a class's own properties and properties inherited from a parent schema (including the array/map item-adder variants: `addXxxItem`, `putXxxItem`).

## Changes
- Updated `pojo.mustache` to wrap all fluent setter variants (single, array-item, map-item; both own and inherited) with the same `{{#deprecated}}@Deprecated{{/deprecated}}` block already used for the standard setter.
- Added a regression test `shouldGenerateDeprecatedAnnotationOnFluentSetter` in `SpringCodegenTest`.
- Regenerated the affected sample (`spring-cloud-deprecated`) to reflect the fix.

## Testing
- New test passes.
- Full `SpringCodegenTest` suite passes (328/328).
- Verified manually against a custom spec with `allOf` inheritance + `deprecated: true`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Annotates all fluent setters for deprecated properties with @Deprecated in the Java Spring generator, matching the existing getters and standard setters. Previously, fluent setters (including inherited and array/map item adders) lacked the annotation; now compilers/IDEs will warn when they are used.

- Updated `JavaSpring/pojo.mustache` to apply @Deprecated to fluent setters for own and inherited properties, including `addXxxItem` and `putXxxItem`, when the property has `deprecated: true`.
- Added regression test `shouldGenerateDeprecatedAnnotationOnFluentSetter` and regenerated the `spring-cloud-deprecated` sample.
- Impact: Generated models may now emit deprecation warnings when calling fluent setters for deprecated fields. No runtime changes or configuration updates required.

<sup>Written for commit 12e4ce179de179a64cc61c75e93ecd346362b33e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24762?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

