### PR TITLE
Add option to use http.Header.Set when setting headers in Go client

### DIFF
--- a/docs/generators/go.md
+++ b/docs/generators/go.md
@@ -31,6 +31,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |prependFormOrBodyParameters|Add form or body parameters to the beginning of the parameter list.| |false|
 |structPrefix|whether to prefix struct with the class name. e.g. DeletePetOpts =&gt; PetApiDeletePetOpts| |false|
 |useDefaultValuesForRequiredVars|Use default values for required variables when available| |false|
+|useHttpHeaderSet|When setting HTTP request headers, use http.Header.Set with canonicalized header names| |false|
 |useOneOfDiscriminatorLookup|Use the discriminator's mapping in oneOf to speed up the model lookup. IMPORTANT: Validation (e.g. one and only one match in oneOf's schemas) will be skipped.| |false|
 |withAWSV4Signature|whether to include AWS v4 signature support| |false|
 |withGoMod|Generate go.mod and go.sum| |true|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
@@ -63,6 +63,8 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
     protected boolean generateUnmarshalJSON = true;
     @Setter
     protected boolean useDefaultValuesForRequiredVars = false;
+    @Setter
+    protected boolean useHttpHeaderSet = false;
 
     @Setter
     protected String packageName = "openapi";

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientCodegen.java
@@ -65,6 +65,7 @@ public class GoClientCodegen extends AbstractGoCodegen {
     public static final String MODEL_FILE_FOLDER = "modelFileFolder";
     public static final String WITH_GO_MOD = "withGoMod";
     public static final String USE_DEFAULT_VALUES_FOR_REQUIRED_VARS = "useDefaultValuesForRequiredVars";
+    public static final String USE_HTTP_HEADER_SET = "useHttpHeaderSet";
     public static final String IMPORT_VALIDATOR = "importValidator";
     @Setter protected String goImportAlias = "openapiclient";
     protected boolean isGoSubmodule = false;
@@ -138,6 +139,7 @@ public class GoClientCodegen extends AbstractGoCodegen {
         cliOptions.add(CliOption.newBoolean(WITH_AWSV4_SIGNATURE, "whether to include AWS v4 signature support"));
         cliOptions.add(CliOption.newBoolean(GENERATE_INTERFACES, "Generate interfaces for api classes"));
         cliOptions.add(CliOption.newBoolean(USE_DEFAULT_VALUES_FOR_REQUIRED_VARS, "Use default values for required variables when available"));
+        cliOptions.add(CliOption.newBoolean(USE_HTTP_HEADER_SET, "When setting HTTP request headers, use http.Header.Set with canonicalized header names"));
 
         // option to change the order of form/body parameter
         cliOptions.add(CliOption.newBoolean(
@@ -274,6 +276,11 @@ public class GoClientCodegen extends AbstractGoCodegen {
         if (additionalProperties.containsKey(USE_DEFAULT_VALUES_FOR_REQUIRED_VARS)) {
             setUseDefaultValuesForRequiredVars(Boolean.parseBoolean(additionalProperties.get(USE_DEFAULT_VALUES_FOR_REQUIRED_VARS).toString()));
             additionalProperties.put(USE_DEFAULT_VALUES_FOR_REQUIRED_VARS, useDefaultValuesForRequiredVars);
+        }
+
+        if (additionalProperties.containsKey(USE_HTTP_HEADER_SET)) {
+            setUseHttpHeaderSet(Boolean.parseBoolean(additionalProperties.get(USE_HTTP_HEADER_SET).toString()));
+            additionalProperties.put(USE_HTTP_HEADER_SET, useHttpHeaderSet);
         }
 
         // Generate the 'signing.py' module, but only if the 'HTTP signature' security scheme is specified in the OAS.

--- a/modules/openapi-generator/src/main/resources/go/client.mustache
+++ b/modules/openapi-generator/src/main/resources/go/client.mustache
@@ -416,12 +416,12 @@ func (c *APIClient) prepareRequest(
 	if len(headerParams) > 0 {
 		headers := http.Header{}
 		for h, v := range headerParams {
-		    {{#useHttpHeaderSet}}
-		    headers.Set(h, v)
-		    {{/useHttpHeaderSet}}
-            {{^useHttpHeaderSet}}
-		    headers[h] = []string{v}
-		    {{/useHttpHeaderSet}}
+			{{#useHttpHeaderSet}}
+			headers.Set(h, v)
+			{{/useHttpHeaderSet}}
+			{{^useHttpHeaderSet}}
+			headers[h] = []string{v}
+			{{/useHttpHeaderSet}}
 		}
 		localVarRequest.Header = headers
 	}

--- a/modules/openapi-generator/src/main/resources/go/client.mustache
+++ b/modules/openapi-generator/src/main/resources/go/client.mustache
@@ -416,7 +416,12 @@ func (c *APIClient) prepareRequest(
 	if len(headerParams) > 0 {
 		headers := http.Header{}
 		for h, v := range headerParams {
-			headers.Set(h, v)
+		    {{#useHttpHeaderSet}}
+		    headers.Set(h, v)
+		    {{/useHttpHeaderSet}}
+            {{^useHttpHeaderSet}}
+		    headers[h] = []string{v}
+		    {{/useHttpHeaderSet}}
 		}
 		localVarRequest.Header = headers
 	}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/GoClientOptionsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/GoClientOptionsTest.java
@@ -56,5 +56,7 @@ public class GoClientOptionsTest extends AbstractOptionsTest {
         verify(clientCodegen).setGenerateUnmarshalJSON(GoClientOptionsProvider.GENERATE_UNMARSHAL_JSON_VALUE);
         verify(clientCodegen).setUseDefaultValuesForRequiredVars(GoClientOptionsProvider.USE_DEFAULT_VALUES_FOR_REQUIRED_VARS_VALUE);
         verify(clientCodegen).setEnumUnknownDefaultCase(Boolean.parseBoolean(GoClientOptionsProvider.ENUM_UNKNOWN_DEFAULT_CASE_VALUE));
+        verify(clientCodegen).setUseHttpHeaderSet(GoClientOptionsProvider.USE_HTTP_HEADER_SET);
+
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/GoClientOptionsProvider.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/GoClientOptionsProvider.java
@@ -41,6 +41,8 @@ public class GoClientOptionsProvider implements OptionsProvider {
     public static final boolean GENERATE_UNMARSHAL_JSON_VALUE = true;
     public static final boolean USE_DEFAULT_VALUES_FOR_REQUIRED_VARS_VALUE = true;
     public static final String ENUM_UNKNOWN_DEFAULT_CASE_VALUE = "false";
+    public static final boolean USE_HTTP_HEADER_SET = true;
+
 
     @Override
     public String getLanguage() {
@@ -68,6 +70,7 @@ public class GoClientOptionsProvider implements OptionsProvider {
                 .put("structPrefix", "true")
                 .put(CodegenConstants.USE_DEFAULT_VALUES_FOR_REQUIRED_VARS, "true")
                 .put(CodegenConstants.ENUM_UNKNOWN_DEFAULT_CASE, ENUM_UNKNOWN_DEFAULT_CASE_VALUE)
+                .put("useHttpHeaderSet", "true")
                 .build();
     }
 

--- a/samples/client/echo_api/go-external-refs/client.go
+++ b/samples/client/echo_api/go-external-refs/client.go
@@ -420,7 +420,7 @@ func (c *APIClient) prepareRequest(
 	if len(headerParams) > 0 {
 		headers := http.Header{}
 		for h, v := range headerParams {
-			headers.Set(h, v)
+		    headers[h] = []string{v}
 		}
 		localVarRequest.Header = headers
 	}

--- a/samples/client/echo_api/go-external-refs/client.go
+++ b/samples/client/echo_api/go-external-refs/client.go
@@ -420,7 +420,7 @@ func (c *APIClient) prepareRequest(
 	if len(headerParams) > 0 {
 		headers := http.Header{}
 		for h, v := range headerParams {
-		    headers[h] = []string{v}
+			headers[h] = []string{v}
 		}
 		localVarRequest.Header = headers
 	}

--- a/samples/client/echo_api/go/client.go
+++ b/samples/client/echo_api/go/client.go
@@ -420,7 +420,7 @@ func (c *APIClient) prepareRequest(
 	if len(headerParams) > 0 {
 		headers := http.Header{}
 		for h, v := range headerParams {
-			headers.Set(h, v)
+		    headers[h] = []string{v}
 		}
 		localVarRequest.Header = headers
 	}

--- a/samples/client/echo_api/go/client.go
+++ b/samples/client/echo_api/go/client.go
@@ -420,7 +420,7 @@ func (c *APIClient) prepareRequest(
 	if len(headerParams) > 0 {
 		headers := http.Header{}
 		for h, v := range headerParams {
-		    headers[h] = []string{v}
+			headers[h] = []string{v}
 		}
 		localVarRequest.Header = headers
 	}

--- a/samples/client/others/go/allof_multiple_ref_and_discriminator/client.go
+++ b/samples/client/others/go/allof_multiple_ref_and_discriminator/client.go
@@ -401,7 +401,7 @@ func (c *APIClient) prepareRequest(
 	if len(headerParams) > 0 {
 		headers := http.Header{}
 		for h, v := range headerParams {
-		    headers[h] = []string{v}
+			headers[h] = []string{v}
 		}
 		localVarRequest.Header = headers
 	}

--- a/samples/client/others/go/allof_multiple_ref_and_discriminator/client.go
+++ b/samples/client/others/go/allof_multiple_ref_and_discriminator/client.go
@@ -401,7 +401,7 @@ func (c *APIClient) prepareRequest(
 	if len(headerParams) > 0 {
 		headers := http.Header{}
 		for h, v := range headerParams {
-			headers.Set(h, v)
+		    headers[h] = []string{v}
 		}
 		localVarRequest.Header = headers
 	}

--- a/samples/client/others/go/issue_20079_go_regex_wrongly_translated/client.go
+++ b/samples/client/others/go/issue_20079_go_regex_wrongly_translated/client.go
@@ -404,7 +404,7 @@ func (c *APIClient) prepareRequest(
 	if len(headerParams) > 0 {
 		headers := http.Header{}
 		for h, v := range headerParams {
-			headers.Set(h, v)
+		    headers[h] = []string{v}
 		}
 		localVarRequest.Header = headers
 	}

--- a/samples/client/others/go/issue_20079_go_regex_wrongly_translated/client.go
+++ b/samples/client/others/go/issue_20079_go_regex_wrongly_translated/client.go
@@ -404,7 +404,7 @@ func (c *APIClient) prepareRequest(
 	if len(headerParams) > 0 {
 		headers := http.Header{}
 		for h, v := range headerParams {
-		    headers[h] = []string{v}
+			headers[h] = []string{v}
 		}
 		localVarRequest.Header = headers
 	}

--- a/samples/client/others/go/oneof-anyof-required/client.go
+++ b/samples/client/others/go/oneof-anyof-required/client.go
@@ -401,7 +401,7 @@ func (c *APIClient) prepareRequest(
 	if len(headerParams) > 0 {
 		headers := http.Header{}
 		for h, v := range headerParams {
-		    headers[h] = []string{v}
+			headers[h] = []string{v}
 		}
 		localVarRequest.Header = headers
 	}

--- a/samples/client/others/go/oneof-anyof-required/client.go
+++ b/samples/client/others/go/oneof-anyof-required/client.go
@@ -401,7 +401,7 @@ func (c *APIClient) prepareRequest(
 	if len(headerParams) > 0 {
 		headers := http.Header{}
 		for h, v := range headerParams {
-			headers.Set(h, v)
+		    headers[h] = []string{v}
 		}
 		localVarRequest.Header = headers
 	}

--- a/samples/client/others/go/oneof-discriminator-lookup/client.go
+++ b/samples/client/others/go/oneof-discriminator-lookup/client.go
@@ -401,7 +401,7 @@ func (c *APIClient) prepareRequest(
 	if len(headerParams) > 0 {
 		headers := http.Header{}
 		for h, v := range headerParams {
-		    headers[h] = []string{v}
+			headers[h] = []string{v}
 		}
 		localVarRequest.Header = headers
 	}

--- a/samples/client/others/go/oneof-discriminator-lookup/client.go
+++ b/samples/client/others/go/oneof-discriminator-lookup/client.go
@@ -401,7 +401,7 @@ func (c *APIClient) prepareRequest(
 	if len(headerParams) > 0 {
 		headers := http.Header{}
 		for h, v := range headerParams {
-			headers.Set(h, v)
+		    headers[h] = []string{v}
 		}
 		localVarRequest.Header = headers
 	}

--- a/samples/client/petstore/go/auth_test.go
+++ b/samples/client/petstore/go/auth_test.go
@@ -89,7 +89,7 @@ func TestAPIKeyNoPrefix(t *testing.T) {
 	}
 
 	reqb, _ := httputil.DumpRequest(r.Request, true)
-	if !strings.Contains((string)(reqb), "Api_key: TEST123") {
+	if !strings.Contains((string)(reqb), "api_key: TEST123") {
 		t.Errorf("APIKey Authentication is missing")
 	}
 
@@ -124,7 +124,7 @@ func TestAPIKeyWithPrefix(t *testing.T) {
 	}
 
 	reqb, _ := httputil.DumpRequest(r.Request, true)
-	if !strings.Contains((string)(reqb), "Api_key: Bearer TEST123") {
+	if !strings.Contains((string)(reqb), "api_key: Bearer TEST123") {
 		t.Errorf("APIKey Authentication is missing")
 	}
 

--- a/samples/client/petstore/go/go-petstore/client.go
+++ b/samples/client/petstore/go/go-petstore/client.go
@@ -420,7 +420,7 @@ func (c *APIClient) prepareRequest(
 	if len(headerParams) > 0 {
 		headers := http.Header{}
 		for h, v := range headerParams {
-			headers.Set(h, v)
+		    headers[h] = []string{v}
 		}
 		localVarRequest.Header = headers
 	}

--- a/samples/client/petstore/go/go-petstore/client.go
+++ b/samples/client/petstore/go/go-petstore/client.go
@@ -420,7 +420,7 @@ func (c *APIClient) prepareRequest(
 	if len(headerParams) > 0 {
 		headers := http.Header{}
 		for h, v := range headerParams {
-		    headers[h] = []string{v}
+			headers[h] = []string{v}
 		}
 		localVarRequest.Header = headers
 	}

--- a/samples/openapi3/client/extensions/x-auth-id-alias/go-experimental/client.go
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/go-experimental/client.go
@@ -404,7 +404,7 @@ func (c *APIClient) prepareRequest(
 	if len(headerParams) > 0 {
 		headers := http.Header{}
 		for h, v := range headerParams {
-			headers.Set(h, v)
+		    headers[h] = []string{v}
 		}
 		localVarRequest.Header = headers
 	}

--- a/samples/openapi3/client/extensions/x-auth-id-alias/go-experimental/client.go
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/go-experimental/client.go
@@ -404,7 +404,7 @@ func (c *APIClient) prepareRequest(
 	if len(headerParams) > 0 {
 		headers := http.Header{}
 		for h, v := range headerParams {
-		    headers[h] = []string{v}
+			headers[h] = []string{v}
 		}
 		localVarRequest.Header = headers
 	}

--- a/samples/openapi3/client/petstore/go-petstore-generateMarshalJSON-false/client.go
+++ b/samples/openapi3/client/petstore/go-petstore-generateMarshalJSON-false/client.go
@@ -405,7 +405,7 @@ func (c *APIClient) prepareRequest(
 	if len(headerParams) > 0 {
 		headers := http.Header{}
 		for h, v := range headerParams {
-		    headers[h] = []string{v}
+			headers[h] = []string{v}
 		}
 		localVarRequest.Header = headers
 	}

--- a/samples/openapi3/client/petstore/go-petstore-generateMarshalJSON-false/client.go
+++ b/samples/openapi3/client/petstore/go-petstore-generateMarshalJSON-false/client.go
@@ -405,7 +405,7 @@ func (c *APIClient) prepareRequest(
 	if len(headerParams) > 0 {
 		headers := http.Header{}
 		for h, v := range headerParams {
-			headers.Set(h, v)
+		    headers[h] = []string{v}
 		}
 		localVarRequest.Header = headers
 	}

--- a/samples/openapi3/client/petstore/go-petstore-withXml/client.go
+++ b/samples/openapi3/client/petstore/go-petstore-withXml/client.go
@@ -405,7 +405,7 @@ func (c *APIClient) prepareRequest(
 	if len(headerParams) > 0 {
 		headers := http.Header{}
 		for h, v := range headerParams {
-		    headers[h] = []string{v}
+			headers[h] = []string{v}
 		}
 		localVarRequest.Header = headers
 	}

--- a/samples/openapi3/client/petstore/go-petstore-withXml/client.go
+++ b/samples/openapi3/client/petstore/go-petstore-withXml/client.go
@@ -405,7 +405,7 @@ func (c *APIClient) prepareRequest(
 	if len(headerParams) > 0 {
 		headers := http.Header{}
 		for h, v := range headerParams {
-			headers.Set(h, v)
+		    headers[h] = []string{v}
 		}
 		localVarRequest.Header = headers
 	}

--- a/samples/openapi3/client/petstore/go/auth_test.go
+++ b/samples/openapi3/client/petstore/go/auth_test.go
@@ -151,7 +151,7 @@ func TestAPIKeyNoPrefix(t *testing.T) {
 	}
 
 	reqb, _ := httputil.DumpRequest(r.Request, true)
-	if !strings.Contains((string)(reqb), "Api_key: TEST123") {
+	if !strings.Contains((string)(reqb), "api_key: TEST123") {
 		t.Errorf("APIKey Authentication is missing")
 	}
 
@@ -186,7 +186,7 @@ func TestAPIKeyWithPrefix(t *testing.T) {
 	}
 
 	reqb, _ := httputil.DumpRequest(r.Request, true)
-	if !strings.Contains((string)(reqb), "Api_key: Bearer TEST123") {
+	if !strings.Contains((string)(reqb), "api_key: Bearer TEST123") {
 		t.Errorf("APIKey Authentication is missing")
 	}
 

--- a/samples/openapi3/client/petstore/go/go-petstore-aws-signature/client.go
+++ b/samples/openapi3/client/petstore/go/go-petstore-aws-signature/client.go
@@ -409,7 +409,7 @@ func (c *APIClient) prepareRequest(
 	if len(headerParams) > 0 {
 		headers := http.Header{}
 		for h, v := range headerParams {
-		    headers[h] = []string{v}
+			headers[h] = []string{v}
 		}
 		localVarRequest.Header = headers
 	}

--- a/samples/openapi3/client/petstore/go/go-petstore-aws-signature/client.go
+++ b/samples/openapi3/client/petstore/go/go-petstore-aws-signature/client.go
@@ -409,7 +409,7 @@ func (c *APIClient) prepareRequest(
 	if len(headerParams) > 0 {
 		headers := http.Header{}
 		for h, v := range headerParams {
-			headers.Set(h, v)
+		    headers[h] = []string{v}
 		}
 		localVarRequest.Header = headers
 	}

--- a/samples/openapi3/client/petstore/go/go-petstore/client.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/client.go
@@ -423,7 +423,7 @@ func (c *APIClient) prepareRequest(
 	if len(headerParams) > 0 {
 		headers := http.Header{}
 		for h, v := range headerParams {
-			headers.Set(h, v)
+		    headers[h] = []string{v}
 		}
 		localVarRequest.Header = headers
 	}

--- a/samples/openapi3/client/petstore/go/go-petstore/client.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/client.go
@@ -423,7 +423,7 @@ func (c *APIClient) prepareRequest(
 	if len(headerParams) > 0 {
 		headers := http.Header{}
 		for h, v := range headerParams {
-		    headers[h] = []string{v}
+			headers[h] = []string{v}
 		}
 		localVarRequest.Header = headers
 	}


### PR DESCRIPTION
a follow up pr to https://github.com/OpenAPITools/openapi-generator/pull/24766
<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `useHttpHeaderSet` option to the Go client generator that changes how `prepareRequest` assigns headers. The new default preserves header-name casing from the API spec instead of canonicalizing; set `useHttpHeaderSet=true` to restore the previous `http.Header.Set` behavior.

**Migration**
- Existing generated clients that relied on canonicalized headers must regenerate with `useHttpHeaderSet=true`.

<sup>Written for commit c0146b6ec5e125583b9673cad16aaed5be628ded. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24791?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



