### PR TITLE
fix(kotlin-server): emit KDoc for operation summary and description in jaxrs-spec interfaces

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-server/libraries/jaxrs-spec/apiInterface.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-server/libraries/jaxrs-spec/apiInterface.mustache
@@ -1,3 +1,19 @@
+    {{#summary}}
+    /**
+     * {{{summary}}}
+    {{#notes}}
+     *
+     * {{{notes}}}
+    {{/notes}}
+{{>operationDoc}}
+    {{/summary}}
+    {{^summary}}
+    {{#notes}}
+    /**
+     * {{{notes}}}
+{{>operationDoc}}
+    {{/notes}}
+    {{/summary}}
     @{{httpMethod}}{{#subresourceOperation}}
     @Path("{{{path}}}"){{/subresourceOperation}}{{#hasConsumes}}
     @Consumes({{#consumes}}"{{{mediaType}}}"{{^-last}}, {{/-last}}{{/consumes}}){{/hasConsumes}}{{#hasProduces}}

--- a/modules/openapi-generator/src/main/resources/kotlin-server/libraries/jaxrs-spec/operationDoc.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-server/libraries/jaxrs-spec/operationDoc.mustache
@@ -1,0 +1,13 @@
+{{#allParams}}
+{{#description}}
+     * @param {{paramName}}{{#isFormParam}}{{#isFile}}InputStream{{/isFile}}{{/isFormParam}} {{{description}}}
+{{/description}}
+{{/allParams}}
+{{#responses.0}}
+     * @return {{#responses}}{{{message}}} (status code {{code}}){{^-last}}
+     *         or {{/-last}}{{/responses}}
+{{/responses.0}}
+{{#isDeprecated}}
+     * @deprecated
+{{/isDeprecated}}
+     */

--- a/samples/server/others/kotlin-server/jaxrs-spec-array-response/src/main/kotlin/org/openapitools/server/apis/StuffApi.kt
+++ b/samples/server/others/kotlin-server/jaxrs-spec-array-response/src/main/kotlin/org/openapitools/server/apis/StuffApi.kt
@@ -14,11 +14,25 @@ import java.io.InputStream
 @jakarta.annotation.Generated(value = arrayOf("org.openapitools.codegen.languages.KotlinServerCodegen"), comments = "Generator version: 7.26.0-SNAPSHOT")
 interface StuffApi {
 
+    /**
+     * Finds stuff
+     *
+     * Finds stuff
+     * @return successful operation (status code 200)
+     *         or Invalid status value (status code 400)
+     */
     @GET
     @Path("/stuff")
     @Produces("application/json")
     fun findStuff(): kotlin.collections.List<Stuff>
 
+    /**
+     * Finds unique stuff
+     *
+     * Finds unique stuff
+     * @return successful operation (status code 200)
+     *         or Invalid status value (status code 400)
+     */
     @GET
     @Path("/uniquestuff")
     @Produces("application/json")

--- a/samples/server/petstore/kotlin-server/jaxrs-spec-mutiny/src/main/kotlin/org/openapitools/server/apis/PetApi.kt
+++ b/samples/server/petstore/kotlin-server/jaxrs-spec-mutiny/src/main/kotlin/org/openapitools/server/apis/PetApi.kt
@@ -15,38 +15,95 @@ import java.io.InputStream
 @javax.annotation.Generated(value = arrayOf("org.openapitools.codegen.languages.KotlinServerCodegen"), comments = "Generator version: 7.26.0-SNAPSHOT")
 interface PetApi {
 
+    /**
+     * Add a new pet to the store
+     * @param body Pet object that needs to be added to the store
+     * @return Invalid input (status code 405)
+     */
     @POST
     @Consumes("application/json", "application/xml")
     fun addPet( body: Pet): io.smallrye.mutiny.Uni<Response>
 
+    /**
+     * Deletes a pet
+     * @param petId Pet id to delete
+     * @return Invalid pet value (status code 400)
+     */
     @DELETE
     @Path("/{petId}")
     fun deletePet(@PathParam("petId") petId: kotlin.Long,@HeaderParam("api_key")  apiKey: kotlin.String?): io.smallrye.mutiny.Uni<Response>
 
+    /**
+     * Finds Pets by status
+     *
+     * Multiple status values can be provided with comma separated strings
+     * @param status Status values that need to be considered for filter
+     * @return successful operation (status code 200)
+     *         or Invalid status value (status code 400)
+     */
     @GET
     @Path("/findByStatus")
     @Produces("application/xml", "application/json")
     fun findPetsByStatus(@QueryParam("status") status: kotlin.collections.List<kotlin.String>): io.smallrye.mutiny.Uni<Response>
 
+    /**
+     * Finds Pets by tags
+     *
+     * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+     * @param tags Tags to filter by
+     * @return successful operation (status code 200)
+     *         or Invalid tag value (status code 400)
+     * @deprecated
+     */
     @GET
     @Path("/findByTags")
     @Produces("application/xml", "application/json")
     fun findPetsByTags(@QueryParam("tags") tags: kotlin.collections.List<kotlin.String>): io.smallrye.mutiny.Uni<Response>
 
+    /**
+     * Find pet by ID
+     *
+     * Returns a single pet
+     * @param petId ID of pet to return
+     * @return successful operation (status code 200)
+     *         or Invalid ID supplied (status code 400)
+     *         or Pet not found (status code 404)
+     */
     @GET
     @Path("/{petId}")
     @Produces("application/xml", "application/json")
     fun getPetById(@PathParam("petId") petId: kotlin.Long): io.smallrye.mutiny.Uni<Response>
 
+    /**
+     * Update an existing pet
+     * @param body Pet object that needs to be added to the store
+     * @return Invalid ID supplied (status code 400)
+     *         or Pet not found (status code 404)
+     *         or Validation exception (status code 405)
+     */
     @PUT
     @Consumes("application/json", "application/xml")
     fun updatePet( body: Pet): io.smallrye.mutiny.Uni<Response>
 
+    /**
+     * Updates a pet in the store with form data
+     * @param petId ID of pet that needs to be updated
+     * @param name Updated name of the pet
+     * @param status Updated status of the pet
+     * @return Invalid input (status code 405)
+     */
     @POST
     @Path("/{petId}")
     @Consumes("application/x-www-form-urlencoded")
     fun updatePetWithForm(@PathParam("petId") petId: kotlin.Long,@FormParam(value = "name") name: kotlin.String?,@FormParam(value = "status") status: kotlin.String?): io.smallrye.mutiny.Uni<Response>
 
+    /**
+     * uploads an image
+     * @param petId ID of pet to update
+     * @param additionalMetadata Additional data to pass to server
+     * @param fileInputStream file to upload
+     * @return successful operation (status code 200)
+     */
     @POST
     @Path("/{petId}/uploadImage")
     @Consumes("multipart/form-data")

--- a/samples/server/petstore/kotlin-server/jaxrs-spec-mutiny/src/main/kotlin/org/openapitools/server/apis/StoreApi.kt
+++ b/samples/server/petstore/kotlin-server/jaxrs-spec-mutiny/src/main/kotlin/org/openapitools/server/apis/StoreApi.kt
@@ -14,20 +14,49 @@ import java.io.InputStream
 @javax.annotation.Generated(value = arrayOf("org.openapitools.codegen.languages.KotlinServerCodegen"), comments = "Generator version: 7.26.0-SNAPSHOT")
 interface StoreApi {
 
+    /**
+     * Delete purchase order by ID
+     *
+     * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
+     * @param orderId ID of the order that needs to be deleted
+     * @return Invalid ID supplied (status code 400)
+     *         or Order not found (status code 404)
+     */
     @DELETE
     @Path("/order/{orderId}")
     fun deleteOrder(@PathParam("orderId") orderId: kotlin.String): io.smallrye.mutiny.Uni<Response>
 
+    /**
+     * Returns pet inventories by status
+     *
+     * Returns a map of status codes to quantities
+     * @return successful operation (status code 200)
+     */
     @GET
     @Path("/inventory")
     @Produces("application/json")
     fun getInventory(): io.smallrye.mutiny.Uni<Response>
 
+    /**
+     * Find purchase order by ID
+     *
+     * For valid response try integer IDs with value <= 5 or > 10. Other values will generate exceptions
+     * @param orderId ID of pet that needs to be fetched
+     * @return successful operation (status code 200)
+     *         or Invalid ID supplied (status code 400)
+     *         or Order not found (status code 404)
+     */
     @GET
     @Path("/order/{orderId}")
     @Produces("application/xml", "application/json")
     fun getOrderById(@PathParam("orderId") orderId: kotlin.Long): io.smallrye.mutiny.Uni<Response>
 
+    /**
+     * Place an order for a pet
+     * @param body order placed for purchasing the pet
+     * @return successful operation (status code 200)
+     *         or Invalid Order (status code 400)
+     */
     @POST
     @Path("/order")
     @Produces("application/xml", "application/json")

--- a/samples/server/petstore/kotlin-server/jaxrs-spec-mutiny/src/main/kotlin/org/openapitools/server/apis/UserApi.kt
+++ b/samples/server/petstore/kotlin-server/jaxrs-spec-mutiny/src/main/kotlin/org/openapitools/server/apis/UserApi.kt
@@ -14,35 +14,87 @@ import java.io.InputStream
 @javax.annotation.Generated(value = arrayOf("org.openapitools.codegen.languages.KotlinServerCodegen"), comments = "Generator version: 7.26.0-SNAPSHOT")
 interface UserApi {
 
+    /**
+     * Create user
+     *
+     * This can only be done by the logged in user.
+     * @param body Created user object
+     * @return successful operation (status code 0)
+     */
     @POST
     fun createUser( body: User): io.smallrye.mutiny.Uni<Response>
 
+    /**
+     * Creates list of users with given input array
+     * @param body List of user object
+     * @return successful operation (status code 0)
+     */
     @POST
     @Path("/createWithArray")
     fun createUsersWithArrayInput( body: kotlin.collections.List<User>): io.smallrye.mutiny.Uni<Response>
 
+    /**
+     * Creates list of users with given input array
+     * @param body List of user object
+     * @return successful operation (status code 0)
+     */
     @POST
     @Path("/createWithList")
     fun createUsersWithListInput( body: kotlin.collections.List<User>): io.smallrye.mutiny.Uni<Response>
 
+    /**
+     * Delete user
+     *
+     * This can only be done by the logged in user.
+     * @param username The name that needs to be deleted
+     * @return Invalid username supplied (status code 400)
+     *         or User not found (status code 404)
+     */
     @DELETE
     @Path("/{username}")
     fun deleteUser(@PathParam("username") username: kotlin.String): io.smallrye.mutiny.Uni<Response>
 
+    /**
+     * Get user by user name
+     * @param username The name that needs to be fetched. Use user1 for testing.
+     * @return successful operation (status code 200)
+     *         or Invalid username supplied (status code 400)
+     *         or User not found (status code 404)
+     */
     @GET
     @Path("/{username}")
     @Produces("application/xml", "application/json")
     fun getUserByName(@PathParam("username") username: kotlin.String): io.smallrye.mutiny.Uni<Response>
 
+    /**
+     * Logs user into the system
+     * @param username The user name for login
+     * @param password The password for login in clear text
+     * @return successful operation (status code 200)
+     *         or Invalid username/password supplied (status code 400)
+     */
     @GET
     @Path("/login")
     @Produces("application/xml", "application/json")
     fun loginUser(@QueryParam("username") username: kotlin.String,@QueryParam("password") password: kotlin.String): io.smallrye.mutiny.Uni<Response>
 
+    /**
+     * Logs out current logged in user session
+     * @return successful operation (status code 0)
+     */
     @GET
     @Path("/logout")
     fun logoutUser(): io.smallrye.mutiny.Uni<Response>
 
+    /**
+     * Updated user
+     *
+     * This can only be done by the logged in user.
+     * @param username name that need to be deleted
+     * @param body Updated user object
+     * @return Invalid user supplied (status code 400)
+     *         or User not found (status code 404)
+     */
     @PUT
     @Path("/{username}")
     fun updateUser(@PathParam("username") username: kotlin.String, body: User): io.smallrye.mutiny.Uni<Response>


### PR DESCRIPTION
Fixes #24794.

The `kotlin-server` `jaxrs-spec` `apiInterface.mustache` template emitted only the JAX-RS annotations, so an `interfaceOnly: true` API interface carried no documentation for its operations at all. The equivalent Java template (`JavaJaxRS/spec/apiInterface.mustache`) has always emitted a Javadoc block, and the models generated by this same library already carry KDoc, so the API interfaces were the odd ones out.

### Change

A KDoc block built from the operation `summary` and `notes`, with `@param` for documented parameters and `@return` listing the responses.

Two details worth flagging for review:

- The `@return` formatting follows the `kotlin-server` `javalin6` templates (`successful operation (status code 200)` / `or ...`) rather than the Java template's `{{#responses}}@return {{{message}}}{{/responses}}`, which emits one `@return` line per response. This keeps the output consistent within the Kotlin generator and valid as KDoc.
- The block is omitted entirely when an operation has neither a summary nor notes, so operations without documentation do not gain an empty `/** */`. The Java template emits its block unconditionally.

`@param` is only emitted for parameters that actually have a description, so undocumented parameters do not produce a bare `@param name` line.

### Generated output

Before:

```kotlin
    @GET
    @Path("/findByStatus")
    @Produces("application/xml", "application/json")
    fun findPetsByStatus(@QueryParam("status") status: kotlin.collections.List<kotlin.String>): io.smallrye.mutiny.Uni<Response>
```

After:

```kotlin
    /**
     * Finds Pets by status
     *
     * Multiple status values can be provided with comma separated strings
     * @param status Status values that need to be considered for filter
     * @return successful operation (status code 200)
     *         or Invalid status value (status code 400)
     */
    @GET
    @Path("/findByStatus")
    @Produces("application/xml", "application/json")
    fun findPetsByStatus(@QueryParam("status") status: kotlin.collections.List<kotlin.String>): io.smallrye.mutiny.Uni<Response>
```

### Samples

Regenerated with `./bin/generate-samples.sh` for the four `kotlin-server-jaxrs-spec*` configs. Only the two that set `interfaceOnly` produce output changes, since the others generate through `apiMethod.mustache`:

- `samples/server/others/kotlin-server/jaxrs-spec-array-response`
- `samples/server/petstore/kotlin-server/jaxrs-spec-mutiny`

### Note

`apiMethod.mustache` in the same library has the same gap for the non-`interfaceOnly` case. I left it out to keep this change scoped to the reported issue — happy to follow up separately, or fold it in here if you would prefer.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the build and regenerated the affected samples, and committed the changed files.
- [x] @jimschubert as the Kotlin technical committee member.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #24794 by emitting KDoc on operation methods in `kotlin-server` `jaxrs-spec` interfaces when `interfaceOnly` is set, so generated API docs match the Java generator and model KDoc. Previously these interfaces had no method documentation.

- Builds KDoc from operation summary/notes, `@param` for described parameters, and `@return` listing responses.
- Omits the block when an operation has no summary or notes.
- Regenerated the two affected samples; `apiMethod.mustache` is out of scope.

<sup>Written for commit 0a85fbbdd69cd31a4e0d380a48715458dddcbfa4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24810?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

