### PR TITLE
fix(core): avoid dangling request-model import for skipped form models

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -1049,6 +1049,8 @@ public class DefaultCodegen implements CodegenConfig {
         return specMajorVersion == 3 && specMinorVersion >= 1;
     }
 
+    private List<String> schemasUsedOnlyInFormParam = null;
+
     /**
      * Set the OpenAPI document.
      * This method is invoked when the input OpenAPI document has been parsed and validated.
@@ -1059,12 +1061,28 @@ public class DefaultCodegen implements CodegenConfig {
             once(LOGGER).warn(UNSUPPORTED_V310_SPEC_MSG);
         }
         this.openAPI = openAPI;
+        this.schemasUsedOnlyInFormParam = null;
         // Set global settings such that helper functions in ModelUtils can lookup the value
         // of the CLI option.
         ModelUtils.setDisallowAdditionalPropertiesIfNotPresent(getDisallowAdditionalPropertiesIfNotPresent());
 
         // Multiple operations rely on proper type aliases, so we should always update them
         typeAliases = getAllAliases(ModelUtils.getSchemas(openAPI));
+    }
+
+    /**
+     * Returns the list of schema names that are used only in form parameters.
+     *
+     * @return list of schema names used only in form parameters
+     */
+    public List<String> getSchemasUsedOnlyInFormParam() {
+        if (this.openAPI == null) {
+            return Collections.emptyList();
+        }
+        if (this.schemasUsedOnlyInFormParam == null) {
+            this.schemasUsedOnlyInFormParam = ModelUtils.getSchemasUsedOnlyInFormParam(this.openAPI);
+        }
+        return this.schemasUsedOnlyInFormParam;
     }
 
     // override with any message to be shown right before the process finishes
@@ -8310,6 +8328,13 @@ public class DefaultCodegen implements CodegenConfig {
      * @return true if skipFormModel is true
      */
     public boolean isSkipFormModel() {
+        if (additionalProperties.containsKey(CodegenConstants.SKIP_FORM_MODEL)) {
+            final Object val = additionalProperties.get(CodegenConstants.SKIP_FORM_MODEL);
+            if (val instanceof Boolean) {
+                return (Boolean) val;
+            }
+            return Boolean.parseBoolean(val.toString());
+        }
         return Boolean.parseBoolean(GlobalSettings.getProperty(CodegenConstants.SKIP_FORM_MODEL, "true"));
     }
 
@@ -8384,8 +8409,18 @@ public class DefaultCodegen implements CodegenConfig {
             }
 
             cmtContent.put(contentType, codegenMt);
-            if (schemaProp != null && (!isFormContentType(contentType) || !isSkipFormModel())) {
-                addImports(imports, schemaProp.getImports(true, importBaseType, generatorMetadata.getFeatureSet()));
+            if (schemaProp != null) {
+                Set<String> propImports = schemaProp.getImports(true, importBaseType, generatorMetadata.getFeatureSet());
+                if (isFormContentType(contentType) && isSkipFormModel()) {
+                    List<String> formOnlySchemas = getSchemasUsedOnlyInFormParam();
+                    Set<String> formOnlyModels = formOnlySchemas.stream()
+                            .flatMap(s -> Stream.of(s, toModelName(s)))
+                            .collect(Collectors.toSet());
+                    propImports = propImports.stream()
+                            .filter(imp -> !formOnlyModels.contains(imp))
+                            .collect(Collectors.toSet());
+                }
+                addImports(imports, propImports);
             }
         }
         return cmtContent;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -8290,6 +8290,29 @@ public class DefaultCodegen implements CodegenConfig {
         return param;
     }
 
+    /**
+     * Check if the content type is form data (e.g. multipart/* or application/x-www-form-urlencoded).
+     *
+     * @param contentType Content type string
+     * @return true if form content type
+     */
+    protected boolean isFormContentType(String contentType) {
+        if (contentType == null) {
+            return false;
+        }
+        String ct = contentType.toLowerCase(Locale.ROOT);
+        return ct.startsWith("application/x-www-form-urlencoded") || ct.startsWith("multipart");
+    }
+
+    /**
+     * Check if skipFormModel is enabled (defaults to true).
+     *
+     * @return true if skipFormModel is true
+     */
+    public boolean isSkipFormModel() {
+        return Boolean.parseBoolean(GlobalSettings.getProperty(CodegenConstants.SKIP_FORM_MODEL, "true"));
+    }
+
     protected LinkedHashMap<String, CodegenMediaType> getContent(Content content, Set<String> imports, String mediaTypeSchemaSuffix) {
         if (content == null) {
             return null;
@@ -8361,7 +8384,7 @@ public class DefaultCodegen implements CodegenConfig {
             }
 
             cmtContent.put(contentType, codegenMt);
-            if (schemaProp != null) {
+            if (schemaProp != null && (!isFormContentType(contentType) || !isSkipFormModel())) {
                 addImports(imports, schemaProp.getImports(true, importBaseType, generatorMetadata.getFeatureSet()));
             }
         }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
@@ -56,6 +56,7 @@ import java.nio.file.Path;
 import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -192,6 +193,21 @@ public class DefaultGenerator implements Generator {
         return defaultValue;
     }
 
+    private Boolean getGlobalOrGeneratorPropertyDefault(final String key, final Boolean defaultValue) {
+        String global = GlobalSettings.getProperty(key);
+        if (global != null) {
+            return Boolean.valueOf(global);
+        }
+        return getGeneratorPropertyDefaultSwitch(key, defaultValue);
+    }
+
+    private boolean convertGlobalPropertyToBooleanAndWriteBack(final String propertyKey, final Consumer<Boolean> booleanSetter, final boolean defaultValue) {
+        boolean value = getGlobalOrGeneratorPropertyDefault(propertyKey, defaultValue);
+        booleanSetter.accept(value);
+        config.additionalProperties().put(propertyKey, value);
+        return value;
+    }
+
     void configureGeneratorProperties() {
         // allows generating only models by specifying a CSV of models to generate, or empty for all
         // NOTE: Boolean.TRUE is required below rather than `true` because of JVM boxing constraints and type inference.
@@ -219,28 +235,16 @@ public class DefaultGenerator implements Generator {
         }
         // model/api tests and documentation options rely on parent generate options (api or model) and no other options.
         // They default to true in all scenarios and can only be marked false explicitly
-        generateModelTests = GlobalSettings.getProperty(CodegenConstants.MODEL_TESTS) != null ? Boolean.valueOf(GlobalSettings.getProperty(CodegenConstants.MODEL_TESTS)) : getGeneratorPropertyDefaultSwitch(CodegenConstants.MODEL_TESTS, true);
-        generateModelDocumentation = GlobalSettings.getProperty(CodegenConstants.MODEL_DOCS) != null ? Boolean.valueOf(GlobalSettings.getProperty(CodegenConstants.MODEL_DOCS)) : getGeneratorPropertyDefaultSwitch(CodegenConstants.MODEL_DOCS, true);
-        generateApiTests = GlobalSettings.getProperty(CodegenConstants.API_TESTS) != null ? Boolean.valueOf(GlobalSettings.getProperty(CodegenConstants.API_TESTS)) : getGeneratorPropertyDefaultSwitch(CodegenConstants.API_TESTS, true);
-        generateApiDocumentation = GlobalSettings.getProperty(CodegenConstants.API_DOCS) != null ? Boolean.valueOf(GlobalSettings.getProperty(CodegenConstants.API_DOCS)) : getGeneratorPropertyDefaultSwitch(CodegenConstants.API_DOCS, true);
-        generateRecursiveDependentModels = GlobalSettings.getProperty(CodegenConstants.GENERATE_RECURSIVE_DEPENDENT_MODELS) != null ? Boolean.valueOf(GlobalSettings.getProperty(CodegenConstants.GENERATE_RECURSIVE_DEPENDENT_MODELS)) : getGeneratorPropertyDefaultSwitch(CodegenConstants.GENERATE_RECURSIVE_DEPENDENT_MODELS, false);
-
-        Boolean skipFormModel = GlobalSettings.getProperty(CodegenConstants.SKIP_FORM_MODEL) != null ?
-                Boolean.valueOf(GlobalSettings.getProperty(CodegenConstants.SKIP_FORM_MODEL)) :
-                getGeneratorPropertyDefaultSwitch(CodegenConstants.SKIP_FORM_MODEL, true);
-
-        // Additional properties added for tests to exclude references in project related files
-        config.additionalProperties().put(CodegenConstants.GENERATE_API_TESTS, generateApiTests);
-        config.additionalProperties().put(CodegenConstants.GENERATE_MODEL_TESTS, generateModelTests);
-
-        config.additionalProperties().put(CodegenConstants.GENERATE_API_DOCS, generateApiDocumentation);
-        config.additionalProperties().put(CodegenConstants.GENERATE_MODEL_DOCS, generateModelDocumentation);
+        convertGlobalPropertyToBooleanAndWriteBack(CodegenConstants.MODEL_TESTS, val -> generateModelTests = val, true);
+        convertGlobalPropertyToBooleanAndWriteBack(CodegenConstants.MODEL_DOCS, val -> generateModelDocumentation = val, true);
+        convertGlobalPropertyToBooleanAndWriteBack(CodegenConstants.API_TESTS, val -> generateApiTests = val, true);
+        convertGlobalPropertyToBooleanAndWriteBack(CodegenConstants.API_DOCS, val -> generateApiDocumentation = val, true);
+        convertGlobalPropertyToBooleanAndWriteBack(CodegenConstants.GENERATE_RECURSIVE_DEPENDENT_MODELS, val -> generateRecursiveDependentModels = val, false);
+        convertGlobalPropertyToBooleanAndWriteBack(CodegenConstants.SKIP_FORM_MODEL, val -> {}, true);
 
         config.additionalProperties().put(CodegenConstants.GENERATE_APIS, generateApis);
         config.additionalProperties().put(CodegenConstants.GENERATE_MODELS, generateModels);
         config.additionalProperties().put(CodegenConstants.GENERATE_WEBHOOKS, generateWebhooks);
-        config.additionalProperties().put(CodegenConstants.GENERATE_RECURSIVE_DEPENDENT_MODELS, generateRecursiveDependentModels);
-        config.additionalProperties().put(CodegenConstants.SKIP_FORM_MODEL, skipFormModel);
 
         if (!generateApiTests && !generateModelTests) {
             config.additionalProperties().put(CodegenConstants.EXCLUDE_TESTS, true);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
@@ -225,6 +225,10 @@ public class DefaultGenerator implements Generator {
         generateApiDocumentation = GlobalSettings.getProperty(CodegenConstants.API_DOCS) != null ? Boolean.valueOf(GlobalSettings.getProperty(CodegenConstants.API_DOCS)) : getGeneratorPropertyDefaultSwitch(CodegenConstants.API_DOCS, true);
         generateRecursiveDependentModels = GlobalSettings.getProperty(CodegenConstants.GENERATE_RECURSIVE_DEPENDENT_MODELS) != null ? Boolean.valueOf(GlobalSettings.getProperty(CodegenConstants.GENERATE_RECURSIVE_DEPENDENT_MODELS)) : getGeneratorPropertyDefaultSwitch(CodegenConstants.GENERATE_RECURSIVE_DEPENDENT_MODELS, false);
 
+        Boolean skipFormModel = GlobalSettings.getProperty(CodegenConstants.SKIP_FORM_MODEL) != null ?
+                Boolean.valueOf(GlobalSettings.getProperty(CodegenConstants.SKIP_FORM_MODEL)) :
+                getGeneratorPropertyDefaultSwitch(CodegenConstants.SKIP_FORM_MODEL, true);
+
         // Additional properties added for tests to exclude references in project related files
         config.additionalProperties().put(CodegenConstants.GENERATE_API_TESTS, generateApiTests);
         config.additionalProperties().put(CodegenConstants.GENERATE_MODEL_TESTS, generateModelTests);
@@ -236,6 +240,7 @@ public class DefaultGenerator implements Generator {
         config.additionalProperties().put(CodegenConstants.GENERATE_MODELS, generateModels);
         config.additionalProperties().put(CodegenConstants.GENERATE_WEBHOOKS, generateWebhooks);
         config.additionalProperties().put(CodegenConstants.GENERATE_RECURSIVE_DEPENDENT_MODELS, generateRecursiveDependentModels);
+        config.additionalProperties().put(CodegenConstants.SKIP_FORM_MODEL, skipFormModel);
 
         if (!generateApiTests && !generateModelTests) {
             config.additionalProperties().put(CodegenConstants.EXCLUDE_TESTS, true);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
@@ -56,7 +56,6 @@ import java.nio.file.Path;
 import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.concurrent.ConcurrentSkipListSet;
-import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -201,13 +200,6 @@ public class DefaultGenerator implements Generator {
         return getGeneratorPropertyDefaultSwitch(key, defaultValue);
     }
 
-    private boolean convertGlobalPropertyToBooleanAndWriteBack(final String propertyKey, final Consumer<Boolean> booleanSetter, final boolean defaultValue) {
-        boolean value = getGlobalOrGeneratorPropertyDefault(propertyKey, defaultValue);
-        booleanSetter.accept(value);
-        config.additionalProperties().put(propertyKey, value);
-        return value;
-    }
-
     void configureGeneratorProperties() {
         // allows generating only models by specifying a CSV of models to generate, or empty for all
         // NOTE: Boolean.TRUE is required below rather than `true` because of JVM boxing constraints and type inference.
@@ -235,16 +227,25 @@ public class DefaultGenerator implements Generator {
         }
         // model/api tests and documentation options rely on parent generate options (api or model) and no other options.
         // They default to true in all scenarios and can only be marked false explicitly
-        convertGlobalPropertyToBooleanAndWriteBack(CodegenConstants.MODEL_TESTS, val -> generateModelTests = val, true);
-        convertGlobalPropertyToBooleanAndWriteBack(CodegenConstants.MODEL_DOCS, val -> generateModelDocumentation = val, true);
-        convertGlobalPropertyToBooleanAndWriteBack(CodegenConstants.API_TESTS, val -> generateApiTests = val, true);
-        convertGlobalPropertyToBooleanAndWriteBack(CodegenConstants.API_DOCS, val -> generateApiDocumentation = val, true);
-        convertGlobalPropertyToBooleanAndWriteBack(CodegenConstants.GENERATE_RECURSIVE_DEPENDENT_MODELS, val -> generateRecursiveDependentModels = val, false);
-        convertGlobalPropertyToBooleanAndWriteBack(CodegenConstants.SKIP_FORM_MODEL, val -> {}, true);
+        generateModelTests = getGlobalOrGeneratorPropertyDefault(CodegenConstants.MODEL_TESTS, true);
+        generateModelDocumentation = getGlobalOrGeneratorPropertyDefault(CodegenConstants.MODEL_DOCS, true);
+        generateApiTests = getGlobalOrGeneratorPropertyDefault(CodegenConstants.API_TESTS, true);
+        generateApiDocumentation = getGlobalOrGeneratorPropertyDefault(CodegenConstants.API_DOCS, true);
+        generateRecursiveDependentModels = getGlobalOrGeneratorPropertyDefault(CodegenConstants.GENERATE_RECURSIVE_DEPENDENT_MODELS, false);
+        Boolean skipFormModel = getGlobalOrGeneratorPropertyDefault(CodegenConstants.SKIP_FORM_MODEL, true);
+
+        // Additional properties added for tests to exclude references in project related files
+        config.additionalProperties().put(CodegenConstants.GENERATE_API_TESTS, generateApiTests);
+        config.additionalProperties().put(CodegenConstants.GENERATE_MODEL_TESTS, generateModelTests);
+
+        config.additionalProperties().put(CodegenConstants.GENERATE_API_DOCS, generateApiDocumentation);
+        config.additionalProperties().put(CodegenConstants.GENERATE_MODEL_DOCS, generateModelDocumentation);
 
         config.additionalProperties().put(CodegenConstants.GENERATE_APIS, generateApis);
         config.additionalProperties().put(CodegenConstants.GENERATE_MODELS, generateModels);
         config.additionalProperties().put(CodegenConstants.GENERATE_WEBHOOKS, generateWebhooks);
+        config.additionalProperties().put(CodegenConstants.GENERATE_RECURSIVE_DEPENDENT_MODELS, generateRecursiveDependentModels);
+        config.additionalProperties().put(CodegenConstants.SKIP_FORM_MODEL, skipFormModel);
 
         if (!generateApiTests && !generateModelTests) {
             config.additionalProperties().put(CodegenConstants.EXCLUDE_TESTS, true);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
@@ -225,20 +225,9 @@ public class DefaultGenerator implements Generator {
         generateApiDocumentation = GlobalSettings.getProperty(CodegenConstants.API_DOCS) != null ? Boolean.valueOf(GlobalSettings.getProperty(CodegenConstants.API_DOCS)) : getGeneratorPropertyDefaultSwitch(CodegenConstants.API_DOCS, true);
         generateRecursiveDependentModels = GlobalSettings.getProperty(CodegenConstants.GENERATE_RECURSIVE_DEPENDENT_MODELS) != null ? Boolean.valueOf(GlobalSettings.getProperty(CodegenConstants.GENERATE_RECURSIVE_DEPENDENT_MODELS)) : getGeneratorPropertyDefaultSwitch(CodegenConstants.GENERATE_RECURSIVE_DEPENDENT_MODELS, false);
 
-        Boolean skipFormModel = null;
-        if (config.additionalProperties().containsKey(CodegenConstants.SKIP_FORM_MODEL)) {
-            final Object val = config.additionalProperties().get(CodegenConstants.SKIP_FORM_MODEL);
-            if (val instanceof Boolean) {
-                skipFormModel = (Boolean) val;
-            } else if (val != null) {
-                skipFormModel = Boolean.parseBoolean(val.toString());
-            }
-        }
-        if (skipFormModel == null) {
-            skipFormModel = GlobalSettings.getProperty(CodegenConstants.SKIP_FORM_MODEL) != null ?
-                    Boolean.valueOf(GlobalSettings.getProperty(CodegenConstants.SKIP_FORM_MODEL)) :
-                    getGeneratorPropertyDefaultSwitch(CodegenConstants.SKIP_FORM_MODEL, true);
-        }
+        Boolean skipFormModel = GlobalSettings.getProperty(CodegenConstants.SKIP_FORM_MODEL) != null ?
+                Boolean.valueOf(GlobalSettings.getProperty(CodegenConstants.SKIP_FORM_MODEL)) :
+                getGeneratorPropertyDefaultSwitch(CodegenConstants.SKIP_FORM_MODEL, true);
 
         // Additional properties added for tests to exclude references in project related files
         config.additionalProperties().put(CodegenConstants.GENERATE_API_TESTS, generateApiTests);
@@ -477,9 +466,7 @@ public class DefaultGenerator implements Generator {
 
         Boolean skipFormModel = config.additionalProperties().containsKey(CodegenConstants.SKIP_FORM_MODEL) ?
                 Boolean.valueOf(config.additionalProperties().get(CodegenConstants.SKIP_FORM_MODEL).toString()) :
-                (GlobalSettings.getProperty(CodegenConstants.SKIP_FORM_MODEL) != null ?
-                        Boolean.valueOf(GlobalSettings.getProperty(CodegenConstants.SKIP_FORM_MODEL)) :
-                        getGeneratorPropertyDefaultSwitch(CodegenConstants.SKIP_FORM_MODEL, true));
+                Boolean.TRUE;
 
         // process models only
         for (String name : modelKeys) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
@@ -225,9 +225,20 @@ public class DefaultGenerator implements Generator {
         generateApiDocumentation = GlobalSettings.getProperty(CodegenConstants.API_DOCS) != null ? Boolean.valueOf(GlobalSettings.getProperty(CodegenConstants.API_DOCS)) : getGeneratorPropertyDefaultSwitch(CodegenConstants.API_DOCS, true);
         generateRecursiveDependentModels = GlobalSettings.getProperty(CodegenConstants.GENERATE_RECURSIVE_DEPENDENT_MODELS) != null ? Boolean.valueOf(GlobalSettings.getProperty(CodegenConstants.GENERATE_RECURSIVE_DEPENDENT_MODELS)) : getGeneratorPropertyDefaultSwitch(CodegenConstants.GENERATE_RECURSIVE_DEPENDENT_MODELS, false);
 
-        Boolean skipFormModel = GlobalSettings.getProperty(CodegenConstants.SKIP_FORM_MODEL) != null ?
-                Boolean.valueOf(GlobalSettings.getProperty(CodegenConstants.SKIP_FORM_MODEL)) :
-                getGeneratorPropertyDefaultSwitch(CodegenConstants.SKIP_FORM_MODEL, true);
+        Boolean skipFormModel = null;
+        if (config.additionalProperties().containsKey(CodegenConstants.SKIP_FORM_MODEL)) {
+            final Object val = config.additionalProperties().get(CodegenConstants.SKIP_FORM_MODEL);
+            if (val instanceof Boolean) {
+                skipFormModel = (Boolean) val;
+            } else if (val != null) {
+                skipFormModel = Boolean.parseBoolean(val.toString());
+            }
+        }
+        if (skipFormModel == null) {
+            skipFormModel = GlobalSettings.getProperty(CodegenConstants.SKIP_FORM_MODEL) != null ?
+                    Boolean.valueOf(GlobalSettings.getProperty(CodegenConstants.SKIP_FORM_MODEL)) :
+                    getGeneratorPropertyDefaultSwitch(CodegenConstants.SKIP_FORM_MODEL, true);
+        }
 
         // Additional properties added for tests to exclude references in project related files
         config.additionalProperties().put(CodegenConstants.GENERATE_API_TESTS, generateApiTests);
@@ -464,9 +475,11 @@ public class DefaultGenerator implements Generator {
         // store all processed models
         Map<String, ModelsMap> allProcessedModels = new TreeMap<>((o1, o2) -> ObjectUtils.compare(config.toModelName(o1), config.toModelName(o2)));
 
-        Boolean skipFormModel = GlobalSettings.getProperty(CodegenConstants.SKIP_FORM_MODEL) != null ?
-                Boolean.valueOf(GlobalSettings.getProperty(CodegenConstants.SKIP_FORM_MODEL)) :
-                getGeneratorPropertyDefaultSwitch(CodegenConstants.SKIP_FORM_MODEL, true);
+        Boolean skipFormModel = config.additionalProperties().containsKey(CodegenConstants.SKIP_FORM_MODEL) ?
+                Boolean.valueOf(config.additionalProperties().get(CodegenConstants.SKIP_FORM_MODEL).toString()) :
+                (GlobalSettings.getProperty(CodegenConstants.SKIP_FORM_MODEL) != null ?
+                        Boolean.valueOf(GlobalSettings.getProperty(CodegenConstants.SKIP_FORM_MODEL)) :
+                        getGeneratorPropertyDefaultSwitch(CodegenConstants.SKIP_FORM_MODEL, true));
 
         // process models only
         for (String name : modelKeys) {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
@@ -9398,4 +9398,44 @@ public class SpringCodegenTest {
                 .fileContains(expectedContains);
     }
 
+    @Test
+    public void testMultipleRequestBodyContentTypesDanglingImport_issue24727() throws Exception {
+        Map<String, Object> additionalProperties = new HashMap<>();
+        additionalProperties.put(INTERFACE_ONLY, "true");
+        additionalProperties.put(USE_TAGS, "true");
+
+        Map<String, File> files = generateFromContract(
+                "src/test/resources/3_0/issue_24727.yaml", SPRING_BOOT,
+                additionalProperties);
+
+        JavaFileAssert.assertThat(files.get("DefaultApi.java"))
+                .fileContains("import org.openapitools.model.MultiArticleImporter;")
+                .fileDoesNotContain("import org.openapitools.model.CreateMultiArticleImporterRequest;");
+
+        Assert.assertNotNull(files.get("MultiArticleImporter.java"));
+        Assert.assertNull(files.get("CreateMultiArticleImporterRequest.java"));
+    }
+
+    @Test
+    public void testMultipleRequestBodyContentTypesWithSkipFormModelFalse_issue24727() throws Exception {
+        GlobalSettings.setProperty("skipFormModel", "false");
+        try {
+            Map<String, Object> additionalProperties = new HashMap<>();
+            additionalProperties.put(INTERFACE_ONLY, "true");
+            additionalProperties.put(USE_TAGS, "true");
+
+            Map<String, File> files = generateFromContract(
+                    "src/test/resources/3_0/issue_24727.yaml", SPRING_BOOT,
+                    additionalProperties);
+
+            JavaFileAssert.assertThat(files.get("DefaultApi.java"))
+                    .fileContains("import org.openapitools.model.MultiArticleImporter;")
+                    .fileContains("import org.openapitools.model.CreateMultiArticleImporterRequest;");
+
+            Assert.assertNotNull(files.get("MultiArticleImporter.java"));
+            Assert.assertNotNull(files.get("CreateMultiArticleImporterRequest.java"));
+        } finally {
+            GlobalSettings.reset();
+        }
+    }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
@@ -9463,4 +9463,23 @@ public class SpringCodegenTest {
 
         Assert.assertNotNull(files.get("ArticlePayload.java"));
     }
+
+    @Test
+    public void testMultipleRequestBodyContentTypesWithSkipFormModelFalseInAdditionalProperties_issue24727() throws Exception {
+        Map<String, Object> additionalProperties = new HashMap<>();
+        additionalProperties.put(INTERFACE_ONLY, "true");
+        additionalProperties.put(USE_TAGS, "true");
+        additionalProperties.put(CodegenConstants.SKIP_FORM_MODEL, "false");
+
+        Map<String, File> files = generateFromContract(
+                "src/test/resources/3_0/issue_24727.yaml", SPRING_BOOT,
+                additionalProperties);
+
+        JavaFileAssert.assertThat(files.get("DefaultApi.java"))
+                .fileContains("import org.openapitools.model.MultiArticleImporter;")
+                .fileContains("import org.openapitools.model.CreateMultiArticleImporterRequest;");
+
+        Assert.assertNotNull(files.get("MultiArticleImporter.java"));
+        Assert.assertNotNull(files.get("CreateMultiArticleImporterRequest.java"));
+    }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
@@ -9463,23 +9463,4 @@ public class SpringCodegenTest {
 
         Assert.assertNotNull(files.get("ArticlePayload.java"));
     }
-
-    @Test
-    public void testMultipleRequestBodyContentTypesWithSkipFormModelFalseInAdditionalProperties_issue24727() throws Exception {
-        Map<String, Object> additionalProperties = new HashMap<>();
-        additionalProperties.put(INTERFACE_ONLY, "true");
-        additionalProperties.put(USE_TAGS, "true");
-        additionalProperties.put(CodegenConstants.SKIP_FORM_MODEL, "false");
-
-        Map<String, File> files = generateFromContract(
-                "src/test/resources/3_0/issue_24727.yaml", SPRING_BOOT,
-                additionalProperties);
-
-        JavaFileAssert.assertThat(files.get("DefaultApi.java"))
-                .fileContains("import org.openapitools.model.MultiArticleImporter;")
-                .fileContains("import org.openapitools.model.CreateMultiArticleImporterRequest;");
-
-        Assert.assertNotNull(files.get("MultiArticleImporter.java"));
-        Assert.assertNotNull(files.get("CreateMultiArticleImporterRequest.java"));
-    }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
@@ -9418,24 +9418,49 @@ public class SpringCodegenTest {
 
     @Test
     public void testMultipleRequestBodyContentTypesWithSkipFormModelFalse_issue24727() throws Exception {
-        GlobalSettings.setProperty("skipFormModel", "false");
-        try {
-            Map<String, Object> additionalProperties = new HashMap<>();
-            additionalProperties.put(INTERFACE_ONLY, "true");
-            additionalProperties.put(USE_TAGS, "true");
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
 
-            Map<String, File> files = generateFromContract(
-                    "src/test/resources/3_0/issue_24727.yaml", SPRING_BOOT,
-                    additionalProperties);
+        OpenAPI openAPI = new OpenAPIParser()
+                .readLocation("src/test/resources/3_0/issue_24727.yaml", null, new ParseOptions()).getOpenAPI();
 
-            JavaFileAssert.assertThat(files.get("DefaultApi.java"))
-                    .fileContains("import org.openapitools.model.MultiArticleImporter;")
-                    .fileContains("import org.openapitools.model.CreateMultiArticleImporterRequest;");
+        SpringCodegen codegen = new SpringCodegen();
+        codegen.setOutputDir(output.getAbsolutePath());
+        codegen.additionalProperties().put(INTERFACE_ONLY, "true");
+        codegen.additionalProperties().put(USE_TAGS, "true");
 
-            Assert.assertNotNull(files.get("MultiArticleImporter.java"));
-            Assert.assertNotNull(files.get("CreateMultiArticleImporterRequest.java"));
-        } finally {
-            GlobalSettings.reset();
-        }
+        ClientOptInput input = new ClientOptInput();
+        input.openAPI(openAPI);
+        input.config(codegen);
+
+        DefaultGenerator generator = new DefaultGenerator();
+        generator.setGeneratorPropertyDefault(CodegenConstants.SKIP_FORM_MODEL, "false");
+        generator.setGenerateMetadata(false);
+
+        Map<String, File> files = generator.opts(input).generate().stream()
+                .collect(Collectors.toMap(this::getUniqueName, Function.identity()));
+
+        JavaFileAssert.assertThat(files.get("DefaultApi.java"))
+                .fileContains("import org.openapitools.model.MultiArticleImporter;")
+                .fileContains("import org.openapitools.model.CreateMultiArticleImporterRequest;");
+
+        Assert.assertNotNull(files.get("MultiArticleImporter.java"));
+        Assert.assertNotNull(files.get("CreateMultiArticleImporterRequest.java"));
+    }
+
+    @Test
+    public void testMultipleRequestBodyContentTypesWithSharedModel_issue24727() throws Exception {
+        Map<String, Object> additionalProperties = new HashMap<>();
+        additionalProperties.put(INTERFACE_ONLY, "true");
+        additionalProperties.put(USE_TAGS, "true");
+
+        Map<String, File> files = generateFromContract(
+                "src/test/resources/3_0/issue_24727_shared.yaml", SPRING_BOOT,
+                additionalProperties);
+
+        JavaFileAssert.assertThat(files.get("DefaultApi.java"))
+                .fileContains("import org.openapitools.model.ArticlePayload;");
+
+        Assert.assertNotNull(files.get("ArticlePayload.java"));
     }
 }

--- a/modules/openapi-generator/src/test/resources/3_0/issue_24727.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/issue_24727.yaml
@@ -1,0 +1,39 @@
+openapi: 3.0.3
+info:
+  title: Multiple request-body content types repro
+  version: 1.0.0
+paths:
+  /api/multi_article_importer:
+    post:
+      operationId: createMultiArticleImporter
+      summary: Create a multi article importer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MultiArticleImporter'
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                file:
+                  type: string
+                  format: binary
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MultiArticleImporter'
+components:
+  schemas:
+    MultiArticleImporter:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string

--- a/modules/openapi-generator/src/test/resources/3_0/issue_24727_shared.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/issue_24727_shared.yaml
@@ -1,0 +1,32 @@
+openapi: 3.0.3
+info:
+  title: Shared form model repro
+  version: 1.0.0
+paths:
+  /api/upload:
+    post:
+      operationId: uploadArticle
+      summary: Upload an article
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/ArticlePayload'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ArticlePayload'
+components:
+  schemas:
+    ArticlePayload:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        title:
+          type: string


### PR DESCRIPTION
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to build the project and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
- [x] Target language technical committee: @wing328 @diyfr @jpfinne

### Description of the change
Fixes #24727.

When an operation's `requestBody` defines multiple content types (for example, `application/json` and `multipart/form-data`), `InlineModelResolver` creates an inline model for the form schema. In `DefaultCodegen#getContent`, all media types in `requestBody.getContent()` were unconditionally adding their schema types to `imports`.

When `skipFormModel` is enabled (default `true`), `DefaultGenerator` skips generating the model class for schemas used only in form parameters. This caused the generated API interface to emit a dangling import for a non-existent model class and fail compilation.

This fix updates `DefaultCodegen#getContent` to avoid registering imports for form/multipart media types when `skipFormModel` is enabled.

### Tests
- Added `testMultipleRequestBodyContentTypesDanglingImport_issue24727` and `testMultipleRequestBodyContentTypesWithSkipFormModelFalse_issue24727` in `SpringCodegenTest.java`.
- Verified `SpringCodegenTest`, `DefaultCodegenTest`, and `ModelUtilsTest` all pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #24727 so `DefaultCodegen#getContent` no longer emits dangling imports for form models skipped by `skipFormModel` (default true). Previously every form/multipart schema type was added to imports even when its model class wasn't generated, which broke compilation; now only schemas used exclusively in form parameters are filtered out, and shared form models still generate.

**Bug Fixes**
- Adds `isFormContentType`, `isSkipFormModel`, and a cached `getSchemasUsedOnlyInFormParam` lookup in `DefaultCodegen`.
- `DefaultGenerator` resolves boolean generator properties (including `skipFormModel`) once via a shared `getGlobalOrGeneratorPropertyDefault` helper, writes the normalized values into `additionalProperties`, and `generateModels` reads from there so generation and import filtering use the same value.
- Adds three `SpringCodegenTest` cases and fixtures `issue_24727.yaml` and `issue_24727_shared.yaml` covering default behavior, `skipFormModel=false`, and shared form models.

<sup>Written for commit 748bb81b38dcbe358e37417a42b272de7a3c930c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24807?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

