### PR TITLE
v7.25.0 release

### DIFF
--- a/modules/openapi-generator-cli/pom.xml
+++ b/modules/openapi-generator-cli/pom.xml
@@ -4,7 +4,7 @@
         <groupId>org.openapitools</groupId>
         <artifactId>openapi-generator-project</artifactId>
         <!-- RELEASE_VERSION -->
-        <version>7.25.0-SNAPSHOT</version>
+        <version>7.25.0</version>
         <!-- /RELEASE_VERSION -->
         <relativePath>../../pom.xml</relativePath>
     </parent>

--- a/modules/openapi-generator-core/pom.xml
+++ b/modules/openapi-generator-core/pom.xml
@@ -6,7 +6,7 @@
     <artifactId>openapi-generator-project</artifactId>
     <groupId>org.openapitools</groupId>
     <!-- RELEASE_VERSION -->
-    <version>7.25.0-SNAPSHOT</version>
+    <version>7.25.0</version>
     <!-- /RELEASE_VERSION -->
     <relativePath>../../pom.xml</relativePath>
   </parent>

--- a/modules/openapi-generator-gradle-plugin/gradle.properties
+++ b/modules/openapi-generator-gradle-plugin/gradle.properties
@@ -1,5 +1,5 @@
 # RELEASE_VERSION
-openApiGeneratorVersion=7.25.0-SNAPSHOT
+openApiGeneratorVersion=7.25.0
 # /RELEASE_VERSION
 
 # BEGIN placeholders

--- a/modules/openapi-generator-gradle-plugin/pom.xml
+++ b/modules/openapi-generator-gradle-plugin/pom.xml
@@ -4,7 +4,7 @@
         <groupId>org.openapitools</groupId>
         <artifactId>openapi-generator-project</artifactId>
         <!-- RELEASE_VERSION -->
-        <version>7.25.0-SNAPSHOT</version>
+        <version>7.25.0</version>
         <!-- /RELEASE_VERSION -->
         <relativePath>../../pom.xml</relativePath>
     </parent>

--- a/modules/openapi-generator-gradle-plugin/samples/local-spec/gradle.properties
+++ b/modules/openapi-generator-gradle-plugin/samples/local-spec/gradle.properties
@@ -1,3 +1,3 @@
 # RELEASE_VERSION
-openApiGeneratorVersion=7.25.0-SNAPSHOT
+openApiGeneratorVersion=7.25.0
 # /RELEASE_VERSION

--- a/modules/openapi-generator-maven-plugin/examples/java-client.xml
+++ b/modules/openapi-generator-maven-plugin/examples/java-client.xml
@@ -13,7 +13,7 @@
                 <groupId>org.openapitools</groupId>
                 <artifactId>openapi-generator-maven-plugin</artifactId>
                 <!-- RELEASE_VERSION -->
-                <version>7.25.0-SNAPSHOT</version>
+                <version>7.25.0</version>
                 <!-- /RELEASE_VERSION -->
                 <executions>
                     <execution>

--- a/modules/openapi-generator-maven-plugin/examples/multi-module/java-client/pom.xml
+++ b/modules/openapi-generator-maven-plugin/examples/multi-module/java-client/pom.xml
@@ -19,7 +19,7 @@
                 <groupId>org.openapitools</groupId>
                 <artifactId>openapi-generator-maven-plugin</artifactId>
                 <!-- RELEASE_VERSION -->
-                <version>7.25.0-SNAPSHOT</version>
+                <version>7.25.0</version>
                 <!-- /RELEASE_VERSION -->
                 <dependencies>
                     <dependency>

--- a/modules/openapi-generator-maven-plugin/examples/non-java-invalid-spec.xml
+++ b/modules/openapi-generator-maven-plugin/examples/non-java-invalid-spec.xml
@@ -13,7 +13,7 @@
                 <groupId>org.openapitools</groupId>
                 <artifactId>openapi-generator-maven-plugin</artifactId>
                 <!-- RELEASE_VERSION -->
-                <version>7.25.0-SNAPSHOT</version>
+                <version>7.25.0</version>
                 <!-- /RELEASE_VERSION -->
                 <executions>
                     <execution>

--- a/modules/openapi-generator-maven-plugin/examples/non-java.xml
+++ b/modules/openapi-generator-maven-plugin/examples/non-java.xml
@@ -13,7 +13,7 @@
                 <groupId>org.openapitools</groupId>
                 <artifactId>openapi-generator-maven-plugin</artifactId>
                 <!-- RELEASE_VERSION -->
-                <version>7.25.0-SNAPSHOT</version>
+                <version>7.25.0</version>
                 <!-- /RELEASE_VERSION -->
                 <executions>
                     <execution>

--- a/modules/openapi-generator-maven-plugin/examples/spring.xml
+++ b/modules/openapi-generator-maven-plugin/examples/spring.xml
@@ -20,7 +20,7 @@
                 <groupId>org.openapitools</groupId>
                 <artifactId>openapi-generator-maven-plugin</artifactId>
                 <!-- RELEASE_VERSION -->
-                <version>7.25.0-SNAPSHOT</version>
+                <version>7.25.0</version>
                 <!-- /RELEASE_VERSION -->
                 <executions>
                     <execution>

--- a/modules/openapi-generator-maven-plugin/pom.xml
+++ b/modules/openapi-generator-maven-plugin/pom.xml
@@ -5,7 +5,7 @@
         <groupId>org.openapitools</groupId>
         <artifactId>openapi-generator-project</artifactId>
         <!-- RELEASE_VERSION -->
-        <version>7.25.0-SNAPSHOT</version>
+        <version>7.25.0</version>
         <!-- /RELEASE_VERSION -->
         <relativePath>../../pom.xml</relativePath>
     </parent>

--- a/modules/openapi-generator-mill-plugin/example/mill-build/version.properties
+++ b/modules/openapi-generator-mill-plugin/example/mill-build/version.properties
@@ -1,3 +1,3 @@
 # RELEASE_VERSION
-openApiGeneratorVersion=7.25.0-SNAPSHOT
+openApiGeneratorVersion=7.25.0
 # /RELEASE_VERSION

--- a/modules/openapi-generator-mill-plugin/pom.xml
+++ b/modules/openapi-generator-mill-plugin/pom.xml
@@ -4,7 +4,7 @@
         <groupId>org.openapitools</groupId>
         <artifactId>openapi-generator-project</artifactId>
         <!-- RELEASE_VERSION -->
-        <version>7.25.0-SNAPSHOT</version>
+        <version>7.25.0</version>
         <!-- /RELEASE_VERSION -->
         <relativePath>../../pom.xml</relativePath>
     </parent>

--- a/modules/openapi-generator-online/pom.xml
+++ b/modules/openapi-generator-online/pom.xml
@@ -4,7 +4,7 @@
         <groupId>org.openapitools</groupId>
         <artifactId>openapi-generator-project</artifactId>
         <!-- RELEASE_VERSION -->
-        <version>7.25.0-SNAPSHOT</version>
+        <version>7.25.0</version>
         <!-- /RELEASE_VERSION -->
         <relativePath>../../pom.xml</relativePath>
     </parent>

--- a/modules/openapi-generator/pom.xml
+++ b/modules/openapi-generator/pom.xml
@@ -4,7 +4,7 @@
         <groupId>org.openapitools</groupId>
         <artifactId>openapi-generator-project</artifactId>
         <!-- RELEASE_VERSION -->
-        <version>7.25.0-SNAPSHOT</version>
+        <version>7.25.0</version>
         <!-- /RELEASE_VERSION -->
         <relativePath>../../pom.xml</relativePath>
     </parent>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <packaging>pom</packaging>
     <name>openapi-generator-project</name>
     <!-- RELEASE_VERSION -->
-    <version>7.25.0-SNAPSHOT</version>
+    <version>7.25.0</version>
     <!-- /RELEASE_VERSION -->
     <url>https://github.com/openapitools/openapi-generator</url>
     <scm>


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Finalize 7.25.0 release by replacing all 7.25.0-SNAPSHOT references with 7.25.0 across the root and module builds. Previously artifacts built as snapshots; now they are pinned for publishing with no functional changes.

- Verify root POM and all module/sample build files reference 7.25.0 (including `openapi-generator`, `openapi-generator-cli`, `openapi-generator-maven-plugin` examples, `openapi-generator-gradle-plugin` properties/samples, `openapi-generator-mill-plugin` properties, and `openapi-generator-online`). Ensure no remaining “-SNAPSHOT”.
- Rollout: tag `v7.25.0` and publish `org.openapitools` artifacts; downstream users should depend on 7.25.0 for the CLI and plugins.

<sup>Written for commit 851ac4b17d349c99479bea798b567dad0ee5bb44. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24763?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

