### PR TITLE
fix(java): make nested enums serializable with serializableModel

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -4610,6 +4610,71 @@ public class DefaultCodegen implements CodegenConfig {
         return currentProperty;
     }
 
+    /**
+     * Applies an action to every property recursively reachable from a model.
+     * Properties are de-duplicated by identity to avoid repeated processing and cycles.
+     *
+     * @param model  model whose properties should be visited
+     * @param action action to apply to each property
+     */
+    protected void forEachModelPropertyRecursively(CodegenModel model, Consumer<CodegenProperty> action) {
+        Set<CodegenProperty> visited = Collections.newSetFromMap(new IdentityHashMap<>());
+        visitNestedProperties(model, visited, action);
+    }
+
+    /**
+     * Applies an action to a property and recursively visits its nested properties.
+     */
+    private void visitProperty(CodegenProperty property, Set<CodegenProperty> visited,
+            Consumer<CodegenProperty> action) {
+        if (property == null || !visited.add(property)) {
+            return;
+        }
+
+        action.accept(property);
+        visitNestedProperties(property, visited, action);
+    }
+
+    /**
+     * Visits every canonical location in which a schema can contain another {@link CodegenProperty}.
+     * Other derived views such as {@code mostInnerItems} are intentionally omitted
+     * because their properties are already reachable through {@code items}. Note that
+     * {@code requiredVarsMap} is traversed explicitly below.
+     */
+    private void visitNestedProperties(IJsonSchemaValidationProperties schema,
+            Set<CodegenProperty> visited, Consumer<CodegenProperty> action) {
+        visitProperties(schema.getVars(), visited, action);
+        visitProperty(schema.getItems(), visited, action);
+        visitProperty(schema.getAdditionalProperties(), visited, action);
+        visitProperty(schema.getContains(), visited, action);
+
+        Map<String, CodegenProperty> requiredVarsMap = schema.getRequiredVarsMap();
+        if (requiredVarsMap != null) {
+            visitProperties(requiredVarsMap.values(), visited, action);
+        }
+
+        CodegenComposedSchemas composedSchemas = schema.getComposedSchemas();
+        if (composedSchemas != null) {
+            visitProperties(composedSchemas.getAllOf(), visited, action);
+            visitProperties(composedSchemas.getOneOf(), visited, action);
+            visitProperties(composedSchemas.getAnyOf(), visited, action);
+            visitProperty(composedSchemas.getNot(), visited, action);
+        }
+    }
+
+    /**
+     * Visits each property in a collection and its nested properties.
+     */
+    private void visitProperties(Collection<CodegenProperty> properties, Set<CodegenProperty> visited,
+            Consumer<CodegenProperty> action) {
+        if (properties == null) {
+            return;
+        }
+        for (CodegenProperty property : properties) {
+            visitProperty(property, visited, action);
+        }
+    }
+
     protected Map<String, Object> getInnerEnumAllowableValues(CodegenProperty property) {
         CodegenProperty currentProperty = getMostInnerItems(property);
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -2330,10 +2330,9 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
 
     /**
      * Visits every canonical location in which a schema can contain another {@link CodegenProperty}.
-+     * Other derived views such as {@code mostInnerItems} are intentionally omitted
-+     * because their properties are already reachable through {@code items}. Note that
-+     * {@code requiredVarsMap} is traversed explicitly below.
-     * because their properties are already reachable through {@code vars} and {@code items}.
+     * Other derived views such as {@code mostInnerItems} are intentionally omitted
+     * because their properties are already reachable through {@code items}. Note that
+     * {@code requiredVarsMap} is traversed explicitly below.
      */
     private void visitNestedProperties(IJsonSchemaValidationProperties schema,
             Set<CodegenProperty> visited, Consumer<CodegenProperty> action) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -67,6 +67,7 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -2214,11 +2215,12 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
         if (this.serializableModel) {
             for (ModelMap mo : objs.getModels()) {
                 CodegenModel cm = mo.getModel();
-                List<String> xImplements = new ArrayList<>(getObjectAsStringList(cm.getVendorExtensions().get(X_IMPLEMENTS)));
-                if (!xImplements.contains("Serializable")) {
-                    xImplements.add("Serializable");
-                }
-                cm.getVendorExtensions().replace(X_IMPLEMENTS, xImplements);
+                addInterfaceToVendorExtensions(cm.getVendorExtensions(), "Serializable");
+                forEachModelPropertyRecursively(cm, property -> {
+                    if (property.isEnum) {
+                        addInterfaceToVendorExtensions(property.getVendorExtensions(), "Serializable");
+                    }
+                });
             }
         }
 
@@ -2300,6 +2302,65 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
 
         for (CodegenProperty property : properties) {
             normalizeVendorExtensionWithStringList(property.vendorExtensions, name);
+        }
+    }
+
+    private void addInterfaceToVendorExtensions(Map<String, Object> vendorExtensions, String interfaceName) {
+        List<String> interfaces = new ArrayList<>(getObjectAsStringList(vendorExtensions.get(X_IMPLEMENTS)));
+        if (!interfaces.contains(interfaceName)) {
+            interfaces.add(interfaceName);
+        }
+        vendorExtensions.put(X_IMPLEMENTS, interfaces);
+    }
+
+    private void forEachModelPropertyRecursively(CodegenModel model, Consumer<CodegenProperty> action) {
+        Set<CodegenProperty> visited = Collections.newSetFromMap(new IdentityHashMap<>());
+        visitNestedProperties(model, visited, action);
+    }
+
+    private void visitProperty(CodegenProperty property, Set<CodegenProperty> visited,
+            Consumer<CodegenProperty> action) {
+        if (property == null || !visited.add(property)) {
+            return;
+        }
+
+        action.accept(property);
+        visitNestedProperties(property, visited, action);
+    }
+
+    /**
+     * Visits every canonical location in which a schema can contain another {@link CodegenProperty}.
+     * Derived views such as {@code requiredVars} and {@code mostInnerItems} are intentionally omitted
+     * because their properties are already reachable through {@code vars} and {@code items}.
+     */
+    private void visitNestedProperties(IJsonSchemaValidationProperties schema,
+            Set<CodegenProperty> visited, Consumer<CodegenProperty> action) {
+        visitProperties(schema.getVars(), visited, action);
+        visitProperty(schema.getItems(), visited, action);
+        visitProperty(schema.getAdditionalProperties(), visited, action);
+        visitProperty(schema.getContains(), visited, action);
+
+        Map<String, CodegenProperty> requiredVarsMap = schema.getRequiredVarsMap();
+        if (requiredVarsMap != null) {
+            visitProperties(requiredVarsMap.values(), visited, action);
+        }
+
+        CodegenComposedSchemas composedSchemas = schema.getComposedSchemas();
+        if (composedSchemas != null) {
+            visitProperties(composedSchemas.getAllOf(), visited, action);
+            visitProperties(composedSchemas.getOneOf(), visited, action);
+            visitProperties(composedSchemas.getAnyOf(), visited, action);
+            visitProperty(composedSchemas.getNot(), visited, action);
+        }
+    }
+
+    private void visitProperties(Collection<CodegenProperty> properties, Set<CodegenProperty> visited,
+            Consumer<CodegenProperty> action) {
+        if (properties == null) {
+            return;
+        }
+        for (CodegenProperty property : properties) {
+            visitProperty(property, visited, action);
         }
     }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -67,7 +67,6 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.concurrent.ConcurrentSkipListSet;
-import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -2305,64 +2304,19 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
         }
     }
 
+    /**
+     * Adds an interface to the {@code x-implements} vendor extension if it is not already present.
+     * The existing extension value is normalized to a mutable list of strings before it is updated.
+     *
+     * @param vendorExtensions vendor extension map to update
+     * @param interfaceName    interface name to add
+     */
     private void addInterfaceToVendorExtensions(Map<String, Object> vendorExtensions, String interfaceName) {
         List<String> interfaces = new ArrayList<>(getObjectAsStringList(vendorExtensions.get(X_IMPLEMENTS)));
         if (!interfaces.contains(interfaceName)) {
             interfaces.add(interfaceName);
         }
         vendorExtensions.put(X_IMPLEMENTS, interfaces);
-    }
-
-    private void forEachModelPropertyRecursively(CodegenModel model, Consumer<CodegenProperty> action) {
-        Set<CodegenProperty> visited = Collections.newSetFromMap(new IdentityHashMap<>());
-        visitNestedProperties(model, visited, action);
-    }
-
-    private void visitProperty(CodegenProperty property, Set<CodegenProperty> visited,
-            Consumer<CodegenProperty> action) {
-        if (property == null || !visited.add(property)) {
-            return;
-        }
-
-        action.accept(property);
-        visitNestedProperties(property, visited, action);
-    }
-
-    /**
-     * Visits every canonical location in which a schema can contain another {@link CodegenProperty}.
-     * Other derived views such as {@code mostInnerItems} are intentionally omitted
-     * because their properties are already reachable through {@code items}. Note that
-     * {@code requiredVarsMap} is traversed explicitly below.
-     */
-    private void visitNestedProperties(IJsonSchemaValidationProperties schema,
-            Set<CodegenProperty> visited, Consumer<CodegenProperty> action) {
-        visitProperties(schema.getVars(), visited, action);
-        visitProperty(schema.getItems(), visited, action);
-        visitProperty(schema.getAdditionalProperties(), visited, action);
-        visitProperty(schema.getContains(), visited, action);
-
-        Map<String, CodegenProperty> requiredVarsMap = schema.getRequiredVarsMap();
-        if (requiredVarsMap != null) {
-            visitProperties(requiredVarsMap.values(), visited, action);
-        }
-
-        CodegenComposedSchemas composedSchemas = schema.getComposedSchemas();
-        if (composedSchemas != null) {
-            visitProperties(composedSchemas.getAllOf(), visited, action);
-            visitProperties(composedSchemas.getOneOf(), visited, action);
-            visitProperties(composedSchemas.getAnyOf(), visited, action);
-            visitProperty(composedSchemas.getNot(), visited, action);
-        }
-    }
-
-    private void visitProperties(Collection<CodegenProperty> properties, Set<CodegenProperty> visited,
-            Consumer<CodegenProperty> action) {
-        if (properties == null) {
-            return;
-        }
-        for (CodegenProperty property : properties) {
-            visitProperty(property, visited, action);
-        }
     }
 
     /**

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -2330,7 +2330,9 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
 
     /**
      * Visits every canonical location in which a schema can contain another {@link CodegenProperty}.
-     * Derived views such as {@code requiredVars} and {@code mostInnerItems} are intentionally omitted
++     * Other derived views such as {@code mostInnerItems} are intentionally omitted
++     * because their properties are already reachable through {@code items}. Note that
++     * {@code requiredVarsMap} is traversed explicitly below.
      * because their properties are already reachable through {@code vars} and {@code items}.
      */
     private void visitNestedProperties(IJsonSchemaValidationProperties schema,

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -43,6 +43,8 @@ import org.openapitools.codegen.languages.JavaClientCodegen;
 import org.openapitools.codegen.languages.features.BeanValidationFeatures;
 import org.openapitools.codegen.languages.features.CXFServerFeatures;
 import org.openapitools.codegen.meta.features.SecurityFeature;
+import org.openapitools.codegen.model.ModelMap;
+import org.openapitools.codegen.model.ModelsMap;
 import org.openapitools.codegen.model.OperationMap;
 import org.openapitools.codegen.model.OperationsMap;
 import org.openapitools.codegen.testutils.ConfigAssert;
@@ -4086,6 +4088,114 @@ public class JavaClientCodegenTest {
                 .generate().stream().collect(Collectors.toMap(File::getName, Function.identity()));
 
         JavaFileAssert.assertThat(files.get("Type.java")).fileContains("Type implements java.io.Serializable {");
+    }
+
+    @Test
+    public void testSerializableModelAddsSerializableToInnerEnums_issue23082() {
+        Map<String, File> files = generateFromContract(
+                "src/test/resources/3_0/issue_23082.yaml",
+                JavaClientCodegen.OKHTTP_GSON,
+                Map.of(SERIALIZABLE_MODEL, true));
+
+        JavaFileAssert.assertThat(files.get("ExampleWithInnerEnums.java")).fileContains(
+                "class ExampleWithInnerEnums implements Serializable {",
+                "enum ExampleInnerEnum implements Serializable {",
+                "enum NestedExamplesEnum implements Serializable {");
+    }
+
+    @Test
+    public void testSerializableModelTraversesEveryNestedPropertyLocation_issue23082() {
+        JavaClientCodegen codegen = new JavaClientCodegen();
+        codegen.additionalProperties().put(SERIALIZABLE_MODEL, true);
+        codegen.processOpts();
+
+        CodegenModel model = new CodegenModel();
+        CodegenProperty container = new CodegenProperty();
+        // components.schemas.Model.properties.container
+        model.vars.add(container);
+
+        CodegenProperty directEnum = newEnumProperty();
+        // properties.directEnum
+        container.vars.add(directEnum);
+
+        CodegenProperty arrayEnum = newEnumProperty();
+        CodegenProperty nestedArray = new CodegenProperty();
+        // type: array
+        // items:
+        //   type: array
+        //   items: { type: string, enum: [...] }
+        nestedArray.setItems(arrayEnum);
+        container.setItems(nestedArray);
+
+        CodegenProperty additionalPropertiesEnum = newEnumProperty();
+        // additionalProperties: { type: string, enum: [...] }
+        container.setAdditionalProperties(additionalPropertiesEnum);
+
+        CodegenProperty containsEnum = newEnumProperty();
+        // contains: { type: string, enum: [...] } (OpenAPI 3.1)
+        container.setContains(containsEnum);
+
+        CodegenProperty requiredPropertyEnum = newEnumProperty();
+        // required: [requiredProperty]
+        // properties.requiredProperty: { type: string, enum: [...] }
+        container.setRequiredVarsMap(Map.of("requiredProperty", requiredPropertyEnum));
+
+        CodegenProperty allOfEnum = newEnumProperty();
+        CodegenProperty oneOfEnum = newEnumProperty();
+        CodegenProperty anyOfEnum = newEnumProperty();
+        CodegenProperty notEnum = newEnumProperty();
+        // allOf: [{ type: string, enum: [...] }]
+        // oneOf: [{ type: string, enum: [...] }]
+        // anyOf: [{ type: string, enum: [...] }]
+        // not: { type: string, enum: [...] }
+        container.setComposedSchemas(new CodegenComposedSchemas(
+                List.of(allOfEnum), List.of(oneOfEnum), List.of(anyOfEnum), notEnum));
+
+        // Exercise model-level schema locations as well as property-level locations.
+        CodegenProperty modelItemsEnum = newEnumProperty();
+        // components.schemas.Model: { type: array, items: { type: string, enum: [...] } }
+        model.setItems(modelItemsEnum);
+        CodegenProperty modelAdditionalPropertiesEnum = newEnumProperty();
+        // components.schemas.Model: { type: object, additionalProperties: { type: string, enum: [...] } }
+        model.setAdditionalProperties(modelAdditionalPropertiesEnum);
+        CodegenProperty modelContainsEnum = newEnumProperty();
+        // components.schemas.Model: { type: array, contains: { type: string, enum: [...] } }
+        model.setContains(modelContainsEnum);
+
+        // A malformed or mutually recursive graph must not cause unbounded traversal.
+        container.vars.add(container);
+
+        ModelMap modelMap = new ModelMap();
+        modelMap.setModel(model);
+        ModelsMap modelsMap = new ModelsMap();
+        modelsMap.setModels(List.of(modelMap));
+        modelsMap.setImports(new ArrayList<>());
+
+        codegen.postProcessModels(modelsMap);
+
+        List<CodegenProperty> nestedEnums = List.of(
+                directEnum,
+                arrayEnum,
+                additionalPropertiesEnum,
+                containsEnum,
+                requiredPropertyEnum,
+                allOfEnum,
+                oneOfEnum,
+                anyOfEnum,
+                notEnum,
+                modelItemsEnum,
+                modelAdditionalPropertiesEnum,
+                modelContainsEnum);
+        for (CodegenProperty nestedEnum : nestedEnums) {
+            assertThat(nestedEnum.getVendorExtensions())
+                    .containsEntry(X_IMPLEMENTS, List.of("Serializable"));
+        }
+    }
+
+    private static CodegenProperty newEnumProperty() {
+        CodegenProperty property = new CodegenProperty();
+        property.isEnum = true;
+        return property;
     }
 
     /**

--- a/modules/openapi-generator/src/test/resources/3_0/issue_23082.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/issue_23082.yaml
@@ -1,0 +1,27 @@
+openapi: 3.0.3
+info:
+  title: Issue 23082 reproduction
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    ExampleWithInnerEnums:
+      type: object
+      description: Example with inner enum class
+      properties:
+        exampleInner:
+          type: string
+          description: Example of an inner enum class
+          enum:
+            - ENUM1
+            - ENUM2
+            - ENUM3
+        nestedExamples:
+          type: array
+          items:
+            type: array
+            items:
+              type: string
+              enum:
+                - NESTED1
+                - NESTED2

--- a/samples/client/others/java/okhttp-gson-streaming/src/main/java/org/openapitools/client/model/SomeObj.java
+++ b/samples/client/others/java/okhttp-gson-streaming/src/main/java/org/openapitools/client/model/SomeObj.java
@@ -58,7 +58,7 @@ public class SomeObj implements Serializable {
    * Gets or Sets $type
    */
   @JsonAdapter(TypeEnum.Adapter.class)
-  public enum TypeEnum {
+  public enum TypeEnum implements Serializable {
     SOMEOBJIDENTIFIER("SomeObjIdentifier");
 
     private String value;


### PR DESCRIPTION
Fixes #23082.

### Description

When `serializableModel` is enabled, Java models implement `Serializable`, but enums declared inside model properties do not.

This change recursively visits nested `CodegenProperty` instances and adds `Serializable` to the `x-implements` vendor extension of enum properties. It covers properties nested through `arrays`, `maps`, `contains`, required-property maps, and composed schemas.

The traversal uses object identity to avoid processing shared properties more than once and to terminate safely for cyclic property graphs. Existing interfaces are preserved, and duplicate `Serializable` entries are avoided.

### Testing

Added:

- A regression spec for a direct inner enum and an enum nested inside multiple array levels.
- A focused traversal test covering:
  - `vars`
  - `items`
  - `additionalProperties`
  - `contains`
  - `requiredVarsMap`
  - `allOf`
  - `oneOf`
  - `anyOf`
  - `not`
  - self-referential property graphs

The focused tests pass:

```shell
./mvnw -pl modules/openapi-generator -am \
  -Dtest=JavaClientCodegenTest#testSerializableModelAddsSerializableToInnerEnums_issue23082+testSerializableModelTraversesEveryNestedPropertyLocation_issue23082 \
  -Dsurefire.failIfNoSpecifiedTests=false \
  test \
  -Dspotless.check.skip=true \
  -Dcheckstyle.skip=true
```
<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10) @martin-mfg (2023/08) @KannaKim (2026/07)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #23082 so inline enums nested inside model properties are made `Serializable` when `serializableModel` is enabled, matching the model itself.

- Adds a reusable recursive traversal in `DefaultCodegen` that visits every nested property location (`vars`, `items`, `additionalProperties`, `contains`, `requiredVarsMap`, and composed schemas) at both the model and property level.
- Uses object identity to avoid duplicate work and terminate safely on cyclic property graphs.
- Preserves existing interfaces and avoids duplicate `Serializable` entries.
- Adds a regression spec and a focused traversal test, and regenerates the `okhttp-gson-streaming` sample so its inner enum implements `Serializable`.

<sup>Written for commit 4534776b71bab66da9c7c70d20101bb2bc76cc52. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24814?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

