### PR TITLE
fix(rust-server): parse the client example's port argument as u16

### DIFF
--- a/modules/openapi-generator/src/main/resources/rust-server/example-client-main.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/example-client-main.mustache
@@ -68,6 +68,7 @@ fn main() {
             .help("Hostname to contact"))
         .arg(Arg::new("port")
             .long("port")
+            .value_parser(clap::value_parser!(u16))
             .default_value("{{{serverPort}}}")
             .help("Port to contact"))
         .get_matches();

--- a/samples/server/petstore/rust-server/output/multipart-v3/examples/client/main.rs
+++ b/samples/server/petstore/rust-server/output/multipart-v3/examples/client/main.rs
@@ -51,6 +51,7 @@ fn main() {
             .help("Hostname to contact"))
         .arg(Arg::new("port")
             .long("port")
+            .value_parser(clap::value_parser!(u16))
             .default_value("8080")
             .help("Port to contact"))
         .get_matches();

--- a/samples/server/petstore/rust-server/output/no-example-v3/examples/client/main.rs
+++ b/samples/server/petstore/rust-server/output/no-example-v3/examples/client/main.rs
@@ -46,6 +46,7 @@ fn main() {
             .help("Hostname to contact"))
         .arg(Arg::new("port")
             .long("port")
+            .value_parser(clap::value_parser!(u16))
             .default_value("8080")
             .help("Port to contact"))
         .get_matches();

--- a/samples/server/petstore/rust-server/output/openapi-v3/examples/client/main.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/examples/client/main.rs
@@ -107,6 +107,7 @@ fn main() {
             .help("Hostname to contact"))
         .arg(Arg::new("port")
             .long("port")
+            .value_parser(clap::value_parser!(u16))
             .default_value("8080")
             .help("Port to contact"))
         .get_matches();

--- a/samples/server/petstore/rust-server/output/ops-v3/examples/client/main.rs
+++ b/samples/server/petstore/rust-server/output/ops-v3/examples/client/main.rs
@@ -119,6 +119,7 @@ fn main() {
             .help("Hostname to contact"))
         .arg(Arg::new("port")
             .long("port")
+            .value_parser(clap::value_parser!(u16))
             .default_value("8080")
             .help("Port to contact"))
         .get_matches();

--- a/samples/server/petstore/rust-server/output/overlapping-auth-schemes/examples/client/main.rs
+++ b/samples/server/petstore/rust-server/output/overlapping-auth-schemes/examples/client/main.rs
@@ -47,6 +47,7 @@ fn main() {
             .help("Hostname to contact"))
         .arg(Arg::new("port")
             .long("port")
+            .value_parser(clap::value_parser!(u16))
             .default_value("8080")
             .help("Port to contact"))
         .get_matches();

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/examples/client/main.rs
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/examples/client/main.rs
@@ -100,6 +100,7 @@ fn main() {
             .help("Hostname to contact"))
         .arg(Arg::new("port")
             .long("port")
+            .value_parser(clap::value_parser!(u16))
             .default_value("80")
             .help("Port to contact"))
         .get_matches();

--- a/samples/server/petstore/rust-server/output/ping-bearer-auth/examples/client/main.rs
+++ b/samples/server/petstore/rust-server/output/ping-bearer-auth/examples/client/main.rs
@@ -47,6 +47,7 @@ fn main() {
             .help("Hostname to contact"))
         .arg(Arg::new("port")
             .long("port")
+            .value_parser(clap::value_parser!(u16))
             .default_value("8080")
             .help("Port to contact"))
         .get_matches();

--- a/samples/server/petstore/rust-server/output/rust-server-test/examples/client/main.rs
+++ b/samples/server/petstore/rust-server/output/rust-server-test/examples/client/main.rs
@@ -61,6 +61,7 @@ fn main() {
             .help("Hostname to contact"))
         .arg(Arg::new("port")
             .long("port")
+            .value_parser(clap::value_parser!(u16))
             .default_value("8080")
             .help("Port to contact"))
         .get_matches();


### PR DESCRIPTION
Fixes #24515.

Every client example generated by `rust-server` panics on startup:

```
thread 'main' panicked at examples/client/main.rs:115:17:
Mismatch between definition and access of `port`.
Could not downcast to u16, need to downcast to alloc::string::String
```

`example-client-main.mustache` declares the argument with no value parser, so clap stores it as a `String`:

```rust
.arg(Arg::new("port")
    .long("port")
    .default_value("{{{serverPort}}}")
    .help("Port to contact"))
```

while the code that builds the base URL reads it as a `u16`:

```rust
matches.get_one::<u16>("port").unwrap()
```

### Change

One line, giving the argument the parser its access already assumes:

```mustache
.value_parser(clap::value_parser!(u16))
```

The reporter suggested the alternative of reading the value as a `String` at the call site, since it is only interpolated into a URL. I went with the value parser instead for two reasons: it keeps the typed access the code was evidently written for, and it makes clap reject a non-numeric `--port` at parse time with a clear message rather than letting it fail later during connection. The template already uses `value_parser` for the operation argument, so this is consistent with its own style.

The templated default is safe with a parser attached: `serverPort` comes from `URLPathUtils.getPort`, which returns either `String.valueOf(url.getPort())` or the numeric default, so it always parses as a `u16`.

### Samples

Regenerated with `./bin/generate-samples.sh ./bin/configs/rust-server-*.yaml` — all 8 rust-server configs. Each generated client picks up the single added line.

I do not have a Rust toolchain on this machine, so I have not run `cargo run --example` against the regenerated output myself; the change is confined to the one clap builder call described above.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a startup panic in every `rust-server` generated client example by parsing the `--port` argument as `u16`. The old template left the argument unparsed so clap stored a `String` while the code read it as `u16`; the new parser also makes clap reject non-numeric ports with a clear error. Fixes #24515.

<sup>Written for commit b61d25bf147418121763ae3de2f707c2841c44c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24819?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

