### PR TITLE
[php-nextgen] Add Null Check to Model Param Validation

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-nextgen/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/model_generic.mustache
@@ -294,44 +294,44 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
         {{#hasValidation}}
 {{#isString}}
         {{#maxLength}}
-        if ({{#notRequiredOrIsNullable}}!is_null($this->container['{{name}}']) && {{/notRequiredOrIsNullable}}(mb_strlen($this->container['{{name}}']) > {{maxLength}})) {
+        if (!is_null($this->container['{{name}}']) && (mb_strlen($this->container['{{name}}']) > {{maxLength}})) {
             $invalidProperties[] = "invalid value for '{{name}}', the character length must be smaller than or equal to {{{maxLength}}}.";
         }
 
         {{/maxLength}}
         {{#minLength}}
-        if ({{#notRequiredOrIsNullable}}!is_null($this->container['{{name}}']) && {{/notRequiredOrIsNullable}}(mb_strlen($this->container['{{name}}']) < {{minLength}})) {
+        if (!is_null($this->container['{{name}}']) && (mb_strlen($this->container['{{name}}']) < {{minLength}})) {
             $invalidProperties[] = "invalid value for '{{name}}', the character length must be bigger than or equal to {{{minLength}}}.";
         }
 
         {{/minLength}}
 {{/isString}}
         {{#maximum}}
-        if ({{#notRequiredOrIsNullable}}!is_null($this->container['{{name}}']) && {{/notRequiredOrIsNullable}}($this->container['{{name}}'] >{{#exclusiveMaximum}}={{/exclusiveMaximum}} {{maximum}})) {
+        if (!is_null($this->container['{{name}}']) && ($this->container['{{name}}'] >{{#exclusiveMaximum}}={{/exclusiveMaximum}} {{maximum}})) {
             $invalidProperties[] = "invalid value for '{{name}}', must be smaller than {{^exclusiveMaximum}}or equal to {{/exclusiveMaximum}}{{maximum}}.";
         }
 
         {{/maximum}}
         {{#minimum}}
-        if ({{#notRequiredOrIsNullable}}!is_null($this->container['{{name}}']) && {{/notRequiredOrIsNullable}}($this->container['{{name}}'] <{{#exclusiveMinimum}}={{/exclusiveMinimum}} {{minimum}})) {
+        if (!is_null($this->container['{{name}}']) && ($this->container['{{name}}'] <{{#exclusiveMinimum}}={{/exclusiveMinimum}} {{minimum}})) {
             $invalidProperties[] = "invalid value for '{{name}}', must be bigger than {{^exclusiveMinimum}}or equal to {{/exclusiveMinimum}}{{minimum}}.";
         }
 
         {{/minimum}}
         {{#pattern}}
-        if ({{#notRequiredOrIsNullable}}!is_null($this->container['{{name}}']) && {{/notRequiredOrIsNullable}}!preg_match("{{{pattern}}}", $this->container['{{name}}'])) {
+        if (!is_null($this->container['{{name}}']) && !preg_match("{{{pattern}}}", $this->container['{{name}}'])) {
             $invalidProperties[] = "invalid value for '{{name}}', must be conform to the pattern {{{pattern}}}.";
         }
 
         {{/pattern}}
         {{#maxItems}}
-        if ({{#notRequiredOrIsNullable}}!is_null($this->container['{{name}}']) && {{/notRequiredOrIsNullable}}(count($this->container['{{name}}']) > {{maxItems}})) {
+        if (!is_null($this->container['{{name}}']) && (count($this->container['{{name}}']) > {{maxItems}})) {
             $invalidProperties[] = "invalid value for '{{name}}', number of items must be less than or equal to {{{maxItems}}}.";
         }
 
         {{/maxItems}}
         {{#minItems}}
-        if ({{#notRequiredOrIsNullable}}!is_null($this->container['{{name}}']) && {{/notRequiredOrIsNullable}}(count($this->container['{{name}}']) < {{minItems}})) {
+        if (!is_null($this->container['{{name}}']) && (count($this->container['{{name}}']) < {{minItems}})) {
             $invalidProperties[] = "invalid value for '{{name}}', number of items must be greater than or equal to {{{minItems}}}.";
         }
 

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/FormatTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/FormatTest.php
@@ -382,11 +382,11 @@ class FormatTest implements ModelInterface, ArrayAccess, JsonSerializable
         if ($this->container['number'] === null) {
             $invalidProperties[] = "'number' can't be null";
         }
-        if (($this->container['number'] > 543.2)) {
+        if (!is_null($this->container['number']) && ($this->container['number'] > 543.2)) {
             $invalidProperties[] = "invalid value for 'number', must be smaller than or equal to 543.2.";
         }
 
-        if (($this->container['number'] < 32.1)) {
+        if (!is_null($this->container['number']) && ($this->container['number'] < 32.1)) {
             $invalidProperties[] = "invalid value for 'number', must be bigger than or equal to 32.1.";
         }
 
@@ -419,11 +419,11 @@ class FormatTest implements ModelInterface, ArrayAccess, JsonSerializable
         if ($this->container['password'] === null) {
             $invalidProperties[] = "'password' can't be null";
         }
-        if ((mb_strlen($this->container['password']) > 64)) {
+        if (!is_null($this->container['password']) && (mb_strlen($this->container['password']) > 64)) {
             $invalidProperties[] = "invalid value for 'password', the character length must be smaller than or equal to 64.";
         }
 
-        if ((mb_strlen($this->container['password']) < 10)) {
+        if (!is_null($this->container['password']) && (mb_strlen($this->container['password']) < 10)) {
             $invalidProperties[] = "invalid value for 'password', the character length must be bigger than or equal to 10.";
         }
 


### PR DESCRIPTION
`listInvalidProperties()` currently skips the null guard for required non-nullable props, so `mb_strlen`/`preg_match`/`count` could be called on `null` when the value is missing. This throws deprecation warnings on PHP 8.1+ and a `TypeError` on the array checks. This PR adds a null guard to each validation to avoid that.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@jebentier (2017/07), @dkarlovi (2017/07), @mandrean (2017/08), @jfastnacht (2017/09), [@ybelenko](https://github.com/ybelenko) (2018/07), @renepardon (2018/12)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes PHP next-gen model validation so required nullable properties no longer crash `listInvalidProperties()` when unset.

Previously, validation called `mb_strlen`, `preg_match`, `count`, and numeric comparisons on `null`, causing deprecation warnings on PHP 8.1+ and a `TypeError` for array checks. Now every validation guards with `!is_null()` before inspecting the value. Regenerated the sample `FormatTest.php` to match.

<sup>Written for commit 8e70b1f702ae14b6bb300140cbff441596c272a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24787?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

