### PR TITLE
[Java] Add generateInsecureTlsHook option to omit the trust-all-certificates hook (jersey2/jersey3)

### DIFF
--- a/docs/generators/java-microprofile.md
+++ b/docs/generators/java-microprofile.md
@@ -56,7 +56,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |generateBuilders|Whether to generate builders for models| |false|
 |generateClientAsBean|For resttemplate, restclient and webclient, configure whether to create `ApiClient.java` and Apis clients as bean (with `@Component` annotation).| |false|
 |generateConstructorWithAllArgs|whether to generate a constructor for all arguments| |false|
-|generateInsecureTlsHook|Generate the ApiClient.disableCertificateValidation hook, which trusts all TLS certificates (default to true). Set to false to omit it, e.g. when static analysis flags the trust-all TrustManager it contains. Available on `jersey2`, `jersey3` libraries.| |false|
+|generateInsecureTlsHook|Generate the ApiClient.disableCertificateValidation hook, which trusts all TLS certificates (default to true). Set to false to omit it, e.g. when static analysis flags the trust-all TrustManager it contains. Available on `jersey2`, `jersey3` libraries.| |true|
 |gradleProperties|Append additional Gradle properties to the gradle.properties file| |null|
 |groupId|groupId in generated pom.xml| |org.openapitools|
 |hideGenerationTimestamp|Hides the generation timestamp when files are generated.| |false|

--- a/docs/generators/java-microprofile.md
+++ b/docs/generators/java-microprofile.md
@@ -56,6 +56,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |generateBuilders|Whether to generate builders for models| |false|
 |generateClientAsBean|For resttemplate, restclient and webclient, configure whether to create `ApiClient.java` and Apis clients as bean (with `@Component` annotation).| |false|
 |generateConstructorWithAllArgs|whether to generate a constructor for all arguments| |false|
+|generateInsecureTlsHook|Generate the ApiClient.disableCertificateValidation hook, which trusts all TLS certificates (default to true). Set to false to omit it, e.g. when static analysis flags the trust-all TrustManager it contains. Available on `jersey2`, `jersey3` libraries.| |false|
 |gradleProperties|Append additional Gradle properties to the gradle.properties file| |null|
 |groupId|groupId in generated pom.xml| |org.openapitools|
 |hideGenerationTimestamp|Hides the generation timestamp when files are generated.| |false|

--- a/docs/generators/java.md
+++ b/docs/generators/java.md
@@ -56,7 +56,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |generateBuilders|Whether to generate builders for models| |false|
 |generateClientAsBean|For resttemplate, restclient and webclient, configure whether to create `ApiClient.java` and Apis clients as bean (with `@Component` annotation).| |false|
 |generateConstructorWithAllArgs|whether to generate a constructor for all arguments| |false|
-|generateInsecureTlsHook|Generate the ApiClient.disableCertificateValidation hook, which trusts all TLS certificates (default to true). Set to false to omit it, e.g. when static analysis flags the trust-all TrustManager it contains. Available on `jersey2`, `jersey3` libraries.| |false|
+|generateInsecureTlsHook|Generate the ApiClient.disableCertificateValidation hook, which trusts all TLS certificates (default to true). Set to false to omit it, e.g. when static analysis flags the trust-all TrustManager it contains. Available on `jersey2`, `jersey3` libraries.| |true|
 |gradleProperties|Append additional Gradle properties to the gradle.properties file| |null|
 |groupId|groupId in generated pom.xml| |org.openapitools|
 |hideGenerationTimestamp|Hides the generation timestamp when files are generated.| |false|

--- a/docs/generators/java.md
+++ b/docs/generators/java.md
@@ -56,6 +56,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |generateBuilders|Whether to generate builders for models| |false|
 |generateClientAsBean|For resttemplate, restclient and webclient, configure whether to create `ApiClient.java` and Apis clients as bean (with `@Component` annotation).| |false|
 |generateConstructorWithAllArgs|whether to generate a constructor for all arguments| |false|
+|generateInsecureTlsHook|Generate the ApiClient.disableCertificateValidation hook, which trusts all TLS certificates (default to true). Set to false to omit it, e.g. when static analysis flags the trust-all TrustManager it contains. Available on `jersey2`, `jersey3` libraries.| |false|
 |gradleProperties|Append additional Gradle properties to the gradle.properties file| |null|
 |groupId|groupId in generated pom.xml| |org.openapitools|
 |hideGenerationTimestamp|Hides the generation timestamp when files are generated.| |false|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
@@ -90,6 +90,7 @@ public class JavaClientCodegen extends AbstractJavaCodegen
     public static final String DYNAMIC_OPERATIONS = "dynamicOperations";
     public static final String SUPPORT_STREAMING = "supportStreaming";
     public static final String SUPPORT_URL_QUERY = "supportUrlQuery";
+    public static final String GENERATE_INSECURE_TLS_HOOK = "generateInsecureTlsHook";
     public static final String GRADLE_PROPERTIES = "gradleProperties";
     public static final String ERROR_OBJECT_TYPE = "errorObjectType";
 
@@ -283,6 +284,7 @@ public class JavaClientCodegen extends AbstractJavaCodegen
         cliOptions.add(CliOption.newBoolean(WEBCLIENT_BLOCKING_OPERATIONS, "Making all WebClient operations blocking(sync). Note that if on operation 'x-webclient-blocking: false' then such operation won't be sync", this.webclientBlockingOperations));
         cliOptions.add(CliOption.newBoolean(GENERATE_CLIENT_AS_BEAN, "For resttemplate, restclient and webclient, configure whether to create `ApiClient.java` and Apis clients as bean (with `@Component` annotation).", this.generateClientAsBean));
         cliOptions.add(CliOption.newBoolean(SUPPORT_URL_QUERY, "Generate toUrlQueryString in POJO (default to true). Available on `native`, `apache-httpclient` libraries."));
+        cliOptions.add(CliOption.newBoolean(GENERATE_INSECURE_TLS_HOOK, "Generate the ApiClient.disableCertificateValidation hook, which trusts all TLS certificates (default to true). Set to false to omit it, e.g. when static analysis flags the trust-all TrustManager it contains. Available on `jersey2`, `jersey3` libraries."));
         cliOptions.add(CliOption.newBoolean(USE_ENUM_CASE_INSENSITIVE, "Use `equalsIgnoreCase` when String for enum comparison", useEnumCaseInsensitive));
         cliOptions.add(CliOption.newBoolean(FAIL_ON_UNKNOWN_PROPERTIES, "Fail Jackson de-serialization on unknown properties", this.failOnUnknownProperties));
         cliOptions.add(CliOption.newBoolean(USE_JACKSON_3, "Use Jackson 3 instead of Jackson 2. Supported for 'native', 'apache-httpclient', and 'jersey3' libraries (requires Java 17+) and for Spring 'resttemplate', 'webclient', and 'restclient' libraries (require useSpringBoot4=true).", this.useJackson3));
@@ -525,6 +527,15 @@ public class JavaClientCodegen extends AbstractJavaCodegen
             }
         } else {
             additionalProperties.put(SUPPORT_URL_QUERY, Boolean.parseBoolean(additionalProperties.get(SUPPORT_URL_QUERY).toString()));
+        }
+
+        // the disableCertificateValidation hook is emitted by default, to keep
+        // existing subclasses that call it compiling
+        if (!additionalProperties.containsKey(GENERATE_INSECURE_TLS_HOOK)) {
+            additionalProperties.put(GENERATE_INSECURE_TLS_HOOK, true);
+        } else {
+            additionalProperties.put(GENERATE_INSECURE_TLS_HOOK,
+                    Boolean.parseBoolean(additionalProperties.get(GENERATE_INSECURE_TLS_HOOK).toString()));
         }
 
         convertPropertyToBooleanAndWriteBack(GENERATE_CLIENT_AS_BEAN, this::setGenerateClientAsBean);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
@@ -284,7 +284,7 @@ public class JavaClientCodegen extends AbstractJavaCodegen
         cliOptions.add(CliOption.newBoolean(WEBCLIENT_BLOCKING_OPERATIONS, "Making all WebClient operations blocking(sync). Note that if on operation 'x-webclient-blocking: false' then such operation won't be sync", this.webclientBlockingOperations));
         cliOptions.add(CliOption.newBoolean(GENERATE_CLIENT_AS_BEAN, "For resttemplate, restclient and webclient, configure whether to create `ApiClient.java` and Apis clients as bean (with `@Component` annotation).", this.generateClientAsBean));
         cliOptions.add(CliOption.newBoolean(SUPPORT_URL_QUERY, "Generate toUrlQueryString in POJO (default to true). Available on `native`, `apache-httpclient` libraries."));
-        cliOptions.add(CliOption.newBoolean(GENERATE_INSECURE_TLS_HOOK, "Generate the ApiClient.disableCertificateValidation hook, which trusts all TLS certificates (default to true). Set to false to omit it, e.g. when static analysis flags the trust-all TrustManager it contains. Available on `jersey2`, `jersey3` libraries."));
+        cliOptions.add(CliOption.newBoolean(GENERATE_INSECURE_TLS_HOOK, "Generate the ApiClient.disableCertificateValidation hook, which trusts all TLS certificates (default to true). Set to false to omit it, e.g. when static analysis flags the trust-all TrustManager it contains. Available on `jersey2`, `jersey3` libraries.", true));
         cliOptions.add(CliOption.newBoolean(USE_ENUM_CASE_INSENSITIVE, "Use `equalsIgnoreCase` when String for enum comparison", useEnumCaseInsensitive));
         cliOptions.add(CliOption.newBoolean(FAIL_ON_UNKNOWN_PROPERTIES, "Fail Jackson de-serialization on unknown properties", this.failOnUnknownProperties));
         cliOptions.add(CliOption.newBoolean(USE_JACKSON_3, "Use Jackson 3 instead of Jackson 2. Supported for 'native', 'apache-httpclient', and 'jersey3' libraries (requires Java 17+) and for Spring 'resttemplate', 'webclient', and 'restclient' libraries (require useSpringBoot4=true).", this.useJackson3));
@@ -529,8 +529,6 @@ public class JavaClientCodegen extends AbstractJavaCodegen
             additionalProperties.put(SUPPORT_URL_QUERY, Boolean.parseBoolean(additionalProperties.get(SUPPORT_URL_QUERY).toString()));
         }
 
-        // the disableCertificateValidation hook is emitted by default, to keep
-        // existing subclasses that call it compiling
         if (!additionalProperties.containsKey(GENERATE_INSECURE_TLS_HOOK)) {
             additionalProperties.put(GENERATE_INSECURE_TLS_HOOK, true);
         } else {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import java.net.URI;
+{{#generateInsecureTlsHook}}
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
@@ -36,6 +37,7 @@ import java.security.cert.X509Certificate;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
+{{/generateInsecureTlsHook}}
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
@@ -1437,14 +1439,17 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
    *    server endpoints from web targets created by the client instance that is using this SSL context.
    * 4. Set the client-side trust store.
    *
+{{#generateInsecureTlsHook}}
    * To completely disable certificate validation (at your own risk), you can
    * override this method and invoke disableCertificateValidation(clientBuilder).
    *
+{{/generateInsecureTlsHook}}
    * @param clientBuilder a {@link {{javaxPackage}}.ws.rs.client.ClientBuilder} object.
    */
   protected void customizeClientBuilder(ClientBuilder clientBuilder) {
     // No-op extension point
   }
+{{#generateInsecureTlsHook}}
 
   /**
    * Disable X.509 certificate validation in TLS connections.
@@ -1475,6 +1480,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
     sslContext.init(null, trustAllCerts, new SecureRandom());
     clientBuilder.sslContext(sslContext);
   }
+{{/generateInsecureTlsHook}}
 
   /**
    * <p>Build the response headers.</p>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/ApiClient.mustache
@@ -34,6 +34,7 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import java.net.URI;
+{{#generateInsecureTlsHook}}
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
@@ -41,6 +42,7 @@ import java.security.cert.X509Certificate;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
+{{/generateInsecureTlsHook}}
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
@@ -1477,14 +1479,17 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
    *    server endpoints from web targets created by the client instance that is using this SSL context.
    * 4. Set the client-side trust store.
    *
+{{#generateInsecureTlsHook}}
    * To completely disable certificate validation (at your own risk), you can
    * override this method and invoke disableCertificateValidation(clientBuilder).
    *
+{{/generateInsecureTlsHook}}
    * @param clientBuilder a {@link {{javaxPackage}}.ws.rs.client.ClientBuilder} object.
    */
   protected void customizeClientBuilder(ClientBuilder clientBuilder) {
     // No-op extension point
   }
+{{#generateInsecureTlsHook}}
 
   /**
    * Disable X.509 certificate validation in TLS connections.
@@ -1515,6 +1520,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
     sslContext.init(null, trustAllCerts, new SecureRandom());
     clientBuilder.sslContext(sslContext);
   }
+{{/generateInsecureTlsHook}}
 
   /**
    * <p>Build the response headers.</p>

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -5003,4 +5003,47 @@ public class JavaClientCodegenTest {
         codegen.additionalProperties().putAll(properties);
         return codegen;
     }
+
+    @DataProvider(name = "jerseyLibraries")
+    public static Object[][] jerseyLibraries() {
+        return new Object[][]{{JavaClientCodegen.JERSEY2}, {JavaClientCodegen.JERSEY3}};
+    }
+
+    @Test(dataProvider = "jerseyLibraries")
+    public void testInsecureTlsHookGeneratedByDefault(String library) {
+        Path output = generateJerseyClient(library, null);
+
+        JavaFileAssert.assertThat(output.resolve("src/main/java/xyz/abcdef/invoker/ApiClient.java").toFile())
+                .assertMethod("disableCertificateValidation");
+    }
+
+    @Test(dataProvider = "jerseyLibraries")
+    public void testInsecureTlsHookOmittedWhenDisabled(String library) {
+        Path output = generateJerseyClient(library, false);
+
+        assertThat(output.resolve("src/main/java/xyz/abcdef/invoker/ApiClient.java")).content()
+                .doesNotContain("disableCertificateValidation")
+                .doesNotContain("X509TrustManager")
+                .doesNotContain("import javax.net.ssl.SSLContext;")
+                .doesNotContain("import java.security.SecureRandom;")
+                .doesNotContain("import java.security.KeyManagementException;")
+                .doesNotContain("import java.security.NoSuchAlgorithmException;")
+                .doesNotContain("import java.security.cert.X509Certificate;");
+    }
+
+    private static Path generateJerseyClient(String library, Boolean generateInsecureTlsHook) {
+        Path output = newTempFolder();
+        CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName(JAVA_GENERATOR)
+                .setLibrary(library)
+                .addAdditionalProperty(CodegenConstants.INVOKER_PACKAGE, "xyz.abcdef.invoker")
+                .setInputSpec("src/test/resources/3_0/petstore.yaml")
+                .setOutputDir(output.toString().replace("\\", "/"));
+        if (generateInsecureTlsHook != null) {
+            configurator.addAdditionalProperty(GENERATE_INSECURE_TLS_HOOK, generateInsecureTlsHook);
+        }
+
+        new DefaultGenerator().opts(configurator.toClientOptInput()).generate();
+        return output;
+    }
 }


### PR DESCRIPTION
Fixes #24785

The `jersey2` and `jersey3` `ApiClient` templates unconditionally emit
`disableCertificateValidation()`, which builds an `X509TrustManager` with empty
`checkClientTrusted`/`checkServerTrusted` bodies and installs it into the
`SSLContext`. CodeQL reports this as `java/insecure-trustmanager` at **high**
severity, which fails the code scanning check on any PR that adds or touches the
generated client. Sonar's `java:S4830` flags the same pattern.

The method is a `protected` opt-in hook — nothing in the generated client calls
it, and the javadoc on `customizeClientBuilder` tells you to override and invoke
it if you want it. But analysers flag code as written, not as reached, so
projects that commit their generated client (or scan `target/`) carry a
high-severity alert for a method they never use, with no way to opt out today:

- no `configOption` gates the block — it is unconditional template text;
- suppression comments do not survive regeneration;
- `.openapi-generator-ignore` excludes whole files, and `ApiClient` is the class
  you configure, so it cannot be skipped.

### What this changes

Adds a `generateInsecureTlsHook` option that gates the method, the javadoc lines
that point at it, and the seven imports that become unused without it
(`SSLContext`, `TrustManager`, `X509TrustManager`, `X509Certificate`,
`SecureRandom`, `KeyManagementException`, `NoSuchAlgorithmException`).

**It defaults to `true`, so generated output is unchanged.** Anyone who
overrides `customizeClientBuilder` and calls the hook keeps compiling. Opting
out is explicit:

```xml
<configOptions>
  <generateInsecureTlsHook>false</generateInsecureTlsHook>
</configOptions>
```

### Scope

Limited to `jersey2` and `jersey3`. `okhttp-gson` contains a similar trust-all
`X509TrustManager`, but there it sits inside `applySslSettings()` behind the
runtime `verifyingSsl` field, which has a public `setVerifyingSsl(boolean)`
setter and is a documented feature. Gating that would be a breaking change, so
it is left alone. `native`, `apache-httpclient` and `resttemplate` do not emit
the block at all.

### Testing

- Added `testInsecureTlsHookGeneratedByDefault` and
  `testInsecureTlsHookOmittedWhenDisabled` to `JavaClientCodegenTest`, both run
  against `jersey2` and `jersey3` via a data provider (4 cases). The second
  asserts the method, the `X509TrustManager` and each of the seven imports are
  absent.
- Full `JavaClientCodegenTest`: 278 tests, 0 failures.
- Regenerated **every** `bin/configs/java*.yaml` sample: **no diff**, confirming
  the default preserves current output.
- Generated `jersey2` and `jersey3` clients with the option off and confirmed no
  residue of the method or its imports, and that spacing around the removal
  stays correct (one blank line between the neighbouring members).
- Regenerated generator docs.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the build and updated samples and docs:
  ```
  ./mvnw clean package
  ./bin/generate-samples.sh ./bin/configs/java*.yaml
  ./bin/utils/export_docs_generators.sh
  ```
  Samples produced no diff, as expected for a default-preserving change. Docs
  were regenerated and are included.
- [x] Filed against `master` as a non-breaking change.
- [x] @mentioning the technical committee for the affected libraries: @xhh
  (Java Jersey2), and @bbdouglas @wing328 as Java maintainers, in case you would
  prefer a different option name or a different default.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `generateInsecureTlsHook` option for `jersey2`/`jersey3` so the generated `ApiClient` no longer has to include the trust-all `disableCertificateValidation` hook that static analyzers flag as `java/insecure-trustmanager` (fixes #24785).

The option defaults to `true`, so generated output is unchanged; docs previously advertised a `false` default because the CLI option wasn't explicitly registered with one, which is now fixed. Setting it to `false` removes the hook, its javadoc, and the seven imports that become unused. `okhttp-gson` is left untouched because its equivalent is a live runtime feature behind `setVerifyingSsl`, not a dead method.

**New Features**
- `generateInsecureTlsHook` is a new `configOptions` boolean for `jersey2`/`jersey3`, defaulting to `true`.
- Regenerating all existing Java samples produces no diff.

<sup>Written for commit 8d3bace32b132b979fdb9d466e1a7c2e6df1c9f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24786?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

