### PR TITLE
Add generateRootResources option for JavaJAXRSSpecServerCodegen

### DIFF
--- a/docs/generators/jaxrs-cxf-cdi.md
+++ b/docs/generators/jaxrs-cxf-cdi.md
@@ -47,6 +47,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |generateBuilders|Whether to generate builders for models| |false|
 |generateConstructorWithAllArgs|whether to generate a constructor for all arguments| |false|
 |generatePom|Whether to generate pom.xml if the file does not already exist.| |true|
+|generateRootResources|Whether to generate the root resource and application classes, only useful if interfaceOnly is true.| |true|
 |groupId|groupId in generated pom.xml| |org.openapitools|
 |hideGenerationTimestamp|Hides the generation timestamp when files are generated.| |false|
 |ignoreAnyOfInEnum|Ignore anyOf keyword in enum| |false|

--- a/docs/generators/jaxrs-spec.md
+++ b/docs/generators/jaxrs-spec.md
@@ -48,6 +48,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |generateConstructorWithAllArgs|whether to generate a constructor for all arguments| |false|
 |generateJsonCreator|Whether to generate @JsonCreator constructor for required properties.| |true|
 |generatePom|Whether to generate pom.xml if the file does not already exist.| |true|
+|generateRootResources|Whether to generate the root resource and application classes, only useful if interfaceOnly is true.| |true|
 |groupId|groupId in generated pom.xml| |org.openapitools|
 |hideGenerationTimestamp|Hides the generation timestamp when files are generated.| |false|
 |ignoreAnyOfInEnum|Ignore anyOf keyword in enum| |false|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaJAXRSSpecServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaJAXRSSpecServerCodegen.java
@@ -52,6 +52,7 @@ public class JavaJAXRSSpecServerCodegen extends AbstractJavaJAXRSServerCodegen {
     public static final String RETURN_RESPONSE = "returnResponse";
     public static final String RETURN_JBOSS_RESPONSE = "returnJBossResponse";
     public static final String GENERATE_POM = "generatePom";
+    public static final String GENERATE_ROOT_RESOURCES = "generateRootResources";
     public static final String USE_SWAGGER_ANNOTATIONS = "useSwaggerAnnotations";
     public static final String USE_MICROPROFILE_OPENAPI_ANNOTATIONS = "useMicroProfileOpenAPIAnnotations";
     public static final String USE_SWAGGER_V3_ANNOTATIONS = "useSwaggerV3Annotations";
@@ -69,6 +70,7 @@ public class JavaJAXRSSpecServerCodegen extends AbstractJavaJAXRSServerCodegen {
     public static final String KUMULUZEE_LIBRARY = "kumuluzee";
 
     private boolean interfaceOnly = false;
+    private boolean generateRootResources = true;
     private boolean returnResponse = false;
     private boolean returnJbossResponse = false;
     private boolean generatePom = true;
@@ -156,6 +158,7 @@ public class JavaJAXRSSpecServerCodegen extends AbstractJavaJAXRSServerCodegen {
         cliOptions.add(library);
         cliOptions.add(CliOption.newBoolean(GENERATE_POM, "Whether to generate pom.xml if the file does not already exist.").defaultValue(String.valueOf(generatePom)));
         cliOptions.add(CliOption.newBoolean(INTERFACE_ONLY, INTERFACE_ONLY_DESC).defaultValue(String.valueOf(interfaceOnly)));
+        cliOptions.add(CliOption.newBoolean(GENERATE_ROOT_RESOURCES, "Whether to generate the root resource and application classes, only useful if interfaceOnly is true.", generateRootResources));
         cliOptions.add(CliOption.newBoolean(RETURN_RESPONSE, "Whether generate API interface should return javax.ws.rs.core.Response instead of a deserialized entity. Only useful if interfaceOnly is true.").defaultValue(String.valueOf(returnResponse)));
         cliOptions.add(CliOption.newBoolean(RETURN_JBOSS_RESPONSE, "Whether generate API interface should return `org.jboss.resteasy.reactive.RestResponse` instead of a deserialized entity. This flag cannot be combined with `returnResponse` flag. It requires the flag `interfaceOnly` and `useJakartaEE` set to true, because `org.jboss.resteasy.reactive.RestResponse` was introduced in Quarkus 2.x").defaultValue(String.valueOf(returnJbossResponse)));
         cliOptions.add(CliOption.newBoolean(USE_SWAGGER_ANNOTATIONS, "Whether to generate Swagger annotations.", useSwaggerAnnotations));
@@ -175,6 +178,7 @@ public class JavaJAXRSSpecServerCodegen extends AbstractJavaJAXRSServerCodegen {
         convertPropertyToBooleanAndWriteBack(GENERATE_POM, value -> generatePom = value);
 
         convertPropertyToBooleanAndWriteBack(INTERFACE_ONLY, value -> interfaceOnly = value);
+        convertPropertyToBooleanAndWriteBack(GENERATE_ROOT_RESOURCES, value -> generateRootResources = value);
         convertPropertyToBooleanAndWriteBack(RETURN_RESPONSE, value -> returnResponse = value);
         convertPropertyToBooleanAndWriteBack(RETURN_JBOSS_RESPONSE, value -> returnJbossResponse = value);
         convertPropertyToBooleanAndWriteBack(SUPPORT_ASYNC, this::setSupportAsync);
@@ -251,7 +255,7 @@ public class JavaJAXRSSpecServerCodegen extends AbstractJavaJAXRSServerCodegen {
         supportingFiles.add(new SupportingFile("README.mustache", "", "README.md")
                 .doNotOverwrite());
 
-        if (!interfaceOnly) {
+        if ((!interfaceOnly) || generateRootResources) {
             supportingFiles.add(new SupportingFile("RestResourceRoot.mustache",
                     (sourceFolder + '/' + invokerPackage).replace(".", "/"), "RestResourceRoot.java")
                     .doNotOverwrite());

--- a/samples/server/petstore/jaxrs-spec-interface-response/.openapi-generator/FILES
+++ b/samples/server/petstore/jaxrs-spec-interface-response/.openapi-generator/FILES
@@ -1,6 +1,8 @@
 README.md
 pom.xml
 src/gen/java/org/openapitools/api/PetApi.java
+src/gen/java/org/openapitools/api/RestApplication.java
+src/gen/java/org/openapitools/api/RestResourceRoot.java
 src/gen/java/org/openapitools/api/StoreApi.java
 src/gen/java/org/openapitools/api/UserApi.java
 src/gen/java/org/openapitools/model/Category.java

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/api/RestApplication.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/api/RestApplication.java
@@ -1,0 +1,9 @@
+package org.openapitools.api;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+@ApplicationPath(RestResourceRoot.APPLICATION_PATH)
+public class RestApplication extends Application {
+
+}

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/api/RestResourceRoot.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/api/RestResourceRoot.java
@@ -1,0 +1,5 @@
+package org.openapitools.api;
+
+public class RestResourceRoot {
+    public static final String APPLICATION_PATH = "/v2";
+}

--- a/samples/server/petstore/jaxrs-spec-interface/.openapi-generator/FILES
+++ b/samples/server/petstore/jaxrs-spec-interface/.openapi-generator/FILES
@@ -1,6 +1,8 @@
 README.md
 pom.xml
 src/gen/java/org/openapitools/api/PetApi.java
+src/gen/java/org/openapitools/api/RestApplication.java
+src/gen/java/org/openapitools/api/RestResourceRoot.java
 src/gen/java/org/openapitools/api/StoreApi.java
 src/gen/java/org/openapitools/api/UserApi.java
 src/gen/java/org/openapitools/model/Category.java

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/api/RestApplication.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/api/RestApplication.java
@@ -1,0 +1,9 @@
+package org.openapitools.api;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+@ApplicationPath(RestResourceRoot.APPLICATION_PATH)
+public class RestApplication extends Application {
+
+}

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/api/RestResourceRoot.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/api/RestResourceRoot.java
@@ -1,0 +1,5 @@
+package org.openapitools.api;
+
+public class RestResourceRoot {
+    public static final String APPLICATION_PATH = "/v2";
+}

--- a/samples/server/petstore/jaxrs-spec/quarkus-security/.openapi-generator/FILES
+++ b/samples/server/petstore/jaxrs-spec/quarkus-security/.openapi-generator/FILES
@@ -6,6 +6,8 @@ src/gen/java/org/openapitools/api/AdminOrUserApi.java
 src/gen/java/org/openapitools/api/AnonymousOrAuthenticatedApi.java
 src/gen/java/org/openapitools/api/AuthenticatedApi.java
 src/gen/java/org/openapitools/api/PublicApi.java
+src/gen/java/org/openapitools/api/RestApplication.java
+src/gen/java/org/openapitools/api/RestResourceRoot.java
 src/main/docker/Dockerfile.jvm
 src/main/docker/Dockerfile.native
 src/main/resources/META-INF/openapi.yaml

--- a/samples/server/petstore/jaxrs-spec/quarkus-security/src/gen/java/org/openapitools/api/RestApplication.java
+++ b/samples/server/petstore/jaxrs-spec/quarkus-security/src/gen/java/org/openapitools/api/RestApplication.java
@@ -1,0 +1,9 @@
+package org.openapitools.api;
+
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+
+@ApplicationPath(RestResourceRoot.APPLICATION_PATH)
+public class RestApplication extends Application {
+
+}

--- a/samples/server/petstore/jaxrs-spec/quarkus-security/src/gen/java/org/openapitools/api/RestResourceRoot.java
+++ b/samples/server/petstore/jaxrs-spec/quarkus-security/src/gen/java/org/openapitools/api/RestResourceRoot.java
@@ -1,0 +1,5 @@
+package org.openapitools.api;
+
+public class RestResourceRoot {
+    public static final String APPLICATION_PATH = "";
+}


### PR DESCRIPTION
Add generateRootResources (default enabled) to restore behaviour pre- https://github.com/OpenAPITools/openapi-generator/pull/22169 which stopped generating root resources when interfaceonly was enabled.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `generateRootResources` to `JavaJAXRSSpecServerCodegen` (default true) to generate the root resource and application classes when `interfaceOnly` is true, restoring the pre-#22169 behavior. This reintroduces `RestApplication.java` and `RestResourceRoot.java` in interface-only outputs; set the option to false to keep the newer no-root-resources behavior.

- Docs for `jaxrs-spec` and `jaxrs-cxf-cdi` list the new option.

**Migration**
- If you depend on interface-only outputs without root resources, pass `--additional-properties=generateRootResources=false` (or set `generateRootResources: false` in your config).

<sup>Written for commit 8d9f4d3487130047f6621668bca7479fd359b545. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24773?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

