### PR TITLE
[JAVA] generate package-info.java for the auth package with useJspecify

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
@@ -1412,6 +1412,12 @@ public class JavaClientCodegen extends AbstractJavaCodegen
                     (sourceFolder + File.separator + invokerPackage).replace(".", java.io.File.separator),
                     "package-info.java"));
         }
+        // the authentication classes live in a sub-package of the invoker package, so they are not
+        // covered by the invoker package-info.java. Libraries such as "native" generate no
+        // authentication class at all, and an empty package must not get a package-info.java.
+        if (supportingFiles.stream().anyMatch(sf -> sf.getTemplateFile().startsWith("auth/"))) {
+            supportingFiles.add(new SupportingFile("authPackageInfo.mustache", authFolder, "package-info.java"));
+        }
         String nullableAnnotation = "@" + additionalProperties.get(JAVAX_PACKAGE) + ".annotation.Nullable";
         //  nullable_var_annotations.mustache generates nullable annotations as @{{javaxPackage}}.annotation.Nullable
         // override the default pattern for the "find and replace"

--- a/modules/openapi-generator/src/main/resources/Java/authPackageInfo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/authPackageInfo.mustache
@@ -1,0 +1,2 @@
+@org.jspecify.annotations.NullMarked
+package {{invokerPackage}}.auth;

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -4786,6 +4786,13 @@ public class JavaClientCodegenTest {
                 .fileContains("@org.jspecify.annotations.NullMarked");
         JavaFileAssert.assertThat(files.get("client/package-info.java"))
                 .fileContains("@org.jspecify.annotations.NullMarked");
+        if (NATIVE.equals(library)) { // native library generates no authentication class
+            assertThat(files).doesNotContainKey("auth/package-info.java");
+        } else {
+            assertThat(files).containsKey("auth/package-info.java");
+            JavaFileAssert.assertThat(files.get("auth/package-info.java"))
+                    .fileContains("@org.jspecify.annotations.NullMarked");
+        }
     }
 
     @Test(dataProvider = "jspecifyLibraries")

--- a/samples/client/petstore/java/restclient-springBoot4-jackson3-jspecify-openapiNullable/.openapi-generator/FILES
+++ b/samples/client/petstore/java/restclient-springBoot4-jackson3-jspecify-openapiNullable/.openapi-generator/FILES
@@ -37,6 +37,7 @@ src/main/java/org/openapitools/client/auth/ApiKeyAuth.java
 src/main/java/org/openapitools/client/auth/Authentication.java
 src/main/java/org/openapitools/client/auth/HttpBasicAuth.java
 src/main/java/org/openapitools/client/auth/HttpBearerAuth.java
+src/main/java/org/openapitools/client/auth/package-info.java
 src/main/java/org/openapitools/client/model/FileContent.java
 src/main/java/org/openapitools/client/model/Foo.java
 src/main/java/org/openapitools/client/model/RequiredAndNullable.java

--- a/samples/client/petstore/java/restclient-springBoot4-jackson3-jspecify-openapiNullable/src/main/java/org/openapitools/client/auth/package-info.java
+++ b/samples/client/petstore/java/restclient-springBoot4-jackson3-jspecify-openapiNullable/src/main/java/org/openapitools/client/auth/package-info.java
@@ -1,0 +1,2 @@
+@org.jspecify.annotations.NullMarked
+package org.openapitools.client.auth;

--- a/samples/client/petstore/java/restclient-springBoot4-jackson3-jspecify/.openapi-generator/FILES
+++ b/samples/client/petstore/java/restclient-springBoot4-jackson3-jspecify/.openapi-generator/FILES
@@ -37,6 +37,7 @@ src/main/java/org/openapitools/client/auth/ApiKeyAuth.java
 src/main/java/org/openapitools/client/auth/Authentication.java
 src/main/java/org/openapitools/client/auth/HttpBasicAuth.java
 src/main/java/org/openapitools/client/auth/HttpBearerAuth.java
+src/main/java/org/openapitools/client/auth/package-info.java
 src/main/java/org/openapitools/client/model/FileContent.java
 src/main/java/org/openapitools/client/model/Foo.java
 src/main/java/org/openapitools/client/model/RequiredAndNullable.java

--- a/samples/client/petstore/java/restclient-springBoot4-jackson3-jspecify/src/main/java/org/openapitools/client/auth/package-info.java
+++ b/samples/client/petstore/java/restclient-springBoot4-jackson3-jspecify/src/main/java/org/openapitools/client/auth/package-info.java
@@ -1,0 +1,2 @@
+@org.jspecify.annotations.NullMarked
+package org.openapitools.client.auth;

--- a/samples/client/petstore/java/resttemplate-springBoot4-jackson3-jspecify/.openapi-generator/FILES
+++ b/samples/client/petstore/java/resttemplate-springBoot4-jackson3-jspecify/.openapi-generator/FILES
@@ -38,6 +38,7 @@ src/main/java/org/openapitools/client/auth/ApiKeyAuth.java
 src/main/java/org/openapitools/client/auth/Authentication.java
 src/main/java/org/openapitools/client/auth/HttpBasicAuth.java
 src/main/java/org/openapitools/client/auth/HttpBearerAuth.java
+src/main/java/org/openapitools/client/auth/package-info.java
 src/main/java/org/openapitools/client/model/FileContent.java
 src/main/java/org/openapitools/client/model/Foo.java
 src/main/java/org/openapitools/client/model/RequiredAndNullable.java

--- a/samples/client/petstore/java/resttemplate-springBoot4-jackson3-jspecify/src/main/java/org/openapitools/client/auth/package-info.java
+++ b/samples/client/petstore/java/resttemplate-springBoot4-jackson3-jspecify/src/main/java/org/openapitools/client/auth/package-info.java
@@ -1,0 +1,2 @@
+@org.jspecify.annotations.NullMarked
+package org.openapitools.client.auth;

--- a/samples/client/petstore/java/webclient-springBoot4-jackson3-jspecify/.openapi-generator/FILES
+++ b/samples/client/petstore/java/webclient-springBoot4-jackson3-jspecify/.openapi-generator/FILES
@@ -39,6 +39,7 @@ src/main/java/org/openapitools/client/auth/ApiKeyAuth.java
 src/main/java/org/openapitools/client/auth/Authentication.java
 src/main/java/org/openapitools/client/auth/HttpBasicAuth.java
 src/main/java/org/openapitools/client/auth/HttpBearerAuth.java
+src/main/java/org/openapitools/client/auth/package-info.java
 src/main/java/org/openapitools/client/model/FileContent.java
 src/main/java/org/openapitools/client/model/Foo.java
 src/main/java/org/openapitools/client/model/RequiredAndNullable.java

--- a/samples/client/petstore/java/webclient-springBoot4-jackson3-jspecify/src/main/java/org/openapitools/client/auth/package-info.java
+++ b/samples/client/petstore/java/webclient-springBoot4-jackson3-jspecify/src/main/java/org/openapitools/client/auth/package-info.java
@@ -1,0 +1,2 @@
+@org.jspecify.annotations.NullMarked
+package org.openapitools.client.auth;


### PR DESCRIPTION
Fixes #24664

With `useJspecify=true` the Java client generator writes a `@NullMarked` `package-info.java` for the model, api and invoker packages. The authentication classes sit in `<invokerPackage>.auth`; a sub-package inherits nothing from the invoker `package-info.java`, so it stays outside the null-marked scope.

`applyJspecify()` now registers `authPackageInfo.mustache` for that folder, guarded on an `auth/` template actually being scheduled, so `native` (no authentication class) gets no `package-info.java` for an empty package.

`JavaClientCodegenTest#testJspecify` asserts the file for restclient/webclient/resttemplate and its absence for native; 6 of its 7 rows fail without the generator change. Full class 275/275 green, and the 4 regenerated samples compile.

cc @martin-mfg @jpfinne


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #24664 by generating a `@NullMarked` `package-info.java` for the auth package when `useJspecify` is enabled; previously the auth sub-package stayed outside the null-marked scope.

**Details**
- Generates the file only when an `auth/` template is actually scheduled, so libraries like `native` that produce no auth classes don't get a `package-info.java` for an empty package.
- Extends `testJspecify` to assert the file for restclient, webclient, and resttemplate, and its absence for `native`; regenerated samples include it.

<sup>Written for commit 793f23ac45a2ace1d503e8dd094551069724ec08. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24808?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

