### PR TITLE
fix(python-fastapi): omit security imports for unauthenticated APIs

### DIFF
--- a/modules/openapi-generator/src/main/resources/python-fastapi/api.mustache
+++ b/modules/openapi-generator/src/main/resources/python-fastapi/api.mustache
@@ -22,11 +22,13 @@ from fastapi import (  # noqa: F401
     status,
 )
 
-from {{modelPackage}}.extra_models import TokenModel  # noqa: F401
 {{#imports}}
 {{import}}
 {{/imports}}
-{{#securityImports.0}}from {{packageName}}.security_api import {{#securityImports}}get_token_{{.}}{{^-last}}, {{/-last}}{{/securityImports}}{{/securityImports.0}}
+{{#securityImports.0}}
+from {{modelPackage}}.extra_models import TokenModel  # noqa: F401
+from {{packageName}}.security_api import {{#securityImports}}get_token_{{.}}{{^-last}}, {{/-last}}{{/securityImports}}
+{{/securityImports.0}}
 
 router = APIRouter()
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonFastAPIServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonFastAPIServerCodegenTest.java
@@ -268,4 +268,23 @@ public class PythonFastAPIServerCodegenTest {
         Assert.assertFalse(content.contains("\n,\n"),
                 "comma wrapped onto its own line in: " + api);
     }
+
+    @Test(description = "security imports are emitted only for APIs with authenticated operations (#23008)")
+    public void testSecurityImportsRequireAuthenticatedOperations() throws IOException {
+        final DefaultCodegen unauthenticatedCodegen = new PythonFastAPIServerCodegen();
+        final String unauthenticatedOutputPath = generateFiles(unauthenticatedCodegen, "src/test/resources/bugs/issue_23008.yaml");
+        final Path unauthenticatedApi = Paths.get(unauthenticatedOutputPath + "src/openapi_server/apis/default_api.py");
+
+        assertFileExists(unauthenticatedApi);
+        assertFileNotContains(unauthenticatedApi, "from openapi_server.models.extra_models import TokenModel");
+        assertFileNotContains(unauthenticatedApi, "from openapi_server.security_api import");
+
+        final DefaultCodegen authenticatedCodegen = new PythonFastAPIServerCodegen();
+        final String authenticatedOutputPath = generateFiles(authenticatedCodegen, "src/test/resources/3_0/python-fastapi/petstore.yaml");
+        final Path authenticatedApi = Paths.get(authenticatedOutputPath + "src/openapi_server/apis/pet_api.py");
+
+        assertFileExists(authenticatedApi);
+        assertFileContains(authenticatedApi, "from openapi_server.models.extra_models import TokenModel");
+        assertFileContains(authenticatedApi, "from openapi_server.security_api import get_token_");
+    }
 }

--- a/modules/openapi-generator/src/test/resources/bugs/issue_23008.yaml
+++ b/modules/openapi-generator/src/test/resources/bugs/issue_23008.yaml
@@ -1,0 +1,26 @@
+openapi: 3.0.3
+info:
+  title: Supporting-files reproduction
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        "200":
+          description: A list of pets
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Pet"
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string

--- a/samples/server/petstore/python-fastapi/src/openapi_server/apis/fake_api.py
+++ b/samples/server/petstore/python-fastapi/src/openapi_server/apis/fake_api.py
@@ -22,11 +22,9 @@ from fastapi import (  # noqa: F401
     status,
 )
 
-from openapi_server.models.extra_models import TokenModel  # noqa: F401
 from pydantic import Field
 from typing import Any, Optional
 from typing_extensions import Annotated
-
 
 router = APIRouter()
 

--- a/samples/server/petstore/python-fastapi/src/openapi_server/apis/pet_api.py
+++ b/samples/server/petstore/python-fastapi/src/openapi_server/apis/pet_api.py
@@ -22,13 +22,13 @@ from fastapi import (  # noqa: F401
     status,
 )
 
-from openapi_server.models.extra_models import TokenModel  # noqa: F401
 from pydantic import Field, StrictBytes, StrictStr, field_validator
 from typing import Any, List, Optional, Tuple, Union
 from typing_extensions import Annotated
 from openapi_server.models.api_response import ApiResponse
 from openapi_server.models.pet import Pet
 from fastapi import File, UploadFile
+from openapi_server.models.extra_models import TokenModel  # noqa: F401
 from openapi_server.security_api import get_token_petstore_auth, get_token_api_key
 
 router = APIRouter()

--- a/samples/server/petstore/python-fastapi/src/openapi_server/apis/store_api.py
+++ b/samples/server/petstore/python-fastapi/src/openapi_server/apis/store_api.py
@@ -22,11 +22,11 @@ from fastapi import (  # noqa: F401
     status,
 )
 
-from openapi_server.models.extra_models import TokenModel  # noqa: F401
 from pydantic import Field, StrictInt
 from typing import Any, Dict
 from typing_extensions import Annotated
 from openapi_server.models.order import Order
+from openapi_server.models.extra_models import TokenModel  # noqa: F401
 from openapi_server.security_api import get_token_api_key
 
 router = APIRouter()

--- a/samples/server/petstore/python-fastapi/src/openapi_server/apis/user_api.py
+++ b/samples/server/petstore/python-fastapi/src/openapi_server/apis/user_api.py
@@ -22,11 +22,11 @@ from fastapi import (  # noqa: F401
     status,
 )
 
-from openapi_server.models.extra_models import TokenModel  # noqa: F401
 from pydantic import Field, StrictStr, field_validator
 from typing import Any, List
 from typing_extensions import Annotated
 from openapi_server.models.user import User
+from openapi_server.models.extra_models import TokenModel  # noqa: F401
 from openapi_server.security_api import get_token_api_key
 
 router = APIRouter()


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Fixes #23008.

### Summary

The Python FastAPI API template unconditionally imports `TokenModel`, even when an API has no authenticated operations.

When only APIs and models are generated, supporting files such as `extra_models.py` are skipped. The resulting API therefore imports a module that was not generated:

```python
from issue_23008_api.models.extra_models import TokenModel
```

This PR emits the `TokenModel` and `security_api` imports only when the API has security imports.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@cbornet (2017/09) @tomplus (2018/10) @krjakbrjak (2023/02) @fa0311 (2023/10)



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Python FastAPI template importing `TokenModel` and `security_api` for APIs with no authenticated operations, which previously referenced modules that were not generated.

- Emits `extra_models.TokenModel` and security API imports only when the API has security imports.
- Adds a regression test and a minimal OpenAPI spec that reproduces the unauthenticated case.

<sup>Written for commit 5a949f6d8893ffb291b9a02abc0e57967005015f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24809?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



