### PR TITLE
[Java][Microprofile] Fix invalid '= ;' initializer on nullable required container properties (#24776)

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/microprofile/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/microprofile/pojo.mustache
@@ -52,7 +52,7 @@ public {{>sealed}}class {{classname}} {{#parent}}extends {{{.}}}{{/parent}}{{#ve
 {{{.}}}
 {{/vendorExtensions.x-field-extra-annotation}}
 {{#isContainer}}
-  protected {{{datatypeWithEnum}}} {{name}}{{#required}} = {{{defaultValue}}}{{/required}}{{^required}} = null{{/required}};
+  protected {{{datatypeWithEnum}}} {{name}}{{#required}}{{#defaultValue}} = {{{.}}}{{/defaultValue}}{{^defaultValue}} = null{{/defaultValue}}{{/required}}{{^required}} = null{{/required}};
 {{/isContainer}}
 {{^isContainer}}
   protected {{{datatypeWithEnum}}} {{name}}{{#defaultValue}} = {{{.}}}{{/defaultValue}};

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -4997,6 +4997,29 @@ public class JavaClientCodegenTest {
                                 + " @FormParam(\"statusArray\")  List<MultipartMixedStatus> statusArray");
     }
 
+    @Test
+    public void testMicroprofileNullableRequiredContainers_issue24776() {
+        final Path output = newTempFolder();
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName(JAVA_GENERATOR)
+                .setLibrary(JavaClientCodegen.MICROPROFILE)
+                .setAdditionalProperties(Map.of(
+                        CodegenConstants.MODEL_PACKAGE, "org.openapitools.client.model",
+                        JavaClientCodegen.MICROPROFILE_REST_CLIENT_VERSION, "3.0"
+                ))
+                .setInputSpec("src/test/resources/3_1/microprofile-nullable-container.yaml")
+                .setOutputDir(output.toString().replace("\\", "/"));
+
+        List<File> files = new DefaultGenerator().opts(configurator.toClientOptInput()).generate();
+
+        validateJavaSourceFiles(files);
+        assertThat(output.resolve("src/main/java/org/openapitools/client/model/Thing.java")).content()
+                .contains("protected Map<String, Object> nullableMap = null;")
+                .contains("protected List<String> nullableArray = null;")
+                .contains("protected List<String> regularArray = new ArrayList<>();")
+                .doesNotContain(" = ;");
+    }
+
     private static JavaClientCodegen newRetrofit2Codegen(Map<String, Object> properties) {
         JavaClientCodegen codegen = new JavaClientCodegen();
         codegen.setLibrary(JavaClientCodegen.RETROFIT_2);

--- a/modules/openapi-generator/src/test/resources/3_1/microprofile-nullable-container.yaml
+++ b/modules/openapi-generator/src/test/resources/3_1/microprofile-nullable-container.yaml
@@ -1,0 +1,35 @@
+openapi: 3.1.0
+info:
+  title: Microprofile Nullable Container Repro
+  version: 1.0.0
+paths:
+  /thing:
+    get:
+      operationId: getThing
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Thing"
+components:
+  schemas:
+    Thing:
+      type: object
+      properties:
+        nullableMap:
+          type: [object, "null"]
+          additionalProperties: true
+        nullableArray:
+          type: [array, "null"]
+          items:
+            type: string
+        regularArray:
+          type: array
+          items:
+            type: string
+      required:
+        - nullableMap
+        - nullableArray
+        - regularArray


### PR DESCRIPTION
### PR checklist
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title cleanly describes the fix/feature.
- [x] Code compiles cleanly by running `mvn clean install -DskipTests`.
- [x] Added unit tests for the fix/feature.
- [x] Regenerated sample code via `./bin/generate-samples.sh ./bin/configs/java-microprofile*`.

### Description of the Change
In `Java/libraries/microprofile/pojo.mustache`, required container properties interpolated `defaultValue` unguarded:
```mustache
{{#isContainer}}
  protected {{{datatypeWithEnum}}} {{name}}{{#required}} = {{{defaultValue}}}{{/required}}{{^required}} = null{{/required}};
{{/isContainer}}
```
When a container property is required and nullable (such as OpenAPI 3.1 `type: [object, "null"]` or `type: [array, "null"]`), `defaultValue` is null. This resulted in generating invalid Java syntax:
```java
protected Map<String, Object> nullableMap = ;
protected List<String> nullableArray = ;
```

This PR updates the required container branch to fall back to `= null;` when `defaultValue` is absent:
```mustache
{{#isContainer}}
  protected {{{datatypeWithEnum}}} {{name}}{{#required}}{{#defaultValue}} = {{{.}}}{{/defaultValue}}{{^defaultValue}} = null{{/defaultValue}}{{/required}}{{^required}} = null{{/required}};
{{/isContainer}}
```

Fixes #24776

cc @bbdouglas @s2308 @javier20 @wing328 @jpfinne


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Microprofile generator emitting invalid Java (`protected Map<String, Object> nullableMap = ;`) when a required container property is nullable, such as OpenAPI 3.1 `type: [object, "null"]` or `type: [array, "null"]`. Required containers now fall back to `= null;` when no default value is present.

- Adds a unit test and OpenAPI 3.1 spec covering nullable required maps, arrays, and a regular array.

<sup>Written for commit 7d571db65de6fcec8936bdbb76190cbb396c2ece. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24799?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

