### PR TITLE
[typescript-fetch] fix: explode object query parameters

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
@@ -1559,6 +1559,12 @@ public class TypeScriptFetchClientCodegen extends AbstractTypeScriptClientCodege
             this.isPrimitiveType = cp.isPrimitiveType;
             this.isModel = cp.isModel;
             this.isExplode = cp.isExplode;
+            this.isDeepObject = cp.isDeepObject;
+            this.isMatrix = cp.isMatrix;
+            this.isAllowEmptyValue = cp.isAllowEmptyValue;
+            this.isFormStyle = cp.isFormStyle;
+            this.isSpaceDelimited = cp.isSpaceDelimited;
+            this.isPipeDelimited = cp.isPipeDelimited;
             this.baseName = cp.baseName;
             this.paramName = cp.paramName;
             this.dataType = cp.dataType;

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
@@ -202,14 +202,24 @@ export class {{classname}} extends runtime.BaseAPI {
         {{^isArray}}
         if (requestParameters['{{paramName}}'] != null) {
             {{#isExplode}}
-            {{#isContainer}}
-            for (let key of Object.keys(requestParameters['{{paramName}}'])) {
-                queryParameters[key] = requestParameters['{{paramName}}'][key];
-            }
-            {{/isContainer}}
-            {{^isContainer}}
+            {{! An exploded object becomes one parameter per entry, keyed by the property name
+                alone. isMap covers both a declared map and a free-form object; isContainer is
+                not set for a free-form object, so it cannot be used here. deepObject is
+                explode: true as well, but nests the property under the parameter name, which
+                the runtime does when the object is assigned as a whole. }}
+            {{#isDeepObject}}
 {{>apisAssignQueryParam}}
-            {{/isContainer}}
+            {{/isDeepObject}}
+            {{^isDeepObject}}
+            {{#isMap}}
+            for (let key of Object.keys(requestParameters['{{paramName}}'])) {
+                queryParameters[key] = (requestParameters['{{paramName}}'] as any)[key];
+            }
+            {{/isMap}}
+            {{^isMap}}
+{{>apisAssignQueryParam}}
+            {{/isMap}}
+            {{/isDeepObject}}
             {{/isExplode}}
             {{^isExplode}}
 {{>apisAssignQueryParam}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchClientCodegenTest.java
@@ -1177,6 +1177,33 @@ public class TypeScriptFetchClientCodegenTest {
         TestUtils.assertFileContains(api, "formParams.append('createdAt', runtime.serializeDateTime(requestParameters['createdAt'] as any))");
     }
 
+    @Test(description = "Verify an object query parameter is exploded, whether or not it declares its properties")
+    public void testExplodedObjectQueryParameter() throws IOException {
+        File output = generate(new HashMap<>(), "src/test/resources/3_0/exploded-object-query-param.yaml");
+        Path api = Paths.get(output + "/apis/DefaultApi.ts");
+
+        // form style with explode - the default - puts every entry on the wire under its own
+        // property name. A free-form object is isMap but not isContainer, so it used to fall
+        // through to a whole-object assignment and end up bracketed by the runtime.
+        TestUtils.assertFileContains(api,
+                "for (let key of Object.keys(requestParameters['filter'])) {",
+                "queryParameters[key] = (requestParameters['filter'] as any)[key];");
+        TestUtils.assertFileNotContains(api, "queryParameters['filter'] = requestParameters['filter'];");
+
+        // a declared map behaves the same way
+        TestUtils.assertFileContains(api,
+                "for (let key of Object.keys(requestParameters['typedFilter'])) {",
+                "queryParameters[key] = (requestParameters['typedFilter'] as any)[key];");
+
+        // deepObject nests under the parameter name, which the runtime does for a whole object
+        TestUtils.assertFileContains(api, "queryParameters['deepFilter'] = requestParameters['deepFilter'];");
+        TestUtils.assertFileNotContains(api, "Object.keys(requestParameters['deepFilter'])");
+
+        // without explode the object stays a single parameter
+        TestUtils.assertFileContains(api, "queryParameters['flatFilter'] = requestParameters['flatFilter'];");
+        TestUtils.assertFileNotContains(api, "Object.keys(requestParameters['flatFilter'])");
+    }
+
     private static final String DATE_HANDLING_SPEC = "src/test/resources/3_0/typescript-fetch/date-handling.yaml";
 
     private static File generate(

--- a/modules/openapi-generator/src/test/resources/3_0/exploded-object-query-param.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/exploded-object-query-param.yaml
@@ -1,0 +1,51 @@
+openapi: 3.0.3
+info:
+  title: Exploded object query parameters
+  description: >
+    Object typed query parameters, covering the four combinations of style and explode that
+    decide how an object is put on the wire. The free-form variants matter because a
+    free-form object is flagged isMap but not isContainer.
+  version: 1.0.0
+servers:
+  - url: localhost:8080
+paths:
+  /items:
+    get:
+      operationId: listItems
+      parameters:
+        # style and explode both left out, so the form/true defaults apply: every entry
+        # becomes its own parameter, keyed by the property name alone.
+        - in: query
+          name: filter
+          schema:
+            type: object
+        # the same, but declared as a map rather than as a free-form object
+        - in: query
+          name: typedFilter
+          schema:
+            type: object
+            additionalProperties:
+              type: string
+        # deepObject nests each entry under the parameter name: deepFilter[key]=value
+        - in: query
+          name: deepFilter
+          style: deepObject
+          explode: true
+          schema:
+            type: object
+        # form without explode keeps a single parameter carrying the whole object
+        - in: query
+          name: flatFilter
+          style: form
+          explode: false
+          schema:
+            type: object
+      responses:
+        '200':
+          description: a list of items
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/FakeApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/FakeApi.ts
@@ -1560,7 +1560,7 @@ export class FakeApi extends runtime.BaseAPI {
 
         if (requestParameters['language'] != null) {
             for (let key of Object.keys(requestParameters['language'])) {
-                queryParameters[key] = requestParameters['language'][key];
+                queryParameters[key] = (requestParameters['language'] as any)[key];
             }
         }
 

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/apis/fake-api.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/apis/fake-api.ts
@@ -1560,7 +1560,7 @@ export class FakeApi extends runtime.BaseAPI {
 
         if (requestParameters['language'] != null) {
             for (let key of Object.keys(requestParameters['language'])) {
-                queryParameters[key] = requestParameters['language'][key];
+                queryParameters[key] = (requestParameters['language'] as any)[key];
             }
         }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/apis/FakeApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/apis/FakeApi.ts
@@ -1378,7 +1378,7 @@ export class FakeApi extends runtime.BaseAPI {
 
         if (requestParameters['language'] != null) {
             for (let key of Object.keys(requestParameters['language'])) {
-                queryParameters[key] = requestParameters['language'][key];
+                queryParameters[key] = (requestParameters['language'] as any)[key];
             }
         }
 


### PR DESCRIPTION
A query parameter whose schema is an object and whose `style`/`explode` are left at their
defaults — `style: form`, `explode: true` — must go on the wire as one parameter per entry,
keyed by the property name alone. The `typescript-fetch` client bracketed it instead, while
`csharp`, `java` and `php` got it right.

Given:

```yaml
parameters:
  - in: query
    name: filter
    schema:
      type: object
```

called with `{"category": "books", "createdDate:gte": "2023-01-01"}`:

| generator | on the wire |
| --- | --- |
| expected | `category=books&createdDate%3Agte=2023-01-01` |
| typescript-fetch | `filter[category]=books&filter[createdDate%3Agte]=2023-01-01` |
| csharp, java, php | correct |

> **Split out of #24797** at the maintainer's request, one PR per language. The `go` half
> stays in #24797, the `python` half is #24802. The three are independent — no shared
> `main/` code — and can be reviewed and merged in any order. They each add the same test
> fixture at the same path with identical content, so whichever lands first, the others
> rebase cleanly.

### Two causes

**1. `typescript-fetch/apis.mustache`** — the explode branch was gated on `isContainer`,
which `DefaultCodegen.fromParameter` only sets via `updateParameterForMap`, which in turn
needs `ModelUtils.isMapSchema` (so, `additionalProperties`). A bare `type: object` instead
goes through `setTypeProperties`, which sets `isMap` and `isFreeFormObject` and leaves
`isContainer` false. The parameter was therefore assigned whole and the runtime's
`querystringSingleKey` bracketed it. Now keyed on `isMap`; inside `{{^isArray}}`,
`isContainer` implies `isMap`, so this is the same condition plus free-form objects.

**2. `TypeScriptFetchClientCodegen`** — `ExtendedCodegenParameter`'s copy constructor copies
`isExplode` and `style` but not `isDeepObject`, `isFormStyle`, `isMatrix`,
`isAllowEmptyValue`, `isSpaceDelimited` or `isPipeDelimited`, so all six were false in every
typescript-fetch template regardless of the document. `--global-property
debugOperations=true` on a parameter declaring `style: deepObject` shows `"isDeepObject":
false` two lines above `"style": "deepObject"`. This is independent of (1), and it is why
fixing (1) alone would have broken deepObject parameters — they are `explode: true` too.

### Verified on the wire, not just asserted

The client was generated from the new fixture and pointed at a server that echoes its own raw
query string back:

| parameter | typescript-fetch |
| --- | --- |
| `filter` (object, defaults) | `category=books&createdDate%3Agte=2023-01-01` |
| `typedFilter` (map, defaults) | same |
| `deepFilter` (`style: deepObject`) | `deepFilter%5Bcategory%5D=books&…` |
| `flatFilter` (`explode: false`) | `flatFilter%5Bcategory%5D=books&…` |

The first two rows are the fixed behaviour; the last two are byte-for-byte what the generator
did before.

### Known gap, called out deliberately

**Declared object models.** A `$ref`ed object model as a query parameter is `isModel`, not
`isMap`, so it still goes on the wire whole. This is pre-existing. It cannot be fixed by
widening the `isMap` branch: typescript-fetch interface properties are not the wire names,
which is what the `ToJSON` functions exist to translate — `FormatTest.ts` maps `'float'` to
`value['_float']` and `'pattern_with_digits'` to `value['patternWithDigits']`, and `dateTime`
needs `serializeDateTime`. Iterating `Object.keys` over a model would put `_float=…` and a raw
`Date` on the wire. A correct fix has to route through `{{dataType}}ToJSON` first, which is a
feature rather than a template branch.

### Note on the diff

The loop body gains an `as any` cast on the indexing. It is not needed for a declared map,
but a free-form object is typed `object` and `object[key]` is `error TS7053` under `strict`,
which is how most consumers compile. Checked both ways against the generated fixture client:
without the cast, one TS7053; with it, zero errors. That cast is the entire diff in the three
existing typescript-fetch petstore samples.

### Tests

`modules/openapi-generator/src/test/resources/3_0/exploded-object-query-param.yaml` covers
the four combinations that decide the wire format:

- `TypeScriptFetchClientCodegenTest#testExplodedObjectQueryParameter`

It fails without the fixes (verified by stashing only the `main/` changes). 67 tests pass
across `TypeScriptFetchClientCodegenTest`, `TypeScriptFetchModelTest` and
`TypeScriptFetchClientOptionsTest`.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Built the project and updated samples (`./bin/generate-samples.sh` for
      `bin/configs/typescript-fetch*.yaml`; `./bin/utils/export_docs_generators.sh` produced
      no diff). 3 sample files changed, all the `as any` cast above, from the petstore
      fixture's `language` parameter — a declared map with the default style.
- [x] Technical committee: @TiFu @macjohnny @topce @akehir @amakhrov @davidgamero @joscha


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `typescript-fetch` client so object query parameters with default `form`/`explode` go on the wire as one parameter per entry, keyed by the property name alone (`category=books`), instead of bracketed under the parameter name (`filter[category]=books`). deepObject and `explode: false` objects keep their previous wire format.

**Bug Fixes**
- The template's explode branch was gated on `isContainer`, which free-form objects never set; it now keys on `isMap`, covering declared maps and free-form objects, with an `as any` cast so strict TypeScript still compiles.
- `ExtendedCodegenParameter`'s copy constructor dropped six style-related flags, so `isDeepObject` and friends were always false in templates; they're now copied, which keeps deepObject parameters intact.
- Adds a test fixture covering the four style/explode combinations.

**Known gap**
- A `$ref`ed object model as a query parameter still goes on the wire as a whole; fixing it requires routing through the model's `ToJSON` for wire-name translation, which is out of scope.

<sup>Written for commit 0dec11830a3555a2963ccc648b1519713a6e791a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24803?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->




---

Generated with Claude Code
