### PR TITLE
fix: add support for nullable arrays in Swift 5,6

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/Swift5ClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/Swift5ClientCodegen.java
@@ -780,7 +780,8 @@ public class Swift5ClientCodegen extends DefaultCodegen implements CodegenConfig
 
     private String getItemsTypeDeclaration(Schema items) {
         String itemsTypeDeclaration = getTypeDeclaration(items);
-        String nullable = ModelUtils.isNullable(unaliasSchema(items)) && !itemsTypeDeclaration.endsWith("?") ? "?" : "";
+        Schema itemsSchema = ModelUtils.getReferencedSchema(openAPI, unaliasSchema(items));
+        String nullable = ModelUtils.isNullable(itemsSchema) && !itemsTypeDeclaration.endsWith("?") ? "?" : "";
         return itemsTypeDeclaration + nullable;
     }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/Swift5ClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/Swift5ClientCodegen.java
@@ -769,12 +769,19 @@ public class Swift5ClientCodegen extends DefaultCodegen implements CodegenConfig
     public String getTypeDeclaration(Schema p) {
         if (ModelUtils.isArraySchema(p)) {
             Schema inner = ModelUtils.getSchemaItems(p);
-            return ModelUtils.isSet(p) ? "Set<" + getTypeDeclaration(inner) + ">" : "[" + getTypeDeclaration(inner) + "]";
+            String innerTypeDeclaration = getItemsTypeDeclaration(inner);
+            return ModelUtils.isSet(p) ? "Set<" + innerTypeDeclaration + ">" : "[" + innerTypeDeclaration + "]";
         } else if (ModelUtils.isMapSchema(p)) {
             Schema inner = ModelUtils.getAdditionalProperties(p);
             return "[String: " + getTypeDeclaration(inner) + "]";
         }
         return super.getTypeDeclaration(p);
+    }
+
+    private String getItemsTypeDeclaration(Schema items) {
+        String itemsTypeDeclaration = getTypeDeclaration(items);
+        String nullable = items.getNullable() != null && items.getNullable() && !itemsTypeDeclaration.endsWith("?") ? "?" : "";
+        return itemsTypeDeclaration + nullable;
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/Swift5ClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/Swift5ClientCodegen.java
@@ -780,7 +780,7 @@ public class Swift5ClientCodegen extends DefaultCodegen implements CodegenConfig
 
     private String getItemsTypeDeclaration(Schema items) {
         String itemsTypeDeclaration = getTypeDeclaration(items);
-        String nullable = items.getNullable() != null && items.getNullable() && !itemsTypeDeclaration.endsWith("?") ? "?" : "";
+        String nullable = ModelUtils.isNullable(unaliasSchema(items)) && !itemsTypeDeclaration.endsWith("?") ? "?" : "";
         return itemsTypeDeclaration + nullable;
     }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/Swift6ClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/Swift6ClientCodegen.java
@@ -826,7 +826,7 @@ public class Swift6ClientCodegen extends DefaultCodegen implements CodegenConfig
 
     private String getItemsTypeDeclaration(Schema items) {
         String itemsTypeDeclaration = getTypeDeclaration(items);
-        String nullable = items.getNullable() != null && items.getNullable() && !itemsTypeDeclaration.endsWith("?") ? "?" : "";
+        String nullable = ModelUtils.isNullable(unaliasSchema(items)) && !itemsTypeDeclaration.endsWith("?") ? "?" : "";
         return itemsTypeDeclaration + nullable;
     }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/Swift6ClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/Swift6ClientCodegen.java
@@ -815,7 +815,8 @@ public class Swift6ClientCodegen extends DefaultCodegen implements CodegenConfig
     public String getTypeDeclaration(Schema p) {
         if (ModelUtils.isArraySchema(p)) {
             Schema inner = ModelUtils.getSchemaItems(p);
-            return ModelUtils.isSet(p) ? "Set<" + getTypeDeclaration(inner) + ">" : "[" + getTypeDeclaration(inner) + "]";
+            String innerTypeDeclaration = getItemsTypeDeclaration(inner);
+            return ModelUtils.isSet(p) ? "Set<" + innerTypeDeclaration + ">" : "[" + innerTypeDeclaration + "]";
         } else if (ModelUtils.isMapSchema(p)) {
             Schema inner = unaliasSchema(ModelUtils.getAdditionalProperties(p));
             return "[String: " + getItemsTypeDeclaration(inner) + "]";

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/Swift6ClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/Swift6ClientCodegen.java
@@ -826,7 +826,8 @@ public class Swift6ClientCodegen extends DefaultCodegen implements CodegenConfig
 
     private String getItemsTypeDeclaration(Schema items) {
         String itemsTypeDeclaration = getTypeDeclaration(items);
-        String nullable = ModelUtils.isNullable(unaliasSchema(items)) && !itemsTypeDeclaration.endsWith("?") ? "?" : "";
+        Schema itemsSchema = ModelUtils.getReferencedSchema(openAPI, unaliasSchema(items));
+        String nullable = ModelUtils.isNullable(itemsSchema) && !itemsTypeDeclaration.endsWith("?") ? "?" : "";
         return itemsTypeDeclaration + nullable;
     }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/swift5/Swift5ClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/swift5/Swift5ClientCodegenTest.java
@@ -418,7 +418,7 @@ public class Swift5ClientCodegenTest {
         final String model = "NullItemsNotNullItems";
         final CodegenModel cm = codegen.fromModel(model, openAPI.getComponents().getSchemas().get(model));
 
-        Assert.assertEquals(cm.vars.size(), 8);
+        Assert.assertEquals(cm.vars.size(), 9);
 
         Assert.assertEquals(cm.vars.get(0).baseName, "nullableItems");
         Assert.assertEquals(cm.vars.get(1).baseName, "notNullableItems");
@@ -428,6 +428,7 @@ public class Swift5ClientCodegenTest {
         Assert.assertEquals(cm.vars.get(5).baseName, "aliasedNullableItems");
         Assert.assertEquals(cm.vars.get(6).baseName, "nullableItemsSet");
         Assert.assertEquals(cm.vars.get(7).baseName, "nestedNullableItems");
+        Assert.assertEquals(cm.vars.get(8).baseName, "modelRefNullableItems");
 
         Assert.assertEquals(cm.vars.get(0).dataType, "[String?]");
         Assert.assertEquals(cm.vars.get(1).dataType, "[String]");
@@ -437,6 +438,7 @@ public class Swift5ClientCodegenTest {
         Assert.assertEquals(cm.vars.get(5).dataType, "[String?]");
         Assert.assertEquals(cm.vars.get(6).dataType, "Set<String?>");
         Assert.assertEquals(cm.vars.get(7).dataType, "[[String?]]");
+        Assert.assertEquals(cm.vars.get(8).dataType, "[NullablePet?]");
     }
 
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/swift5/Swift5ClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/swift5/Swift5ClientCodegenTest.java
@@ -418,21 +418,25 @@ public class Swift5ClientCodegenTest {
         final String model = "NullItemsNotNullItems";
         final CodegenModel cm = codegen.fromModel(model, openAPI.getComponents().getSchemas().get(model));
 
-        Assert.assertEquals(cm.vars.size(), 6);
+        Assert.assertEquals(cm.vars.size(), 8);
 
         Assert.assertEquals(cm.vars.get(0).baseName, "nullableItems");
         Assert.assertEquals(cm.vars.get(1).baseName, "notNullableItems");
         Assert.assertEquals(cm.vars.get(2).baseName, "defaultItems");
         Assert.assertEquals(cm.vars.get(3).baseName, "nullableDoubleItems");
-        Assert.assertEquals(cm.vars.get(4).baseName, "nullableItemsSet");
-        Assert.assertEquals(cm.vars.get(5).baseName, "nestedNullableItems");
+        Assert.assertEquals(cm.vars.get(4).baseName, "xNullableItems");
+        Assert.assertEquals(cm.vars.get(5).baseName, "aliasedNullableItems");
+        Assert.assertEquals(cm.vars.get(6).baseName, "nullableItemsSet");
+        Assert.assertEquals(cm.vars.get(7).baseName, "nestedNullableItems");
 
         Assert.assertEquals(cm.vars.get(0).dataType, "[String?]");
         Assert.assertEquals(cm.vars.get(1).dataType, "[String]");
         Assert.assertEquals(cm.vars.get(2).dataType, "[String]");
         Assert.assertEquals(cm.vars.get(3).dataType, "[Double?]");
-        Assert.assertEquals(cm.vars.get(4).dataType, "Set<String?>");
-        Assert.assertEquals(cm.vars.get(5).dataType, "[[String?]]");
+        Assert.assertEquals(cm.vars.get(4).dataType, "[String?]");
+        Assert.assertEquals(cm.vars.get(5).dataType, "[String?]");
+        Assert.assertEquals(cm.vars.get(6).dataType, "Set<String?>");
+        Assert.assertEquals(cm.vars.get(7).dataType, "[[String?]]");
     }
 
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/swift5/Swift5ClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/swift5/Swift5ClientCodegenTest.java
@@ -410,4 +410,29 @@ public class Swift5ClientCodegenTest {
         Assert.assertEquals(imports.get(2), "BazKit");
     }
 
+    @Test(description = "nullable array items are declared as optionals", enabled = true)
+    public void nullableArrayItemsTest() {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/issue_22355.yaml");
+        final DefaultCodegen codegen = new Swift5ClientCodegen();
+        codegen.setOpenAPI(openAPI);
+        final String model = "NullItemsNotNullItems";
+        final CodegenModel cm = codegen.fromModel(model, openAPI.getComponents().getSchemas().get(model));
+
+        Assert.assertEquals(cm.vars.size(), 6);
+
+        Assert.assertEquals(cm.vars.get(0).baseName, "nullableItems");
+        Assert.assertEquals(cm.vars.get(1).baseName, "notNullableItems");
+        Assert.assertEquals(cm.vars.get(2).baseName, "defaultItems");
+        Assert.assertEquals(cm.vars.get(3).baseName, "nullableDoubleItems");
+        Assert.assertEquals(cm.vars.get(4).baseName, "nullableItemsSet");
+        Assert.assertEquals(cm.vars.get(5).baseName, "nestedNullableItems");
+
+        Assert.assertEquals(cm.vars.get(0).dataType, "[String?]");
+        Assert.assertEquals(cm.vars.get(1).dataType, "[String]");
+        Assert.assertEquals(cm.vars.get(2).dataType, "[String]");
+        Assert.assertEquals(cm.vars.get(3).dataType, "[Double?]");
+        Assert.assertEquals(cm.vars.get(4).dataType, "Set<String?>");
+        Assert.assertEquals(cm.vars.get(5).dataType, "[[String?]]");
+    }
+
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/swift6/Swift6ClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/swift6/Swift6ClientCodegenTest.java
@@ -505,4 +505,26 @@ public class Swift6ClientCodegenTest {
         Assert.assertEquals(notNullableMap.getDataType(), "[String: String]");
         Assert.assertEquals(defaultMap.getDataType(), "[String: String]");
     }
+
+    @Test(description = "Issue #22355")
+    public void testNullableArrayItems() {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/swift6/issue22355-nullable-array-items.yaml");
+
+        Schema test1 = openAPI.getComponents().getSchemas().get("NullItemsNotNullItems");
+        CodegenModel cm1 = swiftCodegen.fromModel("NullItemsNotNullItems", test1);
+
+        // Assert the dataType properly generated
+        CodegenProperty nullableItems = cm1.vars.get(0);
+        CodegenProperty notNullableItems = cm1.vars.get(1);
+        CodegenProperty defaultItems = cm1.vars.get(2);
+        CodegenProperty nullableDoubleItems = cm1.vars.get(3);
+        CodegenProperty nullableItemsSet = cm1.vars.get(4);
+        CodegenProperty nestedNullableItems = cm1.vars.get(5);
+        Assert.assertEquals(nullableItems.getDataType(), "[String?]");
+        Assert.assertEquals(notNullableItems.getDataType(), "[String]");
+        Assert.assertEquals(defaultItems.getDataType(), "[String]");
+        Assert.assertEquals(nullableDoubleItems.getDataType(), "[Double?]");
+        Assert.assertEquals(nullableItemsSet.getDataType(), "Set<String?>");
+        Assert.assertEquals(nestedNullableItems.getDataType(), "[[String?]]");
+    }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/swift6/Swift6ClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/swift6/Swift6ClientCodegenTest.java
@@ -524,6 +524,7 @@ public class Swift6ClientCodegenTest {
         CodegenProperty aliasedNullableItems = cm1.vars.get(5);
         CodegenProperty nullableItemsSet = cm1.vars.get(6);
         CodegenProperty nestedNullableItems = cm1.vars.get(7);
+        CodegenProperty modelRefNullableItems = cm1.vars.get(8);
         Assert.assertEquals(nullableItems.getDataType(), "[String?]");
         Assert.assertEquals(notNullableItems.getDataType(), "[String]");
         Assert.assertEquals(defaultItems.getDataType(), "[String]");
@@ -532,5 +533,6 @@ public class Swift6ClientCodegenTest {
         Assert.assertEquals(aliasedNullableItems.getDataType(), "[String?]");
         Assert.assertEquals(nullableItemsSet.getDataType(), "Set<String?>");
         Assert.assertEquals(nestedNullableItems.getDataType(), "[[String?]]");
+        Assert.assertEquals(modelRefNullableItems.getDataType(), "[NullablePet?]");
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/swift6/Swift6ClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/swift6/Swift6ClientCodegenTest.java
@@ -509,21 +509,27 @@ public class Swift6ClientCodegenTest {
     @Test(description = "Issue #22355")
     public void testNullableArrayItems() {
         final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/swift6/issue22355-nullable-array-items.yaml");
+        final DefaultCodegen codegen = new Swift6ClientCodegen();
+        codegen.setOpenAPI(openAPI);
 
         Schema test1 = openAPI.getComponents().getSchemas().get("NullItemsNotNullItems");
-        CodegenModel cm1 = swiftCodegen.fromModel("NullItemsNotNullItems", test1);
+        CodegenModel cm1 = codegen.fromModel("NullItemsNotNullItems", test1);
 
         // Assert the dataType properly generated
         CodegenProperty nullableItems = cm1.vars.get(0);
         CodegenProperty notNullableItems = cm1.vars.get(1);
         CodegenProperty defaultItems = cm1.vars.get(2);
         CodegenProperty nullableDoubleItems = cm1.vars.get(3);
-        CodegenProperty nullableItemsSet = cm1.vars.get(4);
-        CodegenProperty nestedNullableItems = cm1.vars.get(5);
+        CodegenProperty xNullableItems = cm1.vars.get(4);
+        CodegenProperty aliasedNullableItems = cm1.vars.get(5);
+        CodegenProperty nullableItemsSet = cm1.vars.get(6);
+        CodegenProperty nestedNullableItems = cm1.vars.get(7);
         Assert.assertEquals(nullableItems.getDataType(), "[String?]");
         Assert.assertEquals(notNullableItems.getDataType(), "[String]");
         Assert.assertEquals(defaultItems.getDataType(), "[String]");
         Assert.assertEquals(nullableDoubleItems.getDataType(), "[Double?]");
+        Assert.assertEquals(xNullableItems.getDataType(), "[String?]");
+        Assert.assertEquals(aliasedNullableItems.getDataType(), "[String?]");
         Assert.assertEquals(nullableItemsSet.getDataType(), "Set<String?>");
         Assert.assertEquals(nestedNullableItems.getDataType(), "[[String?]]");
     }

--- a/modules/openapi-generator/src/test/resources/3_0/issue_22355.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/issue_22355.yaml
@@ -26,6 +26,15 @@ components:
             type: number
             format: double
             nullable: true
+        xNullableItems:
+          type: array
+          items:
+            type: string
+            x-nullable: true
+        aliasedNullableItems:
+          type: array
+          items:
+            $ref: '#/components/schemas/NullableString'
         nullableItemsSet:
           type: array
           uniqueItems: true
@@ -39,3 +48,6 @@ components:
             items:
               type: string
               nullable: true
+    NullableString:
+      type: string
+      nullable: true

--- a/modules/openapi-generator/src/test/resources/3_0/issue_22355.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/issue_22355.yaml
@@ -48,6 +48,16 @@ components:
             items:
               type: string
               nullable: true
+        modelRefNullableItems:
+          type: array
+          items:
+            $ref: '#/components/schemas/NullablePet'
     NullableString:
       type: string
       nullable: true
+    NullablePet:
+      type: object
+      nullable: true
+      properties:
+        name:
+          type: string

--- a/modules/openapi-generator/src/test/resources/3_0/issue_22355.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/issue_22355.yaml
@@ -1,0 +1,41 @@
+openapi: 3.0.0
+info:
+  title: 'Issue 22355 Nullable array items'
+  version: latest
+components:
+  schemas:
+    NullItemsNotNullItems:
+      properties:
+        nullableItems:
+          type: array
+          items:
+            type: string
+            nullable: true
+        notNullableItems:
+          type: array
+          items:
+            type: string
+            nullable: false
+        defaultItems:
+          type: array
+          items:
+            type: string
+        nullableDoubleItems:
+          type: array
+          items:
+            type: number
+            format: double
+            nullable: true
+        nullableItemsSet:
+          type: array
+          uniqueItems: true
+          items:
+            type: string
+            nullable: true
+        nestedNullableItems:
+          type: array
+          items:
+            type: array
+            items:
+              type: string
+              nullable: true

--- a/modules/openapi-generator/src/test/resources/3_0/swift6/issue22355-nullable-array-items.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/swift6/issue22355-nullable-array-items.yaml
@@ -26,6 +26,15 @@ components:
             type: number
             format: double
             nullable: true
+        xNullableItems:
+          type: array
+          items:
+            type: string
+            x-nullable: true
+        aliasedNullableItems:
+          type: array
+          items:
+            $ref: '#/components/schemas/NullableString'
         nullableItemsSet:
           type: array
           uniqueItems: true
@@ -39,3 +48,6 @@ components:
             items:
               type: string
               nullable: true
+    NullableString:
+      type: string
+      nullable: true

--- a/modules/openapi-generator/src/test/resources/3_0/swift6/issue22355-nullable-array-items.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/swift6/issue22355-nullable-array-items.yaml
@@ -48,6 +48,16 @@ components:
             items:
               type: string
               nullable: true
+        modelRefNullableItems:
+          type: array
+          items:
+            $ref: '#/components/schemas/NullablePet'
     NullableString:
       type: string
       nullable: true
+    NullablePet:
+      type: object
+      nullable: true
+      properties:
+        name:
+          type: string

--- a/modules/openapi-generator/src/test/resources/3_0/swift6/issue22355-nullable-array-items.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/swift6/issue22355-nullable-array-items.yaml
@@ -1,0 +1,41 @@
+openapi: 3.0.0
+info:
+  title: 'Issue 22355 Nullable array items'
+  version: latest
+components:
+  schemas:
+    NullItemsNotNullItems:
+      properties:
+        nullableItems:
+          type: array
+          items:
+            type: string
+            nullable: true
+        notNullableItems:
+          type: array
+          items:
+            type: string
+            nullable: false
+        defaultItems:
+          type: array
+          items:
+            type: string
+        nullableDoubleItems:
+          type: array
+          items:
+            type: number
+            format: double
+            nullable: true
+        nullableItemsSet:
+          type: array
+          uniqueItems: true
+          items:
+            type: string
+            nullable: true
+        nestedNullableItems:
+          type: array
+          items:
+            type: array
+            items:
+              type: string
+              nullable: true


### PR DESCRIPTION
- Fixes #22355

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

CC: @jgavris @ehyche @Edubits @jaz-ah @4brunu @dydus0x14

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Respect nullable array items in Swift 5 and 6 generators, and nullable map values in Swift 6, so generated types match OpenAPI nullability. Previously arrays/sets and maps used non-optional element/value types; now nullable items/values become optionals (e.g., [String?], Set<String?>, [String: Foo?]).

- Affected generators: `Swift5ClientCodegen` (arrays/sets) and `Swift6ClientCodegen` (arrays/sets and map values); non-nullable items are unchanged.
- Detects nullability via `nullable: true`, `x-nullable`, and `$ref`/aliased schemas, including nested collections.
- Breaking change: callers must handle nil elements and map values where schemas mark items as nullable.

<sup>Written for commit ecc7b3f5dccf87c625bd81001ff85601df7a7463. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24770?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

