### PR TITLE
fix(csharp): throw JsonException from generated converters on invalid JSON

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/JsonConverter.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/JsonConverter.mustache
@@ -296,14 +296,14 @@
             {{#allVars}}
             {{#required}}
             if (!{{#lambda.camelcase_sanitize_param}}{{name}}{{/lambda.camelcase_sanitize_param}}.IsSet)
-                throw new ArgumentException("Property is required for class {{classname}}.", nameof({{#lambda.camelcase_sanitize_param}}{{name}}{{/lambda.camelcase_sanitize_param}}));
+                throw new JsonException("Property is required for class {{classname}}: {{baseName}}.");
 
             {{/required}}
             {{/allVars}}
             {{#allVars}}
             {{^isNullable}}
             if ({{#lambda.camelcase_sanitize_param}}{{name}}{{/lambda.camelcase_sanitize_param}}.IsSet && {{#lambda.camelcase_sanitize_param}}{{name}}{{/lambda.camelcase_sanitize_param}}.Value == null)
-                throw new ArgumentNullException(nameof({{#lambda.camelcase_sanitize_param}}{{name}}{{/lambda.camelcase_sanitize_param}}), "Property is not nullable for class {{classname}}.");
+                throw new JsonException("Property is not nullable for class {{classname}}: {{baseName}}.");
 
             {{/isNullable}}
             {{/allVars}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/csharpnetcore/CSharpClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/csharpnetcore/CSharpClientCodegenTest.java
@@ -120,9 +120,9 @@ public class CSharpClientCodegenTest {
                 "if (requiredNotnullableEnumStringValue == null)\n" +
                         "                                    throw new JsonException();",
                 "if (!requiredNullableEnumString.IsSet)\n" +
-                        "                throw new ArgumentException(\"Property is required for class RequiredClass.\", nameof(requiredNullableEnumString));",
+                        "                throw new JsonException(\"Property is required for class RequiredClass: required_nullable_enum_string.\");",
                 "if (!requiredNotnullableEnumString.IsSet)\n" +
-                        "                throw new ArgumentException(\"Property is required for class RequiredClass.\", nameof(requiredNotnullableEnumString));"
+                        "                throw new JsonException(\"Property is required for class RequiredClass: required_notnullable_enum_string.\");"
         );
     }
 
@@ -440,9 +440,9 @@ public class CSharpClientCodegenTest {
         // Required numeric checks distinguish a missing property from a present null.
         assertThat(modelWithEnumProperties).contains(
                 "if (!requiredInlineIntEnum.IsSet)\n" +
-                        "                throw new ArgumentException(\"Property is required for class ModelWithEnumProperties.\", nameof(requiredInlineIntEnum));",
+                        "                throw new JsonException(\"Property is required for class ModelWithEnumProperties: requiredInlineIntEnum.\");",
                 "if (requiredInlineIntEnum.IsSet && requiredInlineIntEnum.Value == null)\n" +
-                        "                throw new ArgumentNullException(nameof(requiredInlineIntEnum), \"Property is not nullable for class ModelWithEnumProperties.\");"
+                        "                throw new JsonException(\"Property is not nullable for class ModelWithEnumProperties: requiredInlineIntEnum.\");"
         );
 
         // Verify long enum uses int64 reader with validation and actual int64 values

--- a/samples/client/petstore/csharp/generichost/latest/AnnotatedEnum/src/Org.OpenAPITools/Model/OneOfNullAndRef.cs
+++ b/samples/client/petstore/csharp/generichost/latest/AnnotatedEnum/src/Org.OpenAPITools/Model/OneOfNullAndRef.cs
@@ -139,7 +139,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (number.IsSet && number.Value == null)
-                throw new ArgumentNullException(nameof(number), "Property is not nullable for class OneOfNullAndRef.");
+                throw new JsonException("Property is not nullable for class OneOfNullAndRef: number.");
 
             return new OneOfNullAndRef(number);
         }

--- a/samples/client/petstore/csharp/generichost/latest/AnnotatedEnum/src/Org.OpenAPITools/Model/OneOfNullAndRef2.cs
+++ b/samples/client/petstore/csharp/generichost/latest/AnnotatedEnum/src/Org.OpenAPITools/Model/OneOfNullAndRef2.cs
@@ -139,7 +139,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (number.IsSet && number.Value == null)
-                throw new ArgumentNullException(nameof(number), "Property is not nullable for class OneOfNullAndRef2.");
+                throw new JsonException("Property is not nullable for class OneOfNullAndRef2: number.");
 
             return new OneOfNullAndRef2(number);
         }

--- a/samples/client/petstore/csharp/generichost/latest/AnnotatedEnum/src/Org.OpenAPITools/Model/OneOfNullAndRef3.cs
+++ b/samples/client/petstore/csharp/generichost/latest/AnnotatedEnum/src/Org.OpenAPITools/Model/OneOfNullAndRef3.cs
@@ -139,7 +139,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (number.IsSet && number.Value == null)
-                throw new ArgumentNullException(nameof(number), "Property is not nullable for class OneOfNullAndRef3.");
+                throw new JsonException("Property is not nullable for class OneOfNullAndRef3: number.");
 
             return new OneOfNullAndRef3(number);
         }

--- a/samples/client/petstore/csharp/generichost/latest/AnnotatedEnum/src/Org.OpenAPITools/Model/Parent.cs
+++ b/samples/client/petstore/csharp/generichost/latest/AnnotatedEnum/src/Org.OpenAPITools/Model/Parent.cs
@@ -139,7 +139,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (number.IsSet && number.Value == null)
-                throw new ArgumentNullException(nameof(number), "Property is not nullable for class Parent.");
+                throw new JsonException("Property is not nullable for class Parent: number.");
 
             return new Parent(number);
         }

--- a/samples/client/petstore/csharp/generichost/latest/AnnotatedEnum/src/Org.OpenAPITools/Model/ParentWithOneOfProperty.cs
+++ b/samples/client/petstore/csharp/generichost/latest/AnnotatedEnum/src/Org.OpenAPITools/Model/ParentWithOneOfProperty.cs
@@ -139,7 +139,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (number.IsSet && number.Value == null)
-                throw new ArgumentNullException(nameof(number), "Property is not nullable for class ParentWithOneOfProperty.");
+                throw new JsonException("Property is not nullable for class ParentWithOneOfProperty: number.");
 
             return new ParentWithOneOfProperty(number);
         }

--- a/samples/client/petstore/csharp/generichost/latest/AnnotatedEnum/src/Org.OpenAPITools/Model/ParentWithPluralOneOfProperty.cs
+++ b/samples/client/petstore/csharp/generichost/latest/AnnotatedEnum/src/Org.OpenAPITools/Model/ParentWithPluralOneOfProperty.cs
@@ -139,7 +139,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (number.IsSet && number.Value == null)
-                throw new ArgumentNullException(nameof(number), "Property is not nullable for class ParentWithPluralOneOfProperty.");
+                throw new JsonException("Property is not nullable for class ParentWithPluralOneOfProperty: number.");
 
             return new ParentWithPluralOneOfProperty(number);
         }

--- a/samples/client/petstore/csharp/generichost/latest/HelloWorld/src/Org.OpenAPITools/Model/HelloWorldPostRequest.cs
+++ b/samples/client/petstore/csharp/generichost/latest/HelloWorld/src/Org.OpenAPITools/Model/HelloWorldPostRequest.cs
@@ -139,7 +139,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (message.IsSet && message.Value == null)
-                throw new ArgumentNullException(nameof(message), "Property is not nullable for class HelloWorldPostRequest.");
+                throw new JsonException("Property is not nullable for class HelloWorldPostRequest: message.");
 
             return new HelloWorldPostRequest(message);
         }

--- a/samples/client/petstore/csharp/generichost/latest/InlineEnumAnyOf/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/generichost/latest/InlineEnumAnyOf/src/Org.OpenAPITools/Model/Foo.cs
@@ -139,7 +139,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bar.IsSet && bar.Value == null)
-                throw new ArgumentNullException(nameof(bar), "Property is not nullable for class Foo.");
+                throw new JsonException("Property is not nullable for class Foo: bar.");
 
             return new Foo(bar);
         }

--- a/samples/client/petstore/csharp/generichost/latest/InlineEnumAnyOf/src/Org.OpenAPITools/Model/IconsDefaultResponse.cs
+++ b/samples/client/petstore/csharp/generichost/latest/InlineEnumAnyOf/src/Org.OpenAPITools/Model/IconsDefaultResponse.cs
@@ -139,7 +139,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varString.IsSet && varString.Value == null)
-                throw new ArgumentNullException(nameof(varString), "Property is not nullable for class IconsDefaultResponse.");
+                throw new JsonException("Property is not nullable for class IconsDefaultResponse: string.");
 
             return new IconsDefaultResponse(varString);
         }

--- a/samples/client/petstore/csharp/generichost/latest/NullTypes/src/Org.OpenAPITools/Model/Color.cs
+++ b/samples/client/petstore/csharp/generichost/latest/NullTypes/src/Org.OpenAPITools/Model/Color.cs
@@ -215,13 +215,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (b.IsSet && b.Value == null)
-                throw new ArgumentNullException(nameof(b), "Property is not nullable for class Color.");
+                throw new JsonException("Property is not nullable for class Color: b.");
 
             if (g.IsSet && g.Value == null)
-                throw new ArgumentNullException(nameof(g), "Property is not nullable for class Color.");
+                throw new JsonException("Property is not nullable for class Color: g.");
 
             if (r.IsSet && r.Value == null)
-                throw new ArgumentNullException(nameof(r), "Property is not nullable for class Color.");
+                throw new JsonException("Property is not nullable for class Color: r.");
 
             return new Color(b, g, r);
         }

--- a/samples/client/petstore/csharp/generichost/latest/NullTypes/src/Org.OpenAPITools/Model/NullTypeDirect.cs
+++ b/samples/client/petstore/csharp/generichost/latest/NullTypes/src/Org.OpenAPITools/Model/NullTypeDirect.cs
@@ -160,7 +160,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class NullTypeDirect.");
+                throw new JsonException("Property is not nullable for class NullTypeDirect: id.");
 
             return new NullTypeDirect(alwaysNull, id);
         }

--- a/samples/client/petstore/csharp/generichost/latest/NullTypes/src/Org.OpenAPITools/Model/Shape.cs
+++ b/samples/client/petstore/csharp/generichost/latest/NullTypes/src/Org.OpenAPITools/Model/Shape.cs
@@ -154,13 +154,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class Shape.", nameof(shapeType));
+                throw new JsonException("Property is required for class Shape: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class Shape.");
+                throw new JsonException("Property is not nullable for class Shape: shapeType.");
 
             if (area.IsSet && area.Value == null)
-                throw new ArgumentNullException(nameof(area), "Property is not nullable for class Shape.");
+                throw new JsonException("Property is not nullable for class Shape: area.");
 
             return new Shape(shapeType.Value!, area);
         }

--- a/samples/client/petstore/csharp/generichost/latest/NullTypes/src/Org.OpenAPITools/Model/ShapeOrNull.cs
+++ b/samples/client/petstore/csharp/generichost/latest/NullTypes/src/Org.OpenAPITools/Model/ShapeOrNull.cs
@@ -154,13 +154,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ShapeOrNull.", nameof(shapeType));
+                throw new JsonException("Property is required for class ShapeOrNull: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ShapeOrNull.");
+                throw new JsonException("Property is not nullable for class ShapeOrNull: shapeType.");
 
             if (area.IsSet && area.Value == null)
-                throw new ArgumentNullException(nameof(area), "Property is not nullable for class ShapeOrNull.");
+                throw new JsonException("Property is not nullable for class ShapeOrNull: area.");
 
             return new ShapeOrNull(shapeType.Value!, area);
         }

--- a/samples/client/petstore/csharp/generichost/latest/NullTypes/src/Org.OpenAPITools/Model/Widget.cs
+++ b/samples/client/petstore/csharp/generichost/latest/NullTypes/src/Org.OpenAPITools/Model/Widget.cs
@@ -210,16 +210,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!id.IsSet)
-                throw new ArgumentException("Property is required for class Widget.", nameof(id));
+                throw new JsonException("Property is required for class Widget: id.");
 
             if (!name.IsSet)
-                throw new ArgumentException("Property is required for class Widget.", nameof(name));
+                throw new JsonException("Property is required for class Widget: name.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Widget.");
+                throw new JsonException("Property is not nullable for class Widget: id.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Widget.");
+                throw new JsonException("Property is not nullable for class Widget: name.");
 
             return new Widget(id.Value!.Value!, name.Value!, color, debugInfo, shape);
         }

--- a/samples/client/petstore/csharp/generichost/latest/OneOfList/src/Org.OpenAPITools/Model/TestObject.cs
+++ b/samples/client/petstore/csharp/generichost/latest/OneOfList/src/Org.OpenAPITools/Model/TestObject.cs
@@ -139,7 +139,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class TestObject.");
+                throw new JsonException("Property is not nullable for class TestObject: name.");
 
             return new TestObject(name);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Activity.cs
@@ -139,7 +139,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (activityOutputs.IsSet && activityOutputs.Value == null)
-                throw new ArgumentNullException(nameof(activityOutputs), "Property is not nullable for class Activity.");
+                throw new JsonException("Property is not nullable for class Activity: activity_outputs.");
 
             return new Activity(activityOutputs);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -159,10 +159,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (prop1.IsSet && prop1.Value == null)
-                throw new ArgumentNullException(nameof(prop1), "Property is not nullable for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Property is not nullable for class ActivityOutputElementRepresentation: prop1.");
 
             if (prop2.IsSet && prop2.Value == null)
-                throw new ArgumentNullException(nameof(prop2), "Property is not nullable for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Property is not nullable for class ActivityOutputElementRepresentation: prop2.");
 
             return new ActivityOutputElementRepresentation(prop1, prop2);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -280,25 +280,25 @@ namespace Org.OpenAPITools.Model
             }
 
             if (emptyMap.IsSet && emptyMap.Value == null)
-                throw new ArgumentNullException(nameof(emptyMap), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: empty_map.");
 
             if (mapOfMapProperty.IsSet && mapOfMapProperty.Value == null)
-                throw new ArgumentNullException(nameof(mapOfMapProperty), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_of_map_property.");
 
             if (mapProperty.IsSet && mapProperty.Value == null)
-                throw new ArgumentNullException(nameof(mapProperty), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_property.");
 
             if (mapWithUndeclaredPropertiesAnytype1.IsSet && mapWithUndeclaredPropertiesAnytype1.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesAnytype1), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_anytype_1.");
 
             if (mapWithUndeclaredPropertiesAnytype2.IsSet && mapWithUndeclaredPropertiesAnytype2.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesAnytype2), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_anytype_2.");
 
             if (mapWithUndeclaredPropertiesAnytype3.IsSet && mapWithUndeclaredPropertiesAnytype3.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesAnytype3), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_anytype_3.");
 
             if (mapWithUndeclaredPropertiesString.IsSet && mapWithUndeclaredPropertiesString.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesString), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_string.");
 
             return new AdditionalPropertiesClass(anytype1, emptyMap, mapOfMapProperty, mapProperty, mapWithUndeclaredPropertiesAnytype1, mapWithUndeclaredPropertiesAnytype2, mapWithUndeclaredPropertiesAnytype3, mapWithUndeclaredPropertiesString);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Animal.cs
@@ -169,13 +169,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Animal.", nameof(className));
+                throw new JsonException("Property is required for class Animal: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Animal.");
+                throw new JsonException("Property is not nullable for class Animal: className.");
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Animal.");
+                throw new JsonException("Property is not nullable for class Animal: color.");
 
             return new Animal(color);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -179,13 +179,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (code.IsSet && code.Value == null)
-                throw new ArgumentNullException(nameof(code), "Property is not nullable for class ApiResponse.");
+                throw new JsonException("Property is not nullable for class ApiResponse: code.");
 
             if (message.IsSet && message.Value == null)
-                throw new ArgumentNullException(nameof(message), "Property is not nullable for class ApiResponse.");
+                throw new JsonException("Property is not nullable for class ApiResponse: message.");
 
             if (type.IsSet && type.Value == null)
-                throw new ArgumentNullException(nameof(type), "Property is not nullable for class ApiResponse.");
+                throw new JsonException("Property is not nullable for class ApiResponse: type.");
 
             return new ApiResponse(code, message, type);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Apple.cs
@@ -209,13 +209,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (colorCode.IsSet && colorCode.Value == null)
-                throw new ArgumentNullException(nameof(colorCode), "Property is not nullable for class Apple.");
+                throw new JsonException("Property is not nullable for class Apple: color_code.");
 
             if (cultivar.IsSet && cultivar.Value == null)
-                throw new ArgumentNullException(nameof(cultivar), "Property is not nullable for class Apple.");
+                throw new JsonException("Property is not nullable for class Apple: cultivar.");
 
             if (origin.IsSet && origin.Value == null)
-                throw new ArgumentNullException(nameof(origin), "Property is not nullable for class Apple.");
+                throw new JsonException("Property is not nullable for class Apple: origin.");
 
             return new Apple(colorCode, cultivar, origin);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -152,13 +152,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!cultivar.IsSet)
-                throw new ArgumentException("Property is required for class AppleReq.", nameof(cultivar));
+                throw new JsonException("Property is required for class AppleReq: cultivar.");
 
             if (cultivar.IsSet && cultivar.Value == null)
-                throw new ArgumentNullException(nameof(cultivar), "Property is not nullable for class AppleReq.");
+                throw new JsonException("Property is not nullable for class AppleReq: cultivar.");
 
             if (mealy.IsSet && mealy.Value == null)
-                throw new ArgumentNullException(nameof(mealy), "Property is not nullable for class AppleReq.");
+                throw new JsonException("Property is not nullable for class AppleReq: mealy.");
 
             return new AppleReq(cultivar.Value!, mealy);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -139,7 +139,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayArrayNumber.IsSet && arrayArrayNumber.Value == null)
-                throw new ArgumentNullException(nameof(arrayArrayNumber), "Property is not nullable for class ArrayOfArrayOfNumberOnly.");
+                throw new JsonException("Property is not nullable for class ArrayOfArrayOfNumberOnly: ArrayArrayNumber.");
 
             return new ArrayOfArrayOfNumberOnly(arrayArrayNumber);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -139,7 +139,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayNumber.IsSet && arrayNumber.Value == null)
-                throw new ArgumentNullException(nameof(arrayNumber), "Property is not nullable for class ArrayOfNumberOnly.");
+                throw new JsonException("Property is not nullable for class ArrayOfNumberOnly: ArrayNumber.");
 
             return new ArrayOfNumberOnly(arrayNumber);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -179,13 +179,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayArrayOfInteger.IsSet && arrayArrayOfInteger.Value == null)
-                throw new ArgumentNullException(nameof(arrayArrayOfInteger), "Property is not nullable for class ArrayTest.");
+                throw new JsonException("Property is not nullable for class ArrayTest: array_array_of_integer.");
 
             if (arrayArrayOfModel.IsSet && arrayArrayOfModel.Value == null)
-                throw new ArgumentNullException(nameof(arrayArrayOfModel), "Property is not nullable for class ArrayTest.");
+                throw new JsonException("Property is not nullable for class ArrayTest: array_array_of_model.");
 
             if (arrayOfString.IsSet && arrayOfString.Value == null)
-                throw new ArgumentNullException(nameof(arrayOfString), "Property is not nullable for class ArrayTest.");
+                throw new JsonException("Property is not nullable for class ArrayTest: array_of_string.");
 
             return new ArrayTest(arrayArrayOfInteger, arrayArrayOfModel, arrayOfString);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Banana.cs
@@ -139,7 +139,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (lengthCm.IsSet && lengthCm.Value == null)
-                throw new ArgumentNullException(nameof(lengthCm), "Property is not nullable for class Banana.");
+                throw new JsonException("Property is not nullable for class Banana: lengthCm.");
 
             return new Banana(lengthCm);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -152,13 +152,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!lengthCm.IsSet)
-                throw new ArgumentException("Property is required for class BananaReq.", nameof(lengthCm));
+                throw new JsonException("Property is required for class BananaReq: lengthCm.");
 
             if (lengthCm.IsSet && lengthCm.Value == null)
-                throw new ArgumentNullException(nameof(lengthCm), "Property is not nullable for class BananaReq.");
+                throw new JsonException("Property is not nullable for class BananaReq: lengthCm.");
 
             if (sweet.IsSet && sweet.Value == null)
-                throw new ArgumentNullException(nameof(sweet), "Property is not nullable for class BananaReq.");
+                throw new JsonException("Property is not nullable for class BananaReq: sweet.");
 
             return new BananaReq(lengthCm.Value!.Value!, sweet);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/BasquePig.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/BasquePig.cs
@@ -132,10 +132,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class BasquePig.", nameof(className));
+                throw new JsonException("Property is required for class BasquePig: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class BasquePig.");
+                throw new JsonException("Property is not nullable for class BasquePig: className.");
 
             return new BasquePig(className.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -240,22 +240,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (aTTNAME.IsSet && aTTNAME.Value == null)
-                throw new ArgumentNullException(nameof(aTTNAME), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: ATT_NAME.");
 
             if (capitalCamel.IsSet && capitalCamel.Value == null)
-                throw new ArgumentNullException(nameof(capitalCamel), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: CapitalCamel.");
 
             if (capitalSnake.IsSet && capitalSnake.Value == null)
-                throw new ArgumentNullException(nameof(capitalSnake), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: Capital_Snake.");
 
             if (sCAETHFlowPoints.IsSet && sCAETHFlowPoints.Value == null)
-                throw new ArgumentNullException(nameof(sCAETHFlowPoints), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: SCA_ETH_Flow_Points.");
 
             if (smallCamel.IsSet && smallCamel.Value == null)
-                throw new ArgumentNullException(nameof(smallCamel), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: smallCamel.");
 
             if (smallSnake.IsSet && smallSnake.Value == null)
-                throw new ArgumentNullException(nameof(smallSnake), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: small_Snake.");
 
             return new Capitalization(aTTNAME, capitalCamel, capitalSnake, sCAETHFlowPoints, smallCamel, smallSnake);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Cat.cs
@@ -139,16 +139,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Cat.", nameof(className));
+                throw new JsonException("Property is required for class Cat: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Cat.");
+                throw new JsonException("Property is not nullable for class Cat: className.");
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Cat.");
+                throw new JsonException("Property is not nullable for class Cat: color.");
 
             if (declawed.IsSet && declawed.Value == null)
-                throw new ArgumentNullException(nameof(declawed), "Property is not nullable for class Cat.");
+                throw new JsonException("Property is not nullable for class Cat: declawed.");
 
             return new Cat(color, declawed);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Category.cs
@@ -152,13 +152,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!name.IsSet)
-                throw new ArgumentException("Property is required for class Category.", nameof(name));
+                throw new JsonException("Property is required for class Category: name.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Category.");
+                throw new JsonException("Property is not nullable for class Category: id.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Category.");
+                throw new JsonException("Property is not nullable for class Category: name.");
 
             return new Category(id, name.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -201,13 +201,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!petType.IsSet)
-                throw new ArgumentException("Property is required for class ChildCat.", nameof(petType));
+                throw new JsonException("Property is required for class ChildCat: pet_type.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class ChildCat.");
+                throw new JsonException("Property is not nullable for class ChildCat: name.");
 
             if (petType.IsSet && petType.Value == null)
-                throw new ArgumentNullException(nameof(petType), "Property is not nullable for class ChildCat.");
+                throw new JsonException("Property is not nullable for class ChildCat: pet_type.");
 
             return new ChildCat(name);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -139,7 +139,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varClass.IsSet && varClass.Value == null)
-                throw new ArgumentNullException(nameof(varClass), "Property is not nullable for class ClassModel.");
+                throw new JsonException("Property is not nullable for class ClassModel: _class.");
 
             return new ClassModel(varClass);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
@@ -145,16 +145,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class ComplexQuadrilateral.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class ComplexQuadrilateral: quadrilateralType.");
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ComplexQuadrilateral.", nameof(shapeType));
+                throw new JsonException("Property is required for class ComplexQuadrilateral: shapeType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class ComplexQuadrilateral.");
+                throw new JsonException("Property is not nullable for class ComplexQuadrilateral: quadrilateralType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ComplexQuadrilateral.");
+                throw new JsonException("Property is not nullable for class ComplexQuadrilateral: shapeType.");
 
             return new ComplexQuadrilateral(quadrilateralType.Value!, shapeType.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/CopyActivity.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/CopyActivity.cs
@@ -194,16 +194,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!copyActivitytt.IsSet)
-                throw new ArgumentException("Property is required for class CopyActivity.", nameof(copyActivitytt));
+                throw new JsonException("Property is required for class CopyActivity: copyActivitytt.");
 
             if (!schema.IsSet)
-                throw new ArgumentException("Property is required for class CopyActivity.", nameof(schema));
+                throw new JsonException("Property is required for class CopyActivity: $schema.");
 
             if (copyActivitytt.IsSet && copyActivitytt.Value == null)
-                throw new ArgumentNullException(nameof(copyActivitytt), "Property is not nullable for class CopyActivity.");
+                throw new JsonException("Property is not nullable for class CopyActivity: copyActivitytt.");
 
             if (schema.IsSet && schema.Value == null)
-                throw new ArgumentNullException(nameof(schema), "Property is not nullable for class CopyActivity.");
+                throw new JsonException("Property is not nullable for class CopyActivity: $schema.");
 
             return new CopyActivity(copyActivitytt.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/DanishPig.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/DanishPig.cs
@@ -132,10 +132,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class DanishPig.", nameof(className));
+                throw new JsonException("Property is required for class DanishPig: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class DanishPig.");
+                throw new JsonException("Property is not nullable for class DanishPig: className.");
 
             return new DanishPig(className.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (dateOnlyProperty.IsSet && dateOnlyProperty.Value == null)
-                throw new ArgumentNullException(nameof(dateOnlyProperty), "Property is not nullable for class DateOnlyClass.");
+                throw new JsonException("Property is not nullable for class DateOnlyClass: dateOnlyProperty.");
 
             return new DateOnlyClass(dateOnlyProperty);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -139,7 +139,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class DeprecatedObject.");
+                throw new JsonException("Property is not nullable for class DeprecatedObject: name.");
 
             return new DeprecatedObject(name);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Descendant1.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Descendant1.cs
@@ -139,22 +139,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!alternativeName.IsSet)
-                throw new ArgumentException("Property is required for class Descendant1.", nameof(alternativeName));
+                throw new JsonException("Property is required for class Descendant1: alternativeName.");
 
             if (!descendantName.IsSet)
-                throw new ArgumentException("Property is required for class Descendant1.", nameof(descendantName));
+                throw new JsonException("Property is required for class Descendant1: descendantName.");
 
             if (!objectType.IsSet)
-                throw new ArgumentException("Property is required for class Descendant1.", nameof(objectType));
+                throw new JsonException("Property is required for class Descendant1: objectType.");
 
             if (alternativeName.IsSet && alternativeName.Value == null)
-                throw new ArgumentNullException(nameof(alternativeName), "Property is not nullable for class Descendant1.");
+                throw new JsonException("Property is not nullable for class Descendant1: alternativeName.");
 
             if (descendantName.IsSet && descendantName.Value == null)
-                throw new ArgumentNullException(nameof(descendantName), "Property is not nullable for class Descendant1.");
+                throw new JsonException("Property is not nullable for class Descendant1: descendantName.");
 
             if (objectType.IsSet && objectType.Value == null)
-                throw new ArgumentNullException(nameof(objectType), "Property is not nullable for class Descendant1.");
+                throw new JsonException("Property is not nullable for class Descendant1: objectType.");
 
             return new Descendant1(alternativeName.Value!, descendantName.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Descendant2.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Descendant2.cs
@@ -139,22 +139,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!alternativeName.IsSet)
-                throw new ArgumentException("Property is required for class Descendant2.", nameof(alternativeName));
+                throw new JsonException("Property is required for class Descendant2: alternativeName.");
 
             if (!confidentiality.IsSet)
-                throw new ArgumentException("Property is required for class Descendant2.", nameof(confidentiality));
+                throw new JsonException("Property is required for class Descendant2: confidentiality.");
 
             if (!objectType.IsSet)
-                throw new ArgumentException("Property is required for class Descendant2.", nameof(objectType));
+                throw new JsonException("Property is required for class Descendant2: objectType.");
 
             if (alternativeName.IsSet && alternativeName.Value == null)
-                throw new ArgumentNullException(nameof(alternativeName), "Property is not nullable for class Descendant2.");
+                throw new JsonException("Property is not nullable for class Descendant2: alternativeName.");
 
             if (confidentiality.IsSet && confidentiality.Value == null)
-                throw new ArgumentNullException(nameof(confidentiality), "Property is not nullable for class Descendant2.");
+                throw new JsonException("Property is not nullable for class Descendant2: confidentiality.");
 
             if (objectType.IsSet && objectType.Value == null)
-                throw new ArgumentNullException(nameof(objectType), "Property is not nullable for class Descendant2.");
+                throw new JsonException("Property is not nullable for class Descendant2: objectType.");
 
             return new Descendant2(alternativeName.Value!, confidentiality.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Dog.cs
@@ -139,16 +139,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Dog.", nameof(className));
+                throw new JsonException("Property is required for class Dog: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Dog.");
+                throw new JsonException("Property is not nullable for class Dog: className.");
 
             if (breed.IsSet && breed.Value == null)
-                throw new ArgumentNullException(nameof(breed), "Property is not nullable for class Dog.");
+                throw new JsonException("Property is not nullable for class Dog: breed.");
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Dog.");
+                throw new JsonException("Property is not nullable for class Dog: color.");
 
             return new Dog(breed, color);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Drawing.cs
@@ -206,10 +206,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (mainShape.IsSet && mainShape.Value == null)
-                throw new ArgumentNullException(nameof(mainShape), "Property is not nullable for class Drawing.");
+                throw new JsonException("Property is not nullable for class Drawing: mainShape.");
 
             if (shapes.IsSet && shapes.Value == null)
-                throw new ArgumentNullException(nameof(shapes), "Property is not nullable for class Drawing.");
+                throw new JsonException("Property is not nullable for class Drawing: shapes.");
 
             return new Drawing(mainShape, nullableShape, shapeOrNull, shapes);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/EntityBase.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/EntityBase.cs
@@ -146,10 +146,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!schema.IsSet)
-                throw new ArgumentException("Property is required for class EntityBase.", nameof(schema));
+                throw new JsonException("Property is required for class EntityBase: $schema.");
 
             if (schema.IsSet && schema.Value == null)
-                throw new ArgumentNullException(nameof(schema), "Property is not nullable for class EntityBase.");
+                throw new JsonException("Property is not nullable for class EntityBase: $schema.");
 
             return new EntityBase();
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -298,10 +298,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayEnum.IsSet && arrayEnum.Value == null)
-                throw new ArgumentNullException(nameof(arrayEnum), "Property is not nullable for class EnumArrays.");
+                throw new JsonException("Property is not nullable for class EnumArrays: array_enum.");
 
             if (justSymbol.IsSet && justSymbol.Value == null)
-                throw new ArgumentNullException(nameof(justSymbol), "Property is not nullable for class EnumArrays.");
+                throw new JsonException("Property is not nullable for class EnumArrays: just_symbol.");
 
             return new EnumArrays(arrayEnum, justSymbol);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -816,31 +816,31 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!enumStringRequired.IsSet)
-                throw new ArgumentException("Property is required for class EnumTest.", nameof(enumStringRequired));
+                throw new JsonException("Property is required for class EnumTest: enum_string_required.");
 
             if (enumStringRequired.IsSet && enumStringRequired.Value == null)
-                throw new ArgumentNullException(nameof(enumStringRequired), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_string_required.");
 
             if (enumInteger.IsSet && enumInteger.Value == null)
-                throw new ArgumentNullException(nameof(enumInteger), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_integer.");
 
             if (enumIntegerOnly.IsSet && enumIntegerOnly.Value == null)
-                throw new ArgumentNullException(nameof(enumIntegerOnly), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_integer_only.");
 
             if (enumNumber.IsSet && enumNumber.Value == null)
-                throw new ArgumentNullException(nameof(enumNumber), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_number.");
 
             if (enumString.IsSet && enumString.Value == null)
-                throw new ArgumentNullException(nameof(enumString), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_string.");
 
             if (outerEnumDefaultValue.IsSet && outerEnumDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(outerEnumDefaultValue), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: outerEnumDefaultValue.");
 
             if (outerEnumInteger.IsSet && outerEnumInteger.Value == null)
-                throw new ArgumentNullException(nameof(outerEnumInteger), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: outerEnumInteger.");
 
             if (outerEnumIntegerDefaultValue.IsSet && outerEnumIntegerDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(outerEnumIntegerDefaultValue), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: outerEnumIntegerDefaultValue.");
 
             return new EnumTest(enumStringRequired.Value!.Value!, enumInteger, enumIntegerOnly, enumNumber, enumString, outerEnum, outerEnumDefaultValue, outerEnumInteger, outerEnumIntegerDefaultValue);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
@@ -145,16 +145,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class EquilateralTriangle.", nameof(shapeType));
+                throw new JsonException("Property is required for class EquilateralTriangle: shapeType.");
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class EquilateralTriangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class EquilateralTriangle: triangleType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class EquilateralTriangle.");
+                throw new JsonException("Property is not nullable for class EquilateralTriangle: shapeType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class EquilateralTriangle.");
+                throw new JsonException("Property is not nullable for class EquilateralTriangle: triangleType.");
 
             return new EquilateralTriangle(shapeType.Value!, triangleType.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/File.cs
@@ -140,7 +140,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (sourceURI.IsSet && sourceURI.Value == null)
-                throw new ArgumentNullException(nameof(sourceURI), "Property is not nullable for class File.");
+                throw new JsonException("Property is not nullable for class File: sourceURI.");
 
             return new File(sourceURI);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -159,10 +159,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (file.IsSet && file.Value == null)
-                throw new ArgumentNullException(nameof(file), "Property is not nullable for class FileSchemaTestClass.");
+                throw new JsonException("Property is not nullable for class FileSchemaTestClass: file.");
 
             if (files.IsSet && files.Value == null)
-                throw new ArgumentNullException(nameof(files), "Property is not nullable for class FileSchemaTestClass.");
+                throw new JsonException("Property is not nullable for class FileSchemaTestClass: files.");
 
             return new FileSchemaTestClass(file, files);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Foo.cs
@@ -139,7 +139,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bar.IsSet && bar.Value == null)
-                throw new ArgumentNullException(nameof(bar), "Property is not nullable for class Foo.");
+                throw new JsonException("Property is not nullable for class Foo: bar.");
 
             return new Foo(bar);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -139,7 +139,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varString.IsSet && varString.Value == null)
-                throw new ArgumentNullException(nameof(varString), "Property is not nullable for class FooGetDefaultResponse.");
+                throw new JsonException("Property is not nullable for class FooGetDefaultResponse: string.");
 
             return new FooGetDefaultResponse(varString);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -820,103 +820,103 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!varByte.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(varByte));
+                throw new JsonException("Property is required for class FormatTest: byte.");
 
             if (!date.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(date));
+                throw new JsonException("Property is required for class FormatTest: date.");
 
             if (!number.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(number));
+                throw new JsonException("Property is required for class FormatTest: number.");
 
             if (!password.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(password));
+                throw new JsonException("Property is required for class FormatTest: password.");
 
             if (!stringFormattedAsDecimalRequired.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(stringFormattedAsDecimalRequired));
+                throw new JsonException("Property is required for class FormatTest: string_formatted_as_decimal_required.");
 
             if (varByte.IsSet && varByte.Value == null)
-                throw new ArgumentNullException(nameof(varByte), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: byte.");
 
             if (date.IsSet && date.Value == null)
-                throw new ArgumentNullException(nameof(date), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: date.");
 
             if (number.IsSet && number.Value == null)
-                throw new ArgumentNullException(nameof(number), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: number.");
 
             if (password.IsSet && password.Value == null)
-                throw new ArgumentNullException(nameof(password), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: password.");
 
             if (stringFormattedAsDecimalRequired.IsSet && stringFormattedAsDecimalRequired.Value == null)
-                throw new ArgumentNullException(nameof(stringFormattedAsDecimalRequired), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: string_formatted_as_decimal_required.");
 
             if (binary.IsSet && binary.Value == null)
-                throw new ArgumentNullException(nameof(binary), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: binary.");
 
             if (dateTime.IsSet && dateTime.Value == null)
-                throw new ArgumentNullException(nameof(dateTime), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: dateTime.");
 
             if (varDecimal.IsSet && varDecimal.Value == null)
-                throw new ArgumentNullException(nameof(varDecimal), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: decimal.");
 
             if (varDouble.IsSet && varDouble.Value == null)
-                throw new ArgumentNullException(nameof(varDouble), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: double.");
 
             if (duplicatePropertyName2.IsSet && duplicatePropertyName2.Value == null)
-                throw new ArgumentNullException(nameof(duplicatePropertyName2), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: duplicate_property_name.");
 
             if (duplicatePropertyName.IsSet && duplicatePropertyName.Value == null)
-                throw new ArgumentNullException(nameof(duplicatePropertyName), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: @duplicate_property_name.");
 
             if (varFloat.IsSet && varFloat.Value == null)
-                throw new ArgumentNullException(nameof(varFloat), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: float.");
 
             if (int32.IsSet && int32.Value == null)
-                throw new ArgumentNullException(nameof(int32), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int32.");
 
             if (int32Range.IsSet && int32Range.Value == null)
-                throw new ArgumentNullException(nameof(int32Range), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int32Range.");
 
             if (int64.IsSet && int64.Value == null)
-                throw new ArgumentNullException(nameof(int64), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64.");
 
             if (int64Negative.IsSet && int64Negative.Value == null)
-                throw new ArgumentNullException(nameof(int64Negative), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64Negative.");
 
             if (int64NegativeExclusive.IsSet && int64NegativeExclusive.Value == null)
-                throw new ArgumentNullException(nameof(int64NegativeExclusive), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64NegativeExclusive.");
 
             if (int64Positive.IsSet && int64Positive.Value == null)
-                throw new ArgumentNullException(nameof(int64Positive), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64Positive.");
 
             if (int64PositiveExclusive.IsSet && int64PositiveExclusive.Value == null)
-                throw new ArgumentNullException(nameof(int64PositiveExclusive), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64PositiveExclusive.");
 
             if (integer.IsSet && integer.Value == null)
-                throw new ArgumentNullException(nameof(integer), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: integer.");
 
             if (patternWithBackslash.IsSet && patternWithBackslash.Value == null)
-                throw new ArgumentNullException(nameof(patternWithBackslash), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: pattern_with_backslash.");
 
             if (patternWithDigits.IsSet && patternWithDigits.Value == null)
-                throw new ArgumentNullException(nameof(patternWithDigits), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: pattern_with_digits.");
 
             if (patternWithDigitsAndDelimiter.IsSet && patternWithDigitsAndDelimiter.Value == null)
-                throw new ArgumentNullException(nameof(patternWithDigitsAndDelimiter), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: pattern_with_digits_and_delimiter.");
 
             if (varString.IsSet && varString.Value == null)
-                throw new ArgumentNullException(nameof(varString), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: string.");
 
             if (stringFormattedAsDecimal.IsSet && stringFormattedAsDecimal.Value == null)
-                throw new ArgumentNullException(nameof(stringFormattedAsDecimal), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: string_formatted_as_decimal.");
 
             if (unsignedInteger.IsSet && unsignedInteger.Value == null)
-                throw new ArgumentNullException(nameof(unsignedInteger), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: unsigned_integer.");
 
             if (unsignedLong.IsSet && unsignedLong.Value == null)
-                throw new ArgumentNullException(nameof(unsignedLong), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: unsigned_long.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: uuid.");
 
             return new FormatTest(varByte.Value!, date.Value!.Value!, number.Value!.Value!, password.Value!, stringFormattedAsDecimalRequired.Value!.Value!, binary, dateTime, varDecimal, varDouble, duplicatePropertyName2, duplicatePropertyName, varFloat, int32, int32Range, int64, int64Negative, int64NegativeExclusive, int64Positive, int64PositiveExclusive, integer, patternWithBackslash, patternWithDigits, patternWithDigitsAndDelimiter, varString, stringFormattedAsDecimal, unsignedInteger, unsignedLong, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Fruit.cs
@@ -184,7 +184,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Fruit.");
+                throw new JsonException("Property is not nullable for class Fruit: color.");
 
             if (apple != null)
                 return new Fruit(apple, color);

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -188,7 +188,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class GmFruit.");
+                throw new JsonException("Property is not nullable for class GmFruit: color.");
 
             Option<Apple?> appleParsedValue = apple == null
                 ? default

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
@@ -149,10 +149,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!petType.IsSet)
-                throw new ArgumentException("Property is required for class GrandparentAnimal.", nameof(petType));
+                throw new JsonException("Property is required for class GrandparentAnimal: pet_type.");
 
             if (petType.IsSet && petType.Value == null)
-                throw new ArgumentNullException(nameof(petType), "Property is not nullable for class GrandparentAnimal.");
+                throw new JsonException("Property is not nullable for class GrandparentAnimal: pet_type.");
 
             return new GrandparentAnimal();
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -159,10 +159,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bar.IsSet && bar.Value == null)
-                throw new ArgumentNullException(nameof(bar), "Property is not nullable for class HasOnlyReadOnly.");
+                throw new JsonException("Property is not nullable for class HasOnlyReadOnly: bar.");
 
             if (foo.IsSet && foo.Value == null)
-                throw new ArgumentNullException(nameof(foo), "Property is not nullable for class HasOnlyReadOnly.");
+                throw new JsonException("Property is not nullable for class HasOnlyReadOnly: foo.");
 
             return new HasOnlyReadOnly(bar, foo);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
@@ -239,22 +239,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (potentiallyOverriddenPropertyAccessor.IsSet && potentiallyOverriddenPropertyAccessor.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyAccessor), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyAccessor.");
 
             if (potentiallyOverriddenPropertyToInternal.IsSet && potentiallyOverriddenPropertyToInternal.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyToInternal), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyToInternal.");
 
             if (potentiallyOverriddenPropertyToPrivate.IsSet && potentiallyOverriddenPropertyToPrivate.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyToPrivate), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyToPrivate.");
 
             if (potentiallyOverriddenPropertyToPublic.IsSet && potentiallyOverriddenPropertyToPublic.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyToPublic), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyToPublic.");
 
             if (unalteredProperty.IsSet && unalteredProperty.Value == null)
-                throw new ArgumentNullException(nameof(unalteredProperty), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: unalteredProperty.");
 
             if (unalteredPropertyAccessor.IsSet && unalteredPropertyAccessor.Value == null)
-                throw new ArgumentNullException(nameof(unalteredPropertyAccessor), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: unalteredPropertyAccessor.");
 
             return new InjectedVendorExtensionsTest(potentiallyOverriddenPropertyAccessor, potentiallyOverriddenPropertyToInternal, potentiallyOverriddenPropertyToPrivate, potentiallyOverriddenPropertyToPublic, unalteredProperty, unalteredPropertyAccessor);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
@@ -145,16 +145,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class IsoscelesTriangle.", nameof(shapeType));
+                throw new JsonException("Property is required for class IsoscelesTriangle: shapeType.");
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class IsoscelesTriangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class IsoscelesTriangle: triangleType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class IsoscelesTriangle.");
+                throw new JsonException("Property is not nullable for class IsoscelesTriangle: shapeType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class IsoscelesTriangle.");
+                throw new JsonException("Property is not nullable for class IsoscelesTriangle: triangleType.");
 
             return new IsoscelesTriangle(shapeType.Value!, triangleType.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/List.cs
@@ -139,7 +139,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (var123List.IsSet && var123List.Value == null)
-                throw new ArgumentNullException(nameof(var123List), "Property is not nullable for class List.");
+                throw new JsonException("Property is not nullable for class List: 123-list.");
 
             return new List(var123List);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -159,10 +159,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (escapedLiteralString.IsSet && escapedLiteralString.Value == null)
-                throw new ArgumentNullException(nameof(escapedLiteralString), "Property is not nullable for class LiteralStringClass.");
+                throw new JsonException("Property is not nullable for class LiteralStringClass: escapedLiteralString.");
 
             if (unescapedLiteralString.IsSet && unescapedLiteralString.Value == null)
-                throw new ArgumentNullException(nameof(unescapedLiteralString), "Property is not nullable for class LiteralStringClass.");
+                throw new JsonException("Property is not nullable for class LiteralStringClass: unescapedLiteralString.");
 
             return new LiteralStringClass(escapedLiteralString, unescapedLiteralString);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Mammal.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Mammal.cs
@@ -208,10 +208,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Mammal.", nameof(className));
+                throw new JsonException("Property is required for class Mammal: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Mammal.");
+                throw new JsonException("Property is not nullable for class Mammal: className.");
 
             if (pig != null)
                 return new Mammal(pig);

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/MapTest.cs
@@ -265,16 +265,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (directMap.IsSet && directMap.Value == null)
-                throw new ArgumentNullException(nameof(directMap), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: direct_map.");
 
             if (indirectMap.IsSet && indirectMap.Value == null)
-                throw new ArgumentNullException(nameof(indirectMap), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: indirect_map.");
 
             if (mapMapOfString.IsSet && mapMapOfString.Value == null)
-                throw new ArgumentNullException(nameof(mapMapOfString), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: map_map_of_string.");
 
             if (mapOfEnumString.IsSet && mapOfEnumString.Value == null)
-                throw new ArgumentNullException(nameof(mapOfEnumString), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: map_of_enum_string.");
 
             return new MapTest(directMap, indirectMap, mapMapOfString, mapOfEnumString);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/MixedAnyOf.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/MixedAnyOf.cs
@@ -139,7 +139,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (content.IsSet && content.Value == null)
-                throw new ArgumentNullException(nameof(content), "Property is not nullable for class MixedAnyOf.");
+                throw new JsonException("Property is not nullable for class MixedAnyOf: content.");
 
             return new MixedAnyOf(content);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/MixedOneOf.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/MixedOneOf.cs
@@ -139,7 +139,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (content.IsSet && content.Value == null)
-                throw new ArgumentNullException(nameof(content), "Property is not nullable for class MixedOneOf.");
+                throw new JsonException("Property is not nullable for class MixedOneOf: content.");
 
             return new MixedOneOf(content);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -211,16 +211,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (dateTime.IsSet && dateTime.Value == null)
-                throw new ArgumentNullException(nameof(dateTime), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: dateTime.");
 
             if (map.IsSet && map.Value == null)
-                throw new ArgumentNullException(nameof(map), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: map.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: uuid.");
 
             if (uuidWithPattern.IsSet && uuidWithPattern.Value == null)
-                throw new ArgumentNullException(nameof(uuidWithPattern), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: uuid_with_pattern.");
 
             return new MixedPropertiesAndAdditionalPropertiesClass(dateTime, map, uuid, uuidWithPattern);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/MixedSubId.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/MixedSubId.cs
@@ -139,7 +139,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class MixedSubId.");
+                throw new JsonException("Property is not nullable for class MixedSubId: id.");
 
             return new MixedSubId(id);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -159,10 +159,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varClass.IsSet && varClass.Value == null)
-                throw new ArgumentNullException(nameof(varClass), "Property is not nullable for class Model200Response.");
+                throw new JsonException("Property is not nullable for class Model200Response: class.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Model200Response.");
+                throw new JsonException("Property is not nullable for class Model200Response: name.");
 
             return new Model200Response(varClass, name);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -139,7 +139,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varClient.IsSet && varClient.Value == null)
-                throw new ArgumentNullException(nameof(varClient), "Property is not nullable for class ModelClient.");
+                throw new JsonException("Property is not nullable for class ModelClient: client.");
 
             return new ModelClient(varClient);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Name.cs
@@ -192,19 +192,19 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!varName.IsSet)
-                throw new ArgumentException("Property is required for class Name.", nameof(varName));
+                throw new JsonException("Property is required for class Name: name.");
 
             if (varName.IsSet && varName.Value == null)
-                throw new ArgumentNullException(nameof(varName), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: name.");
 
             if (property.IsSet && property.Value == null)
-                throw new ArgumentNullException(nameof(property), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: property.");
 
             if (snakeCase.IsSet && snakeCase.Value == null)
-                throw new ArgumentNullException(nameof(snakeCase), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: snake_case.");
 
             if (var123Number.IsSet && var123Number.Value == null)
-                throw new ArgumentNullException(nameof(var123Number), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: 123Number.");
 
             return new Name(varName.Value!.Value!, property, snakeCase, var123Number);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
@@ -145,16 +145,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!aObjVariableobject.IsSet)
-                throw new ArgumentException("Property is required for class NotificationtestGetElementsV1ResponseMPayload.", nameof(aObjVariableobject));
+                throw new JsonException("Property is required for class NotificationtestGetElementsV1ResponseMPayload: a_objVariableobject.");
 
             if (!pkiNotificationtestID.IsSet)
-                throw new ArgumentException("Property is required for class NotificationtestGetElementsV1ResponseMPayload.", nameof(pkiNotificationtestID));
+                throw new JsonException("Property is required for class NotificationtestGetElementsV1ResponseMPayload: pkiNotificationtestID.");
 
             if (aObjVariableobject.IsSet && aObjVariableobject.Value == null)
-                throw new ArgumentNullException(nameof(aObjVariableobject), "Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload.");
+                throw new JsonException("Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload: a_objVariableobject.");
 
             if (pkiNotificationtestID.IsSet && pkiNotificationtestID.Value == null)
-                throw new ArgumentNullException(nameof(pkiNotificationtestID), "Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload.");
+                throw new JsonException("Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload: pkiNotificationtestID.");
 
             return new NotificationtestGetElementsV1ResponseMPayload(aObjVariableobject.Value!, pkiNotificationtestID.Value!.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -376,10 +376,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayItemsNullable.IsSet && arrayItemsNullable.Value == null)
-                throw new ArgumentNullException(nameof(arrayItemsNullable), "Property is not nullable for class NullableClass.");
+                throw new JsonException("Property is not nullable for class NullableClass: array_items_nullable.");
 
             if (objectItemsNullable.IsSet && objectItemsNullable.Value == null)
-                throw new ArgumentNullException(nameof(objectItemsNullable), "Property is not nullable for class NullableClass.");
+                throw new JsonException("Property is not nullable for class NullableClass: object_items_nullable.");
 
             return new NullableClass(arrayAndItemsNullableProp, arrayItemsNullable, arrayNullableProp, booleanProp, dateProp, datetimeProp, integerProp, numberProp, objectAndItemsNullableProp, objectItemsNullable, objectNullableProp, stringProp);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/NullableShape.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/NullableShape.cs
@@ -187,10 +187,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class NullableShape.", nameof(shapeType));
+                throw new JsonException("Property is required for class NullableShape: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class NullableShape.");
+                throw new JsonException("Property is not nullable for class NullableShape: shapeType.");
 
             if (quadrilateral != null)
                 return new NullableShape(quadrilateral);

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -139,7 +139,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (justNumber.IsSet && justNumber.Value == null)
-                throw new ArgumentNullException(nameof(justNumber), "Property is not nullable for class NumberOnly.");
+                throw new JsonException("Property is not nullable for class NumberOnly: JustNumber.");
 
             return new NumberOnly(justNumber);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -202,16 +202,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bars.IsSet && bars.Value == null)
-                throw new ArgumentNullException(nameof(bars), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: bars.");
 
             if (deprecatedRef.IsSet && deprecatedRef.Value == null)
-                throw new ArgumentNullException(nameof(deprecatedRef), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: deprecatedRef.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: id.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: uuid.");
 
             return new ObjectWithDeprecatedFields(bars, deprecatedRef, id, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Order.cs
@@ -334,22 +334,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (complete.IsSet && complete.Value == null)
-                throw new ArgumentNullException(nameof(complete), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: complete.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: id.");
 
             if (petId.IsSet && petId.Value == null)
-                throw new ArgumentNullException(nameof(petId), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: petId.");
 
             if (quantity.IsSet && quantity.Value == null)
-                throw new ArgumentNullException(nameof(quantity), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: quantity.");
 
             if (shipDate.IsSet && shipDate.Value == null)
-                throw new ArgumentNullException(nameof(shipDate), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: shipDate.");
 
             if (status.IsSet && status.Value == null)
-                throw new ArgumentNullException(nameof(status), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: status.");
 
             return new Order(complete, id, petId, quantity, shipDate, status);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -179,13 +179,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (myBoolean.IsSet && myBoolean.Value == null)
-                throw new ArgumentNullException(nameof(myBoolean), "Property is not nullable for class OuterComposite.");
+                throw new JsonException("Property is not nullable for class OuterComposite: my_boolean.");
 
             if (myNumber.IsSet && myNumber.Value == null)
-                throw new ArgumentNullException(nameof(myNumber), "Property is not nullable for class OuterComposite.");
+                throw new JsonException("Property is not nullable for class OuterComposite: my_number.");
 
             if (myString.IsSet && myString.Value == null)
-                throw new ArgumentNullException(nameof(myString), "Property is not nullable for class OuterComposite.");
+                throw new JsonException("Property is not nullable for class OuterComposite: my_string.");
 
             return new OuterComposite(myBoolean, myNumber, myString);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/ParentPet.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/ParentPet.cs
@@ -119,10 +119,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!petType.IsSet)
-                throw new ArgumentException("Property is required for class ParentPet.", nameof(petType));
+                throw new JsonException("Property is required for class ParentPet: pet_type.");
 
             if (petType.IsSet && petType.Value == null)
-                throw new ArgumentNullException(nameof(petType), "Property is not nullable for class ParentPet.");
+                throw new JsonException("Property is not nullable for class ParentPet: pet_type.");
 
             return new ParentPet();
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Pet.cs
@@ -315,28 +315,28 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!name.IsSet)
-                throw new ArgumentException("Property is required for class Pet.", nameof(name));
+                throw new JsonException("Property is required for class Pet: name.");
 
             if (!photoUrls.IsSet)
-                throw new ArgumentException("Property is required for class Pet.", nameof(photoUrls));
+                throw new JsonException("Property is required for class Pet: photoUrls.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: name.");
 
             if (photoUrls.IsSet && photoUrls.Value == null)
-                throw new ArgumentNullException(nameof(photoUrls), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: photoUrls.");
 
             if (category.IsSet && category.Value == null)
-                throw new ArgumentNullException(nameof(category), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: category.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: id.");
 
             if (status.IsSet && status.Value == null)
-                throw new ArgumentNullException(nameof(status), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: status.");
 
             if (tags.IsSet && tags.Value == null)
-                throw new ArgumentNullException(nameof(tags), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: tags.");
 
             return new Pet(name.Value!, photoUrls.Value!, category, id, status, tags);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Pig.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Pig.cs
@@ -187,10 +187,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Pig.", nameof(className));
+                throw new JsonException("Property is required for class Pig: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Pig.");
+                throw new JsonException("Property is not nullable for class Pig: className.");
 
             if (basquePig != null)
                 return new Pig(basquePig);

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Quadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Quadrilateral.cs
@@ -187,10 +187,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class Quadrilateral.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class Quadrilateral: quadrilateralType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class Quadrilateral.");
+                throw new JsonException("Property is not nullable for class Quadrilateral: quadrilateralType.");
 
             if (complexQuadrilateral != null)
                 return new Quadrilateral(complexQuadrilateral);

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
@@ -132,10 +132,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class QuadrilateralInterface.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class QuadrilateralInterface: quadrilateralType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class QuadrilateralInterface.");
+                throw new JsonException("Property is not nullable for class QuadrilateralInterface: quadrilateralType.");
 
             return new QuadrilateralInterface(quadrilateralType.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -159,10 +159,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bar.IsSet && bar.Value == null)
-                throw new ArgumentNullException(nameof(bar), "Property is not nullable for class ReadOnlyFirst.");
+                throw new JsonException("Property is not nullable for class ReadOnlyFirst: bar.");
 
             if (baz.IsSet && baz.Value == null)
-                throw new ArgumentNullException(nameof(baz), "Property is not nullable for class ReadOnlyFirst.");
+                throw new JsonException("Property is not nullable for class ReadOnlyFirst: baz.");
 
             return new ReadOnlyFirst(bar, baz);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -2071,136 +2071,136 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!requiredNotNullableDateProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotNullableDateProp));
+                throw new JsonException("Property is required for class RequiredClass: required_not_nullable_date_prop.");
 
             if (!requiredNotnullableArrayOfString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableArrayOfString));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_array_of_string.");
 
             if (!requiredNotnullableBooleanProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableBooleanProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_boolean_prop.");
 
             if (!requiredNotnullableDatetimeProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableDatetimeProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_datetime_prop.");
 
             if (!requiredNotnullableEnumInteger.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableEnumInteger));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_enum_integer.");
 
             if (!requiredNotnullableEnumIntegerOnly.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableEnumIntegerOnly));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_enum_integer_only.");
 
             if (!requiredNotnullableEnumString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableEnumString));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_enum_string.");
 
             if (!requiredNotnullableOuterEnumDefaultValue.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableOuterEnumDefaultValue));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_outerEnumDefaultValue.");
 
             if (!requiredNotnullableStringProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableStringProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_string_prop.");
 
             if (!requiredNotnullableUuid.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableUuid));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_uuid.");
 
             if (!requiredNotnullableintegerProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableintegerProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullableinteger_prop.");
 
             if (!requiredNullableArrayOfString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableArrayOfString));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_array_of_string.");
 
             if (!requiredNullableBooleanProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableBooleanProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_boolean_prop.");
 
             if (!requiredNullableDateProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableDateProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_date_prop.");
 
             if (!requiredNullableDatetimeProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableDatetimeProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_datetime_prop.");
 
             if (!requiredNullableEnumInteger.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableEnumInteger));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_enum_integer.");
 
             if (!requiredNullableEnumIntegerOnly.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableEnumIntegerOnly));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_enum_integer_only.");
 
             if (!requiredNullableEnumString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableEnumString));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_enum_string.");
 
             if (!requiredNullableIntegerProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableIntegerProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_integer_prop.");
 
             if (!requiredNullableOuterEnumDefaultValue.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableOuterEnumDefaultValue));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_outerEnumDefaultValue.");
 
             if (!requiredNullableStringProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableStringProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_string_prop.");
 
             if (!requiredNullableUuid.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableUuid));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_uuid.");
 
             if (requiredNotNullableDateProp.IsSet && requiredNotNullableDateProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotNullableDateProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_not_nullable_date_prop.");
 
             if (requiredNotnullableArrayOfString.IsSet && requiredNotnullableArrayOfString.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableArrayOfString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_array_of_string.");
 
             if (requiredNotnullableBooleanProp.IsSet && requiredNotnullableBooleanProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableBooleanProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_boolean_prop.");
 
             if (requiredNotnullableDatetimeProp.IsSet && requiredNotnullableDatetimeProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableDatetimeProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_datetime_prop.");
 
             if (requiredNotnullableEnumInteger.IsSet && requiredNotnullableEnumInteger.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableEnumInteger), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_enum_integer.");
 
             if (requiredNotnullableEnumIntegerOnly.IsSet && requiredNotnullableEnumIntegerOnly.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableEnumIntegerOnly), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_enum_integer_only.");
 
             if (requiredNotnullableEnumString.IsSet && requiredNotnullableEnumString.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableEnumString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_enum_string.");
 
             if (requiredNotnullableOuterEnumDefaultValue.IsSet && requiredNotnullableOuterEnumDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableOuterEnumDefaultValue), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_outerEnumDefaultValue.");
 
             if (requiredNotnullableStringProp.IsSet && requiredNotnullableStringProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableStringProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_string_prop.");
 
             if (requiredNotnullableUuid.IsSet && requiredNotnullableUuid.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableUuid), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_uuid.");
 
             if (requiredNotnullableintegerProp.IsSet && requiredNotnullableintegerProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableintegerProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullableinteger_prop.");
 
             if (notRequiredNotnullableDateProp.IsSet && notRequiredNotnullableDateProp.Value == null)
-                throw new ArgumentNullException(nameof(notRequiredNotnullableDateProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: not_required_notnullable_date_prop.");
 
             if (notRequiredNotnullableintegerProp.IsSet && notRequiredNotnullableintegerProp.Value == null)
-                throw new ArgumentNullException(nameof(notRequiredNotnullableintegerProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: not_required_notnullableinteger_prop.");
 
             if (notrequiredNotnullableArrayOfString.IsSet && notrequiredNotnullableArrayOfString.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableArrayOfString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_array_of_string.");
 
             if (notrequiredNotnullableBooleanProp.IsSet && notrequiredNotnullableBooleanProp.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableBooleanProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_boolean_prop.");
 
             if (notrequiredNotnullableDatetimeProp.IsSet && notrequiredNotnullableDatetimeProp.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableDatetimeProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_datetime_prop.");
 
             if (notrequiredNotnullableEnumInteger.IsSet && notrequiredNotnullableEnumInteger.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableEnumInteger), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_enum_integer.");
 
             if (notrequiredNotnullableEnumIntegerOnly.IsSet && notrequiredNotnullableEnumIntegerOnly.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableEnumIntegerOnly), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_enum_integer_only.");
 
             if (notrequiredNotnullableEnumString.IsSet && notrequiredNotnullableEnumString.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableEnumString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_enum_string.");
 
             if (notrequiredNotnullableOuterEnumDefaultValue.IsSet && notrequiredNotnullableOuterEnumDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableOuterEnumDefaultValue), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_outerEnumDefaultValue.");
 
             if (notrequiredNotnullableStringProp.IsSet && notrequiredNotnullableStringProp.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableStringProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_string_prop.");
 
             if (notrequiredNotnullableUuid.IsSet && notrequiredNotnullableUuid.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableUuid), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_uuid.");
 
             return new RequiredClass(requiredNotNullableDateProp.Value!.Value!, requiredNotnullableArrayOfString.Value!, requiredNotnullableBooleanProp.Value!.Value!, requiredNotnullableDatetimeProp.Value!.Value!, requiredNotnullableEnumInteger.Value!.Value!, requiredNotnullableEnumIntegerOnly.Value!.Value!, requiredNotnullableEnumString.Value!.Value!, requiredNotnullableOuterEnumDefaultValue.Value!.Value!, requiredNotnullableStringProp.Value!, requiredNotnullableUuid.Value!.Value!, requiredNotnullableintegerProp.Value!.Value!, notRequiredNotnullableDateProp, notRequiredNotnullableintegerProp, notRequiredNullableDateProp, notRequiredNullableIntegerProp, notrequiredNotnullableArrayOfString, notrequiredNotnullableBooleanProp, notrequiredNotnullableDatetimeProp, notrequiredNotnullableEnumInteger, notrequiredNotnullableEnumIntegerOnly, notrequiredNotnullableEnumString, notrequiredNotnullableOuterEnumDefaultValue, notrequiredNotnullableStringProp, notrequiredNotnullableUuid, notrequiredNullableArrayOfString, notrequiredNullableBooleanProp, notrequiredNullableDatetimeProp, notrequiredNullableEnumInteger, notrequiredNullableEnumIntegerOnly, notrequiredNullableEnumString, notrequiredNullableOuterEnumDefaultValue, notrequiredNullableStringProp, notrequiredNullableUuid, requiredNullableArrayOfString.Value!, requiredNullableBooleanProp.Value!, requiredNullableDateProp.Value!, requiredNullableDatetimeProp.Value!, requiredNullableEnumInteger.Value!, requiredNullableEnumIntegerOnly.Value!, requiredNullableEnumString.Value!, requiredNullableIntegerProp.Value!, requiredNullableOuterEnumDefaultValue.Value!, requiredNullableStringProp.Value!, requiredNullableUuid.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Result.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Result.cs
@@ -182,13 +182,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (code.IsSet && code.Value == null)
-                throw new ArgumentNullException(nameof(code), "Property is not nullable for class Result.");
+                throw new JsonException("Property is not nullable for class Result: code.");
 
             if (data.IsSet && data.Value == null)
-                throw new ArgumentNullException(nameof(data), "Property is not nullable for class Result.");
+                throw new JsonException("Property is not nullable for class Result: data.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class Result.");
+                throw new JsonException("Property is not nullable for class Result: uuid.");
 
             return new Result(code, data, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Return.cs
@@ -185,19 +185,19 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!varLock.IsSet)
-                throw new ArgumentException("Property is required for class Return.", nameof(varLock));
+                throw new JsonException("Property is required for class Return: lock.");
 
             if (!varAbstract.IsSet)
-                throw new ArgumentException("Property is required for class Return.", nameof(varAbstract));
+                throw new JsonException("Property is required for class Return: abstract.");
 
             if (varLock.IsSet && varLock.Value == null)
-                throw new ArgumentNullException(nameof(varLock), "Property is not nullable for class Return.");
+                throw new JsonException("Property is not nullable for class Return: lock.");
 
             if (varReturn.IsSet && varReturn.Value == null)
-                throw new ArgumentNullException(nameof(varReturn), "Property is not nullable for class Return.");
+                throw new JsonException("Property is not nullable for class Return: return.");
 
             if (varUnsafe.IsSet && varUnsafe.Value == null)
-                throw new ArgumentNullException(nameof(varUnsafe), "Property is not nullable for class Return.");
+                throw new JsonException("Property is not nullable for class Return: unsafe.");
 
             return new Return(varLock.Value!, varAbstract.Value!, varReturn, varUnsafe);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -159,10 +159,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (role.IsSet && role.Value == null)
-                throw new ArgumentNullException(nameof(role), "Property is not nullable for class RolesReportsHash.");
+                throw new JsonException("Property is not nullable for class RolesReportsHash: role.");
 
             if (roleUuid.IsSet && roleUuid.Value == null)
-                throw new ArgumentNullException(nameof(roleUuid), "Property is not nullable for class RolesReportsHash.");
+                throw new JsonException("Property is not nullable for class RolesReportsHash: role_uuid.");
 
             return new RolesReportsHash(role, roleUuid);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
@@ -139,7 +139,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class RolesReportsHashRole.");
+                throw new JsonException("Property is not nullable for class RolesReportsHashRole: name.");
 
             return new RolesReportsHashRole(name);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
@@ -145,16 +145,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ScaleneTriangle.", nameof(shapeType));
+                throw new JsonException("Property is required for class ScaleneTriangle: shapeType.");
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class ScaleneTriangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class ScaleneTriangle: triangleType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ScaleneTriangle.");
+                throw new JsonException("Property is not nullable for class ScaleneTriangle: shapeType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class ScaleneTriangle.");
+                throw new JsonException("Property is not nullable for class ScaleneTriangle: triangleType.");
 
             return new ScaleneTriangle(shapeType.Value!, triangleType.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Shape.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Shape.cs
@@ -187,10 +187,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class Shape.", nameof(shapeType));
+                throw new JsonException("Property is required for class Shape: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class Shape.");
+                throw new JsonException("Property is not nullable for class Shape: shapeType.");
 
             if (quadrilateral != null)
                 return new Shape(quadrilateral);

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/ShapeInterface.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/ShapeInterface.cs
@@ -132,10 +132,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ShapeInterface.", nameof(shapeType));
+                throw new JsonException("Property is required for class ShapeInterface: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ShapeInterface.");
+                throw new JsonException("Property is not nullable for class ShapeInterface: shapeType.");
 
             return new ShapeInterface(shapeType.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/ShapeOrNull.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/ShapeOrNull.cs
@@ -187,10 +187,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ShapeOrNull.", nameof(shapeType));
+                throw new JsonException("Property is required for class ShapeOrNull: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ShapeOrNull.");
+                throw new JsonException("Property is not nullable for class ShapeOrNull: shapeType.");
 
             if (quadrilateral != null)
                 return new ShapeOrNull(quadrilateral);

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
@@ -145,16 +145,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class SimpleQuadrilateral.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class SimpleQuadrilateral: quadrilateralType.");
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class SimpleQuadrilateral.", nameof(shapeType));
+                throw new JsonException("Property is required for class SimpleQuadrilateral: shapeType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class SimpleQuadrilateral.");
+                throw new JsonException("Property is not nullable for class SimpleQuadrilateral: quadrilateralType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class SimpleQuadrilateral.");
+                throw new JsonException("Property is not nullable for class SimpleQuadrilateral: shapeType.");
 
             return new SimpleQuadrilateral(quadrilateralType.Value!, shapeType.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -159,10 +159,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varSpecialModelName.IsSet && varSpecialModelName.Value == null)
-                throw new ArgumentNullException(nameof(varSpecialModelName), "Property is not nullable for class SpecialModelName.");
+                throw new JsonException("Property is not nullable for class SpecialModelName: _special_model.name_.");
 
             if (specialPropertyName.IsSet && specialPropertyName.Value == null)
-                throw new ArgumentNullException(nameof(specialPropertyName), "Property is not nullable for class SpecialModelName.");
+                throw new JsonException("Property is not nullable for class SpecialModelName: $special[property.name].");
 
             return new SpecialModelName(varSpecialModelName, specialPropertyName);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Tag.cs
@@ -159,10 +159,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Tag.");
+                throw new JsonException("Property is not nullable for class Tag: id.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Tag.");
+                throw new JsonException("Property is not nullable for class Tag: name.");
 
             return new Tag(id, name);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -139,7 +139,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (value.IsSet && value.Value == null)
-                throw new ArgumentNullException(nameof(value), "Property is not nullable for class TestCollectionEndingWithWordList.");
+                throw new JsonException("Property is not nullable for class TestCollectionEndingWithWordList: value.");
 
             return new TestCollectionEndingWithWordList(value);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -139,7 +139,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (testCollectionEndingWithWordList.IsSet && testCollectionEndingWithWordList.Value == null)
-                throw new ArgumentNullException(nameof(testCollectionEndingWithWordList), "Property is not nullable for class TestCollectionEndingWithWordListObject.");
+                throw new JsonException("Property is not nullable for class TestCollectionEndingWithWordListObject: TestCollectionEndingWithWordList.");
 
             return new TestCollectionEndingWithWordListObject(testCollectionEndingWithWordList);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/TestDescendants.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/TestDescendants.cs
@@ -235,16 +235,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!alternativeName.IsSet)
-                throw new ArgumentException("Property is required for class TestDescendants.", nameof(alternativeName));
+                throw new JsonException("Property is required for class TestDescendants: alternativeName.");
 
             if (!objectType.IsSet)
-                throw new ArgumentException("Property is required for class TestDescendants.", nameof(objectType));
+                throw new JsonException("Property is required for class TestDescendants: objectType.");
 
             if (alternativeName.IsSet && alternativeName.Value == null)
-                throw new ArgumentNullException(nameof(alternativeName), "Property is not nullable for class TestDescendants.");
+                throw new JsonException("Property is not nullable for class TestDescendants: alternativeName.");
 
             if (objectType.IsSet && objectType.Value == null)
-                throw new ArgumentNullException(nameof(objectType), "Property is not nullable for class TestDescendants.");
+                throw new JsonException("Property is not nullable for class TestDescendants: objectType.");
 
             return new TestDescendants(alternativeName.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
@@ -146,7 +146,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (someProperty.IsSet && someProperty.Value == null)
-                throw new ArgumentNullException(nameof(someProperty), "Property is not nullable for class TestInlineFreeformAdditionalPropertiesRequest.");
+                throw new JsonException("Property is not nullable for class TestInlineFreeformAdditionalPropertiesRequest: someProperty.");
 
             return new TestInlineFreeformAdditionalPropertiesRequest(someProperty);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/TestResult.cs
@@ -181,13 +181,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (code.IsSet && code.Value == null)
-                throw new ArgumentNullException(nameof(code), "Property is not nullable for class TestResult.");
+                throw new JsonException("Property is not nullable for class TestResult: code.");
 
             if (data.IsSet && data.Value == null)
-                throw new ArgumentNullException(nameof(data), "Property is not nullable for class TestResult.");
+                throw new JsonException("Property is not nullable for class TestResult: data.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class TestResult.");
+                throw new JsonException("Property is not nullable for class TestResult: uuid.");
 
             return new TestResult(code, data, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Triangle.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Triangle.cs
@@ -208,10 +208,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class Triangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class Triangle: triangleType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class Triangle.");
+                throw new JsonException("Property is not nullable for class Triangle: triangleType.");
 
             if (equilateralTriangle != null)
                 return new Triangle(equilateralTriangle);

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/TriangleInterface.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/TriangleInterface.cs
@@ -132,10 +132,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class TriangleInterface.", nameof(triangleType));
+                throw new JsonException("Property is required for class TriangleInterface: triangleType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class TriangleInterface.");
+                throw new JsonException("Property is not nullable for class TriangleInterface: triangleType.");
 
             return new TriangleInterface(triangleType.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/User.cs
@@ -364,31 +364,31 @@ namespace Org.OpenAPITools.Model
             }
 
             if (email.IsSet && email.Value == null)
-                throw new ArgumentNullException(nameof(email), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: email.");
 
             if (firstName.IsSet && firstName.Value == null)
-                throw new ArgumentNullException(nameof(firstName), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: firstName.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: id.");
 
             if (lastName.IsSet && lastName.Value == null)
-                throw new ArgumentNullException(nameof(lastName), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: lastName.");
 
             if (objectWithNoDeclaredProps.IsSet && objectWithNoDeclaredProps.Value == null)
-                throw new ArgumentNullException(nameof(objectWithNoDeclaredProps), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: objectWithNoDeclaredProps.");
 
             if (password.IsSet && password.Value == null)
-                throw new ArgumentNullException(nameof(password), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: password.");
 
             if (phone.IsSet && phone.Value == null)
-                throw new ArgumentNullException(nameof(phone), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: phone.");
 
             if (userStatus.IsSet && userStatus.Value == null)
-                throw new ArgumentNullException(nameof(userStatus), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: userStatus.");
 
             if (username.IsSet && username.Value == null)
-                throw new ArgumentNullException(nameof(username), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: username.");
 
             return new User(anyTypeProp, anyTypePropNullable, email, firstName, id, lastName, objectWithNoDeclaredProps, objectWithNoDeclaredPropsNullable, password, phone, userStatus, username);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Whale.cs
@@ -172,16 +172,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Whale.", nameof(className));
+                throw new JsonException("Property is required for class Whale: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Whale.");
+                throw new JsonException("Property is not nullable for class Whale: className.");
 
             if (hasBaleen.IsSet && hasBaleen.Value == null)
-                throw new ArgumentNullException(nameof(hasBaleen), "Property is not nullable for class Whale.");
+                throw new JsonException("Property is not nullable for class Whale: hasBaleen.");
 
             if (hasTeeth.IsSet && hasTeeth.Value == null)
-                throw new ArgumentNullException(nameof(hasTeeth), "Property is not nullable for class Whale.");
+                throw new JsonException("Property is not nullable for class Whale: hasTeeth.");
 
             return new Whale(className.Value!, hasBaleen, hasTeeth);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Zebra.cs
@@ -246,13 +246,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Zebra.", nameof(className));
+                throw new JsonException("Property is required for class Zebra: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Zebra.");
+                throw new JsonException("Property is not nullable for class Zebra: className.");
 
             if (type.IsSet && type.Value == null)
-                throw new ArgumentNullException(nameof(type), "Property is not nullable for class Zebra.");
+                throw new JsonException("Property is not nullable for class Zebra: type.");
 
             return new Zebra(className.Value!, type);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
@@ -212,7 +212,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (zeroBasedEnum.IsSet && zeroBasedEnum.Value == null)
-                throw new ArgumentNullException(nameof(zeroBasedEnum), "Property is not nullable for class ZeroBasedEnumClass.");
+                throw new JsonException("Property is not nullable for class ZeroBasedEnumClass: ZeroBasedEnum.");
 
             return new ZeroBasedEnumClass(zeroBasedEnum);
         }

--- a/samples/client/petstore/csharp/generichost/net10/AllOf/src/Org.OpenAPITools/Model/Adult.cs
+++ b/samples/client/petstore/csharp/generichost/net10/AllOf/src/Org.OpenAPITools/Model/Adult.cs
@@ -145,16 +145,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (children.IsSet && children.Value == null)
-                throw new ArgumentNullException(nameof(children), "Property is not nullable for class Adult.");
+                throw new JsonException("Property is not nullable for class Adult: children.");
 
             if (firstName.IsSet && firstName.Value == null)
-                throw new ArgumentNullException(nameof(firstName), "Property is not nullable for class Adult.");
+                throw new JsonException("Property is not nullable for class Adult: firstName.");
 
             if (lastName.IsSet && lastName.Value == null)
-                throw new ArgumentNullException(nameof(lastName), "Property is not nullable for class Adult.");
+                throw new JsonException("Property is not nullable for class Adult: lastName.");
 
             if (type.IsSet && type.Value == null)
-                throw new ArgumentNullException(nameof(type), "Property is not nullable for class Adult.");
+                throw new JsonException("Property is not nullable for class Adult: $_type.");
 
             return new Adult(children, firstName, lastName);
         }

--- a/samples/client/petstore/csharp/generichost/net10/AllOf/src/Org.OpenAPITools/Model/Child.cs
+++ b/samples/client/petstore/csharp/generichost/net10/AllOf/src/Org.OpenAPITools/Model/Child.cs
@@ -165,19 +165,19 @@ namespace Org.OpenAPITools.Model
             }
 
             if (age.IsSet && age.Value == null)
-                throw new ArgumentNullException(nameof(age), "Property is not nullable for class Child.");
+                throw new JsonException("Property is not nullable for class Child: age.");
 
             if (boosterSeat.IsSet && boosterSeat.Value == null)
-                throw new ArgumentNullException(nameof(boosterSeat), "Property is not nullable for class Child.");
+                throw new JsonException("Property is not nullable for class Child: boosterSeat.");
 
             if (firstName.IsSet && firstName.Value == null)
-                throw new ArgumentNullException(nameof(firstName), "Property is not nullable for class Child.");
+                throw new JsonException("Property is not nullable for class Child: firstName.");
 
             if (lastName.IsSet && lastName.Value == null)
-                throw new ArgumentNullException(nameof(lastName), "Property is not nullable for class Child.");
+                throw new JsonException("Property is not nullable for class Child: lastName.");
 
             if (type.IsSet && type.Value == null)
-                throw new ArgumentNullException(nameof(type), "Property is not nullable for class Child.");
+                throw new JsonException("Property is not nullable for class Child: $_type.");
 
             return new Child(age, boosterSeat, firstName, lastName);
         }

--- a/samples/client/petstore/csharp/generichost/net10/AllOf/src/Org.OpenAPITools/Model/Person.cs
+++ b/samples/client/petstore/csharp/generichost/net10/AllOf/src/Org.OpenAPITools/Model/Person.cs
@@ -197,13 +197,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (firstName.IsSet && firstName.Value == null)
-                throw new ArgumentNullException(nameof(firstName), "Property is not nullable for class Person.");
+                throw new JsonException("Property is not nullable for class Person: firstName.");
 
             if (lastName.IsSet && lastName.Value == null)
-                throw new ArgumentNullException(nameof(lastName), "Property is not nullable for class Person.");
+                throw new JsonException("Property is not nullable for class Person: lastName.");
 
             if (type.IsSet && type.Value == null)
-                throw new ArgumentNullException(nameof(type), "Property is not nullable for class Person.");
+                throw new JsonException("Property is not nullable for class Person: $_type.");
 
             return new Person(firstName, lastName);
         }

--- a/samples/client/petstore/csharp/generichost/net10/AnyOf/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net10/AnyOf/src/Org.OpenAPITools/Model/Apple.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (kind.IsSet && kind.Value == null)
-                throw new ArgumentNullException(nameof(kind), "Property is not nullable for class Apple.");
+                throw new JsonException("Property is not nullable for class Apple: kind.");
 
             return new Apple(kind);
         }

--- a/samples/client/petstore/csharp/generichost/net10/AnyOf/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net10/AnyOf/src/Org.OpenAPITools/Model/Banana.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (count.IsSet && count.Value == null)
-                throw new ArgumentNullException(nameof(count), "Property is not nullable for class Banana.");
+                throw new JsonException("Property is not nullable for class Banana: count.");
 
             return new Banana(count);
         }

--- a/samples/client/petstore/csharp/generichost/net10/AnyOf/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net10/AnyOf/src/Org.OpenAPITools/Model/Fruit.cs
@@ -196,7 +196,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Fruit.");
+                throw new JsonException("Property is not nullable for class Fruit: color.");
 
             Option<Apple?> appleParsedValue = apple == null
                 ? default

--- a/samples/client/petstore/csharp/generichost/net10/AnyOfNoCompare/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net10/AnyOfNoCompare/src/Org.OpenAPITools/Model/Apple.cs
@@ -146,7 +146,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (kind.IsSet && kind.Value == null)
-                throw new ArgumentNullException(nameof(kind), "Property is not nullable for class Apple.");
+                throw new JsonException("Property is not nullable for class Apple: kind.");
 
             return new Apple(kind);
         }

--- a/samples/client/petstore/csharp/generichost/net10/AnyOfNoCompare/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net10/AnyOfNoCompare/src/Org.OpenAPITools/Model/Banana.cs
@@ -146,7 +146,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (count.IsSet && count.Value == null)
-                throw new ArgumentNullException(nameof(count), "Property is not nullable for class Banana.");
+                throw new JsonException("Property is not nullable for class Banana: count.");
 
             return new Banana(count);
         }

--- a/samples/client/petstore/csharp/generichost/net10/AnyOfNoCompare/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net10/AnyOfNoCompare/src/Org.OpenAPITools/Model/Fruit.cs
@@ -195,7 +195,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Fruit.");
+                throw new JsonException("Property is not nullable for class Fruit: color.");
 
             Option<Apple?> appleParsedValue = apple == null
                 ? default

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Activity.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (activityOutputs.IsSet && activityOutputs.Value == null)
-                throw new ArgumentNullException(nameof(activityOutputs), "Property is not nullable for class Activity.");
+                throw new JsonException("Property is not nullable for class Activity: activity_outputs.");
 
             return new Activity(activityOutputs);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (prop1.IsSet && prop1.Value == null)
-                throw new ArgumentNullException(nameof(prop1), "Property is not nullable for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Property is not nullable for class ActivityOutputElementRepresentation: prop1.");
 
             if (prop2.IsSet && prop2.Value == null)
-                throw new ArgumentNullException(nameof(prop2), "Property is not nullable for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Property is not nullable for class ActivityOutputElementRepresentation: prop2.");
 
             return new ActivityOutputElementRepresentation(prop1, prop2);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -286,25 +286,25 @@ namespace Org.OpenAPITools.Model
             }
 
             if (emptyMap.IsSet && emptyMap.Value == null)
-                throw new ArgumentNullException(nameof(emptyMap), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: empty_map.");
 
             if (mapOfMapProperty.IsSet && mapOfMapProperty.Value == null)
-                throw new ArgumentNullException(nameof(mapOfMapProperty), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_of_map_property.");
 
             if (mapProperty.IsSet && mapProperty.Value == null)
-                throw new ArgumentNullException(nameof(mapProperty), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_property.");
 
             if (mapWithUndeclaredPropertiesAnytype1.IsSet && mapWithUndeclaredPropertiesAnytype1.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesAnytype1), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_anytype_1.");
 
             if (mapWithUndeclaredPropertiesAnytype2.IsSet && mapWithUndeclaredPropertiesAnytype2.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesAnytype2), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_anytype_2.");
 
             if (mapWithUndeclaredPropertiesAnytype3.IsSet && mapWithUndeclaredPropertiesAnytype3.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesAnytype3), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_anytype_3.");
 
             if (mapWithUndeclaredPropertiesString.IsSet && mapWithUndeclaredPropertiesString.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesString), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_string.");
 
             return new AdditionalPropertiesClass(anytype1, emptyMap, mapOfMapProperty, mapProperty, mapWithUndeclaredPropertiesAnytype1, mapWithUndeclaredPropertiesAnytype2, mapWithUndeclaredPropertiesAnytype3, mapWithUndeclaredPropertiesString);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Animal.cs
@@ -175,13 +175,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Animal.", nameof(className));
+                throw new JsonException("Property is required for class Animal: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Animal.");
+                throw new JsonException("Property is not nullable for class Animal: className.");
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Animal.");
+                throw new JsonException("Property is not nullable for class Animal: color.");
 
             return new Animal(color);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -185,13 +185,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (code.IsSet && code.Value == null)
-                throw new ArgumentNullException(nameof(code), "Property is not nullable for class ApiResponse.");
+                throw new JsonException("Property is not nullable for class ApiResponse: code.");
 
             if (message.IsSet && message.Value == null)
-                throw new ArgumentNullException(nameof(message), "Property is not nullable for class ApiResponse.");
+                throw new JsonException("Property is not nullable for class ApiResponse: message.");
 
             if (type.IsSet && type.Value == null)
-                throw new ArgumentNullException(nameof(type), "Property is not nullable for class ApiResponse.");
+                throw new JsonException("Property is not nullable for class ApiResponse: type.");
 
             return new ApiResponse(code, message, type);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Apple.cs
@@ -215,13 +215,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (colorCode.IsSet && colorCode.Value == null)
-                throw new ArgumentNullException(nameof(colorCode), "Property is not nullable for class Apple.");
+                throw new JsonException("Property is not nullable for class Apple: color_code.");
 
             if (cultivar.IsSet && cultivar.Value == null)
-                throw new ArgumentNullException(nameof(cultivar), "Property is not nullable for class Apple.");
+                throw new JsonException("Property is not nullable for class Apple: cultivar.");
 
             if (origin.IsSet && origin.Value == null)
-                throw new ArgumentNullException(nameof(origin), "Property is not nullable for class Apple.");
+                throw new JsonException("Property is not nullable for class Apple: origin.");
 
             return new Apple(colorCode, cultivar, origin);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -151,13 +151,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!cultivar.IsSet)
-                throw new ArgumentException("Property is required for class AppleReq.", nameof(cultivar));
+                throw new JsonException("Property is required for class AppleReq: cultivar.");
 
             if (cultivar.IsSet && cultivar.Value == null)
-                throw new ArgumentNullException(nameof(cultivar), "Property is not nullable for class AppleReq.");
+                throw new JsonException("Property is not nullable for class AppleReq: cultivar.");
 
             if (mealy.IsSet && mealy.Value == null)
-                throw new ArgumentNullException(nameof(mealy), "Property is not nullable for class AppleReq.");
+                throw new JsonException("Property is not nullable for class AppleReq: mealy.");
 
             return new AppleReq(cultivar.Value, mealy);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayArrayNumber.IsSet && arrayArrayNumber.Value == null)
-                throw new ArgumentNullException(nameof(arrayArrayNumber), "Property is not nullable for class ArrayOfArrayOfNumberOnly.");
+                throw new JsonException("Property is not nullable for class ArrayOfArrayOfNumberOnly: ArrayArrayNumber.");
 
             return new ArrayOfArrayOfNumberOnly(arrayArrayNumber);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayNumber.IsSet && arrayNumber.Value == null)
-                throw new ArgumentNullException(nameof(arrayNumber), "Property is not nullable for class ArrayOfNumberOnly.");
+                throw new JsonException("Property is not nullable for class ArrayOfNumberOnly: ArrayNumber.");
 
             return new ArrayOfNumberOnly(arrayNumber);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -185,13 +185,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayArrayOfInteger.IsSet && arrayArrayOfInteger.Value == null)
-                throw new ArgumentNullException(nameof(arrayArrayOfInteger), "Property is not nullable for class ArrayTest.");
+                throw new JsonException("Property is not nullable for class ArrayTest: array_array_of_integer.");
 
             if (arrayArrayOfModel.IsSet && arrayArrayOfModel.Value == null)
-                throw new ArgumentNullException(nameof(arrayArrayOfModel), "Property is not nullable for class ArrayTest.");
+                throw new JsonException("Property is not nullable for class ArrayTest: array_array_of_model.");
 
             if (arrayOfString.IsSet && arrayOfString.Value == null)
-                throw new ArgumentNullException(nameof(arrayOfString), "Property is not nullable for class ArrayTest.");
+                throw new JsonException("Property is not nullable for class ArrayTest: array_of_string.");
 
             return new ArrayTest(arrayArrayOfInteger, arrayArrayOfModel, arrayOfString);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Banana.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (lengthCm.IsSet && lengthCm.Value == null)
-                throw new ArgumentNullException(nameof(lengthCm), "Property is not nullable for class Banana.");
+                throw new JsonException("Property is not nullable for class Banana: lengthCm.");
 
             return new Banana(lengthCm);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -151,13 +151,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!lengthCm.IsSet)
-                throw new ArgumentException("Property is required for class BananaReq.", nameof(lengthCm));
+                throw new JsonException("Property is required for class BananaReq: lengthCm.");
 
             if (lengthCm.IsSet && lengthCm.Value == null)
-                throw new ArgumentNullException(nameof(lengthCm), "Property is not nullable for class BananaReq.");
+                throw new JsonException("Property is not nullable for class BananaReq: lengthCm.");
 
             if (sweet.IsSet && sweet.Value == null)
-                throw new ArgumentNullException(nameof(sweet), "Property is not nullable for class BananaReq.");
+                throw new JsonException("Property is not nullable for class BananaReq: sweet.");
 
             return new BananaReq(lengthCm.Value.Value, sweet);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/BasquePig.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/BasquePig.cs
@@ -138,10 +138,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class BasquePig.", nameof(className));
+                throw new JsonException("Property is required for class BasquePig: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class BasquePig.");
+                throw new JsonException("Property is not nullable for class BasquePig: className.");
 
             return new BasquePig(className.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -246,22 +246,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (aTTNAME.IsSet && aTTNAME.Value == null)
-                throw new ArgumentNullException(nameof(aTTNAME), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: ATT_NAME.");
 
             if (capitalCamel.IsSet && capitalCamel.Value == null)
-                throw new ArgumentNullException(nameof(capitalCamel), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: CapitalCamel.");
 
             if (capitalSnake.IsSet && capitalSnake.Value == null)
-                throw new ArgumentNullException(nameof(capitalSnake), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: Capital_Snake.");
 
             if (sCAETHFlowPoints.IsSet && sCAETHFlowPoints.Value == null)
-                throw new ArgumentNullException(nameof(sCAETHFlowPoints), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: SCA_ETH_Flow_Points.");
 
             if (smallCamel.IsSet && smallCamel.Value == null)
-                throw new ArgumentNullException(nameof(smallCamel), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: smallCamel.");
 
             if (smallSnake.IsSet && smallSnake.Value == null)
-                throw new ArgumentNullException(nameof(smallSnake), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: small_Snake.");
 
             return new Capitalization(aTTNAME, capitalCamel, capitalSnake, sCAETHFlowPoints, smallCamel, smallSnake);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Cat.cs
@@ -138,16 +138,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Cat.", nameof(className));
+                throw new JsonException("Property is required for class Cat: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Cat.");
+                throw new JsonException("Property is not nullable for class Cat: className.");
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Cat.");
+                throw new JsonException("Property is not nullable for class Cat: color.");
 
             if (declawed.IsSet && declawed.Value == null)
-                throw new ArgumentNullException(nameof(declawed), "Property is not nullable for class Cat.");
+                throw new JsonException("Property is not nullable for class Cat: declawed.");
 
             return new Cat(color, declawed);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Category.cs
@@ -158,13 +158,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!name.IsSet)
-                throw new ArgumentException("Property is required for class Category.", nameof(name));
+                throw new JsonException("Property is required for class Category: name.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Category.");
+                throw new JsonException("Property is not nullable for class Category: id.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Category.");
+                throw new JsonException("Property is not nullable for class Category: name.");
 
             return new Category(id, name.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -141,13 +141,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!petType.IsSet)
-                throw new ArgumentException("Property is required for class ChildCat.", nameof(petType));
+                throw new JsonException("Property is required for class ChildCat: pet_type.");
 
             if (petType.IsSet && petType.Value == null)
-                throw new ArgumentNullException(nameof(petType), "Property is not nullable for class ChildCat.");
+                throw new JsonException("Property is not nullable for class ChildCat: pet_type.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class ChildCat.");
+                throw new JsonException("Property is not nullable for class ChildCat: name.");
 
             return new ChildCat(name);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varClass.IsSet && varClass.Value == null)
-                throw new ArgumentNullException(nameof(varClass), "Property is not nullable for class ClassModel.");
+                throw new JsonException("Property is not nullable for class ClassModel: _class.");
 
             return new ClassModel(varClass);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
@@ -151,16 +151,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class ComplexQuadrilateral.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class ComplexQuadrilateral: quadrilateralType.");
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ComplexQuadrilateral.", nameof(shapeType));
+                throw new JsonException("Property is required for class ComplexQuadrilateral: shapeType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class ComplexQuadrilateral.");
+                throw new JsonException("Property is not nullable for class ComplexQuadrilateral: quadrilateralType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ComplexQuadrilateral.");
+                throw new JsonException("Property is not nullable for class ComplexQuadrilateral: shapeType.");
 
             return new ComplexQuadrilateral(quadrilateralType.Value, shapeType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/CopyActivity.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/CopyActivity.cs
@@ -134,16 +134,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!copyActivitytt.IsSet)
-                throw new ArgumentException("Property is required for class CopyActivity.", nameof(copyActivitytt));
+                throw new JsonException("Property is required for class CopyActivity: copyActivitytt.");
 
             if (!schema.IsSet)
-                throw new ArgumentException("Property is required for class CopyActivity.", nameof(schema));
+                throw new JsonException("Property is required for class CopyActivity: $schema.");
 
             if (copyActivitytt.IsSet && copyActivitytt.Value == null)
-                throw new ArgumentNullException(nameof(copyActivitytt), "Property is not nullable for class CopyActivity.");
+                throw new JsonException("Property is not nullable for class CopyActivity: copyActivitytt.");
 
             if (schema.IsSet && schema.Value == null)
-                throw new ArgumentNullException(nameof(schema), "Property is not nullable for class CopyActivity.");
+                throw new JsonException("Property is not nullable for class CopyActivity: $schema.");
 
             return new CopyActivity(copyActivitytt.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/DanishPig.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/DanishPig.cs
@@ -138,10 +138,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class DanishPig.", nameof(className));
+                throw new JsonException("Property is required for class DanishPig: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class DanishPig.");
+                throw new JsonException("Property is not nullable for class DanishPig: className.");
 
             return new DanishPig(className.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -151,7 +151,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (dateOnlyProperty.IsSet && dateOnlyProperty.Value == null)
-                throw new ArgumentNullException(nameof(dateOnlyProperty), "Property is not nullable for class DateOnlyClass.");
+                throw new JsonException("Property is not nullable for class DateOnlyClass: dateOnlyProperty.");
 
             return new DateOnlyClass(dateOnlyProperty);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class DeprecatedObject.");
+                throw new JsonException("Property is not nullable for class DeprecatedObject: name.");
 
             return new DeprecatedObject(name);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Descendant1.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Descendant1.cs
@@ -131,22 +131,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!alternativeName.IsSet)
-                throw new ArgumentException("Property is required for class Descendant1.", nameof(alternativeName));
+                throw new JsonException("Property is required for class Descendant1: alternativeName.");
 
             if (!descendantName.IsSet)
-                throw new ArgumentException("Property is required for class Descendant1.", nameof(descendantName));
+                throw new JsonException("Property is required for class Descendant1: descendantName.");
 
             if (!objectType.IsSet)
-                throw new ArgumentException("Property is required for class Descendant1.", nameof(objectType));
+                throw new JsonException("Property is required for class Descendant1: objectType.");
 
             if (alternativeName.IsSet && alternativeName.Value == null)
-                throw new ArgumentNullException(nameof(alternativeName), "Property is not nullable for class Descendant1.");
+                throw new JsonException("Property is not nullable for class Descendant1: alternativeName.");
 
             if (descendantName.IsSet && descendantName.Value == null)
-                throw new ArgumentNullException(nameof(descendantName), "Property is not nullable for class Descendant1.");
+                throw new JsonException("Property is not nullable for class Descendant1: descendantName.");
 
             if (objectType.IsSet && objectType.Value == null)
-                throw new ArgumentNullException(nameof(objectType), "Property is not nullable for class Descendant1.");
+                throw new JsonException("Property is not nullable for class Descendant1: objectType.");
 
             return new Descendant1(alternativeName.Value, descendantName.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Descendant2.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Descendant2.cs
@@ -131,22 +131,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!alternativeName.IsSet)
-                throw new ArgumentException("Property is required for class Descendant2.", nameof(alternativeName));
+                throw new JsonException("Property is required for class Descendant2: alternativeName.");
 
             if (!confidentiality.IsSet)
-                throw new ArgumentException("Property is required for class Descendant2.", nameof(confidentiality));
+                throw new JsonException("Property is required for class Descendant2: confidentiality.");
 
             if (!objectType.IsSet)
-                throw new ArgumentException("Property is required for class Descendant2.", nameof(objectType));
+                throw new JsonException("Property is required for class Descendant2: objectType.");
 
             if (alternativeName.IsSet && alternativeName.Value == null)
-                throw new ArgumentNullException(nameof(alternativeName), "Property is not nullable for class Descendant2.");
+                throw new JsonException("Property is not nullable for class Descendant2: alternativeName.");
 
             if (confidentiality.IsSet && confidentiality.Value == null)
-                throw new ArgumentNullException(nameof(confidentiality), "Property is not nullable for class Descendant2.");
+                throw new JsonException("Property is not nullable for class Descendant2: confidentiality.");
 
             if (objectType.IsSet && objectType.Value == null)
-                throw new ArgumentNullException(nameof(objectType), "Property is not nullable for class Descendant2.");
+                throw new JsonException("Property is not nullable for class Descendant2: objectType.");
 
             return new Descendant2(alternativeName.Value, confidentiality.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Dog.cs
@@ -138,16 +138,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Dog.", nameof(className));
+                throw new JsonException("Property is required for class Dog: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Dog.");
+                throw new JsonException("Property is not nullable for class Dog: className.");
 
             if (breed.IsSet && breed.Value == null)
-                throw new ArgumentNullException(nameof(breed), "Property is not nullable for class Dog.");
+                throw new JsonException("Property is not nullable for class Dog: breed.");
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Dog.");
+                throw new JsonException("Property is not nullable for class Dog: color.");
 
             return new Dog(breed, color);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Drawing.cs
@@ -205,10 +205,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (mainShape.IsSet && mainShape.Value == null)
-                throw new ArgumentNullException(nameof(mainShape), "Property is not nullable for class Drawing.");
+                throw new JsonException("Property is not nullable for class Drawing: mainShape.");
 
             if (shapes.IsSet && shapes.Value == null)
-                throw new ArgumentNullException(nameof(shapes), "Property is not nullable for class Drawing.");
+                throw new JsonException("Property is not nullable for class Drawing: shapes.");
 
             return new Drawing(mainShape, nullableShape, shapeOrNull, shapes);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/EntityBase.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/EntityBase.cs
@@ -152,10 +152,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!schema.IsSet)
-                throw new ArgumentException("Property is required for class EntityBase.", nameof(schema));
+                throw new JsonException("Property is required for class EntityBase: $schema.");
 
             if (schema.IsSet && schema.Value == null)
-                throw new ArgumentNullException(nameof(schema), "Property is not nullable for class EntityBase.");
+                throw new JsonException("Property is not nullable for class EntityBase: $schema.");
 
             return new EntityBase();
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayEnum.IsSet && arrayEnum.Value == null)
-                throw new ArgumentNullException(nameof(arrayEnum), "Property is not nullable for class EnumArrays.");
+                throw new JsonException("Property is not nullable for class EnumArrays: array_enum.");
 
             if (justSymbol.IsSet && justSymbol.Value == null)
-                throw new ArgumentNullException(nameof(justSymbol), "Property is not nullable for class EnumArrays.");
+                throw new JsonException("Property is not nullable for class EnumArrays: just_symbol.");
 
             return new EnumArrays(arrayEnum, justSymbol);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -298,31 +298,31 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!enumStringRequired.IsSet)
-                throw new ArgumentException("Property is required for class EnumTest.", nameof(enumStringRequired));
+                throw new JsonException("Property is required for class EnumTest: enum_string_required.");
 
             if (enumStringRequired.IsSet && enumStringRequired.Value == null)
-                throw new ArgumentNullException(nameof(enumStringRequired), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_string_required.");
 
             if (enumInteger.IsSet && enumInteger.Value == null)
-                throw new ArgumentNullException(nameof(enumInteger), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_integer.");
 
             if (enumIntegerOnly.IsSet && enumIntegerOnly.Value == null)
-                throw new ArgumentNullException(nameof(enumIntegerOnly), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_integer_only.");
 
             if (enumNumber.IsSet && enumNumber.Value == null)
-                throw new ArgumentNullException(nameof(enumNumber), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_number.");
 
             if (enumString.IsSet && enumString.Value == null)
-                throw new ArgumentNullException(nameof(enumString), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_string.");
 
             if (outerEnumDefaultValue.IsSet && outerEnumDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(outerEnumDefaultValue), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: outerEnumDefaultValue.");
 
             if (outerEnumInteger.IsSet && outerEnumInteger.Value == null)
-                throw new ArgumentNullException(nameof(outerEnumInteger), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: outerEnumInteger.");
 
             if (outerEnumIntegerDefaultValue.IsSet && outerEnumIntegerDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(outerEnumIntegerDefaultValue), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: outerEnumIntegerDefaultValue.");
 
             return new EnumTest(enumStringRequired.Value.Value, enumInteger, enumIntegerOnly, enumNumber, enumString, outerEnum, outerEnumDefaultValue, outerEnumInteger, outerEnumIntegerDefaultValue);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
@@ -151,16 +151,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class EquilateralTriangle.", nameof(shapeType));
+                throw new JsonException("Property is required for class EquilateralTriangle: shapeType.");
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class EquilateralTriangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class EquilateralTriangle: triangleType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class EquilateralTriangle.");
+                throw new JsonException("Property is not nullable for class EquilateralTriangle: shapeType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class EquilateralTriangle.");
+                throw new JsonException("Property is not nullable for class EquilateralTriangle: triangleType.");
 
             return new EquilateralTriangle(shapeType.Value, triangleType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/File.cs
@@ -146,7 +146,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (sourceURI.IsSet && sourceURI.Value == null)
-                throw new ArgumentNullException(nameof(sourceURI), "Property is not nullable for class File.");
+                throw new JsonException("Property is not nullable for class File: sourceURI.");
 
             return new File(sourceURI);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (file.IsSet && file.Value == null)
-                throw new ArgumentNullException(nameof(file), "Property is not nullable for class FileSchemaTestClass.");
+                throw new JsonException("Property is not nullable for class FileSchemaTestClass: file.");
 
             if (files.IsSet && files.Value == null)
-                throw new ArgumentNullException(nameof(files), "Property is not nullable for class FileSchemaTestClass.");
+                throw new JsonException("Property is not nullable for class FileSchemaTestClass: files.");
 
             return new FileSchemaTestClass(file, files);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Foo.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bar.IsSet && bar.Value == null)
-                throw new ArgumentNullException(nameof(bar), "Property is not nullable for class Foo.");
+                throw new JsonException("Property is not nullable for class Foo: bar.");
 
             return new Foo(bar);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varString.IsSet && varString.Value == null)
-                throw new ArgumentNullException(nameof(varString), "Property is not nullable for class FooGetDefaultResponse.");
+                throw new JsonException("Property is not nullable for class FooGetDefaultResponse: string.");
 
             return new FooGetDefaultResponse(varString);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -826,103 +826,103 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!varByte.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(varByte));
+                throw new JsonException("Property is required for class FormatTest: byte.");
 
             if (!date.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(date));
+                throw new JsonException("Property is required for class FormatTest: date.");
 
             if (!number.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(number));
+                throw new JsonException("Property is required for class FormatTest: number.");
 
             if (!password.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(password));
+                throw new JsonException("Property is required for class FormatTest: password.");
 
             if (!stringFormattedAsDecimalRequired.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(stringFormattedAsDecimalRequired));
+                throw new JsonException("Property is required for class FormatTest: string_formatted_as_decimal_required.");
 
             if (varByte.IsSet && varByte.Value == null)
-                throw new ArgumentNullException(nameof(varByte), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: byte.");
 
             if (date.IsSet && date.Value == null)
-                throw new ArgumentNullException(nameof(date), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: date.");
 
             if (number.IsSet && number.Value == null)
-                throw new ArgumentNullException(nameof(number), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: number.");
 
             if (password.IsSet && password.Value == null)
-                throw new ArgumentNullException(nameof(password), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: password.");
 
             if (stringFormattedAsDecimalRequired.IsSet && stringFormattedAsDecimalRequired.Value == null)
-                throw new ArgumentNullException(nameof(stringFormattedAsDecimalRequired), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: string_formatted_as_decimal_required.");
 
             if (binary.IsSet && binary.Value == null)
-                throw new ArgumentNullException(nameof(binary), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: binary.");
 
             if (dateTime.IsSet && dateTime.Value == null)
-                throw new ArgumentNullException(nameof(dateTime), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: dateTime.");
 
             if (varDecimal.IsSet && varDecimal.Value == null)
-                throw new ArgumentNullException(nameof(varDecimal), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: decimal.");
 
             if (varDouble.IsSet && varDouble.Value == null)
-                throw new ArgumentNullException(nameof(varDouble), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: double.");
 
             if (duplicatePropertyName2.IsSet && duplicatePropertyName2.Value == null)
-                throw new ArgumentNullException(nameof(duplicatePropertyName2), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: duplicate_property_name.");
 
             if (duplicatePropertyName.IsSet && duplicatePropertyName.Value == null)
-                throw new ArgumentNullException(nameof(duplicatePropertyName), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: @duplicate_property_name.");
 
             if (varFloat.IsSet && varFloat.Value == null)
-                throw new ArgumentNullException(nameof(varFloat), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: float.");
 
             if (int32.IsSet && int32.Value == null)
-                throw new ArgumentNullException(nameof(int32), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int32.");
 
             if (int32Range.IsSet && int32Range.Value == null)
-                throw new ArgumentNullException(nameof(int32Range), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int32Range.");
 
             if (int64.IsSet && int64.Value == null)
-                throw new ArgumentNullException(nameof(int64), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64.");
 
             if (int64Negative.IsSet && int64Negative.Value == null)
-                throw new ArgumentNullException(nameof(int64Negative), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64Negative.");
 
             if (int64NegativeExclusive.IsSet && int64NegativeExclusive.Value == null)
-                throw new ArgumentNullException(nameof(int64NegativeExclusive), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64NegativeExclusive.");
 
             if (int64Positive.IsSet && int64Positive.Value == null)
-                throw new ArgumentNullException(nameof(int64Positive), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64Positive.");
 
             if (int64PositiveExclusive.IsSet && int64PositiveExclusive.Value == null)
-                throw new ArgumentNullException(nameof(int64PositiveExclusive), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64PositiveExclusive.");
 
             if (integer.IsSet && integer.Value == null)
-                throw new ArgumentNullException(nameof(integer), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: integer.");
 
             if (patternWithBackslash.IsSet && patternWithBackslash.Value == null)
-                throw new ArgumentNullException(nameof(patternWithBackslash), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: pattern_with_backslash.");
 
             if (patternWithDigits.IsSet && patternWithDigits.Value == null)
-                throw new ArgumentNullException(nameof(patternWithDigits), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: pattern_with_digits.");
 
             if (patternWithDigitsAndDelimiter.IsSet && patternWithDigitsAndDelimiter.Value == null)
-                throw new ArgumentNullException(nameof(patternWithDigitsAndDelimiter), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: pattern_with_digits_and_delimiter.");
 
             if (varString.IsSet && varString.Value == null)
-                throw new ArgumentNullException(nameof(varString), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: string.");
 
             if (stringFormattedAsDecimal.IsSet && stringFormattedAsDecimal.Value == null)
-                throw new ArgumentNullException(nameof(stringFormattedAsDecimal), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: string_formatted_as_decimal.");
 
             if (unsignedInteger.IsSet && unsignedInteger.Value == null)
-                throw new ArgumentNullException(nameof(unsignedInteger), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: unsigned_integer.");
 
             if (unsignedLong.IsSet && unsignedLong.Value == null)
-                throw new ArgumentNullException(nameof(unsignedLong), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: unsigned_long.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: uuid.");
 
             return new FormatTest(varByte.Value, date.Value.Value, number.Value.Value, password.Value, stringFormattedAsDecimalRequired.Value.Value, binary, dateTime, varDecimal, varDouble, duplicatePropertyName2, duplicatePropertyName, varFloat, int32, int32Range, int64, int64Negative, int64NegativeExclusive, int64Positive, int64PositiveExclusive, integer, patternWithBackslash, patternWithDigits, patternWithDigitsAndDelimiter, varString, stringFormattedAsDecimal, unsignedInteger, unsignedLong, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Fruit.cs
@@ -183,7 +183,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Fruit.");
+                throw new JsonException("Property is not nullable for class Fruit: color.");
 
             if (apple != null)
                 return new Fruit(apple, color);

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -187,7 +187,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class GmFruit.");
+                throw new JsonException("Property is not nullable for class GmFruit: color.");
 
             Option<Apple> appleParsedValue = apple == null
                 ? default

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
@@ -155,10 +155,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!petType.IsSet)
-                throw new ArgumentException("Property is required for class GrandparentAnimal.", nameof(petType));
+                throw new JsonException("Property is required for class GrandparentAnimal: pet_type.");
 
             if (petType.IsSet && petType.Value == null)
-                throw new ArgumentNullException(nameof(petType), "Property is not nullable for class GrandparentAnimal.");
+                throw new JsonException("Property is not nullable for class GrandparentAnimal: pet_type.");
 
             return new GrandparentAnimal();
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -206,10 +206,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bar.IsSet && bar.Value == null)
-                throw new ArgumentNullException(nameof(bar), "Property is not nullable for class HasOnlyReadOnly.");
+                throw new JsonException("Property is not nullable for class HasOnlyReadOnly: bar.");
 
             if (foo.IsSet && foo.Value == null)
-                throw new ArgumentNullException(nameof(foo), "Property is not nullable for class HasOnlyReadOnly.");
+                throw new JsonException("Property is not nullable for class HasOnlyReadOnly: foo.");
 
             return new HasOnlyReadOnly(bar, foo);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
@@ -292,22 +292,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (potentiallyOverriddenPropertyAccessor.IsSet && potentiallyOverriddenPropertyAccessor.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyAccessor), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyAccessor.");
 
             if (potentiallyOverriddenPropertyToInternal.IsSet && potentiallyOverriddenPropertyToInternal.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyToInternal), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyToInternal.");
 
             if (potentiallyOverriddenPropertyToPrivate.IsSet && potentiallyOverriddenPropertyToPrivate.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyToPrivate), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyToPrivate.");
 
             if (potentiallyOverriddenPropertyToPublic.IsSet && potentiallyOverriddenPropertyToPublic.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyToPublic), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyToPublic.");
 
             if (unalteredProperty.IsSet && unalteredProperty.Value == null)
-                throw new ArgumentNullException(nameof(unalteredProperty), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: unalteredProperty.");
 
             if (unalteredPropertyAccessor.IsSet && unalteredPropertyAccessor.Value == null)
-                throw new ArgumentNullException(nameof(unalteredPropertyAccessor), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: unalteredPropertyAccessor.");
 
             return new InjectedVendorExtensionsTest(potentiallyOverriddenPropertyAccessor, potentiallyOverriddenPropertyToInternal, potentiallyOverriddenPropertyToPrivate, potentiallyOverriddenPropertyToPublic, unalteredProperty, unalteredPropertyAccessor);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
@@ -144,16 +144,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class IsoscelesTriangle.", nameof(shapeType));
+                throw new JsonException("Property is required for class IsoscelesTriangle: shapeType.");
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class IsoscelesTriangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class IsoscelesTriangle: triangleType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class IsoscelesTriangle.");
+                throw new JsonException("Property is not nullable for class IsoscelesTriangle: shapeType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class IsoscelesTriangle.");
+                throw new JsonException("Property is not nullable for class IsoscelesTriangle: triangleType.");
 
             return new IsoscelesTriangle(shapeType.Value, triangleType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/List.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (var123List.IsSet && var123List.Value == null)
-                throw new ArgumentNullException(nameof(var123List), "Property is not nullable for class List.");
+                throw new JsonException("Property is not nullable for class List: 123-list.");
 
             return new List(var123List);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (escapedLiteralString.IsSet && escapedLiteralString.Value == null)
-                throw new ArgumentNullException(nameof(escapedLiteralString), "Property is not nullable for class LiteralStringClass.");
+                throw new JsonException("Property is not nullable for class LiteralStringClass: escapedLiteralString.");
 
             if (unescapedLiteralString.IsSet && unescapedLiteralString.Value == null)
-                throw new ArgumentNullException(nameof(unescapedLiteralString), "Property is not nullable for class LiteralStringClass.");
+                throw new JsonException("Property is not nullable for class LiteralStringClass: unescapedLiteralString.");
 
             return new LiteralStringClass(escapedLiteralString, unescapedLiteralString);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Mammal.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Mammal.cs
@@ -214,10 +214,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Mammal.", nameof(className));
+                throw new JsonException("Property is required for class Mammal: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Mammal.");
+                throw new JsonException("Property is not nullable for class Mammal: className.");
 
             if (pig != null)
                 return new Mammal(pig);

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/MapTest.cs
@@ -205,16 +205,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (directMap.IsSet && directMap.Value == null)
-                throw new ArgumentNullException(nameof(directMap), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: direct_map.");
 
             if (indirectMap.IsSet && indirectMap.Value == null)
-                throw new ArgumentNullException(nameof(indirectMap), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: indirect_map.");
 
             if (mapMapOfString.IsSet && mapMapOfString.Value == null)
-                throw new ArgumentNullException(nameof(mapMapOfString), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: map_map_of_string.");
 
             if (mapOfEnumString.IsSet && mapOfEnumString.Value == null)
-                throw new ArgumentNullException(nameof(mapOfEnumString), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: map_of_enum_string.");
 
             return new MapTest(directMap, indirectMap, mapMapOfString, mapOfEnumString);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/MixedAnyOf.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/MixedAnyOf.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (content.IsSet && content.Value == null)
-                throw new ArgumentNullException(nameof(content), "Property is not nullable for class MixedAnyOf.");
+                throw new JsonException("Property is not nullable for class MixedAnyOf: content.");
 
             return new MixedAnyOf(content);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/MixedOneOf.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/MixedOneOf.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (content.IsSet && content.Value == null)
-                throw new ArgumentNullException(nameof(content), "Property is not nullable for class MixedOneOf.");
+                throw new JsonException("Property is not nullable for class MixedOneOf: content.");
 
             return new MixedOneOf(content);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -217,16 +217,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (dateTime.IsSet && dateTime.Value == null)
-                throw new ArgumentNullException(nameof(dateTime), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: dateTime.");
 
             if (map.IsSet && map.Value == null)
-                throw new ArgumentNullException(nameof(map), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: map.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: uuid.");
 
             if (uuidWithPattern.IsSet && uuidWithPattern.Value == null)
-                throw new ArgumentNullException(nameof(uuidWithPattern), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: uuid_with_pattern.");
 
             return new MixedPropertiesAndAdditionalPropertiesClass(dateTime, map, uuid, uuidWithPattern);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/MixedSubId.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/MixedSubId.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class MixedSubId.");
+                throw new JsonException("Property is not nullable for class MixedSubId: id.");
 
             return new MixedSubId(id);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varClass.IsSet && varClass.Value == null)
-                throw new ArgumentNullException(nameof(varClass), "Property is not nullable for class Model200Response.");
+                throw new JsonException("Property is not nullable for class Model200Response: class.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Model200Response.");
+                throw new JsonException("Property is not nullable for class Model200Response: name.");
 
             return new Model200Response(varClass, name);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varClient.IsSet && varClient.Value == null)
-                throw new ArgumentNullException(nameof(varClient), "Property is not nullable for class ModelClient.");
+                throw new JsonException("Property is not nullable for class ModelClient: client.");
 
             return new ModelClient(varClient);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Name.cs
@@ -239,19 +239,19 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!varName.IsSet)
-                throw new ArgumentException("Property is required for class Name.", nameof(varName));
+                throw new JsonException("Property is required for class Name: name.");
 
             if (varName.IsSet && varName.Value == null)
-                throw new ArgumentNullException(nameof(varName), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: name.");
 
             if (property.IsSet && property.Value == null)
-                throw new ArgumentNullException(nameof(property), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: property.");
 
             if (snakeCase.IsSet && snakeCase.Value == null)
-                throw new ArgumentNullException(nameof(snakeCase), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: snake_case.");
 
             if (var123Number.IsSet && var123Number.Value == null)
-                throw new ArgumentNullException(nameof(var123Number), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: 123Number.");
 
             return new Name(varName.Value.Value, property, snakeCase, var123Number);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
@@ -151,16 +151,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!aObjVariableobject.IsSet)
-                throw new ArgumentException("Property is required for class NotificationtestGetElementsV1ResponseMPayload.", nameof(aObjVariableobject));
+                throw new JsonException("Property is required for class NotificationtestGetElementsV1ResponseMPayload: a_objVariableobject.");
 
             if (!pkiNotificationtestID.IsSet)
-                throw new ArgumentException("Property is required for class NotificationtestGetElementsV1ResponseMPayload.", nameof(pkiNotificationtestID));
+                throw new JsonException("Property is required for class NotificationtestGetElementsV1ResponseMPayload: pkiNotificationtestID.");
 
             if (aObjVariableobject.IsSet && aObjVariableobject.Value == null)
-                throw new ArgumentNullException(nameof(aObjVariableobject), "Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload.");
+                throw new JsonException("Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload: a_objVariableobject.");
 
             if (pkiNotificationtestID.IsSet && pkiNotificationtestID.Value == null)
-                throw new ArgumentNullException(nameof(pkiNotificationtestID), "Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload.");
+                throw new JsonException("Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload: pkiNotificationtestID.");
 
             return new NotificationtestGetElementsV1ResponseMPayload(aObjVariableobject.Value, pkiNotificationtestID.Value.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -375,10 +375,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayItemsNullable.IsSet && arrayItemsNullable.Value == null)
-                throw new ArgumentNullException(nameof(arrayItemsNullable), "Property is not nullable for class NullableClass.");
+                throw new JsonException("Property is not nullable for class NullableClass: array_items_nullable.");
 
             if (objectItemsNullable.IsSet && objectItemsNullable.Value == null)
-                throw new ArgumentNullException(nameof(objectItemsNullable), "Property is not nullable for class NullableClass.");
+                throw new JsonException("Property is not nullable for class NullableClass: object_items_nullable.");
 
             return new NullableClass(arrayAndItemsNullableProp, arrayItemsNullable, arrayNullableProp, booleanProp, dateProp, datetimeProp, integerProp, numberProp, objectAndItemsNullableProp, objectItemsNullable, objectNullableProp, stringProp);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/NullableShape.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/NullableShape.cs
@@ -193,10 +193,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class NullableShape.", nameof(shapeType));
+                throw new JsonException("Property is required for class NullableShape: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class NullableShape.");
+                throw new JsonException("Property is not nullable for class NullableShape: shapeType.");
 
             if (quadrilateral != null)
                 return new NullableShape(quadrilateral);

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (justNumber.IsSet && justNumber.Value == null)
-                throw new ArgumentNullException(nameof(justNumber), "Property is not nullable for class NumberOnly.");
+                throw new JsonException("Property is not nullable for class NumberOnly: JustNumber.");
 
             return new NumberOnly(justNumber);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -208,16 +208,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bars.IsSet && bars.Value == null)
-                throw new ArgumentNullException(nameof(bars), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: bars.");
 
             if (deprecatedRef.IsSet && deprecatedRef.Value == null)
-                throw new ArgumentNullException(nameof(deprecatedRef), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: deprecatedRef.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: id.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: uuid.");
 
             return new ObjectWithDeprecatedFields(bars, deprecatedRef, id, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Order.cs
@@ -251,22 +251,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (complete.IsSet && complete.Value == null)
-                throw new ArgumentNullException(nameof(complete), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: complete.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: id.");
 
             if (petId.IsSet && petId.Value == null)
-                throw new ArgumentNullException(nameof(petId), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: petId.");
 
             if (quantity.IsSet && quantity.Value == null)
-                throw new ArgumentNullException(nameof(quantity), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: quantity.");
 
             if (shipDate.IsSet && shipDate.Value == null)
-                throw new ArgumentNullException(nameof(shipDate), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: shipDate.");
 
             if (status.IsSet && status.Value == null)
-                throw new ArgumentNullException(nameof(status), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: status.");
 
             return new Order(complete, id, petId, quantity, shipDate, status);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -185,13 +185,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (myBoolean.IsSet && myBoolean.Value == null)
-                throw new ArgumentNullException(nameof(myBoolean), "Property is not nullable for class OuterComposite.");
+                throw new JsonException("Property is not nullable for class OuterComposite: my_boolean.");
 
             if (myNumber.IsSet && myNumber.Value == null)
-                throw new ArgumentNullException(nameof(myNumber), "Property is not nullable for class OuterComposite.");
+                throw new JsonException("Property is not nullable for class OuterComposite: my_number.");
 
             if (myString.IsSet && myString.Value == null)
-                throw new ArgumentNullException(nameof(myString), "Property is not nullable for class OuterComposite.");
+                throw new JsonException("Property is not nullable for class OuterComposite: my_string.");
 
             return new OuterComposite(myBoolean, myNumber, myString);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ParentPet.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ParentPet.cs
@@ -118,10 +118,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!petType.IsSet)
-                throw new ArgumentException("Property is required for class ParentPet.", nameof(petType));
+                throw new JsonException("Property is required for class ParentPet: pet_type.");
 
             if (petType.IsSet && petType.Value == null)
-                throw new ArgumentNullException(nameof(petType), "Property is not nullable for class ParentPet.");
+                throw new JsonException("Property is not nullable for class ParentPet: pet_type.");
 
             return new ParentPet();
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Pet.cs
@@ -232,28 +232,28 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!name.IsSet)
-                throw new ArgumentException("Property is required for class Pet.", nameof(name));
+                throw new JsonException("Property is required for class Pet: name.");
 
             if (!photoUrls.IsSet)
-                throw new ArgumentException("Property is required for class Pet.", nameof(photoUrls));
+                throw new JsonException("Property is required for class Pet: photoUrls.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: name.");
 
             if (photoUrls.IsSet && photoUrls.Value == null)
-                throw new ArgumentNullException(nameof(photoUrls), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: photoUrls.");
 
             if (category.IsSet && category.Value == null)
-                throw new ArgumentNullException(nameof(category), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: category.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: id.");
 
             if (status.IsSet && status.Value == null)
-                throw new ArgumentNullException(nameof(status), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: status.");
 
             if (tags.IsSet && tags.Value == null)
-                throw new ArgumentNullException(nameof(tags), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: tags.");
 
             return new Pet(name.Value, photoUrls.Value, category, id, status, tags);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Pig.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Pig.cs
@@ -193,10 +193,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Pig.", nameof(className));
+                throw new JsonException("Property is required for class Pig: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Pig.");
+                throw new JsonException("Property is not nullable for class Pig: className.");
 
             if (basquePig != null)
                 return new Pig(basquePig);

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Quadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Quadrilateral.cs
@@ -193,10 +193,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class Quadrilateral.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class Quadrilateral: quadrilateralType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class Quadrilateral.");
+                throw new JsonException("Property is not nullable for class Quadrilateral: quadrilateralType.");
 
             if (complexQuadrilateral != null)
                 return new Quadrilateral(complexQuadrilateral);

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
@@ -138,10 +138,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class QuadrilateralInterface.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class QuadrilateralInterface: quadrilateralType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class QuadrilateralInterface.");
+                throw new JsonException("Property is not nullable for class QuadrilateralInterface: quadrilateralType.");
 
             return new QuadrilateralInterface(quadrilateralType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -203,10 +203,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bar.IsSet && bar.Value == null)
-                throw new ArgumentNullException(nameof(bar), "Property is not nullable for class ReadOnlyFirst.");
+                throw new JsonException("Property is not nullable for class ReadOnlyFirst: bar.");
 
             if (baz.IsSet && baz.Value == null)
-                throw new ArgumentNullException(nameof(baz), "Property is not nullable for class ReadOnlyFirst.");
+                throw new JsonException("Property is not nullable for class ReadOnlyFirst: baz.");
 
             return new ReadOnlyFirst(bar, baz);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -895,136 +895,136 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!requiredNotNullableDateProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotNullableDateProp));
+                throw new JsonException("Property is required for class RequiredClass: required_not_nullable_date_prop.");
 
             if (!requiredNotnullableArrayOfString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableArrayOfString));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_array_of_string.");
 
             if (!requiredNotnullableBooleanProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableBooleanProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_boolean_prop.");
 
             if (!requiredNotnullableDatetimeProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableDatetimeProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_datetime_prop.");
 
             if (!requiredNotnullableEnumInteger.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableEnumInteger));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_enum_integer.");
 
             if (!requiredNotnullableEnumIntegerOnly.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableEnumIntegerOnly));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_enum_integer_only.");
 
             if (!requiredNotnullableEnumString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableEnumString));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_enum_string.");
 
             if (!requiredNotnullableOuterEnumDefaultValue.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableOuterEnumDefaultValue));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_outerEnumDefaultValue.");
 
             if (!requiredNotnullableStringProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableStringProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_string_prop.");
 
             if (!requiredNotnullableUuid.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableUuid));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_uuid.");
 
             if (!requiredNotnullableintegerProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableintegerProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullableinteger_prop.");
 
             if (!requiredNullableArrayOfString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableArrayOfString));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_array_of_string.");
 
             if (!requiredNullableBooleanProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableBooleanProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_boolean_prop.");
 
             if (!requiredNullableDateProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableDateProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_date_prop.");
 
             if (!requiredNullableDatetimeProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableDatetimeProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_datetime_prop.");
 
             if (!requiredNullableEnumInteger.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableEnumInteger));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_enum_integer.");
 
             if (!requiredNullableEnumIntegerOnly.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableEnumIntegerOnly));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_enum_integer_only.");
 
             if (!requiredNullableEnumString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableEnumString));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_enum_string.");
 
             if (!requiredNullableIntegerProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableIntegerProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_integer_prop.");
 
             if (!requiredNullableOuterEnumDefaultValue.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableOuterEnumDefaultValue));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_outerEnumDefaultValue.");
 
             if (!requiredNullableStringProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableStringProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_string_prop.");
 
             if (!requiredNullableUuid.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableUuid));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_uuid.");
 
             if (requiredNotNullableDateProp.IsSet && requiredNotNullableDateProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotNullableDateProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_not_nullable_date_prop.");
 
             if (requiredNotnullableArrayOfString.IsSet && requiredNotnullableArrayOfString.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableArrayOfString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_array_of_string.");
 
             if (requiredNotnullableBooleanProp.IsSet && requiredNotnullableBooleanProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableBooleanProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_boolean_prop.");
 
             if (requiredNotnullableDatetimeProp.IsSet && requiredNotnullableDatetimeProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableDatetimeProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_datetime_prop.");
 
             if (requiredNotnullableEnumInteger.IsSet && requiredNotnullableEnumInteger.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableEnumInteger), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_enum_integer.");
 
             if (requiredNotnullableEnumIntegerOnly.IsSet && requiredNotnullableEnumIntegerOnly.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableEnumIntegerOnly), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_enum_integer_only.");
 
             if (requiredNotnullableEnumString.IsSet && requiredNotnullableEnumString.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableEnumString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_enum_string.");
 
             if (requiredNotnullableOuterEnumDefaultValue.IsSet && requiredNotnullableOuterEnumDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableOuterEnumDefaultValue), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_outerEnumDefaultValue.");
 
             if (requiredNotnullableStringProp.IsSet && requiredNotnullableStringProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableStringProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_string_prop.");
 
             if (requiredNotnullableUuid.IsSet && requiredNotnullableUuid.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableUuid), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_uuid.");
 
             if (requiredNotnullableintegerProp.IsSet && requiredNotnullableintegerProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableintegerProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullableinteger_prop.");
 
             if (notRequiredNotnullableDateProp.IsSet && notRequiredNotnullableDateProp.Value == null)
-                throw new ArgumentNullException(nameof(notRequiredNotnullableDateProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: not_required_notnullable_date_prop.");
 
             if (notRequiredNotnullableintegerProp.IsSet && notRequiredNotnullableintegerProp.Value == null)
-                throw new ArgumentNullException(nameof(notRequiredNotnullableintegerProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: not_required_notnullableinteger_prop.");
 
             if (notrequiredNotnullableArrayOfString.IsSet && notrequiredNotnullableArrayOfString.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableArrayOfString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_array_of_string.");
 
             if (notrequiredNotnullableBooleanProp.IsSet && notrequiredNotnullableBooleanProp.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableBooleanProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_boolean_prop.");
 
             if (notrequiredNotnullableDatetimeProp.IsSet && notrequiredNotnullableDatetimeProp.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableDatetimeProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_datetime_prop.");
 
             if (notrequiredNotnullableEnumInteger.IsSet && notrequiredNotnullableEnumInteger.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableEnumInteger), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_enum_integer.");
 
             if (notrequiredNotnullableEnumIntegerOnly.IsSet && notrequiredNotnullableEnumIntegerOnly.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableEnumIntegerOnly), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_enum_integer_only.");
 
             if (notrequiredNotnullableEnumString.IsSet && notrequiredNotnullableEnumString.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableEnumString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_enum_string.");
 
             if (notrequiredNotnullableOuterEnumDefaultValue.IsSet && notrequiredNotnullableOuterEnumDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableOuterEnumDefaultValue), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_outerEnumDefaultValue.");
 
             if (notrequiredNotnullableStringProp.IsSet && notrequiredNotnullableStringProp.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableStringProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_string_prop.");
 
             if (notrequiredNotnullableUuid.IsSet && notrequiredNotnullableUuid.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableUuid), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_uuid.");
 
             return new RequiredClass(requiredNotNullableDateProp.Value.Value, requiredNotnullableArrayOfString.Value, requiredNotnullableBooleanProp.Value.Value, requiredNotnullableDatetimeProp.Value.Value, requiredNotnullableEnumInteger.Value.Value, requiredNotnullableEnumIntegerOnly.Value.Value, requiredNotnullableEnumString.Value.Value, requiredNotnullableOuterEnumDefaultValue.Value.Value, requiredNotnullableStringProp.Value, requiredNotnullableUuid.Value.Value, requiredNotnullableintegerProp.Value.Value, notRequiredNotnullableDateProp, notRequiredNotnullableintegerProp, notRequiredNullableDateProp, notRequiredNullableIntegerProp, notrequiredNotnullableArrayOfString, notrequiredNotnullableBooleanProp, notrequiredNotnullableDatetimeProp, notrequiredNotnullableEnumInteger, notrequiredNotnullableEnumIntegerOnly, notrequiredNotnullableEnumString, notrequiredNotnullableOuterEnumDefaultValue, notrequiredNotnullableStringProp, notrequiredNotnullableUuid, notrequiredNullableArrayOfString, notrequiredNullableBooleanProp, notrequiredNullableDatetimeProp, notrequiredNullableEnumInteger, notrequiredNullableEnumIntegerOnly, notrequiredNullableEnumString, notrequiredNullableOuterEnumDefaultValue, notrequiredNullableStringProp, notrequiredNullableUuid, requiredNullableArrayOfString.Value, requiredNullableBooleanProp.Value, requiredNullableDateProp.Value, requiredNullableDatetimeProp.Value, requiredNullableEnumInteger.Value, requiredNullableEnumIntegerOnly.Value, requiredNullableEnumString.Value, requiredNullableIntegerProp.Value, requiredNullableOuterEnumDefaultValue.Value, requiredNullableStringProp.Value, requiredNullableUuid.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Result.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Result.cs
@@ -188,13 +188,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (code.IsSet && code.Value == null)
-                throw new ArgumentNullException(nameof(code), "Property is not nullable for class Result.");
+                throw new JsonException("Property is not nullable for class Result: code.");
 
             if (data.IsSet && data.Value == null)
-                throw new ArgumentNullException(nameof(data), "Property is not nullable for class Result.");
+                throw new JsonException("Property is not nullable for class Result: data.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class Result.");
+                throw new JsonException("Property is not nullable for class Result: uuid.");
 
             return new Result(code, data, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Return.cs
@@ -191,19 +191,19 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!varLock.IsSet)
-                throw new ArgumentException("Property is required for class Return.", nameof(varLock));
+                throw new JsonException("Property is required for class Return: lock.");
 
             if (!varAbstract.IsSet)
-                throw new ArgumentException("Property is required for class Return.", nameof(varAbstract));
+                throw new JsonException("Property is required for class Return: abstract.");
 
             if (varLock.IsSet && varLock.Value == null)
-                throw new ArgumentNullException(nameof(varLock), "Property is not nullable for class Return.");
+                throw new JsonException("Property is not nullable for class Return: lock.");
 
             if (varReturn.IsSet && varReturn.Value == null)
-                throw new ArgumentNullException(nameof(varReturn), "Property is not nullable for class Return.");
+                throw new JsonException("Property is not nullable for class Return: return.");
 
             if (varUnsafe.IsSet && varUnsafe.Value == null)
-                throw new ArgumentNullException(nameof(varUnsafe), "Property is not nullable for class Return.");
+                throw new JsonException("Property is not nullable for class Return: unsafe.");
 
             return new Return(varLock.Value, varAbstract.Value, varReturn, varUnsafe);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (role.IsSet && role.Value == null)
-                throw new ArgumentNullException(nameof(role), "Property is not nullable for class RolesReportsHash.");
+                throw new JsonException("Property is not nullable for class RolesReportsHash: role.");
 
             if (roleUuid.IsSet && roleUuid.Value == null)
-                throw new ArgumentNullException(nameof(roleUuid), "Property is not nullable for class RolesReportsHash.");
+                throw new JsonException("Property is not nullable for class RolesReportsHash: role_uuid.");
 
             return new RolesReportsHash(role, roleUuid);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class RolesReportsHashRole.");
+                throw new JsonException("Property is not nullable for class RolesReportsHashRole: name.");
 
             return new RolesReportsHashRole(name);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
@@ -151,16 +151,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ScaleneTriangle.", nameof(shapeType));
+                throw new JsonException("Property is required for class ScaleneTriangle: shapeType.");
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class ScaleneTriangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class ScaleneTriangle: triangleType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ScaleneTriangle.");
+                throw new JsonException("Property is not nullable for class ScaleneTriangle: shapeType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class ScaleneTriangle.");
+                throw new JsonException("Property is not nullable for class ScaleneTriangle: triangleType.");
 
             return new ScaleneTriangle(shapeType.Value, triangleType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Shape.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Shape.cs
@@ -193,10 +193,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class Shape.", nameof(shapeType));
+                throw new JsonException("Property is required for class Shape: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class Shape.");
+                throw new JsonException("Property is not nullable for class Shape: shapeType.");
 
             if (quadrilateral != null)
                 return new Shape(quadrilateral);

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ShapeInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ShapeInterface.cs
@@ -138,10 +138,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ShapeInterface.", nameof(shapeType));
+                throw new JsonException("Property is required for class ShapeInterface: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ShapeInterface.");
+                throw new JsonException("Property is not nullable for class ShapeInterface: shapeType.");
 
             return new ShapeInterface(shapeType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ShapeOrNull.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ShapeOrNull.cs
@@ -193,10 +193,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ShapeOrNull.", nameof(shapeType));
+                throw new JsonException("Property is required for class ShapeOrNull: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ShapeOrNull.");
+                throw new JsonException("Property is not nullable for class ShapeOrNull: shapeType.");
 
             if (quadrilateral != null)
                 return new ShapeOrNull(quadrilateral);

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
@@ -151,16 +151,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class SimpleQuadrilateral.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class SimpleQuadrilateral: quadrilateralType.");
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class SimpleQuadrilateral.", nameof(shapeType));
+                throw new JsonException("Property is required for class SimpleQuadrilateral: shapeType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class SimpleQuadrilateral.");
+                throw new JsonException("Property is not nullable for class SimpleQuadrilateral: quadrilateralType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class SimpleQuadrilateral.");
+                throw new JsonException("Property is not nullable for class SimpleQuadrilateral: shapeType.");
 
             return new SimpleQuadrilateral(quadrilateralType.Value, shapeType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varSpecialModelName.IsSet && varSpecialModelName.Value == null)
-                throw new ArgumentNullException(nameof(varSpecialModelName), "Property is not nullable for class SpecialModelName.");
+                throw new JsonException("Property is not nullable for class SpecialModelName: _special_model.name_.");
 
             if (specialPropertyName.IsSet && specialPropertyName.Value == null)
-                throw new ArgumentNullException(nameof(specialPropertyName), "Property is not nullable for class SpecialModelName.");
+                throw new JsonException("Property is not nullable for class SpecialModelName: $special[property.name].");
 
             return new SpecialModelName(varSpecialModelName, specialPropertyName);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Tag.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Tag.");
+                throw new JsonException("Property is not nullable for class Tag: id.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Tag.");
+                throw new JsonException("Property is not nullable for class Tag: name.");
 
             return new Tag(id, name);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (value.IsSet && value.Value == null)
-                throw new ArgumentNullException(nameof(value), "Property is not nullable for class TestCollectionEndingWithWordList.");
+                throw new JsonException("Property is not nullable for class TestCollectionEndingWithWordList: value.");
 
             return new TestCollectionEndingWithWordList(value);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (testCollectionEndingWithWordList.IsSet && testCollectionEndingWithWordList.Value == null)
-                throw new ArgumentNullException(nameof(testCollectionEndingWithWordList), "Property is not nullable for class TestCollectionEndingWithWordListObject.");
+                throw new JsonException("Property is not nullable for class TestCollectionEndingWithWordListObject: TestCollectionEndingWithWordList.");
 
             return new TestCollectionEndingWithWordListObject(testCollectionEndingWithWordList);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/TestDescendants.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/TestDescendants.cs
@@ -168,16 +168,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!alternativeName.IsSet)
-                throw new ArgumentException("Property is required for class TestDescendants.", nameof(alternativeName));
+                throw new JsonException("Property is required for class TestDescendants: alternativeName.");
 
             if (!objectType.IsSet)
-                throw new ArgumentException("Property is required for class TestDescendants.", nameof(objectType));
+                throw new JsonException("Property is required for class TestDescendants: objectType.");
 
             if (alternativeName.IsSet && alternativeName.Value == null)
-                throw new ArgumentNullException(nameof(alternativeName), "Property is not nullable for class TestDescendants.");
+                throw new JsonException("Property is not nullable for class TestDescendants: alternativeName.");
 
             if (objectType.IsSet && objectType.Value == null)
-                throw new ArgumentNullException(nameof(objectType), "Property is not nullable for class TestDescendants.");
+                throw new JsonException("Property is not nullable for class TestDescendants: objectType.");
 
             return new TestDescendants(alternativeName.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (someProperty.IsSet && someProperty.Value == null)
-                throw new ArgumentNullException(nameof(someProperty), "Property is not nullable for class TestInlineFreeformAdditionalPropertiesRequest.");
+                throw new JsonException("Property is not nullable for class TestInlineFreeformAdditionalPropertiesRequest: someProperty.");
 
             return new TestInlineFreeformAdditionalPropertiesRequest(someProperty);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/TestResult.cs
@@ -187,13 +187,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (code.IsSet && code.Value == null)
-                throw new ArgumentNullException(nameof(code), "Property is not nullable for class TestResult.");
+                throw new JsonException("Property is not nullable for class TestResult: code.");
 
             if (data.IsSet && data.Value == null)
-                throw new ArgumentNullException(nameof(data), "Property is not nullable for class TestResult.");
+                throw new JsonException("Property is not nullable for class TestResult: data.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class TestResult.");
+                throw new JsonException("Property is not nullable for class TestResult: uuid.");
 
             return new TestResult(code, data, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Triangle.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Triangle.cs
@@ -214,10 +214,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class Triangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class Triangle: triangleType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class Triangle.");
+                throw new JsonException("Property is not nullable for class Triangle: triangleType.");
 
             if (equilateralTriangle != null)
                 return new Triangle(equilateralTriangle);

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/TriangleInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/TriangleInterface.cs
@@ -138,10 +138,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class TriangleInterface.", nameof(triangleType));
+                throw new JsonException("Property is required for class TriangleInterface: triangleType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class TriangleInterface.");
+                throw new JsonException("Property is not nullable for class TriangleInterface: triangleType.");
 
             return new TriangleInterface(triangleType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/User.cs
@@ -370,31 +370,31 @@ namespace Org.OpenAPITools.Model
             }
 
             if (email.IsSet && email.Value == null)
-                throw new ArgumentNullException(nameof(email), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: email.");
 
             if (firstName.IsSet && firstName.Value == null)
-                throw new ArgumentNullException(nameof(firstName), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: firstName.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: id.");
 
             if (lastName.IsSet && lastName.Value == null)
-                throw new ArgumentNullException(nameof(lastName), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: lastName.");
 
             if (objectWithNoDeclaredProps.IsSet && objectWithNoDeclaredProps.Value == null)
-                throw new ArgumentNullException(nameof(objectWithNoDeclaredProps), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: objectWithNoDeclaredProps.");
 
             if (password.IsSet && password.Value == null)
-                throw new ArgumentNullException(nameof(password), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: password.");
 
             if (phone.IsSet && phone.Value == null)
-                throw new ArgumentNullException(nameof(phone), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: phone.");
 
             if (userStatus.IsSet && userStatus.Value == null)
-                throw new ArgumentNullException(nameof(userStatus), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: userStatus.");
 
             if (username.IsSet && username.Value == null)
-                throw new ArgumentNullException(nameof(username), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: username.");
 
             return new User(anyTypeProp, anyTypePropNullable, email, firstName, id, lastName, objectWithNoDeclaredProps, objectWithNoDeclaredPropsNullable, password, phone, userStatus, username);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Whale.cs
@@ -178,16 +178,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Whale.", nameof(className));
+                throw new JsonException("Property is required for class Whale: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Whale.");
+                throw new JsonException("Property is not nullable for class Whale: className.");
 
             if (hasBaleen.IsSet && hasBaleen.Value == null)
-                throw new ArgumentNullException(nameof(hasBaleen), "Property is not nullable for class Whale.");
+                throw new JsonException("Property is not nullable for class Whale: hasBaleen.");
 
             if (hasTeeth.IsSet && hasTeeth.Value == null)
-                throw new ArgumentNullException(nameof(hasTeeth), "Property is not nullable for class Whale.");
+                throw new JsonException("Property is not nullable for class Whale: hasTeeth.");
 
             return new Whale(className.Value, hasBaleen, hasTeeth);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Zebra.cs
@@ -158,13 +158,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Zebra.", nameof(className));
+                throw new JsonException("Property is required for class Zebra: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Zebra.");
+                throw new JsonException("Property is not nullable for class Zebra: className.");
 
             if (type.IsSet && type.Value == null)
-                throw new ArgumentNullException(nameof(type), "Property is not nullable for class Zebra.");
+                throw new JsonException("Property is not nullable for class Zebra: type.");
 
             return new Zebra(className.Value, type);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (zeroBasedEnum.IsSet && zeroBasedEnum.Value == null)
-                throw new ArgumentNullException(nameof(zeroBasedEnum), "Property is not nullable for class ZeroBasedEnumClass.");
+                throw new JsonException("Property is not nullable for class ZeroBasedEnumClass: ZeroBasedEnum.");
 
             return new ZeroBasedEnumClass(zeroBasedEnum);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Activity.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (activityOutputs.IsSet && activityOutputs.Value == null)
-                throw new ArgumentNullException(nameof(activityOutputs), "Property is not nullable for class Activity.");
+                throw new JsonException("Property is not nullable for class Activity: activity_outputs.");
 
             return new Activity(activityOutputs);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -167,10 +167,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (prop1.IsSet && prop1.Value == null)
-                throw new ArgumentNullException(nameof(prop1), "Property is not nullable for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Property is not nullable for class ActivityOutputElementRepresentation: prop1.");
 
             if (prop2.IsSet && prop2.Value == null)
-                throw new ArgumentNullException(nameof(prop2), "Property is not nullable for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Property is not nullable for class ActivityOutputElementRepresentation: prop2.");
 
             return new ActivityOutputElementRepresentation(prop1, prop2);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -288,25 +288,25 @@ namespace Org.OpenAPITools.Model
             }
 
             if (emptyMap.IsSet && emptyMap.Value == null)
-                throw new ArgumentNullException(nameof(emptyMap), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: empty_map.");
 
             if (mapOfMapProperty.IsSet && mapOfMapProperty.Value == null)
-                throw new ArgumentNullException(nameof(mapOfMapProperty), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_of_map_property.");
 
             if (mapProperty.IsSet && mapProperty.Value == null)
-                throw new ArgumentNullException(nameof(mapProperty), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_property.");
 
             if (mapWithUndeclaredPropertiesAnytype1.IsSet && mapWithUndeclaredPropertiesAnytype1.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesAnytype1), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_anytype_1.");
 
             if (mapWithUndeclaredPropertiesAnytype2.IsSet && mapWithUndeclaredPropertiesAnytype2.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesAnytype2), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_anytype_2.");
 
             if (mapWithUndeclaredPropertiesAnytype3.IsSet && mapWithUndeclaredPropertiesAnytype3.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesAnytype3), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_anytype_3.");
 
             if (mapWithUndeclaredPropertiesString.IsSet && mapWithUndeclaredPropertiesString.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesString), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_string.");
 
             return new AdditionalPropertiesClass(anytype1, emptyMap, mapOfMapProperty, mapProperty, mapWithUndeclaredPropertiesAnytype1, mapWithUndeclaredPropertiesAnytype2, mapWithUndeclaredPropertiesAnytype3, mapWithUndeclaredPropertiesString);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Animal.cs
@@ -177,13 +177,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Animal.", nameof(className));
+                throw new JsonException("Property is required for class Animal: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Animal.");
+                throw new JsonException("Property is not nullable for class Animal: className.");
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Animal.");
+                throw new JsonException("Property is not nullable for class Animal: color.");
 
             return new Animal(color);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -187,13 +187,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (code.IsSet && code.Value == null)
-                throw new ArgumentNullException(nameof(code), "Property is not nullable for class ApiResponse.");
+                throw new JsonException("Property is not nullable for class ApiResponse: code.");
 
             if (message.IsSet && message.Value == null)
-                throw new ArgumentNullException(nameof(message), "Property is not nullable for class ApiResponse.");
+                throw new JsonException("Property is not nullable for class ApiResponse: message.");
 
             if (type.IsSet && type.Value == null)
-                throw new ArgumentNullException(nameof(type), "Property is not nullable for class ApiResponse.");
+                throw new JsonException("Property is not nullable for class ApiResponse: type.");
 
             return new ApiResponse(code, message, type);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Apple.cs
@@ -217,13 +217,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (colorCode.IsSet && colorCode.Value == null)
-                throw new ArgumentNullException(nameof(colorCode), "Property is not nullable for class Apple.");
+                throw new JsonException("Property is not nullable for class Apple: color_code.");
 
             if (cultivar.IsSet && cultivar.Value == null)
-                throw new ArgumentNullException(nameof(cultivar), "Property is not nullable for class Apple.");
+                throw new JsonException("Property is not nullable for class Apple: cultivar.");
 
             if (origin.IsSet && origin.Value == null)
-                throw new ArgumentNullException(nameof(origin), "Property is not nullable for class Apple.");
+                throw new JsonException("Property is not nullable for class Apple: origin.");
 
             return new Apple(colorCode, cultivar, origin);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -153,13 +153,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!cultivar.IsSet)
-                throw new ArgumentException("Property is required for class AppleReq.", nameof(cultivar));
+                throw new JsonException("Property is required for class AppleReq: cultivar.");
 
             if (cultivar.IsSet && cultivar.Value == null)
-                throw new ArgumentNullException(nameof(cultivar), "Property is not nullable for class AppleReq.");
+                throw new JsonException("Property is not nullable for class AppleReq: cultivar.");
 
             if (mealy.IsSet && mealy.Value == null)
-                throw new ArgumentNullException(nameof(mealy), "Property is not nullable for class AppleReq.");
+                throw new JsonException("Property is not nullable for class AppleReq: mealy.");
 
             return new AppleReq(cultivar.Value!, mealy);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayArrayNumber.IsSet && arrayArrayNumber.Value == null)
-                throw new ArgumentNullException(nameof(arrayArrayNumber), "Property is not nullable for class ArrayOfArrayOfNumberOnly.");
+                throw new JsonException("Property is not nullable for class ArrayOfArrayOfNumberOnly: ArrayArrayNumber.");
 
             return new ArrayOfArrayOfNumberOnly(arrayArrayNumber);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayNumber.IsSet && arrayNumber.Value == null)
-                throw new ArgumentNullException(nameof(arrayNumber), "Property is not nullable for class ArrayOfNumberOnly.");
+                throw new JsonException("Property is not nullable for class ArrayOfNumberOnly: ArrayNumber.");
 
             return new ArrayOfNumberOnly(arrayNumber);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -187,13 +187,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayArrayOfInteger.IsSet && arrayArrayOfInteger.Value == null)
-                throw new ArgumentNullException(nameof(arrayArrayOfInteger), "Property is not nullable for class ArrayTest.");
+                throw new JsonException("Property is not nullable for class ArrayTest: array_array_of_integer.");
 
             if (arrayArrayOfModel.IsSet && arrayArrayOfModel.Value == null)
-                throw new ArgumentNullException(nameof(arrayArrayOfModel), "Property is not nullable for class ArrayTest.");
+                throw new JsonException("Property is not nullable for class ArrayTest: array_array_of_model.");
 
             if (arrayOfString.IsSet && arrayOfString.Value == null)
-                throw new ArgumentNullException(nameof(arrayOfString), "Property is not nullable for class ArrayTest.");
+                throw new JsonException("Property is not nullable for class ArrayTest: array_of_string.");
 
             return new ArrayTest(arrayArrayOfInteger, arrayArrayOfModel, arrayOfString);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Banana.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (lengthCm.IsSet && lengthCm.Value == null)
-                throw new ArgumentNullException(nameof(lengthCm), "Property is not nullable for class Banana.");
+                throw new JsonException("Property is not nullable for class Banana: lengthCm.");
 
             return new Banana(lengthCm);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -153,13 +153,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!lengthCm.IsSet)
-                throw new ArgumentException("Property is required for class BananaReq.", nameof(lengthCm));
+                throw new JsonException("Property is required for class BananaReq: lengthCm.");
 
             if (lengthCm.IsSet && lengthCm.Value == null)
-                throw new ArgumentNullException(nameof(lengthCm), "Property is not nullable for class BananaReq.");
+                throw new JsonException("Property is not nullable for class BananaReq: lengthCm.");
 
             if (sweet.IsSet && sweet.Value == null)
-                throw new ArgumentNullException(nameof(sweet), "Property is not nullable for class BananaReq.");
+                throw new JsonException("Property is not nullable for class BananaReq: sweet.");
 
             return new BananaReq(lengthCm.Value!.Value!, sweet);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/BasquePig.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/BasquePig.cs
@@ -140,10 +140,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class BasquePig.", nameof(className));
+                throw new JsonException("Property is required for class BasquePig: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class BasquePig.");
+                throw new JsonException("Property is not nullable for class BasquePig: className.");
 
             return new BasquePig(className.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -248,22 +248,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (aTTNAME.IsSet && aTTNAME.Value == null)
-                throw new ArgumentNullException(nameof(aTTNAME), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: ATT_NAME.");
 
             if (capitalCamel.IsSet && capitalCamel.Value == null)
-                throw new ArgumentNullException(nameof(capitalCamel), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: CapitalCamel.");
 
             if (capitalSnake.IsSet && capitalSnake.Value == null)
-                throw new ArgumentNullException(nameof(capitalSnake), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: Capital_Snake.");
 
             if (sCAETHFlowPoints.IsSet && sCAETHFlowPoints.Value == null)
-                throw new ArgumentNullException(nameof(sCAETHFlowPoints), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: SCA_ETH_Flow_Points.");
 
             if (smallCamel.IsSet && smallCamel.Value == null)
-                throw new ArgumentNullException(nameof(smallCamel), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: smallCamel.");
 
             if (smallSnake.IsSet && smallSnake.Value == null)
-                throw new ArgumentNullException(nameof(smallSnake), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: small_Snake.");
 
             return new Capitalization(aTTNAME, capitalCamel, capitalSnake, sCAETHFlowPoints, smallCamel, smallSnake);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Cat.cs
@@ -140,16 +140,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Cat.", nameof(className));
+                throw new JsonException("Property is required for class Cat: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Cat.");
+                throw new JsonException("Property is not nullable for class Cat: className.");
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Cat.");
+                throw new JsonException("Property is not nullable for class Cat: color.");
 
             if (declawed.IsSet && declawed.Value == null)
-                throw new ArgumentNullException(nameof(declawed), "Property is not nullable for class Cat.");
+                throw new JsonException("Property is not nullable for class Cat: declawed.");
 
             return new Cat(color, declawed);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Category.cs
@@ -160,13 +160,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!name.IsSet)
-                throw new ArgumentException("Property is required for class Category.", nameof(name));
+                throw new JsonException("Property is required for class Category: name.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Category.");
+                throw new JsonException("Property is not nullable for class Category: id.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Category.");
+                throw new JsonException("Property is not nullable for class Category: name.");
 
             return new Category(id, name.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -202,13 +202,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!petType.IsSet)
-                throw new ArgumentException("Property is required for class ChildCat.", nameof(petType));
+                throw new JsonException("Property is required for class ChildCat: pet_type.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class ChildCat.");
+                throw new JsonException("Property is not nullable for class ChildCat: name.");
 
             if (petType.IsSet && petType.Value == null)
-                throw new ArgumentNullException(nameof(petType), "Property is not nullable for class ChildCat.");
+                throw new JsonException("Property is not nullable for class ChildCat: pet_type.");
 
             return new ChildCat(name);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varClass.IsSet && varClass.Value == null)
-                throw new ArgumentNullException(nameof(varClass), "Property is not nullable for class ClassModel.");
+                throw new JsonException("Property is not nullable for class ClassModel: _class.");
 
             return new ClassModel(varClass);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
@@ -153,16 +153,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class ComplexQuadrilateral.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class ComplexQuadrilateral: quadrilateralType.");
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ComplexQuadrilateral.", nameof(shapeType));
+                throw new JsonException("Property is required for class ComplexQuadrilateral: shapeType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class ComplexQuadrilateral.");
+                throw new JsonException("Property is not nullable for class ComplexQuadrilateral: quadrilateralType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ComplexQuadrilateral.");
+                throw new JsonException("Property is not nullable for class ComplexQuadrilateral: shapeType.");
 
             return new ComplexQuadrilateral(quadrilateralType.Value!, shapeType.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/CopyActivity.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/CopyActivity.cs
@@ -195,16 +195,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!copyActivitytt.IsSet)
-                throw new ArgumentException("Property is required for class CopyActivity.", nameof(copyActivitytt));
+                throw new JsonException("Property is required for class CopyActivity: copyActivitytt.");
 
             if (!schema.IsSet)
-                throw new ArgumentException("Property is required for class CopyActivity.", nameof(schema));
+                throw new JsonException("Property is required for class CopyActivity: $schema.");
 
             if (copyActivitytt.IsSet && copyActivitytt.Value == null)
-                throw new ArgumentNullException(nameof(copyActivitytt), "Property is not nullable for class CopyActivity.");
+                throw new JsonException("Property is not nullable for class CopyActivity: copyActivitytt.");
 
             if (schema.IsSet && schema.Value == null)
-                throw new ArgumentNullException(nameof(schema), "Property is not nullable for class CopyActivity.");
+                throw new JsonException("Property is not nullable for class CopyActivity: $schema.");
 
             return new CopyActivity(copyActivitytt.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/DanishPig.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/DanishPig.cs
@@ -140,10 +140,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class DanishPig.", nameof(className));
+                throw new JsonException("Property is required for class DanishPig: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class DanishPig.");
+                throw new JsonException("Property is not nullable for class DanishPig: className.");
 
             return new DanishPig(className.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -153,7 +153,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (dateOnlyProperty.IsSet && dateOnlyProperty.Value == null)
-                throw new ArgumentNullException(nameof(dateOnlyProperty), "Property is not nullable for class DateOnlyClass.");
+                throw new JsonException("Property is not nullable for class DateOnlyClass: dateOnlyProperty.");
 
             return new DateOnlyClass(dateOnlyProperty);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class DeprecatedObject.");
+                throw new JsonException("Property is not nullable for class DeprecatedObject: name.");
 
             return new DeprecatedObject(name);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Descendant1.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Descendant1.cs
@@ -140,22 +140,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!alternativeName.IsSet)
-                throw new ArgumentException("Property is required for class Descendant1.", nameof(alternativeName));
+                throw new JsonException("Property is required for class Descendant1: alternativeName.");
 
             if (!descendantName.IsSet)
-                throw new ArgumentException("Property is required for class Descendant1.", nameof(descendantName));
+                throw new JsonException("Property is required for class Descendant1: descendantName.");
 
             if (!objectType.IsSet)
-                throw new ArgumentException("Property is required for class Descendant1.", nameof(objectType));
+                throw new JsonException("Property is required for class Descendant1: objectType.");
 
             if (alternativeName.IsSet && alternativeName.Value == null)
-                throw new ArgumentNullException(nameof(alternativeName), "Property is not nullable for class Descendant1.");
+                throw new JsonException("Property is not nullable for class Descendant1: alternativeName.");
 
             if (descendantName.IsSet && descendantName.Value == null)
-                throw new ArgumentNullException(nameof(descendantName), "Property is not nullable for class Descendant1.");
+                throw new JsonException("Property is not nullable for class Descendant1: descendantName.");
 
             if (objectType.IsSet && objectType.Value == null)
-                throw new ArgumentNullException(nameof(objectType), "Property is not nullable for class Descendant1.");
+                throw new JsonException("Property is not nullable for class Descendant1: objectType.");
 
             return new Descendant1(alternativeName.Value!, descendantName.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Descendant2.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Descendant2.cs
@@ -140,22 +140,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!alternativeName.IsSet)
-                throw new ArgumentException("Property is required for class Descendant2.", nameof(alternativeName));
+                throw new JsonException("Property is required for class Descendant2: alternativeName.");
 
             if (!confidentiality.IsSet)
-                throw new ArgumentException("Property is required for class Descendant2.", nameof(confidentiality));
+                throw new JsonException("Property is required for class Descendant2: confidentiality.");
 
             if (!objectType.IsSet)
-                throw new ArgumentException("Property is required for class Descendant2.", nameof(objectType));
+                throw new JsonException("Property is required for class Descendant2: objectType.");
 
             if (alternativeName.IsSet && alternativeName.Value == null)
-                throw new ArgumentNullException(nameof(alternativeName), "Property is not nullable for class Descendant2.");
+                throw new JsonException("Property is not nullable for class Descendant2: alternativeName.");
 
             if (confidentiality.IsSet && confidentiality.Value == null)
-                throw new ArgumentNullException(nameof(confidentiality), "Property is not nullable for class Descendant2.");
+                throw new JsonException("Property is not nullable for class Descendant2: confidentiality.");
 
             if (objectType.IsSet && objectType.Value == null)
-                throw new ArgumentNullException(nameof(objectType), "Property is not nullable for class Descendant2.");
+                throw new JsonException("Property is not nullable for class Descendant2: objectType.");
 
             return new Descendant2(alternativeName.Value!, confidentiality.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Dog.cs
@@ -140,16 +140,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Dog.", nameof(className));
+                throw new JsonException("Property is required for class Dog: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Dog.");
+                throw new JsonException("Property is not nullable for class Dog: className.");
 
             if (breed.IsSet && breed.Value == null)
-                throw new ArgumentNullException(nameof(breed), "Property is not nullable for class Dog.");
+                throw new JsonException("Property is not nullable for class Dog: breed.");
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Dog.");
+                throw new JsonException("Property is not nullable for class Dog: color.");
 
             return new Dog(breed, color);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Drawing.cs
@@ -207,10 +207,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (mainShape.IsSet && mainShape.Value == null)
-                throw new ArgumentNullException(nameof(mainShape), "Property is not nullable for class Drawing.");
+                throw new JsonException("Property is not nullable for class Drawing: mainShape.");
 
             if (shapes.IsSet && shapes.Value == null)
-                throw new ArgumentNullException(nameof(shapes), "Property is not nullable for class Drawing.");
+                throw new JsonException("Property is not nullable for class Drawing: shapes.");
 
             return new Drawing(mainShape, nullableShape, shapeOrNull, shapes);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/EntityBase.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/EntityBase.cs
@@ -154,10 +154,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!schema.IsSet)
-                throw new ArgumentException("Property is required for class EntityBase.", nameof(schema));
+                throw new JsonException("Property is required for class EntityBase: $schema.");
 
             if (schema.IsSet && schema.Value == null)
-                throw new ArgumentNullException(nameof(schema), "Property is not nullable for class EntityBase.");
+                throw new JsonException("Property is not nullable for class EntityBase: $schema.");
 
             return new EntityBase();
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -306,10 +306,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayEnum.IsSet && arrayEnum.Value == null)
-                throw new ArgumentNullException(nameof(arrayEnum), "Property is not nullable for class EnumArrays.");
+                throw new JsonException("Property is not nullable for class EnumArrays: array_enum.");
 
             if (justSymbol.IsSet && justSymbol.Value == null)
-                throw new ArgumentNullException(nameof(justSymbol), "Property is not nullable for class EnumArrays.");
+                throw new JsonException("Property is not nullable for class EnumArrays: just_symbol.");
 
             return new EnumArrays(arrayEnum, justSymbol);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -824,31 +824,31 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!enumStringRequired.IsSet)
-                throw new ArgumentException("Property is required for class EnumTest.", nameof(enumStringRequired));
+                throw new JsonException("Property is required for class EnumTest: enum_string_required.");
 
             if (enumStringRequired.IsSet && enumStringRequired.Value == null)
-                throw new ArgumentNullException(nameof(enumStringRequired), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_string_required.");
 
             if (enumInteger.IsSet && enumInteger.Value == null)
-                throw new ArgumentNullException(nameof(enumInteger), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_integer.");
 
             if (enumIntegerOnly.IsSet && enumIntegerOnly.Value == null)
-                throw new ArgumentNullException(nameof(enumIntegerOnly), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_integer_only.");
 
             if (enumNumber.IsSet && enumNumber.Value == null)
-                throw new ArgumentNullException(nameof(enumNumber), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_number.");
 
             if (enumString.IsSet && enumString.Value == null)
-                throw new ArgumentNullException(nameof(enumString), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_string.");
 
             if (outerEnumDefaultValue.IsSet && outerEnumDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(outerEnumDefaultValue), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: outerEnumDefaultValue.");
 
             if (outerEnumInteger.IsSet && outerEnumInteger.Value == null)
-                throw new ArgumentNullException(nameof(outerEnumInteger), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: outerEnumInteger.");
 
             if (outerEnumIntegerDefaultValue.IsSet && outerEnumIntegerDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(outerEnumIntegerDefaultValue), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: outerEnumIntegerDefaultValue.");
 
             return new EnumTest(enumStringRequired.Value!.Value!, enumInteger, enumIntegerOnly, enumNumber, enumString, outerEnum, outerEnumDefaultValue, outerEnumInteger, outerEnumIntegerDefaultValue);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
@@ -153,16 +153,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class EquilateralTriangle.", nameof(shapeType));
+                throw new JsonException("Property is required for class EquilateralTriangle: shapeType.");
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class EquilateralTriangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class EquilateralTriangle: triangleType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class EquilateralTriangle.");
+                throw new JsonException("Property is not nullable for class EquilateralTriangle: shapeType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class EquilateralTriangle.");
+                throw new JsonException("Property is not nullable for class EquilateralTriangle: triangleType.");
 
             return new EquilateralTriangle(shapeType.Value!, triangleType.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/File.cs
@@ -148,7 +148,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (sourceURI.IsSet && sourceURI.Value == null)
-                throw new ArgumentNullException(nameof(sourceURI), "Property is not nullable for class File.");
+                throw new JsonException("Property is not nullable for class File: sourceURI.");
 
             return new File(sourceURI);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -167,10 +167,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (file.IsSet && file.Value == null)
-                throw new ArgumentNullException(nameof(file), "Property is not nullable for class FileSchemaTestClass.");
+                throw new JsonException("Property is not nullable for class FileSchemaTestClass: file.");
 
             if (files.IsSet && files.Value == null)
-                throw new ArgumentNullException(nameof(files), "Property is not nullable for class FileSchemaTestClass.");
+                throw new JsonException("Property is not nullable for class FileSchemaTestClass: files.");
 
             return new FileSchemaTestClass(file, files);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Foo.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bar.IsSet && bar.Value == null)
-                throw new ArgumentNullException(nameof(bar), "Property is not nullable for class Foo.");
+                throw new JsonException("Property is not nullable for class Foo: bar.");
 
             return new Foo(bar);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varString.IsSet && varString.Value == null)
-                throw new ArgumentNullException(nameof(varString), "Property is not nullable for class FooGetDefaultResponse.");
+                throw new JsonException("Property is not nullable for class FooGetDefaultResponse: string.");
 
             return new FooGetDefaultResponse(varString);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -828,103 +828,103 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!varByte.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(varByte));
+                throw new JsonException("Property is required for class FormatTest: byte.");
 
             if (!date.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(date));
+                throw new JsonException("Property is required for class FormatTest: date.");
 
             if (!number.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(number));
+                throw new JsonException("Property is required for class FormatTest: number.");
 
             if (!password.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(password));
+                throw new JsonException("Property is required for class FormatTest: password.");
 
             if (!stringFormattedAsDecimalRequired.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(stringFormattedAsDecimalRequired));
+                throw new JsonException("Property is required for class FormatTest: string_formatted_as_decimal_required.");
 
             if (varByte.IsSet && varByte.Value == null)
-                throw new ArgumentNullException(nameof(varByte), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: byte.");
 
             if (date.IsSet && date.Value == null)
-                throw new ArgumentNullException(nameof(date), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: date.");
 
             if (number.IsSet && number.Value == null)
-                throw new ArgumentNullException(nameof(number), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: number.");
 
             if (password.IsSet && password.Value == null)
-                throw new ArgumentNullException(nameof(password), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: password.");
 
             if (stringFormattedAsDecimalRequired.IsSet && stringFormattedAsDecimalRequired.Value == null)
-                throw new ArgumentNullException(nameof(stringFormattedAsDecimalRequired), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: string_formatted_as_decimal_required.");
 
             if (binary.IsSet && binary.Value == null)
-                throw new ArgumentNullException(nameof(binary), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: binary.");
 
             if (dateTime.IsSet && dateTime.Value == null)
-                throw new ArgumentNullException(nameof(dateTime), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: dateTime.");
 
             if (varDecimal.IsSet && varDecimal.Value == null)
-                throw new ArgumentNullException(nameof(varDecimal), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: decimal.");
 
             if (varDouble.IsSet && varDouble.Value == null)
-                throw new ArgumentNullException(nameof(varDouble), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: double.");
 
             if (duplicatePropertyName2.IsSet && duplicatePropertyName2.Value == null)
-                throw new ArgumentNullException(nameof(duplicatePropertyName2), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: duplicate_property_name.");
 
             if (duplicatePropertyName.IsSet && duplicatePropertyName.Value == null)
-                throw new ArgumentNullException(nameof(duplicatePropertyName), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: @duplicate_property_name.");
 
             if (varFloat.IsSet && varFloat.Value == null)
-                throw new ArgumentNullException(nameof(varFloat), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: float.");
 
             if (int32.IsSet && int32.Value == null)
-                throw new ArgumentNullException(nameof(int32), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int32.");
 
             if (int32Range.IsSet && int32Range.Value == null)
-                throw new ArgumentNullException(nameof(int32Range), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int32Range.");
 
             if (int64.IsSet && int64.Value == null)
-                throw new ArgumentNullException(nameof(int64), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64.");
 
             if (int64Negative.IsSet && int64Negative.Value == null)
-                throw new ArgumentNullException(nameof(int64Negative), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64Negative.");
 
             if (int64NegativeExclusive.IsSet && int64NegativeExclusive.Value == null)
-                throw new ArgumentNullException(nameof(int64NegativeExclusive), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64NegativeExclusive.");
 
             if (int64Positive.IsSet && int64Positive.Value == null)
-                throw new ArgumentNullException(nameof(int64Positive), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64Positive.");
 
             if (int64PositiveExclusive.IsSet && int64PositiveExclusive.Value == null)
-                throw new ArgumentNullException(nameof(int64PositiveExclusive), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64PositiveExclusive.");
 
             if (integer.IsSet && integer.Value == null)
-                throw new ArgumentNullException(nameof(integer), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: integer.");
 
             if (patternWithBackslash.IsSet && patternWithBackslash.Value == null)
-                throw new ArgumentNullException(nameof(patternWithBackslash), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: pattern_with_backslash.");
 
             if (patternWithDigits.IsSet && patternWithDigits.Value == null)
-                throw new ArgumentNullException(nameof(patternWithDigits), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: pattern_with_digits.");
 
             if (patternWithDigitsAndDelimiter.IsSet && patternWithDigitsAndDelimiter.Value == null)
-                throw new ArgumentNullException(nameof(patternWithDigitsAndDelimiter), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: pattern_with_digits_and_delimiter.");
 
             if (varString.IsSet && varString.Value == null)
-                throw new ArgumentNullException(nameof(varString), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: string.");
 
             if (stringFormattedAsDecimal.IsSet && stringFormattedAsDecimal.Value == null)
-                throw new ArgumentNullException(nameof(stringFormattedAsDecimal), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: string_formatted_as_decimal.");
 
             if (unsignedInteger.IsSet && unsignedInteger.Value == null)
-                throw new ArgumentNullException(nameof(unsignedInteger), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: unsigned_integer.");
 
             if (unsignedLong.IsSet && unsignedLong.Value == null)
-                throw new ArgumentNullException(nameof(unsignedLong), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: unsigned_long.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: uuid.");
 
             return new FormatTest(varByte.Value!, date.Value!.Value!, number.Value!.Value!, password.Value!, stringFormattedAsDecimalRequired.Value!.Value!, binary, dateTime, varDecimal, varDouble, duplicatePropertyName2, duplicatePropertyName, varFloat, int32, int32Range, int64, int64Negative, int64NegativeExclusive, int64Positive, int64PositiveExclusive, integer, patternWithBackslash, patternWithDigits, patternWithDigitsAndDelimiter, varString, stringFormattedAsDecimal, unsignedInteger, unsignedLong, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Fruit.cs
@@ -185,7 +185,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Fruit.");
+                throw new JsonException("Property is not nullable for class Fruit: color.");
 
             if (apple != null)
                 return new Fruit(apple, color);

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -189,7 +189,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class GmFruit.");
+                throw new JsonException("Property is not nullable for class GmFruit: color.");
 
             Option<Apple?> appleParsedValue = apple == null
                 ? default

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
@@ -157,10 +157,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!petType.IsSet)
-                throw new ArgumentException("Property is required for class GrandparentAnimal.", nameof(petType));
+                throw new JsonException("Property is required for class GrandparentAnimal: pet_type.");
 
             if (petType.IsSet && petType.Value == null)
-                throw new ArgumentNullException(nameof(petType), "Property is not nullable for class GrandparentAnimal.");
+                throw new JsonException("Property is not nullable for class GrandparentAnimal: pet_type.");
 
             return new GrandparentAnimal();
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -208,10 +208,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bar.IsSet && bar.Value == null)
-                throw new ArgumentNullException(nameof(bar), "Property is not nullable for class HasOnlyReadOnly.");
+                throw new JsonException("Property is not nullable for class HasOnlyReadOnly: bar.");
 
             if (foo.IsSet && foo.Value == null)
-                throw new ArgumentNullException(nameof(foo), "Property is not nullable for class HasOnlyReadOnly.");
+                throw new JsonException("Property is not nullable for class HasOnlyReadOnly: foo.");
 
             return new HasOnlyReadOnly(bar, foo);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
@@ -294,22 +294,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (potentiallyOverriddenPropertyAccessor.IsSet && potentiallyOverriddenPropertyAccessor.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyAccessor), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyAccessor.");
 
             if (potentiallyOverriddenPropertyToInternal.IsSet && potentiallyOverriddenPropertyToInternal.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyToInternal), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyToInternal.");
 
             if (potentiallyOverriddenPropertyToPrivate.IsSet && potentiallyOverriddenPropertyToPrivate.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyToPrivate), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyToPrivate.");
 
             if (potentiallyOverriddenPropertyToPublic.IsSet && potentiallyOverriddenPropertyToPublic.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyToPublic), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyToPublic.");
 
             if (unalteredProperty.IsSet && unalteredProperty.Value == null)
-                throw new ArgumentNullException(nameof(unalteredProperty), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: unalteredProperty.");
 
             if (unalteredPropertyAccessor.IsSet && unalteredPropertyAccessor.Value == null)
-                throw new ArgumentNullException(nameof(unalteredPropertyAccessor), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: unalteredPropertyAccessor.");
 
             return new InjectedVendorExtensionsTest(potentiallyOverriddenPropertyAccessor, potentiallyOverriddenPropertyToInternal, potentiallyOverriddenPropertyToPrivate, potentiallyOverriddenPropertyToPublic, unalteredProperty, unalteredPropertyAccessor);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
@@ -146,16 +146,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class IsoscelesTriangle.", nameof(shapeType));
+                throw new JsonException("Property is required for class IsoscelesTriangle: shapeType.");
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class IsoscelesTriangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class IsoscelesTriangle: triangleType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class IsoscelesTriangle.");
+                throw new JsonException("Property is not nullable for class IsoscelesTriangle: shapeType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class IsoscelesTriangle.");
+                throw new JsonException("Property is not nullable for class IsoscelesTriangle: triangleType.");
 
             return new IsoscelesTriangle(shapeType.Value!, triangleType.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/List.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (var123List.IsSet && var123List.Value == null)
-                throw new ArgumentNullException(nameof(var123List), "Property is not nullable for class List.");
+                throw new JsonException("Property is not nullable for class List: 123-list.");
 
             return new List(var123List);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -167,10 +167,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (escapedLiteralString.IsSet && escapedLiteralString.Value == null)
-                throw new ArgumentNullException(nameof(escapedLiteralString), "Property is not nullable for class LiteralStringClass.");
+                throw new JsonException("Property is not nullable for class LiteralStringClass: escapedLiteralString.");
 
             if (unescapedLiteralString.IsSet && unescapedLiteralString.Value == null)
-                throw new ArgumentNullException(nameof(unescapedLiteralString), "Property is not nullable for class LiteralStringClass.");
+                throw new JsonException("Property is not nullable for class LiteralStringClass: unescapedLiteralString.");
 
             return new LiteralStringClass(escapedLiteralString, unescapedLiteralString);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Mammal.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Mammal.cs
@@ -216,10 +216,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Mammal.", nameof(className));
+                throw new JsonException("Property is required for class Mammal: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Mammal.");
+                throw new JsonException("Property is not nullable for class Mammal: className.");
 
             if (pig != null)
                 return new Mammal(pig);

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/MapTest.cs
@@ -273,16 +273,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (directMap.IsSet && directMap.Value == null)
-                throw new ArgumentNullException(nameof(directMap), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: direct_map.");
 
             if (indirectMap.IsSet && indirectMap.Value == null)
-                throw new ArgumentNullException(nameof(indirectMap), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: indirect_map.");
 
             if (mapMapOfString.IsSet && mapMapOfString.Value == null)
-                throw new ArgumentNullException(nameof(mapMapOfString), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: map_map_of_string.");
 
             if (mapOfEnumString.IsSet && mapOfEnumString.Value == null)
-                throw new ArgumentNullException(nameof(mapOfEnumString), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: map_of_enum_string.");
 
             return new MapTest(directMap, indirectMap, mapMapOfString, mapOfEnumString);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedAnyOf.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedAnyOf.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (content.IsSet && content.Value == null)
-                throw new ArgumentNullException(nameof(content), "Property is not nullable for class MixedAnyOf.");
+                throw new JsonException("Property is not nullable for class MixedAnyOf: content.");
 
             return new MixedAnyOf(content);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedOneOf.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedOneOf.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (content.IsSet && content.Value == null)
-                throw new ArgumentNullException(nameof(content), "Property is not nullable for class MixedOneOf.");
+                throw new JsonException("Property is not nullable for class MixedOneOf: content.");
 
             return new MixedOneOf(content);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -219,16 +219,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (dateTime.IsSet && dateTime.Value == null)
-                throw new ArgumentNullException(nameof(dateTime), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: dateTime.");
 
             if (map.IsSet && map.Value == null)
-                throw new ArgumentNullException(nameof(map), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: map.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: uuid.");
 
             if (uuidWithPattern.IsSet && uuidWithPattern.Value == null)
-                throw new ArgumentNullException(nameof(uuidWithPattern), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: uuid_with_pattern.");
 
             return new MixedPropertiesAndAdditionalPropertiesClass(dateTime, map, uuid, uuidWithPattern);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedSubId.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedSubId.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class MixedSubId.");
+                throw new JsonException("Property is not nullable for class MixedSubId: id.");
 
             return new MixedSubId(id);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -167,10 +167,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varClass.IsSet && varClass.Value == null)
-                throw new ArgumentNullException(nameof(varClass), "Property is not nullable for class Model200Response.");
+                throw new JsonException("Property is not nullable for class Model200Response: class.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Model200Response.");
+                throw new JsonException("Property is not nullable for class Model200Response: name.");
 
             return new Model200Response(varClass, name);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varClient.IsSet && varClient.Value == null)
-                throw new ArgumentNullException(nameof(varClient), "Property is not nullable for class ModelClient.");
+                throw new JsonException("Property is not nullable for class ModelClient: client.");
 
             return new ModelClient(varClient);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Name.cs
@@ -241,19 +241,19 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!varName.IsSet)
-                throw new ArgumentException("Property is required for class Name.", nameof(varName));
+                throw new JsonException("Property is required for class Name: name.");
 
             if (varName.IsSet && varName.Value == null)
-                throw new ArgumentNullException(nameof(varName), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: name.");
 
             if (property.IsSet && property.Value == null)
-                throw new ArgumentNullException(nameof(property), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: property.");
 
             if (snakeCase.IsSet && snakeCase.Value == null)
-                throw new ArgumentNullException(nameof(snakeCase), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: snake_case.");
 
             if (var123Number.IsSet && var123Number.Value == null)
-                throw new ArgumentNullException(nameof(var123Number), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: 123Number.");
 
             return new Name(varName.Value!.Value!, property, snakeCase, var123Number);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
@@ -153,16 +153,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!aObjVariableobject.IsSet)
-                throw new ArgumentException("Property is required for class NotificationtestGetElementsV1ResponseMPayload.", nameof(aObjVariableobject));
+                throw new JsonException("Property is required for class NotificationtestGetElementsV1ResponseMPayload: a_objVariableobject.");
 
             if (!pkiNotificationtestID.IsSet)
-                throw new ArgumentException("Property is required for class NotificationtestGetElementsV1ResponseMPayload.", nameof(pkiNotificationtestID));
+                throw new JsonException("Property is required for class NotificationtestGetElementsV1ResponseMPayload: pkiNotificationtestID.");
 
             if (aObjVariableobject.IsSet && aObjVariableobject.Value == null)
-                throw new ArgumentNullException(nameof(aObjVariableobject), "Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload.");
+                throw new JsonException("Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload: a_objVariableobject.");
 
             if (pkiNotificationtestID.IsSet && pkiNotificationtestID.Value == null)
-                throw new ArgumentNullException(nameof(pkiNotificationtestID), "Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload.");
+                throw new JsonException("Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload: pkiNotificationtestID.");
 
             return new NotificationtestGetElementsV1ResponseMPayload(aObjVariableobject.Value!, pkiNotificationtestID.Value!.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -377,10 +377,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayItemsNullable.IsSet && arrayItemsNullable.Value == null)
-                throw new ArgumentNullException(nameof(arrayItemsNullable), "Property is not nullable for class NullableClass.");
+                throw new JsonException("Property is not nullable for class NullableClass: array_items_nullable.");
 
             if (objectItemsNullable.IsSet && objectItemsNullable.Value == null)
-                throw new ArgumentNullException(nameof(objectItemsNullable), "Property is not nullable for class NullableClass.");
+                throw new JsonException("Property is not nullable for class NullableClass: object_items_nullable.");
 
             return new NullableClass(arrayAndItemsNullableProp, arrayItemsNullable, arrayNullableProp, booleanProp, dateProp, datetimeProp, integerProp, numberProp, objectAndItemsNullableProp, objectItemsNullable, objectNullableProp, stringProp);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/NullableShape.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/NullableShape.cs
@@ -195,10 +195,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class NullableShape.", nameof(shapeType));
+                throw new JsonException("Property is required for class NullableShape: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class NullableShape.");
+                throw new JsonException("Property is not nullable for class NullableShape: shapeType.");
 
             if (quadrilateral != null)
                 return new NullableShape(quadrilateral);

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (justNumber.IsSet && justNumber.Value == null)
-                throw new ArgumentNullException(nameof(justNumber), "Property is not nullable for class NumberOnly.");
+                throw new JsonException("Property is not nullable for class NumberOnly: JustNumber.");
 
             return new NumberOnly(justNumber);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -210,16 +210,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bars.IsSet && bars.Value == null)
-                throw new ArgumentNullException(nameof(bars), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: bars.");
 
             if (deprecatedRef.IsSet && deprecatedRef.Value == null)
-                throw new ArgumentNullException(nameof(deprecatedRef), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: deprecatedRef.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: id.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: uuid.");
 
             return new ObjectWithDeprecatedFields(bars, deprecatedRef, id, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Order.cs
@@ -342,22 +342,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (complete.IsSet && complete.Value == null)
-                throw new ArgumentNullException(nameof(complete), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: complete.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: id.");
 
             if (petId.IsSet && petId.Value == null)
-                throw new ArgumentNullException(nameof(petId), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: petId.");
 
             if (quantity.IsSet && quantity.Value == null)
-                throw new ArgumentNullException(nameof(quantity), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: quantity.");
 
             if (shipDate.IsSet && shipDate.Value == null)
-                throw new ArgumentNullException(nameof(shipDate), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: shipDate.");
 
             if (status.IsSet && status.Value == null)
-                throw new ArgumentNullException(nameof(status), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: status.");
 
             return new Order(complete, id, petId, quantity, shipDate, status);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -187,13 +187,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (myBoolean.IsSet && myBoolean.Value == null)
-                throw new ArgumentNullException(nameof(myBoolean), "Property is not nullable for class OuterComposite.");
+                throw new JsonException("Property is not nullable for class OuterComposite: my_boolean.");
 
             if (myNumber.IsSet && myNumber.Value == null)
-                throw new ArgumentNullException(nameof(myNumber), "Property is not nullable for class OuterComposite.");
+                throw new JsonException("Property is not nullable for class OuterComposite: my_number.");
 
             if (myString.IsSet && myString.Value == null)
-                throw new ArgumentNullException(nameof(myString), "Property is not nullable for class OuterComposite.");
+                throw new JsonException("Property is not nullable for class OuterComposite: my_string.");
 
             return new OuterComposite(myBoolean, myNumber, myString);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ParentPet.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ParentPet.cs
@@ -120,10 +120,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!petType.IsSet)
-                throw new ArgumentException("Property is required for class ParentPet.", nameof(petType));
+                throw new JsonException("Property is required for class ParentPet: pet_type.");
 
             if (petType.IsSet && petType.Value == null)
-                throw new ArgumentNullException(nameof(petType), "Property is not nullable for class ParentPet.");
+                throw new JsonException("Property is not nullable for class ParentPet: pet_type.");
 
             return new ParentPet();
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Pet.cs
@@ -323,28 +323,28 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!name.IsSet)
-                throw new ArgumentException("Property is required for class Pet.", nameof(name));
+                throw new JsonException("Property is required for class Pet: name.");
 
             if (!photoUrls.IsSet)
-                throw new ArgumentException("Property is required for class Pet.", nameof(photoUrls));
+                throw new JsonException("Property is required for class Pet: photoUrls.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: name.");
 
             if (photoUrls.IsSet && photoUrls.Value == null)
-                throw new ArgumentNullException(nameof(photoUrls), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: photoUrls.");
 
             if (category.IsSet && category.Value == null)
-                throw new ArgumentNullException(nameof(category), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: category.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: id.");
 
             if (status.IsSet && status.Value == null)
-                throw new ArgumentNullException(nameof(status), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: status.");
 
             if (tags.IsSet && tags.Value == null)
-                throw new ArgumentNullException(nameof(tags), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: tags.");
 
             return new Pet(name.Value!, photoUrls.Value!, category, id, status, tags);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Pig.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Pig.cs
@@ -195,10 +195,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Pig.", nameof(className));
+                throw new JsonException("Property is required for class Pig: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Pig.");
+                throw new JsonException("Property is not nullable for class Pig: className.");
 
             if (basquePig != null)
                 return new Pig(basquePig);

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Quadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Quadrilateral.cs
@@ -195,10 +195,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class Quadrilateral.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class Quadrilateral: quadrilateralType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class Quadrilateral.");
+                throw new JsonException("Property is not nullable for class Quadrilateral: quadrilateralType.");
 
             if (complexQuadrilateral != null)
                 return new Quadrilateral(complexQuadrilateral);

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
@@ -140,10 +140,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class QuadrilateralInterface.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class QuadrilateralInterface: quadrilateralType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class QuadrilateralInterface.");
+                throw new JsonException("Property is not nullable for class QuadrilateralInterface: quadrilateralType.");
 
             return new QuadrilateralInterface(quadrilateralType.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -205,10 +205,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bar.IsSet && bar.Value == null)
-                throw new ArgumentNullException(nameof(bar), "Property is not nullable for class ReadOnlyFirst.");
+                throw new JsonException("Property is not nullable for class ReadOnlyFirst: bar.");
 
             if (baz.IsSet && baz.Value == null)
-                throw new ArgumentNullException(nameof(baz), "Property is not nullable for class ReadOnlyFirst.");
+                throw new JsonException("Property is not nullable for class ReadOnlyFirst: baz.");
 
             return new ReadOnlyFirst(bar, baz);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -2079,136 +2079,136 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!requiredNotNullableDateProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotNullableDateProp));
+                throw new JsonException("Property is required for class RequiredClass: required_not_nullable_date_prop.");
 
             if (!requiredNotnullableArrayOfString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableArrayOfString));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_array_of_string.");
 
             if (!requiredNotnullableBooleanProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableBooleanProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_boolean_prop.");
 
             if (!requiredNotnullableDatetimeProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableDatetimeProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_datetime_prop.");
 
             if (!requiredNotnullableEnumInteger.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableEnumInteger));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_enum_integer.");
 
             if (!requiredNotnullableEnumIntegerOnly.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableEnumIntegerOnly));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_enum_integer_only.");
 
             if (!requiredNotnullableEnumString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableEnumString));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_enum_string.");
 
             if (!requiredNotnullableOuterEnumDefaultValue.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableOuterEnumDefaultValue));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_outerEnumDefaultValue.");
 
             if (!requiredNotnullableStringProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableStringProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_string_prop.");
 
             if (!requiredNotnullableUuid.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableUuid));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_uuid.");
 
             if (!requiredNotnullableintegerProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableintegerProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullableinteger_prop.");
 
             if (!requiredNullableArrayOfString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableArrayOfString));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_array_of_string.");
 
             if (!requiredNullableBooleanProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableBooleanProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_boolean_prop.");
 
             if (!requiredNullableDateProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableDateProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_date_prop.");
 
             if (!requiredNullableDatetimeProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableDatetimeProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_datetime_prop.");
 
             if (!requiredNullableEnumInteger.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableEnumInteger));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_enum_integer.");
 
             if (!requiredNullableEnumIntegerOnly.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableEnumIntegerOnly));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_enum_integer_only.");
 
             if (!requiredNullableEnumString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableEnumString));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_enum_string.");
 
             if (!requiredNullableIntegerProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableIntegerProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_integer_prop.");
 
             if (!requiredNullableOuterEnumDefaultValue.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableOuterEnumDefaultValue));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_outerEnumDefaultValue.");
 
             if (!requiredNullableStringProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableStringProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_string_prop.");
 
             if (!requiredNullableUuid.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableUuid));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_uuid.");
 
             if (requiredNotNullableDateProp.IsSet && requiredNotNullableDateProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotNullableDateProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_not_nullable_date_prop.");
 
             if (requiredNotnullableArrayOfString.IsSet && requiredNotnullableArrayOfString.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableArrayOfString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_array_of_string.");
 
             if (requiredNotnullableBooleanProp.IsSet && requiredNotnullableBooleanProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableBooleanProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_boolean_prop.");
 
             if (requiredNotnullableDatetimeProp.IsSet && requiredNotnullableDatetimeProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableDatetimeProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_datetime_prop.");
 
             if (requiredNotnullableEnumInteger.IsSet && requiredNotnullableEnumInteger.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableEnumInteger), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_enum_integer.");
 
             if (requiredNotnullableEnumIntegerOnly.IsSet && requiredNotnullableEnumIntegerOnly.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableEnumIntegerOnly), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_enum_integer_only.");
 
             if (requiredNotnullableEnumString.IsSet && requiredNotnullableEnumString.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableEnumString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_enum_string.");
 
             if (requiredNotnullableOuterEnumDefaultValue.IsSet && requiredNotnullableOuterEnumDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableOuterEnumDefaultValue), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_outerEnumDefaultValue.");
 
             if (requiredNotnullableStringProp.IsSet && requiredNotnullableStringProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableStringProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_string_prop.");
 
             if (requiredNotnullableUuid.IsSet && requiredNotnullableUuid.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableUuid), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_uuid.");
 
             if (requiredNotnullableintegerProp.IsSet && requiredNotnullableintegerProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableintegerProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullableinteger_prop.");
 
             if (notRequiredNotnullableDateProp.IsSet && notRequiredNotnullableDateProp.Value == null)
-                throw new ArgumentNullException(nameof(notRequiredNotnullableDateProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: not_required_notnullable_date_prop.");
 
             if (notRequiredNotnullableintegerProp.IsSet && notRequiredNotnullableintegerProp.Value == null)
-                throw new ArgumentNullException(nameof(notRequiredNotnullableintegerProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: not_required_notnullableinteger_prop.");
 
             if (notrequiredNotnullableArrayOfString.IsSet && notrequiredNotnullableArrayOfString.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableArrayOfString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_array_of_string.");
 
             if (notrequiredNotnullableBooleanProp.IsSet && notrequiredNotnullableBooleanProp.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableBooleanProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_boolean_prop.");
 
             if (notrequiredNotnullableDatetimeProp.IsSet && notrequiredNotnullableDatetimeProp.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableDatetimeProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_datetime_prop.");
 
             if (notrequiredNotnullableEnumInteger.IsSet && notrequiredNotnullableEnumInteger.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableEnumInteger), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_enum_integer.");
 
             if (notrequiredNotnullableEnumIntegerOnly.IsSet && notrequiredNotnullableEnumIntegerOnly.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableEnumIntegerOnly), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_enum_integer_only.");
 
             if (notrequiredNotnullableEnumString.IsSet && notrequiredNotnullableEnumString.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableEnumString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_enum_string.");
 
             if (notrequiredNotnullableOuterEnumDefaultValue.IsSet && notrequiredNotnullableOuterEnumDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableOuterEnumDefaultValue), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_outerEnumDefaultValue.");
 
             if (notrequiredNotnullableStringProp.IsSet && notrequiredNotnullableStringProp.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableStringProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_string_prop.");
 
             if (notrequiredNotnullableUuid.IsSet && notrequiredNotnullableUuid.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableUuid), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_uuid.");
 
             return new RequiredClass(requiredNotNullableDateProp.Value!.Value!, requiredNotnullableArrayOfString.Value!, requiredNotnullableBooleanProp.Value!.Value!, requiredNotnullableDatetimeProp.Value!.Value!, requiredNotnullableEnumInteger.Value!.Value!, requiredNotnullableEnumIntegerOnly.Value!.Value!, requiredNotnullableEnumString.Value!.Value!, requiredNotnullableOuterEnumDefaultValue.Value!.Value!, requiredNotnullableStringProp.Value!, requiredNotnullableUuid.Value!.Value!, requiredNotnullableintegerProp.Value!.Value!, notRequiredNotnullableDateProp, notRequiredNotnullableintegerProp, notRequiredNullableDateProp, notRequiredNullableIntegerProp, notrequiredNotnullableArrayOfString, notrequiredNotnullableBooleanProp, notrequiredNotnullableDatetimeProp, notrequiredNotnullableEnumInteger, notrequiredNotnullableEnumIntegerOnly, notrequiredNotnullableEnumString, notrequiredNotnullableOuterEnumDefaultValue, notrequiredNotnullableStringProp, notrequiredNotnullableUuid, notrequiredNullableArrayOfString, notrequiredNullableBooleanProp, notrequiredNullableDatetimeProp, notrequiredNullableEnumInteger, notrequiredNullableEnumIntegerOnly, notrequiredNullableEnumString, notrequiredNullableOuterEnumDefaultValue, notrequiredNullableStringProp, notrequiredNullableUuid, requiredNullableArrayOfString.Value!, requiredNullableBooleanProp.Value!, requiredNullableDateProp.Value!, requiredNullableDatetimeProp.Value!, requiredNullableEnumInteger.Value!, requiredNullableEnumIntegerOnly.Value!, requiredNullableEnumString.Value!, requiredNullableIntegerProp.Value!, requiredNullableOuterEnumDefaultValue.Value!, requiredNullableStringProp.Value!, requiredNullableUuid.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Result.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Result.cs
@@ -190,13 +190,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (code.IsSet && code.Value == null)
-                throw new ArgumentNullException(nameof(code), "Property is not nullable for class Result.");
+                throw new JsonException("Property is not nullable for class Result: code.");
 
             if (data.IsSet && data.Value == null)
-                throw new ArgumentNullException(nameof(data), "Property is not nullable for class Result.");
+                throw new JsonException("Property is not nullable for class Result: data.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class Result.");
+                throw new JsonException("Property is not nullable for class Result: uuid.");
 
             return new Result(code, data, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Return.cs
@@ -193,19 +193,19 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!varLock.IsSet)
-                throw new ArgumentException("Property is required for class Return.", nameof(varLock));
+                throw new JsonException("Property is required for class Return: lock.");
 
             if (!varAbstract.IsSet)
-                throw new ArgumentException("Property is required for class Return.", nameof(varAbstract));
+                throw new JsonException("Property is required for class Return: abstract.");
 
             if (varLock.IsSet && varLock.Value == null)
-                throw new ArgumentNullException(nameof(varLock), "Property is not nullable for class Return.");
+                throw new JsonException("Property is not nullable for class Return: lock.");
 
             if (varReturn.IsSet && varReturn.Value == null)
-                throw new ArgumentNullException(nameof(varReturn), "Property is not nullable for class Return.");
+                throw new JsonException("Property is not nullable for class Return: return.");
 
             if (varUnsafe.IsSet && varUnsafe.Value == null)
-                throw new ArgumentNullException(nameof(varUnsafe), "Property is not nullable for class Return.");
+                throw new JsonException("Property is not nullable for class Return: unsafe.");
 
             return new Return(varLock.Value!, varAbstract.Value!, varReturn, varUnsafe);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -167,10 +167,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (role.IsSet && role.Value == null)
-                throw new ArgumentNullException(nameof(role), "Property is not nullable for class RolesReportsHash.");
+                throw new JsonException("Property is not nullable for class RolesReportsHash: role.");
 
             if (roleUuid.IsSet && roleUuid.Value == null)
-                throw new ArgumentNullException(nameof(roleUuid), "Property is not nullable for class RolesReportsHash.");
+                throw new JsonException("Property is not nullable for class RolesReportsHash: role_uuid.");
 
             return new RolesReportsHash(role, roleUuid);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class RolesReportsHashRole.");
+                throw new JsonException("Property is not nullable for class RolesReportsHashRole: name.");
 
             return new RolesReportsHashRole(name);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
@@ -153,16 +153,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ScaleneTriangle.", nameof(shapeType));
+                throw new JsonException("Property is required for class ScaleneTriangle: shapeType.");
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class ScaleneTriangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class ScaleneTriangle: triangleType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ScaleneTriangle.");
+                throw new JsonException("Property is not nullable for class ScaleneTriangle: shapeType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class ScaleneTriangle.");
+                throw new JsonException("Property is not nullable for class ScaleneTriangle: triangleType.");
 
             return new ScaleneTriangle(shapeType.Value!, triangleType.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Shape.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Shape.cs
@@ -195,10 +195,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class Shape.", nameof(shapeType));
+                throw new JsonException("Property is required for class Shape: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class Shape.");
+                throw new JsonException("Property is not nullable for class Shape: shapeType.");
 
             if (quadrilateral != null)
                 return new Shape(quadrilateral);

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ShapeInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ShapeInterface.cs
@@ -140,10 +140,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ShapeInterface.", nameof(shapeType));
+                throw new JsonException("Property is required for class ShapeInterface: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ShapeInterface.");
+                throw new JsonException("Property is not nullable for class ShapeInterface: shapeType.");
 
             return new ShapeInterface(shapeType.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ShapeOrNull.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ShapeOrNull.cs
@@ -195,10 +195,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ShapeOrNull.", nameof(shapeType));
+                throw new JsonException("Property is required for class ShapeOrNull: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ShapeOrNull.");
+                throw new JsonException("Property is not nullable for class ShapeOrNull: shapeType.");
 
             if (quadrilateral != null)
                 return new ShapeOrNull(quadrilateral);

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
@@ -153,16 +153,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class SimpleQuadrilateral.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class SimpleQuadrilateral: quadrilateralType.");
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class SimpleQuadrilateral.", nameof(shapeType));
+                throw new JsonException("Property is required for class SimpleQuadrilateral: shapeType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class SimpleQuadrilateral.");
+                throw new JsonException("Property is not nullable for class SimpleQuadrilateral: quadrilateralType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class SimpleQuadrilateral.");
+                throw new JsonException("Property is not nullable for class SimpleQuadrilateral: shapeType.");
 
             return new SimpleQuadrilateral(quadrilateralType.Value!, shapeType.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -167,10 +167,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varSpecialModelName.IsSet && varSpecialModelName.Value == null)
-                throw new ArgumentNullException(nameof(varSpecialModelName), "Property is not nullable for class SpecialModelName.");
+                throw new JsonException("Property is not nullable for class SpecialModelName: _special_model.name_.");
 
             if (specialPropertyName.IsSet && specialPropertyName.Value == null)
-                throw new ArgumentNullException(nameof(specialPropertyName), "Property is not nullable for class SpecialModelName.");
+                throw new JsonException("Property is not nullable for class SpecialModelName: $special[property.name].");
 
             return new SpecialModelName(varSpecialModelName, specialPropertyName);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Tag.cs
@@ -167,10 +167,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Tag.");
+                throw new JsonException("Property is not nullable for class Tag: id.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Tag.");
+                throw new JsonException("Property is not nullable for class Tag: name.");
 
             return new Tag(id, name);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (value.IsSet && value.Value == null)
-                throw new ArgumentNullException(nameof(value), "Property is not nullable for class TestCollectionEndingWithWordList.");
+                throw new JsonException("Property is not nullable for class TestCollectionEndingWithWordList: value.");
 
             return new TestCollectionEndingWithWordList(value);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (testCollectionEndingWithWordList.IsSet && testCollectionEndingWithWordList.Value == null)
-                throw new ArgumentNullException(nameof(testCollectionEndingWithWordList), "Property is not nullable for class TestCollectionEndingWithWordListObject.");
+                throw new JsonException("Property is not nullable for class TestCollectionEndingWithWordListObject: TestCollectionEndingWithWordList.");
 
             return new TestCollectionEndingWithWordListObject(testCollectionEndingWithWordList);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/TestDescendants.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/TestDescendants.cs
@@ -243,16 +243,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!alternativeName.IsSet)
-                throw new ArgumentException("Property is required for class TestDescendants.", nameof(alternativeName));
+                throw new JsonException("Property is required for class TestDescendants: alternativeName.");
 
             if (!objectType.IsSet)
-                throw new ArgumentException("Property is required for class TestDescendants.", nameof(objectType));
+                throw new JsonException("Property is required for class TestDescendants: objectType.");
 
             if (alternativeName.IsSet && alternativeName.Value == null)
-                throw new ArgumentNullException(nameof(alternativeName), "Property is not nullable for class TestDescendants.");
+                throw new JsonException("Property is not nullable for class TestDescendants: alternativeName.");
 
             if (objectType.IsSet && objectType.Value == null)
-                throw new ArgumentNullException(nameof(objectType), "Property is not nullable for class TestDescendants.");
+                throw new JsonException("Property is not nullable for class TestDescendants: objectType.");
 
             return new TestDescendants(alternativeName.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (someProperty.IsSet && someProperty.Value == null)
-                throw new ArgumentNullException(nameof(someProperty), "Property is not nullable for class TestInlineFreeformAdditionalPropertiesRequest.");
+                throw new JsonException("Property is not nullable for class TestInlineFreeformAdditionalPropertiesRequest: someProperty.");
 
             return new TestInlineFreeformAdditionalPropertiesRequest(someProperty);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/TestResult.cs
@@ -189,13 +189,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (code.IsSet && code.Value == null)
-                throw new ArgumentNullException(nameof(code), "Property is not nullable for class TestResult.");
+                throw new JsonException("Property is not nullable for class TestResult: code.");
 
             if (data.IsSet && data.Value == null)
-                throw new ArgumentNullException(nameof(data), "Property is not nullable for class TestResult.");
+                throw new JsonException("Property is not nullable for class TestResult: data.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class TestResult.");
+                throw new JsonException("Property is not nullable for class TestResult: uuid.");
 
             return new TestResult(code, data, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Triangle.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Triangle.cs
@@ -216,10 +216,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class Triangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class Triangle: triangleType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class Triangle.");
+                throw new JsonException("Property is not nullable for class Triangle: triangleType.");
 
             if (equilateralTriangle != null)
                 return new Triangle(equilateralTriangle);

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/TriangleInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/TriangleInterface.cs
@@ -140,10 +140,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class TriangleInterface.", nameof(triangleType));
+                throw new JsonException("Property is required for class TriangleInterface: triangleType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class TriangleInterface.");
+                throw new JsonException("Property is not nullable for class TriangleInterface: triangleType.");
 
             return new TriangleInterface(triangleType.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/User.cs
@@ -372,31 +372,31 @@ namespace Org.OpenAPITools.Model
             }
 
             if (email.IsSet && email.Value == null)
-                throw new ArgumentNullException(nameof(email), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: email.");
 
             if (firstName.IsSet && firstName.Value == null)
-                throw new ArgumentNullException(nameof(firstName), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: firstName.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: id.");
 
             if (lastName.IsSet && lastName.Value == null)
-                throw new ArgumentNullException(nameof(lastName), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: lastName.");
 
             if (objectWithNoDeclaredProps.IsSet && objectWithNoDeclaredProps.Value == null)
-                throw new ArgumentNullException(nameof(objectWithNoDeclaredProps), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: objectWithNoDeclaredProps.");
 
             if (password.IsSet && password.Value == null)
-                throw new ArgumentNullException(nameof(password), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: password.");
 
             if (phone.IsSet && phone.Value == null)
-                throw new ArgumentNullException(nameof(phone), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: phone.");
 
             if (userStatus.IsSet && userStatus.Value == null)
-                throw new ArgumentNullException(nameof(userStatus), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: userStatus.");
 
             if (username.IsSet && username.Value == null)
-                throw new ArgumentNullException(nameof(username), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: username.");
 
             return new User(anyTypeProp, anyTypePropNullable, email, firstName, id, lastName, objectWithNoDeclaredProps, objectWithNoDeclaredPropsNullable, password, phone, userStatus, username);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Whale.cs
@@ -180,16 +180,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Whale.", nameof(className));
+                throw new JsonException("Property is required for class Whale: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Whale.");
+                throw new JsonException("Property is not nullable for class Whale: className.");
 
             if (hasBaleen.IsSet && hasBaleen.Value == null)
-                throw new ArgumentNullException(nameof(hasBaleen), "Property is not nullable for class Whale.");
+                throw new JsonException("Property is not nullable for class Whale: hasBaleen.");
 
             if (hasTeeth.IsSet && hasTeeth.Value == null)
-                throw new ArgumentNullException(nameof(hasTeeth), "Property is not nullable for class Whale.");
+                throw new JsonException("Property is not nullable for class Whale: hasTeeth.");
 
             return new Whale(className.Value!, hasBaleen, hasTeeth);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Zebra.cs
@@ -247,13 +247,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Zebra.", nameof(className));
+                throw new JsonException("Property is required for class Zebra: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Zebra.");
+                throw new JsonException("Property is not nullable for class Zebra: className.");
 
             if (type.IsSet && type.Value == null)
-                throw new ArgumentNullException(nameof(type), "Property is not nullable for class Zebra.");
+                throw new JsonException("Property is not nullable for class Zebra: type.");
 
             return new Zebra(className.Value!, type);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
@@ -220,7 +220,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (zeroBasedEnum.IsSet && zeroBasedEnum.Value == null)
-                throw new ArgumentNullException(nameof(zeroBasedEnum), "Property is not nullable for class ZeroBasedEnumClass.");
+                throw new JsonException("Property is not nullable for class ZeroBasedEnumClass: ZeroBasedEnum.");
 
             return new ZeroBasedEnumClass(zeroBasedEnum);
         }

--- a/samples/client/petstore/csharp/generichost/net10/OneOf/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net10/OneOf/src/Org.OpenAPITools/Model/Apple.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (kind.IsSet && kind.Value == null)
-                throw new ArgumentNullException(nameof(kind), "Property is not nullable for class Apple.");
+                throw new JsonException("Property is not nullable for class Apple: kind.");
 
             return new Apple(kind);
         }

--- a/samples/client/petstore/csharp/generichost/net10/OneOf/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net10/OneOf/src/Org.OpenAPITools/Model/Banana.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (count.IsSet && count.Value == null)
-                throw new ArgumentNullException(nameof(count), "Property is not nullable for class Banana.");
+                throw new JsonException("Property is not nullable for class Banana: count.");
 
             return new Banana(count);
         }

--- a/samples/client/petstore/csharp/generichost/net10/OneOf/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net10/OneOf/src/Org.OpenAPITools/Model/Fruit.cs
@@ -213,7 +213,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Fruit.");
+                throw new JsonException("Property is not nullable for class Fruit: color.");
 
             if (apple != null)
                 return new Fruit(apple, color);

--- a/samples/client/petstore/csharp/generichost/net10/OneOf/src/Org.OpenAPITools/Model/Orange.cs
+++ b/samples/client/petstore/csharp/generichost/net10/OneOf/src/Org.OpenAPITools/Model/Orange.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (sweet.IsSet && sweet.Value == null)
-                throw new ArgumentNullException(nameof(sweet), "Property is not nullable for class Orange.");
+                throw new JsonException("Property is not nullable for class Orange: sweet.");
 
             return new Orange(sweet);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Activity.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (activityOutputs.IsSet && activityOutputs.Value == null)
-                throw new ArgumentNullException(nameof(activityOutputs), "Property is not nullable for class Activity.");
+                throw new JsonException("Property is not nullable for class Activity: activity_outputs.");
 
             return new Activity(activityOutputs);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (prop1.IsSet && prop1.Value == null)
-                throw new ArgumentNullException(nameof(prop1), "Property is not nullable for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Property is not nullable for class ActivityOutputElementRepresentation: prop1.");
 
             if (prop2.IsSet && prop2.Value == null)
-                throw new ArgumentNullException(nameof(prop2), "Property is not nullable for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Property is not nullable for class ActivityOutputElementRepresentation: prop2.");
 
             return new ActivityOutputElementRepresentation(prop1, prop2);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -286,25 +286,25 @@ namespace Org.OpenAPITools.Model
             }
 
             if (emptyMap.IsSet && emptyMap.Value == null)
-                throw new ArgumentNullException(nameof(emptyMap), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: empty_map.");
 
             if (mapOfMapProperty.IsSet && mapOfMapProperty.Value == null)
-                throw new ArgumentNullException(nameof(mapOfMapProperty), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_of_map_property.");
 
             if (mapProperty.IsSet && mapProperty.Value == null)
-                throw new ArgumentNullException(nameof(mapProperty), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_property.");
 
             if (mapWithUndeclaredPropertiesAnytype1.IsSet && mapWithUndeclaredPropertiesAnytype1.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesAnytype1), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_anytype_1.");
 
             if (mapWithUndeclaredPropertiesAnytype2.IsSet && mapWithUndeclaredPropertiesAnytype2.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesAnytype2), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_anytype_2.");
 
             if (mapWithUndeclaredPropertiesAnytype3.IsSet && mapWithUndeclaredPropertiesAnytype3.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesAnytype3), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_anytype_3.");
 
             if (mapWithUndeclaredPropertiesString.IsSet && mapWithUndeclaredPropertiesString.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesString), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_string.");
 
             return new AdditionalPropertiesClass(anytype1, emptyMap, mapOfMapProperty, mapProperty, mapWithUndeclaredPropertiesAnytype1, mapWithUndeclaredPropertiesAnytype2, mapWithUndeclaredPropertiesAnytype3, mapWithUndeclaredPropertiesString);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Animal.cs
@@ -175,13 +175,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Animal.", nameof(className));
+                throw new JsonException("Property is required for class Animal: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Animal.");
+                throw new JsonException("Property is not nullable for class Animal: className.");
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Animal.");
+                throw new JsonException("Property is not nullable for class Animal: color.");
 
             return new Animal(color);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -185,13 +185,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (code.IsSet && code.Value == null)
-                throw new ArgumentNullException(nameof(code), "Property is not nullable for class ApiResponse.");
+                throw new JsonException("Property is not nullable for class ApiResponse: code.");
 
             if (message.IsSet && message.Value == null)
-                throw new ArgumentNullException(nameof(message), "Property is not nullable for class ApiResponse.");
+                throw new JsonException("Property is not nullable for class ApiResponse: message.");
 
             if (type.IsSet && type.Value == null)
-                throw new ArgumentNullException(nameof(type), "Property is not nullable for class ApiResponse.");
+                throw new JsonException("Property is not nullable for class ApiResponse: type.");
 
             return new ApiResponse(code, message, type);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Apple.cs
@@ -215,13 +215,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (colorCode.IsSet && colorCode.Value == null)
-                throw new ArgumentNullException(nameof(colorCode), "Property is not nullable for class Apple.");
+                throw new JsonException("Property is not nullable for class Apple: color_code.");
 
             if (cultivar.IsSet && cultivar.Value == null)
-                throw new ArgumentNullException(nameof(cultivar), "Property is not nullable for class Apple.");
+                throw new JsonException("Property is not nullable for class Apple: cultivar.");
 
             if (origin.IsSet && origin.Value == null)
-                throw new ArgumentNullException(nameof(origin), "Property is not nullable for class Apple.");
+                throw new JsonException("Property is not nullable for class Apple: origin.");
 
             return new Apple(colorCode, cultivar, origin);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -151,13 +151,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!cultivar.IsSet)
-                throw new ArgumentException("Property is required for class AppleReq.", nameof(cultivar));
+                throw new JsonException("Property is required for class AppleReq: cultivar.");
 
             if (cultivar.IsSet && cultivar.Value == null)
-                throw new ArgumentNullException(nameof(cultivar), "Property is not nullable for class AppleReq.");
+                throw new JsonException("Property is not nullable for class AppleReq: cultivar.");
 
             if (mealy.IsSet && mealy.Value == null)
-                throw new ArgumentNullException(nameof(mealy), "Property is not nullable for class AppleReq.");
+                throw new JsonException("Property is not nullable for class AppleReq: mealy.");
 
             return new AppleReq(cultivar.Value, mealy);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayArrayNumber.IsSet && arrayArrayNumber.Value == null)
-                throw new ArgumentNullException(nameof(arrayArrayNumber), "Property is not nullable for class ArrayOfArrayOfNumberOnly.");
+                throw new JsonException("Property is not nullable for class ArrayOfArrayOfNumberOnly: ArrayArrayNumber.");
 
             return new ArrayOfArrayOfNumberOnly(arrayArrayNumber);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayNumber.IsSet && arrayNumber.Value == null)
-                throw new ArgumentNullException(nameof(arrayNumber), "Property is not nullable for class ArrayOfNumberOnly.");
+                throw new JsonException("Property is not nullable for class ArrayOfNumberOnly: ArrayNumber.");
 
             return new ArrayOfNumberOnly(arrayNumber);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -185,13 +185,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayArrayOfInteger.IsSet && arrayArrayOfInteger.Value == null)
-                throw new ArgumentNullException(nameof(arrayArrayOfInteger), "Property is not nullable for class ArrayTest.");
+                throw new JsonException("Property is not nullable for class ArrayTest: array_array_of_integer.");
 
             if (arrayArrayOfModel.IsSet && arrayArrayOfModel.Value == null)
-                throw new ArgumentNullException(nameof(arrayArrayOfModel), "Property is not nullable for class ArrayTest.");
+                throw new JsonException("Property is not nullable for class ArrayTest: array_array_of_model.");
 
             if (arrayOfString.IsSet && arrayOfString.Value == null)
-                throw new ArgumentNullException(nameof(arrayOfString), "Property is not nullable for class ArrayTest.");
+                throw new JsonException("Property is not nullable for class ArrayTest: array_of_string.");
 
             return new ArrayTest(arrayArrayOfInteger, arrayArrayOfModel, arrayOfString);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Banana.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (lengthCm.IsSet && lengthCm.Value == null)
-                throw new ArgumentNullException(nameof(lengthCm), "Property is not nullable for class Banana.");
+                throw new JsonException("Property is not nullable for class Banana: lengthCm.");
 
             return new Banana(lengthCm);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -151,13 +151,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!lengthCm.IsSet)
-                throw new ArgumentException("Property is required for class BananaReq.", nameof(lengthCm));
+                throw new JsonException("Property is required for class BananaReq: lengthCm.");
 
             if (lengthCm.IsSet && lengthCm.Value == null)
-                throw new ArgumentNullException(nameof(lengthCm), "Property is not nullable for class BananaReq.");
+                throw new JsonException("Property is not nullable for class BananaReq: lengthCm.");
 
             if (sweet.IsSet && sweet.Value == null)
-                throw new ArgumentNullException(nameof(sweet), "Property is not nullable for class BananaReq.");
+                throw new JsonException("Property is not nullable for class BananaReq: sweet.");
 
             return new BananaReq(lengthCm.Value.Value, sweet);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/BasquePig.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/BasquePig.cs
@@ -138,10 +138,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class BasquePig.", nameof(className));
+                throw new JsonException("Property is required for class BasquePig: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class BasquePig.");
+                throw new JsonException("Property is not nullable for class BasquePig: className.");
 
             return new BasquePig(className.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -246,22 +246,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (aTTNAME.IsSet && aTTNAME.Value == null)
-                throw new ArgumentNullException(nameof(aTTNAME), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: ATT_NAME.");
 
             if (capitalCamel.IsSet && capitalCamel.Value == null)
-                throw new ArgumentNullException(nameof(capitalCamel), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: CapitalCamel.");
 
             if (capitalSnake.IsSet && capitalSnake.Value == null)
-                throw new ArgumentNullException(nameof(capitalSnake), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: Capital_Snake.");
 
             if (sCAETHFlowPoints.IsSet && sCAETHFlowPoints.Value == null)
-                throw new ArgumentNullException(nameof(sCAETHFlowPoints), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: SCA_ETH_Flow_Points.");
 
             if (smallCamel.IsSet && smallCamel.Value == null)
-                throw new ArgumentNullException(nameof(smallCamel), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: smallCamel.");
 
             if (smallSnake.IsSet && smallSnake.Value == null)
-                throw new ArgumentNullException(nameof(smallSnake), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: small_Snake.");
 
             return new Capitalization(aTTNAME, capitalCamel, capitalSnake, sCAETHFlowPoints, smallCamel, smallSnake);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Cat.cs
@@ -138,16 +138,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Cat.", nameof(className));
+                throw new JsonException("Property is required for class Cat: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Cat.");
+                throw new JsonException("Property is not nullable for class Cat: className.");
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Cat.");
+                throw new JsonException("Property is not nullable for class Cat: color.");
 
             if (declawed.IsSet && declawed.Value == null)
-                throw new ArgumentNullException(nameof(declawed), "Property is not nullable for class Cat.");
+                throw new JsonException("Property is not nullable for class Cat: declawed.");
 
             return new Cat(color, declawed);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Category.cs
@@ -158,13 +158,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!name.IsSet)
-                throw new ArgumentException("Property is required for class Category.", nameof(name));
+                throw new JsonException("Property is required for class Category: name.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Category.");
+                throw new JsonException("Property is not nullable for class Category: id.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Category.");
+                throw new JsonException("Property is not nullable for class Category: name.");
 
             return new Category(id, name.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -200,13 +200,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!petType.IsSet)
-                throw new ArgumentException("Property is required for class ChildCat.", nameof(petType));
+                throw new JsonException("Property is required for class ChildCat: pet_type.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class ChildCat.");
+                throw new JsonException("Property is not nullable for class ChildCat: name.");
 
             if (petType.IsSet && petType.Value == null)
-                throw new ArgumentNullException(nameof(petType), "Property is not nullable for class ChildCat.");
+                throw new JsonException("Property is not nullable for class ChildCat: pet_type.");
 
             return new ChildCat(name);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varClass.IsSet && varClass.Value == null)
-                throw new ArgumentNullException(nameof(varClass), "Property is not nullable for class ClassModel.");
+                throw new JsonException("Property is not nullable for class ClassModel: _class.");
 
             return new ClassModel(varClass);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
@@ -151,16 +151,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class ComplexQuadrilateral.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class ComplexQuadrilateral: quadrilateralType.");
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ComplexQuadrilateral.", nameof(shapeType));
+                throw new JsonException("Property is required for class ComplexQuadrilateral: shapeType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class ComplexQuadrilateral.");
+                throw new JsonException("Property is not nullable for class ComplexQuadrilateral: quadrilateralType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ComplexQuadrilateral.");
+                throw new JsonException("Property is not nullable for class ComplexQuadrilateral: shapeType.");
 
             return new ComplexQuadrilateral(quadrilateralType.Value, shapeType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/CopyActivity.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/CopyActivity.cs
@@ -193,16 +193,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!copyActivitytt.IsSet)
-                throw new ArgumentException("Property is required for class CopyActivity.", nameof(copyActivitytt));
+                throw new JsonException("Property is required for class CopyActivity: copyActivitytt.");
 
             if (!schema.IsSet)
-                throw new ArgumentException("Property is required for class CopyActivity.", nameof(schema));
+                throw new JsonException("Property is required for class CopyActivity: $schema.");
 
             if (copyActivitytt.IsSet && copyActivitytt.Value == null)
-                throw new ArgumentNullException(nameof(copyActivitytt), "Property is not nullable for class CopyActivity.");
+                throw new JsonException("Property is not nullable for class CopyActivity: copyActivitytt.");
 
             if (schema.IsSet && schema.Value == null)
-                throw new ArgumentNullException(nameof(schema), "Property is not nullable for class CopyActivity.");
+                throw new JsonException("Property is not nullable for class CopyActivity: $schema.");
 
             return new CopyActivity(copyActivitytt.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/DanishPig.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/DanishPig.cs
@@ -138,10 +138,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class DanishPig.", nameof(className));
+                throw new JsonException("Property is required for class DanishPig: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class DanishPig.");
+                throw new JsonException("Property is not nullable for class DanishPig: className.");
 
             return new DanishPig(className.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -151,7 +151,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (dateOnlyProperty.IsSet && dateOnlyProperty.Value == null)
-                throw new ArgumentNullException(nameof(dateOnlyProperty), "Property is not nullable for class DateOnlyClass.");
+                throw new JsonException("Property is not nullable for class DateOnlyClass: dateOnlyProperty.");
 
             return new DateOnlyClass(dateOnlyProperty);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class DeprecatedObject.");
+                throw new JsonException("Property is not nullable for class DeprecatedObject: name.");
 
             return new DeprecatedObject(name);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Descendant1.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Descendant1.cs
@@ -138,22 +138,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!alternativeName.IsSet)
-                throw new ArgumentException("Property is required for class Descendant1.", nameof(alternativeName));
+                throw new JsonException("Property is required for class Descendant1: alternativeName.");
 
             if (!descendantName.IsSet)
-                throw new ArgumentException("Property is required for class Descendant1.", nameof(descendantName));
+                throw new JsonException("Property is required for class Descendant1: descendantName.");
 
             if (!objectType.IsSet)
-                throw new ArgumentException("Property is required for class Descendant1.", nameof(objectType));
+                throw new JsonException("Property is required for class Descendant1: objectType.");
 
             if (alternativeName.IsSet && alternativeName.Value == null)
-                throw new ArgumentNullException(nameof(alternativeName), "Property is not nullable for class Descendant1.");
+                throw new JsonException("Property is not nullable for class Descendant1: alternativeName.");
 
             if (descendantName.IsSet && descendantName.Value == null)
-                throw new ArgumentNullException(nameof(descendantName), "Property is not nullable for class Descendant1.");
+                throw new JsonException("Property is not nullable for class Descendant1: descendantName.");
 
             if (objectType.IsSet && objectType.Value == null)
-                throw new ArgumentNullException(nameof(objectType), "Property is not nullable for class Descendant1.");
+                throw new JsonException("Property is not nullable for class Descendant1: objectType.");
 
             return new Descendant1(alternativeName.Value, descendantName.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Descendant2.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Descendant2.cs
@@ -138,22 +138,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!alternativeName.IsSet)
-                throw new ArgumentException("Property is required for class Descendant2.", nameof(alternativeName));
+                throw new JsonException("Property is required for class Descendant2: alternativeName.");
 
             if (!confidentiality.IsSet)
-                throw new ArgumentException("Property is required for class Descendant2.", nameof(confidentiality));
+                throw new JsonException("Property is required for class Descendant2: confidentiality.");
 
             if (!objectType.IsSet)
-                throw new ArgumentException("Property is required for class Descendant2.", nameof(objectType));
+                throw new JsonException("Property is required for class Descendant2: objectType.");
 
             if (alternativeName.IsSet && alternativeName.Value == null)
-                throw new ArgumentNullException(nameof(alternativeName), "Property is not nullable for class Descendant2.");
+                throw new JsonException("Property is not nullable for class Descendant2: alternativeName.");
 
             if (confidentiality.IsSet && confidentiality.Value == null)
-                throw new ArgumentNullException(nameof(confidentiality), "Property is not nullable for class Descendant2.");
+                throw new JsonException("Property is not nullable for class Descendant2: confidentiality.");
 
             if (objectType.IsSet && objectType.Value == null)
-                throw new ArgumentNullException(nameof(objectType), "Property is not nullable for class Descendant2.");
+                throw new JsonException("Property is not nullable for class Descendant2: objectType.");
 
             return new Descendant2(alternativeName.Value, confidentiality.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Dog.cs
@@ -138,16 +138,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Dog.", nameof(className));
+                throw new JsonException("Property is required for class Dog: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Dog.");
+                throw new JsonException("Property is not nullable for class Dog: className.");
 
             if (breed.IsSet && breed.Value == null)
-                throw new ArgumentNullException(nameof(breed), "Property is not nullable for class Dog.");
+                throw new JsonException("Property is not nullable for class Dog: breed.");
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Dog.");
+                throw new JsonException("Property is not nullable for class Dog: color.");
 
             return new Dog(breed, color);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Drawing.cs
@@ -205,10 +205,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (mainShape.IsSet && mainShape.Value == null)
-                throw new ArgumentNullException(nameof(mainShape), "Property is not nullable for class Drawing.");
+                throw new JsonException("Property is not nullable for class Drawing: mainShape.");
 
             if (shapes.IsSet && shapes.Value == null)
-                throw new ArgumentNullException(nameof(shapes), "Property is not nullable for class Drawing.");
+                throw new JsonException("Property is not nullable for class Drawing: shapes.");
 
             return new Drawing(mainShape, nullableShape, shapeOrNull, shapes);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/EntityBase.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/EntityBase.cs
@@ -152,10 +152,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!schema.IsSet)
-                throw new ArgumentException("Property is required for class EntityBase.", nameof(schema));
+                throw new JsonException("Property is required for class EntityBase: $schema.");
 
             if (schema.IsSet && schema.Value == null)
-                throw new ArgumentNullException(nameof(schema), "Property is not nullable for class EntityBase.");
+                throw new JsonException("Property is not nullable for class EntityBase: $schema.");
 
             return new EntityBase();
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -304,10 +304,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayEnum.IsSet && arrayEnum.Value == null)
-                throw new ArgumentNullException(nameof(arrayEnum), "Property is not nullable for class EnumArrays.");
+                throw new JsonException("Property is not nullable for class EnumArrays: array_enum.");
 
             if (justSymbol.IsSet && justSymbol.Value == null)
-                throw new ArgumentNullException(nameof(justSymbol), "Property is not nullable for class EnumArrays.");
+                throw new JsonException("Property is not nullable for class EnumArrays: just_symbol.");
 
             return new EnumArrays(arrayEnum, justSymbol);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -822,31 +822,31 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!enumStringRequired.IsSet)
-                throw new ArgumentException("Property is required for class EnumTest.", nameof(enumStringRequired));
+                throw new JsonException("Property is required for class EnumTest: enum_string_required.");
 
             if (enumStringRequired.IsSet && enumStringRequired.Value == null)
-                throw new ArgumentNullException(nameof(enumStringRequired), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_string_required.");
 
             if (enumInteger.IsSet && enumInteger.Value == null)
-                throw new ArgumentNullException(nameof(enumInteger), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_integer.");
 
             if (enumIntegerOnly.IsSet && enumIntegerOnly.Value == null)
-                throw new ArgumentNullException(nameof(enumIntegerOnly), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_integer_only.");
 
             if (enumNumber.IsSet && enumNumber.Value == null)
-                throw new ArgumentNullException(nameof(enumNumber), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_number.");
 
             if (enumString.IsSet && enumString.Value == null)
-                throw new ArgumentNullException(nameof(enumString), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_string.");
 
             if (outerEnumDefaultValue.IsSet && outerEnumDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(outerEnumDefaultValue), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: outerEnumDefaultValue.");
 
             if (outerEnumInteger.IsSet && outerEnumInteger.Value == null)
-                throw new ArgumentNullException(nameof(outerEnumInteger), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: outerEnumInteger.");
 
             if (outerEnumIntegerDefaultValue.IsSet && outerEnumIntegerDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(outerEnumIntegerDefaultValue), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: outerEnumIntegerDefaultValue.");
 
             return new EnumTest(enumStringRequired.Value.Value, enumInteger, enumIntegerOnly, enumNumber, enumString, outerEnum, outerEnumDefaultValue, outerEnumInteger, outerEnumIntegerDefaultValue);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
@@ -151,16 +151,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class EquilateralTriangle.", nameof(shapeType));
+                throw new JsonException("Property is required for class EquilateralTriangle: shapeType.");
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class EquilateralTriangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class EquilateralTriangle: triangleType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class EquilateralTriangle.");
+                throw new JsonException("Property is not nullable for class EquilateralTriangle: shapeType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class EquilateralTriangle.");
+                throw new JsonException("Property is not nullable for class EquilateralTriangle: triangleType.");
 
             return new EquilateralTriangle(shapeType.Value, triangleType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/File.cs
@@ -146,7 +146,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (sourceURI.IsSet && sourceURI.Value == null)
-                throw new ArgumentNullException(nameof(sourceURI), "Property is not nullable for class File.");
+                throw new JsonException("Property is not nullable for class File: sourceURI.");
 
             return new File(sourceURI);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (file.IsSet && file.Value == null)
-                throw new ArgumentNullException(nameof(file), "Property is not nullable for class FileSchemaTestClass.");
+                throw new JsonException("Property is not nullable for class FileSchemaTestClass: file.");
 
             if (files.IsSet && files.Value == null)
-                throw new ArgumentNullException(nameof(files), "Property is not nullable for class FileSchemaTestClass.");
+                throw new JsonException("Property is not nullable for class FileSchemaTestClass: files.");
 
             return new FileSchemaTestClass(file, files);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Foo.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bar.IsSet && bar.Value == null)
-                throw new ArgumentNullException(nameof(bar), "Property is not nullable for class Foo.");
+                throw new JsonException("Property is not nullable for class Foo: bar.");
 
             return new Foo(bar);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varString.IsSet && varString.Value == null)
-                throw new ArgumentNullException(nameof(varString), "Property is not nullable for class FooGetDefaultResponse.");
+                throw new JsonException("Property is not nullable for class FooGetDefaultResponse: string.");
 
             return new FooGetDefaultResponse(varString);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -826,103 +826,103 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!varByte.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(varByte));
+                throw new JsonException("Property is required for class FormatTest: byte.");
 
             if (!date.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(date));
+                throw new JsonException("Property is required for class FormatTest: date.");
 
             if (!number.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(number));
+                throw new JsonException("Property is required for class FormatTest: number.");
 
             if (!password.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(password));
+                throw new JsonException("Property is required for class FormatTest: password.");
 
             if (!stringFormattedAsDecimalRequired.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(stringFormattedAsDecimalRequired));
+                throw new JsonException("Property is required for class FormatTest: string_formatted_as_decimal_required.");
 
             if (varByte.IsSet && varByte.Value == null)
-                throw new ArgumentNullException(nameof(varByte), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: byte.");
 
             if (date.IsSet && date.Value == null)
-                throw new ArgumentNullException(nameof(date), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: date.");
 
             if (number.IsSet && number.Value == null)
-                throw new ArgumentNullException(nameof(number), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: number.");
 
             if (password.IsSet && password.Value == null)
-                throw new ArgumentNullException(nameof(password), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: password.");
 
             if (stringFormattedAsDecimalRequired.IsSet && stringFormattedAsDecimalRequired.Value == null)
-                throw new ArgumentNullException(nameof(stringFormattedAsDecimalRequired), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: string_formatted_as_decimal_required.");
 
             if (binary.IsSet && binary.Value == null)
-                throw new ArgumentNullException(nameof(binary), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: binary.");
 
             if (dateTime.IsSet && dateTime.Value == null)
-                throw new ArgumentNullException(nameof(dateTime), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: dateTime.");
 
             if (varDecimal.IsSet && varDecimal.Value == null)
-                throw new ArgumentNullException(nameof(varDecimal), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: decimal.");
 
             if (varDouble.IsSet && varDouble.Value == null)
-                throw new ArgumentNullException(nameof(varDouble), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: double.");
 
             if (duplicatePropertyName2.IsSet && duplicatePropertyName2.Value == null)
-                throw new ArgumentNullException(nameof(duplicatePropertyName2), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: duplicate_property_name.");
 
             if (duplicatePropertyName.IsSet && duplicatePropertyName.Value == null)
-                throw new ArgumentNullException(nameof(duplicatePropertyName), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: @duplicate_property_name.");
 
             if (varFloat.IsSet && varFloat.Value == null)
-                throw new ArgumentNullException(nameof(varFloat), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: float.");
 
             if (int32.IsSet && int32.Value == null)
-                throw new ArgumentNullException(nameof(int32), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int32.");
 
             if (int32Range.IsSet && int32Range.Value == null)
-                throw new ArgumentNullException(nameof(int32Range), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int32Range.");
 
             if (int64.IsSet && int64.Value == null)
-                throw new ArgumentNullException(nameof(int64), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64.");
 
             if (int64Negative.IsSet && int64Negative.Value == null)
-                throw new ArgumentNullException(nameof(int64Negative), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64Negative.");
 
             if (int64NegativeExclusive.IsSet && int64NegativeExclusive.Value == null)
-                throw new ArgumentNullException(nameof(int64NegativeExclusive), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64NegativeExclusive.");
 
             if (int64Positive.IsSet && int64Positive.Value == null)
-                throw new ArgumentNullException(nameof(int64Positive), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64Positive.");
 
             if (int64PositiveExclusive.IsSet && int64PositiveExclusive.Value == null)
-                throw new ArgumentNullException(nameof(int64PositiveExclusive), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64PositiveExclusive.");
 
             if (integer.IsSet && integer.Value == null)
-                throw new ArgumentNullException(nameof(integer), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: integer.");
 
             if (patternWithBackslash.IsSet && patternWithBackslash.Value == null)
-                throw new ArgumentNullException(nameof(patternWithBackslash), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: pattern_with_backslash.");
 
             if (patternWithDigits.IsSet && patternWithDigits.Value == null)
-                throw new ArgumentNullException(nameof(patternWithDigits), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: pattern_with_digits.");
 
             if (patternWithDigitsAndDelimiter.IsSet && patternWithDigitsAndDelimiter.Value == null)
-                throw new ArgumentNullException(nameof(patternWithDigitsAndDelimiter), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: pattern_with_digits_and_delimiter.");
 
             if (varString.IsSet && varString.Value == null)
-                throw new ArgumentNullException(nameof(varString), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: string.");
 
             if (stringFormattedAsDecimal.IsSet && stringFormattedAsDecimal.Value == null)
-                throw new ArgumentNullException(nameof(stringFormattedAsDecimal), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: string_formatted_as_decimal.");
 
             if (unsignedInteger.IsSet && unsignedInteger.Value == null)
-                throw new ArgumentNullException(nameof(unsignedInteger), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: unsigned_integer.");
 
             if (unsignedLong.IsSet && unsignedLong.Value == null)
-                throw new ArgumentNullException(nameof(unsignedLong), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: unsigned_long.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: uuid.");
 
             return new FormatTest(varByte.Value, date.Value.Value, number.Value.Value, password.Value, stringFormattedAsDecimalRequired.Value.Value, binary, dateTime, varDecimal, varDouble, duplicatePropertyName2, duplicatePropertyName, varFloat, int32, int32Range, int64, int64Negative, int64NegativeExclusive, int64Positive, int64PositiveExclusive, integer, patternWithBackslash, patternWithDigits, patternWithDigitsAndDelimiter, varString, stringFormattedAsDecimal, unsignedInteger, unsignedLong, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
@@ -183,7 +183,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Fruit.");
+                throw new JsonException("Property is not nullable for class Fruit: color.");
 
             if (apple != null)
                 return new Fruit(apple, color);

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -187,7 +187,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class GmFruit.");
+                throw new JsonException("Property is not nullable for class GmFruit: color.");
 
             Option<Apple> appleParsedValue = apple == null
                 ? default

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
@@ -155,10 +155,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!petType.IsSet)
-                throw new ArgumentException("Property is required for class GrandparentAnimal.", nameof(petType));
+                throw new JsonException("Property is required for class GrandparentAnimal: pet_type.");
 
             if (petType.IsSet && petType.Value == null)
-                throw new ArgumentNullException(nameof(petType), "Property is not nullable for class GrandparentAnimal.");
+                throw new JsonException("Property is not nullable for class GrandparentAnimal: pet_type.");
 
             return new GrandparentAnimal();
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -206,10 +206,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bar.IsSet && bar.Value == null)
-                throw new ArgumentNullException(nameof(bar), "Property is not nullable for class HasOnlyReadOnly.");
+                throw new JsonException("Property is not nullable for class HasOnlyReadOnly: bar.");
 
             if (foo.IsSet && foo.Value == null)
-                throw new ArgumentNullException(nameof(foo), "Property is not nullable for class HasOnlyReadOnly.");
+                throw new JsonException("Property is not nullable for class HasOnlyReadOnly: foo.");
 
             return new HasOnlyReadOnly(bar, foo);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
@@ -292,22 +292,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (potentiallyOverriddenPropertyAccessor.IsSet && potentiallyOverriddenPropertyAccessor.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyAccessor), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyAccessor.");
 
             if (potentiallyOverriddenPropertyToInternal.IsSet && potentiallyOverriddenPropertyToInternal.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyToInternal), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyToInternal.");
 
             if (potentiallyOverriddenPropertyToPrivate.IsSet && potentiallyOverriddenPropertyToPrivate.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyToPrivate), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyToPrivate.");
 
             if (potentiallyOverriddenPropertyToPublic.IsSet && potentiallyOverriddenPropertyToPublic.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyToPublic), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyToPublic.");
 
             if (unalteredProperty.IsSet && unalteredProperty.Value == null)
-                throw new ArgumentNullException(nameof(unalteredProperty), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: unalteredProperty.");
 
             if (unalteredPropertyAccessor.IsSet && unalteredPropertyAccessor.Value == null)
-                throw new ArgumentNullException(nameof(unalteredPropertyAccessor), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: unalteredPropertyAccessor.");
 
             return new InjectedVendorExtensionsTest(potentiallyOverriddenPropertyAccessor, potentiallyOverriddenPropertyToInternal, potentiallyOverriddenPropertyToPrivate, potentiallyOverriddenPropertyToPublic, unalteredProperty, unalteredPropertyAccessor);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
@@ -144,16 +144,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class IsoscelesTriangle.", nameof(shapeType));
+                throw new JsonException("Property is required for class IsoscelesTriangle: shapeType.");
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class IsoscelesTriangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class IsoscelesTriangle: triangleType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class IsoscelesTriangle.");
+                throw new JsonException("Property is not nullable for class IsoscelesTriangle: shapeType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class IsoscelesTriangle.");
+                throw new JsonException("Property is not nullable for class IsoscelesTriangle: triangleType.");
 
             return new IsoscelesTriangle(shapeType.Value, triangleType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/List.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (var123List.IsSet && var123List.Value == null)
-                throw new ArgumentNullException(nameof(var123List), "Property is not nullable for class List.");
+                throw new JsonException("Property is not nullable for class List: 123-list.");
 
             return new List(var123List);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (escapedLiteralString.IsSet && escapedLiteralString.Value == null)
-                throw new ArgumentNullException(nameof(escapedLiteralString), "Property is not nullable for class LiteralStringClass.");
+                throw new JsonException("Property is not nullable for class LiteralStringClass: escapedLiteralString.");
 
             if (unescapedLiteralString.IsSet && unescapedLiteralString.Value == null)
-                throw new ArgumentNullException(nameof(unescapedLiteralString), "Property is not nullable for class LiteralStringClass.");
+                throw new JsonException("Property is not nullable for class LiteralStringClass: unescapedLiteralString.");
 
             return new LiteralStringClass(escapedLiteralString, unescapedLiteralString);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Mammal.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Mammal.cs
@@ -214,10 +214,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Mammal.", nameof(className));
+                throw new JsonException("Property is required for class Mammal: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Mammal.");
+                throw new JsonException("Property is not nullable for class Mammal: className.");
 
             if (pig != null)
                 return new Mammal(pig);

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/MapTest.cs
@@ -271,16 +271,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (directMap.IsSet && directMap.Value == null)
-                throw new ArgumentNullException(nameof(directMap), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: direct_map.");
 
             if (indirectMap.IsSet && indirectMap.Value == null)
-                throw new ArgumentNullException(nameof(indirectMap), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: indirect_map.");
 
             if (mapMapOfString.IsSet && mapMapOfString.Value == null)
-                throw new ArgumentNullException(nameof(mapMapOfString), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: map_map_of_string.");
 
             if (mapOfEnumString.IsSet && mapOfEnumString.Value == null)
-                throw new ArgumentNullException(nameof(mapOfEnumString), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: map_of_enum_string.");
 
             return new MapTest(directMap, indirectMap, mapMapOfString, mapOfEnumString);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/MixedAnyOf.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/MixedAnyOf.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (content.IsSet && content.Value == null)
-                throw new ArgumentNullException(nameof(content), "Property is not nullable for class MixedAnyOf.");
+                throw new JsonException("Property is not nullable for class MixedAnyOf: content.");
 
             return new MixedAnyOf(content);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/MixedOneOf.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/MixedOneOf.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (content.IsSet && content.Value == null)
-                throw new ArgumentNullException(nameof(content), "Property is not nullable for class MixedOneOf.");
+                throw new JsonException("Property is not nullable for class MixedOneOf: content.");
 
             return new MixedOneOf(content);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -217,16 +217,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (dateTime.IsSet && dateTime.Value == null)
-                throw new ArgumentNullException(nameof(dateTime), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: dateTime.");
 
             if (map.IsSet && map.Value == null)
-                throw new ArgumentNullException(nameof(map), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: map.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: uuid.");
 
             if (uuidWithPattern.IsSet && uuidWithPattern.Value == null)
-                throw new ArgumentNullException(nameof(uuidWithPattern), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: uuid_with_pattern.");
 
             return new MixedPropertiesAndAdditionalPropertiesClass(dateTime, map, uuid, uuidWithPattern);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/MixedSubId.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/MixedSubId.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class MixedSubId.");
+                throw new JsonException("Property is not nullable for class MixedSubId: id.");
 
             return new MixedSubId(id);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varClass.IsSet && varClass.Value == null)
-                throw new ArgumentNullException(nameof(varClass), "Property is not nullable for class Model200Response.");
+                throw new JsonException("Property is not nullable for class Model200Response: class.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Model200Response.");
+                throw new JsonException("Property is not nullable for class Model200Response: name.");
 
             return new Model200Response(varClass, name);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varClient.IsSet && varClient.Value == null)
-                throw new ArgumentNullException(nameof(varClient), "Property is not nullable for class ModelClient.");
+                throw new JsonException("Property is not nullable for class ModelClient: client.");
 
             return new ModelClient(varClient);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Name.cs
@@ -239,19 +239,19 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!varName.IsSet)
-                throw new ArgumentException("Property is required for class Name.", nameof(varName));
+                throw new JsonException("Property is required for class Name: name.");
 
             if (varName.IsSet && varName.Value == null)
-                throw new ArgumentNullException(nameof(varName), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: name.");
 
             if (property.IsSet && property.Value == null)
-                throw new ArgumentNullException(nameof(property), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: property.");
 
             if (snakeCase.IsSet && snakeCase.Value == null)
-                throw new ArgumentNullException(nameof(snakeCase), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: snake_case.");
 
             if (var123Number.IsSet && var123Number.Value == null)
-                throw new ArgumentNullException(nameof(var123Number), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: 123Number.");
 
             return new Name(varName.Value.Value, property, snakeCase, var123Number);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
@@ -151,16 +151,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!aObjVariableobject.IsSet)
-                throw new ArgumentException("Property is required for class NotificationtestGetElementsV1ResponseMPayload.", nameof(aObjVariableobject));
+                throw new JsonException("Property is required for class NotificationtestGetElementsV1ResponseMPayload: a_objVariableobject.");
 
             if (!pkiNotificationtestID.IsSet)
-                throw new ArgumentException("Property is required for class NotificationtestGetElementsV1ResponseMPayload.", nameof(pkiNotificationtestID));
+                throw new JsonException("Property is required for class NotificationtestGetElementsV1ResponseMPayload: pkiNotificationtestID.");
 
             if (aObjVariableobject.IsSet && aObjVariableobject.Value == null)
-                throw new ArgumentNullException(nameof(aObjVariableobject), "Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload.");
+                throw new JsonException("Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload: a_objVariableobject.");
 
             if (pkiNotificationtestID.IsSet && pkiNotificationtestID.Value == null)
-                throw new ArgumentNullException(nameof(pkiNotificationtestID), "Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload.");
+                throw new JsonException("Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload: pkiNotificationtestID.");
 
             return new NotificationtestGetElementsV1ResponseMPayload(aObjVariableobject.Value, pkiNotificationtestID.Value.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -375,10 +375,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayItemsNullable.IsSet && arrayItemsNullable.Value == null)
-                throw new ArgumentNullException(nameof(arrayItemsNullable), "Property is not nullable for class NullableClass.");
+                throw new JsonException("Property is not nullable for class NullableClass: array_items_nullable.");
 
             if (objectItemsNullable.IsSet && objectItemsNullable.Value == null)
-                throw new ArgumentNullException(nameof(objectItemsNullable), "Property is not nullable for class NullableClass.");
+                throw new JsonException("Property is not nullable for class NullableClass: object_items_nullable.");
 
             return new NullableClass(arrayAndItemsNullableProp, arrayItemsNullable, arrayNullableProp, booleanProp, dateProp, datetimeProp, integerProp, numberProp, objectAndItemsNullableProp, objectItemsNullable, objectNullableProp, stringProp);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/NullableShape.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/NullableShape.cs
@@ -193,10 +193,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class NullableShape.", nameof(shapeType));
+                throw new JsonException("Property is required for class NullableShape: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class NullableShape.");
+                throw new JsonException("Property is not nullable for class NullableShape: shapeType.");
 
             if (quadrilateral != null)
                 return new NullableShape(quadrilateral);

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (justNumber.IsSet && justNumber.Value == null)
-                throw new ArgumentNullException(nameof(justNumber), "Property is not nullable for class NumberOnly.");
+                throw new JsonException("Property is not nullable for class NumberOnly: JustNumber.");
 
             return new NumberOnly(justNumber);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -208,16 +208,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bars.IsSet && bars.Value == null)
-                throw new ArgumentNullException(nameof(bars), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: bars.");
 
             if (deprecatedRef.IsSet && deprecatedRef.Value == null)
-                throw new ArgumentNullException(nameof(deprecatedRef), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: deprecatedRef.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: id.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: uuid.");
 
             return new ObjectWithDeprecatedFields(bars, deprecatedRef, id, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Order.cs
@@ -340,22 +340,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (complete.IsSet && complete.Value == null)
-                throw new ArgumentNullException(nameof(complete), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: complete.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: id.");
 
             if (petId.IsSet && petId.Value == null)
-                throw new ArgumentNullException(nameof(petId), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: petId.");
 
             if (quantity.IsSet && quantity.Value == null)
-                throw new ArgumentNullException(nameof(quantity), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: quantity.");
 
             if (shipDate.IsSet && shipDate.Value == null)
-                throw new ArgumentNullException(nameof(shipDate), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: shipDate.");
 
             if (status.IsSet && status.Value == null)
-                throw new ArgumentNullException(nameof(status), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: status.");
 
             return new Order(complete, id, petId, quantity, shipDate, status);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -185,13 +185,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (myBoolean.IsSet && myBoolean.Value == null)
-                throw new ArgumentNullException(nameof(myBoolean), "Property is not nullable for class OuterComposite.");
+                throw new JsonException("Property is not nullable for class OuterComposite: my_boolean.");
 
             if (myNumber.IsSet && myNumber.Value == null)
-                throw new ArgumentNullException(nameof(myNumber), "Property is not nullable for class OuterComposite.");
+                throw new JsonException("Property is not nullable for class OuterComposite: my_number.");
 
             if (myString.IsSet && myString.Value == null)
-                throw new ArgumentNullException(nameof(myString), "Property is not nullable for class OuterComposite.");
+                throw new JsonException("Property is not nullable for class OuterComposite: my_string.");
 
             return new OuterComposite(myBoolean, myNumber, myString);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ParentPet.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ParentPet.cs
@@ -118,10 +118,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!petType.IsSet)
-                throw new ArgumentException("Property is required for class ParentPet.", nameof(petType));
+                throw new JsonException("Property is required for class ParentPet: pet_type.");
 
             if (petType.IsSet && petType.Value == null)
-                throw new ArgumentNullException(nameof(petType), "Property is not nullable for class ParentPet.");
+                throw new JsonException("Property is not nullable for class ParentPet: pet_type.");
 
             return new ParentPet();
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Pet.cs
@@ -321,28 +321,28 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!name.IsSet)
-                throw new ArgumentException("Property is required for class Pet.", nameof(name));
+                throw new JsonException("Property is required for class Pet: name.");
 
             if (!photoUrls.IsSet)
-                throw new ArgumentException("Property is required for class Pet.", nameof(photoUrls));
+                throw new JsonException("Property is required for class Pet: photoUrls.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: name.");
 
             if (photoUrls.IsSet && photoUrls.Value == null)
-                throw new ArgumentNullException(nameof(photoUrls), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: photoUrls.");
 
             if (category.IsSet && category.Value == null)
-                throw new ArgumentNullException(nameof(category), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: category.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: id.");
 
             if (status.IsSet && status.Value == null)
-                throw new ArgumentNullException(nameof(status), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: status.");
 
             if (tags.IsSet && tags.Value == null)
-                throw new ArgumentNullException(nameof(tags), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: tags.");
 
             return new Pet(name.Value, photoUrls.Value, category, id, status, tags);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Pig.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Pig.cs
@@ -193,10 +193,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Pig.", nameof(className));
+                throw new JsonException("Property is required for class Pig: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Pig.");
+                throw new JsonException("Property is not nullable for class Pig: className.");
 
             if (basquePig != null)
                 return new Pig(basquePig);

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Quadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Quadrilateral.cs
@@ -193,10 +193,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class Quadrilateral.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class Quadrilateral: quadrilateralType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class Quadrilateral.");
+                throw new JsonException("Property is not nullable for class Quadrilateral: quadrilateralType.");
 
             if (complexQuadrilateral != null)
                 return new Quadrilateral(complexQuadrilateral);

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
@@ -138,10 +138,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class QuadrilateralInterface.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class QuadrilateralInterface: quadrilateralType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class QuadrilateralInterface.");
+                throw new JsonException("Property is not nullable for class QuadrilateralInterface: quadrilateralType.");
 
             return new QuadrilateralInterface(quadrilateralType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -203,10 +203,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bar.IsSet && bar.Value == null)
-                throw new ArgumentNullException(nameof(bar), "Property is not nullable for class ReadOnlyFirst.");
+                throw new JsonException("Property is not nullable for class ReadOnlyFirst: bar.");
 
             if (baz.IsSet && baz.Value == null)
-                throw new ArgumentNullException(nameof(baz), "Property is not nullable for class ReadOnlyFirst.");
+                throw new JsonException("Property is not nullable for class ReadOnlyFirst: baz.");
 
             return new ReadOnlyFirst(bar, baz);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -2077,136 +2077,136 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!requiredNotNullableDateProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotNullableDateProp));
+                throw new JsonException("Property is required for class RequiredClass: required_not_nullable_date_prop.");
 
             if (!requiredNotnullableArrayOfString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableArrayOfString));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_array_of_string.");
 
             if (!requiredNotnullableBooleanProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableBooleanProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_boolean_prop.");
 
             if (!requiredNotnullableDatetimeProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableDatetimeProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_datetime_prop.");
 
             if (!requiredNotnullableEnumInteger.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableEnumInteger));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_enum_integer.");
 
             if (!requiredNotnullableEnumIntegerOnly.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableEnumIntegerOnly));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_enum_integer_only.");
 
             if (!requiredNotnullableEnumString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableEnumString));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_enum_string.");
 
             if (!requiredNotnullableOuterEnumDefaultValue.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableOuterEnumDefaultValue));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_outerEnumDefaultValue.");
 
             if (!requiredNotnullableStringProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableStringProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_string_prop.");
 
             if (!requiredNotnullableUuid.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableUuid));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_uuid.");
 
             if (!requiredNotnullableintegerProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableintegerProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullableinteger_prop.");
 
             if (!requiredNullableArrayOfString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableArrayOfString));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_array_of_string.");
 
             if (!requiredNullableBooleanProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableBooleanProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_boolean_prop.");
 
             if (!requiredNullableDateProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableDateProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_date_prop.");
 
             if (!requiredNullableDatetimeProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableDatetimeProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_datetime_prop.");
 
             if (!requiredNullableEnumInteger.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableEnumInteger));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_enum_integer.");
 
             if (!requiredNullableEnumIntegerOnly.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableEnumIntegerOnly));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_enum_integer_only.");
 
             if (!requiredNullableEnumString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableEnumString));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_enum_string.");
 
             if (!requiredNullableIntegerProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableIntegerProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_integer_prop.");
 
             if (!requiredNullableOuterEnumDefaultValue.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableOuterEnumDefaultValue));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_outerEnumDefaultValue.");
 
             if (!requiredNullableStringProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableStringProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_string_prop.");
 
             if (!requiredNullableUuid.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableUuid));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_uuid.");
 
             if (requiredNotNullableDateProp.IsSet && requiredNotNullableDateProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotNullableDateProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_not_nullable_date_prop.");
 
             if (requiredNotnullableArrayOfString.IsSet && requiredNotnullableArrayOfString.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableArrayOfString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_array_of_string.");
 
             if (requiredNotnullableBooleanProp.IsSet && requiredNotnullableBooleanProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableBooleanProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_boolean_prop.");
 
             if (requiredNotnullableDatetimeProp.IsSet && requiredNotnullableDatetimeProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableDatetimeProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_datetime_prop.");
 
             if (requiredNotnullableEnumInteger.IsSet && requiredNotnullableEnumInteger.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableEnumInteger), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_enum_integer.");
 
             if (requiredNotnullableEnumIntegerOnly.IsSet && requiredNotnullableEnumIntegerOnly.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableEnumIntegerOnly), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_enum_integer_only.");
 
             if (requiredNotnullableEnumString.IsSet && requiredNotnullableEnumString.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableEnumString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_enum_string.");
 
             if (requiredNotnullableOuterEnumDefaultValue.IsSet && requiredNotnullableOuterEnumDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableOuterEnumDefaultValue), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_outerEnumDefaultValue.");
 
             if (requiredNotnullableStringProp.IsSet && requiredNotnullableStringProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableStringProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_string_prop.");
 
             if (requiredNotnullableUuid.IsSet && requiredNotnullableUuid.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableUuid), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_uuid.");
 
             if (requiredNotnullableintegerProp.IsSet && requiredNotnullableintegerProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableintegerProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullableinteger_prop.");
 
             if (notRequiredNotnullableDateProp.IsSet && notRequiredNotnullableDateProp.Value == null)
-                throw new ArgumentNullException(nameof(notRequiredNotnullableDateProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: not_required_notnullable_date_prop.");
 
             if (notRequiredNotnullableintegerProp.IsSet && notRequiredNotnullableintegerProp.Value == null)
-                throw new ArgumentNullException(nameof(notRequiredNotnullableintegerProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: not_required_notnullableinteger_prop.");
 
             if (notrequiredNotnullableArrayOfString.IsSet && notrequiredNotnullableArrayOfString.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableArrayOfString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_array_of_string.");
 
             if (notrequiredNotnullableBooleanProp.IsSet && notrequiredNotnullableBooleanProp.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableBooleanProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_boolean_prop.");
 
             if (notrequiredNotnullableDatetimeProp.IsSet && notrequiredNotnullableDatetimeProp.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableDatetimeProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_datetime_prop.");
 
             if (notrequiredNotnullableEnumInteger.IsSet && notrequiredNotnullableEnumInteger.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableEnumInteger), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_enum_integer.");
 
             if (notrequiredNotnullableEnumIntegerOnly.IsSet && notrequiredNotnullableEnumIntegerOnly.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableEnumIntegerOnly), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_enum_integer_only.");
 
             if (notrequiredNotnullableEnumString.IsSet && notrequiredNotnullableEnumString.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableEnumString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_enum_string.");
 
             if (notrequiredNotnullableOuterEnumDefaultValue.IsSet && notrequiredNotnullableOuterEnumDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableOuterEnumDefaultValue), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_outerEnumDefaultValue.");
 
             if (notrequiredNotnullableStringProp.IsSet && notrequiredNotnullableStringProp.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableStringProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_string_prop.");
 
             if (notrequiredNotnullableUuid.IsSet && notrequiredNotnullableUuid.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableUuid), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_uuid.");
 
             return new RequiredClass(requiredNotNullableDateProp.Value.Value, requiredNotnullableArrayOfString.Value, requiredNotnullableBooleanProp.Value.Value, requiredNotnullableDatetimeProp.Value.Value, requiredNotnullableEnumInteger.Value.Value, requiredNotnullableEnumIntegerOnly.Value.Value, requiredNotnullableEnumString.Value.Value, requiredNotnullableOuterEnumDefaultValue.Value.Value, requiredNotnullableStringProp.Value, requiredNotnullableUuid.Value.Value, requiredNotnullableintegerProp.Value.Value, notRequiredNotnullableDateProp, notRequiredNotnullableintegerProp, notRequiredNullableDateProp, notRequiredNullableIntegerProp, notrequiredNotnullableArrayOfString, notrequiredNotnullableBooleanProp, notrequiredNotnullableDatetimeProp, notrequiredNotnullableEnumInteger, notrequiredNotnullableEnumIntegerOnly, notrequiredNotnullableEnumString, notrequiredNotnullableOuterEnumDefaultValue, notrequiredNotnullableStringProp, notrequiredNotnullableUuid, notrequiredNullableArrayOfString, notrequiredNullableBooleanProp, notrequiredNullableDatetimeProp, notrequiredNullableEnumInteger, notrequiredNullableEnumIntegerOnly, notrequiredNullableEnumString, notrequiredNullableOuterEnumDefaultValue, notrequiredNullableStringProp, notrequiredNullableUuid, requiredNullableArrayOfString.Value, requiredNullableBooleanProp.Value, requiredNullableDateProp.Value, requiredNullableDatetimeProp.Value, requiredNullableEnumInteger.Value, requiredNullableEnumIntegerOnly.Value, requiredNullableEnumString.Value, requiredNullableIntegerProp.Value, requiredNullableOuterEnumDefaultValue.Value, requiredNullableStringProp.Value, requiredNullableUuid.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Result.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Result.cs
@@ -188,13 +188,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (code.IsSet && code.Value == null)
-                throw new ArgumentNullException(nameof(code), "Property is not nullable for class Result.");
+                throw new JsonException("Property is not nullable for class Result: code.");
 
             if (data.IsSet && data.Value == null)
-                throw new ArgumentNullException(nameof(data), "Property is not nullable for class Result.");
+                throw new JsonException("Property is not nullable for class Result: data.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class Result.");
+                throw new JsonException("Property is not nullable for class Result: uuid.");
 
             return new Result(code, data, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Return.cs
@@ -191,19 +191,19 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!varLock.IsSet)
-                throw new ArgumentException("Property is required for class Return.", nameof(varLock));
+                throw new JsonException("Property is required for class Return: lock.");
 
             if (!varAbstract.IsSet)
-                throw new ArgumentException("Property is required for class Return.", nameof(varAbstract));
+                throw new JsonException("Property is required for class Return: abstract.");
 
             if (varLock.IsSet && varLock.Value == null)
-                throw new ArgumentNullException(nameof(varLock), "Property is not nullable for class Return.");
+                throw new JsonException("Property is not nullable for class Return: lock.");
 
             if (varReturn.IsSet && varReturn.Value == null)
-                throw new ArgumentNullException(nameof(varReturn), "Property is not nullable for class Return.");
+                throw new JsonException("Property is not nullable for class Return: return.");
 
             if (varUnsafe.IsSet && varUnsafe.Value == null)
-                throw new ArgumentNullException(nameof(varUnsafe), "Property is not nullable for class Return.");
+                throw new JsonException("Property is not nullable for class Return: unsafe.");
 
             return new Return(varLock.Value, varAbstract.Value, varReturn, varUnsafe);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (role.IsSet && role.Value == null)
-                throw new ArgumentNullException(nameof(role), "Property is not nullable for class RolesReportsHash.");
+                throw new JsonException("Property is not nullable for class RolesReportsHash: role.");
 
             if (roleUuid.IsSet && roleUuid.Value == null)
-                throw new ArgumentNullException(nameof(roleUuid), "Property is not nullable for class RolesReportsHash.");
+                throw new JsonException("Property is not nullable for class RolesReportsHash: role_uuid.");
 
             return new RolesReportsHash(role, roleUuid);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class RolesReportsHashRole.");
+                throw new JsonException("Property is not nullable for class RolesReportsHashRole: name.");
 
             return new RolesReportsHashRole(name);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
@@ -151,16 +151,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ScaleneTriangle.", nameof(shapeType));
+                throw new JsonException("Property is required for class ScaleneTriangle: shapeType.");
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class ScaleneTriangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class ScaleneTriangle: triangleType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ScaleneTriangle.");
+                throw new JsonException("Property is not nullable for class ScaleneTriangle: shapeType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class ScaleneTriangle.");
+                throw new JsonException("Property is not nullable for class ScaleneTriangle: triangleType.");
 
             return new ScaleneTriangle(shapeType.Value, triangleType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Shape.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Shape.cs
@@ -193,10 +193,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class Shape.", nameof(shapeType));
+                throw new JsonException("Property is required for class Shape: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class Shape.");
+                throw new JsonException("Property is not nullable for class Shape: shapeType.");
 
             if (quadrilateral != null)
                 return new Shape(quadrilateral);

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ShapeInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ShapeInterface.cs
@@ -138,10 +138,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ShapeInterface.", nameof(shapeType));
+                throw new JsonException("Property is required for class ShapeInterface: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ShapeInterface.");
+                throw new JsonException("Property is not nullable for class ShapeInterface: shapeType.");
 
             return new ShapeInterface(shapeType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ShapeOrNull.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ShapeOrNull.cs
@@ -193,10 +193,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ShapeOrNull.", nameof(shapeType));
+                throw new JsonException("Property is required for class ShapeOrNull: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ShapeOrNull.");
+                throw new JsonException("Property is not nullable for class ShapeOrNull: shapeType.");
 
             if (quadrilateral != null)
                 return new ShapeOrNull(quadrilateral);

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
@@ -151,16 +151,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class SimpleQuadrilateral.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class SimpleQuadrilateral: quadrilateralType.");
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class SimpleQuadrilateral.", nameof(shapeType));
+                throw new JsonException("Property is required for class SimpleQuadrilateral: shapeType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class SimpleQuadrilateral.");
+                throw new JsonException("Property is not nullable for class SimpleQuadrilateral: quadrilateralType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class SimpleQuadrilateral.");
+                throw new JsonException("Property is not nullable for class SimpleQuadrilateral: shapeType.");
 
             return new SimpleQuadrilateral(quadrilateralType.Value, shapeType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varSpecialModelName.IsSet && varSpecialModelName.Value == null)
-                throw new ArgumentNullException(nameof(varSpecialModelName), "Property is not nullable for class SpecialModelName.");
+                throw new JsonException("Property is not nullable for class SpecialModelName: _special_model.name_.");
 
             if (specialPropertyName.IsSet && specialPropertyName.Value == null)
-                throw new ArgumentNullException(nameof(specialPropertyName), "Property is not nullable for class SpecialModelName.");
+                throw new JsonException("Property is not nullable for class SpecialModelName: $special[property.name].");
 
             return new SpecialModelName(varSpecialModelName, specialPropertyName);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Tag.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Tag.");
+                throw new JsonException("Property is not nullable for class Tag: id.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Tag.");
+                throw new JsonException("Property is not nullable for class Tag: name.");
 
             return new Tag(id, name);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (value.IsSet && value.Value == null)
-                throw new ArgumentNullException(nameof(value), "Property is not nullable for class TestCollectionEndingWithWordList.");
+                throw new JsonException("Property is not nullable for class TestCollectionEndingWithWordList: value.");
 
             return new TestCollectionEndingWithWordList(value);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (testCollectionEndingWithWordList.IsSet && testCollectionEndingWithWordList.Value == null)
-                throw new ArgumentNullException(nameof(testCollectionEndingWithWordList), "Property is not nullable for class TestCollectionEndingWithWordListObject.");
+                throw new JsonException("Property is not nullable for class TestCollectionEndingWithWordListObject: TestCollectionEndingWithWordList.");
 
             return new TestCollectionEndingWithWordListObject(testCollectionEndingWithWordList);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/TestDescendants.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/TestDescendants.cs
@@ -241,16 +241,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!alternativeName.IsSet)
-                throw new ArgumentException("Property is required for class TestDescendants.", nameof(alternativeName));
+                throw new JsonException("Property is required for class TestDescendants: alternativeName.");
 
             if (!objectType.IsSet)
-                throw new ArgumentException("Property is required for class TestDescendants.", nameof(objectType));
+                throw new JsonException("Property is required for class TestDescendants: objectType.");
 
             if (alternativeName.IsSet && alternativeName.Value == null)
-                throw new ArgumentNullException(nameof(alternativeName), "Property is not nullable for class TestDescendants.");
+                throw new JsonException("Property is not nullable for class TestDescendants: alternativeName.");
 
             if (objectType.IsSet && objectType.Value == null)
-                throw new ArgumentNullException(nameof(objectType), "Property is not nullable for class TestDescendants.");
+                throw new JsonException("Property is not nullable for class TestDescendants: objectType.");
 
             return new TestDescendants(alternativeName.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (someProperty.IsSet && someProperty.Value == null)
-                throw new ArgumentNullException(nameof(someProperty), "Property is not nullable for class TestInlineFreeformAdditionalPropertiesRequest.");
+                throw new JsonException("Property is not nullable for class TestInlineFreeformAdditionalPropertiesRequest: someProperty.");
 
             return new TestInlineFreeformAdditionalPropertiesRequest(someProperty);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/TestResult.cs
@@ -187,13 +187,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (code.IsSet && code.Value == null)
-                throw new ArgumentNullException(nameof(code), "Property is not nullable for class TestResult.");
+                throw new JsonException("Property is not nullable for class TestResult: code.");
 
             if (data.IsSet && data.Value == null)
-                throw new ArgumentNullException(nameof(data), "Property is not nullable for class TestResult.");
+                throw new JsonException("Property is not nullable for class TestResult: data.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class TestResult.");
+                throw new JsonException("Property is not nullable for class TestResult: uuid.");
 
             return new TestResult(code, data, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Triangle.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Triangle.cs
@@ -214,10 +214,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class Triangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class Triangle: triangleType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class Triangle.");
+                throw new JsonException("Property is not nullable for class Triangle: triangleType.");
 
             if (equilateralTriangle != null)
                 return new Triangle(equilateralTriangle);

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/TriangleInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/TriangleInterface.cs
@@ -138,10 +138,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class TriangleInterface.", nameof(triangleType));
+                throw new JsonException("Property is required for class TriangleInterface: triangleType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class TriangleInterface.");
+                throw new JsonException("Property is not nullable for class TriangleInterface: triangleType.");
 
             return new TriangleInterface(triangleType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/User.cs
@@ -370,31 +370,31 @@ namespace Org.OpenAPITools.Model
             }
 
             if (email.IsSet && email.Value == null)
-                throw new ArgumentNullException(nameof(email), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: email.");
 
             if (firstName.IsSet && firstName.Value == null)
-                throw new ArgumentNullException(nameof(firstName), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: firstName.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: id.");
 
             if (lastName.IsSet && lastName.Value == null)
-                throw new ArgumentNullException(nameof(lastName), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: lastName.");
 
             if (objectWithNoDeclaredProps.IsSet && objectWithNoDeclaredProps.Value == null)
-                throw new ArgumentNullException(nameof(objectWithNoDeclaredProps), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: objectWithNoDeclaredProps.");
 
             if (password.IsSet && password.Value == null)
-                throw new ArgumentNullException(nameof(password), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: password.");
 
             if (phone.IsSet && phone.Value == null)
-                throw new ArgumentNullException(nameof(phone), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: phone.");
 
             if (userStatus.IsSet && userStatus.Value == null)
-                throw new ArgumentNullException(nameof(userStatus), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: userStatus.");
 
             if (username.IsSet && username.Value == null)
-                throw new ArgumentNullException(nameof(username), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: username.");
 
             return new User(anyTypeProp, anyTypePropNullable, email, firstName, id, lastName, objectWithNoDeclaredProps, objectWithNoDeclaredPropsNullable, password, phone, userStatus, username);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Whale.cs
@@ -178,16 +178,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Whale.", nameof(className));
+                throw new JsonException("Property is required for class Whale: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Whale.");
+                throw new JsonException("Property is not nullable for class Whale: className.");
 
             if (hasBaleen.IsSet && hasBaleen.Value == null)
-                throw new ArgumentNullException(nameof(hasBaleen), "Property is not nullable for class Whale.");
+                throw new JsonException("Property is not nullable for class Whale: hasBaleen.");
 
             if (hasTeeth.IsSet && hasTeeth.Value == null)
-                throw new ArgumentNullException(nameof(hasTeeth), "Property is not nullable for class Whale.");
+                throw new JsonException("Property is not nullable for class Whale: hasTeeth.");
 
             return new Whale(className.Value, hasBaleen, hasTeeth);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Zebra.cs
@@ -245,13 +245,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Zebra.", nameof(className));
+                throw new JsonException("Property is required for class Zebra: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Zebra.");
+                throw new JsonException("Property is not nullable for class Zebra: className.");
 
             if (type.IsSet && type.Value == null)
-                throw new ArgumentNullException(nameof(type), "Property is not nullable for class Zebra.");
+                throw new JsonException("Property is not nullable for class Zebra: type.");
 
             return new Zebra(className.Value, type);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
@@ -218,7 +218,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (zeroBasedEnum.IsSet && zeroBasedEnum.Value == null)
-                throw new ArgumentNullException(nameof(zeroBasedEnum), "Property is not nullable for class ZeroBasedEnumClass.");
+                throw new JsonException("Property is not nullable for class ZeroBasedEnumClass: ZeroBasedEnum.");
 
             return new ZeroBasedEnumClass(zeroBasedEnum);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Activity.cs
@@ -148,7 +148,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (activityOutputs.IsSet && activityOutputs.Value == null)
-                throw new ArgumentNullException(nameof(activityOutputs), "Property is not nullable for class Activity.");
+                throw new JsonException("Property is not nullable for class Activity: activity_outputs.");
 
             return new Activity(activityOutputs);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -168,10 +168,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (prop1.IsSet && prop1.Value == null)
-                throw new ArgumentNullException(nameof(prop1), "Property is not nullable for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Property is not nullable for class ActivityOutputElementRepresentation: prop1.");
 
             if (prop2.IsSet && prop2.Value == null)
-                throw new ArgumentNullException(nameof(prop2), "Property is not nullable for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Property is not nullable for class ActivityOutputElementRepresentation: prop2.");
 
             return new ActivityOutputElementRepresentation(prop1, prop2);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -289,25 +289,25 @@ namespace Org.OpenAPITools.Model
             }
 
             if (emptyMap.IsSet && emptyMap.Value == null)
-                throw new ArgumentNullException(nameof(emptyMap), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: empty_map.");
 
             if (mapOfMapProperty.IsSet && mapOfMapProperty.Value == null)
-                throw new ArgumentNullException(nameof(mapOfMapProperty), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_of_map_property.");
 
             if (mapProperty.IsSet && mapProperty.Value == null)
-                throw new ArgumentNullException(nameof(mapProperty), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_property.");
 
             if (mapWithUndeclaredPropertiesAnytype1.IsSet && mapWithUndeclaredPropertiesAnytype1.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesAnytype1), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_anytype_1.");
 
             if (mapWithUndeclaredPropertiesAnytype2.IsSet && mapWithUndeclaredPropertiesAnytype2.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesAnytype2), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_anytype_2.");
 
             if (mapWithUndeclaredPropertiesAnytype3.IsSet && mapWithUndeclaredPropertiesAnytype3.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesAnytype3), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_anytype_3.");
 
             if (mapWithUndeclaredPropertiesString.IsSet && mapWithUndeclaredPropertiesString.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesString), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_string.");
 
             return new AdditionalPropertiesClass(anytype1, emptyMap, mapOfMapProperty, mapProperty, mapWithUndeclaredPropertiesAnytype1, mapWithUndeclaredPropertiesAnytype2, mapWithUndeclaredPropertiesAnytype3, mapWithUndeclaredPropertiesString);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Animal.cs
@@ -178,13 +178,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Animal.", nameof(className));
+                throw new JsonException("Property is required for class Animal: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Animal.");
+                throw new JsonException("Property is not nullable for class Animal: className.");
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Animal.");
+                throw new JsonException("Property is not nullable for class Animal: color.");
 
             return new Animal(color);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -188,13 +188,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (code.IsSet && code.Value == null)
-                throw new ArgumentNullException(nameof(code), "Property is not nullable for class ApiResponse.");
+                throw new JsonException("Property is not nullable for class ApiResponse: code.");
 
             if (message.IsSet && message.Value == null)
-                throw new ArgumentNullException(nameof(message), "Property is not nullable for class ApiResponse.");
+                throw new JsonException("Property is not nullable for class ApiResponse: message.");
 
             if (type.IsSet && type.Value == null)
-                throw new ArgumentNullException(nameof(type), "Property is not nullable for class ApiResponse.");
+                throw new JsonException("Property is not nullable for class ApiResponse: type.");
 
             return new ApiResponse(code, message, type);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Apple.cs
@@ -218,13 +218,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (colorCode.IsSet && colorCode.Value == null)
-                throw new ArgumentNullException(nameof(colorCode), "Property is not nullable for class Apple.");
+                throw new JsonException("Property is not nullable for class Apple: color_code.");
 
             if (cultivar.IsSet && cultivar.Value == null)
-                throw new ArgumentNullException(nameof(cultivar), "Property is not nullable for class Apple.");
+                throw new JsonException("Property is not nullable for class Apple: cultivar.");
 
             if (origin.IsSet && origin.Value == null)
-                throw new ArgumentNullException(nameof(origin), "Property is not nullable for class Apple.");
+                throw new JsonException("Property is not nullable for class Apple: origin.");
 
             return new Apple(colorCode, cultivar, origin);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -154,13 +154,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!cultivar.IsSet)
-                throw new ArgumentException("Property is required for class AppleReq.", nameof(cultivar));
+                throw new JsonException("Property is required for class AppleReq: cultivar.");
 
             if (cultivar.IsSet && cultivar.Value == null)
-                throw new ArgumentNullException(nameof(cultivar), "Property is not nullable for class AppleReq.");
+                throw new JsonException("Property is not nullable for class AppleReq: cultivar.");
 
             if (mealy.IsSet && mealy.Value == null)
-                throw new ArgumentNullException(nameof(mealy), "Property is not nullable for class AppleReq.");
+                throw new JsonException("Property is not nullable for class AppleReq: mealy.");
 
             return new AppleReq(cultivar.Value!, mealy);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -148,7 +148,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayArrayNumber.IsSet && arrayArrayNumber.Value == null)
-                throw new ArgumentNullException(nameof(arrayArrayNumber), "Property is not nullable for class ArrayOfArrayOfNumberOnly.");
+                throw new JsonException("Property is not nullable for class ArrayOfArrayOfNumberOnly: ArrayArrayNumber.");
 
             return new ArrayOfArrayOfNumberOnly(arrayArrayNumber);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -148,7 +148,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayNumber.IsSet && arrayNumber.Value == null)
-                throw new ArgumentNullException(nameof(arrayNumber), "Property is not nullable for class ArrayOfNumberOnly.");
+                throw new JsonException("Property is not nullable for class ArrayOfNumberOnly: ArrayNumber.");
 
             return new ArrayOfNumberOnly(arrayNumber);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -188,13 +188,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayArrayOfInteger.IsSet && arrayArrayOfInteger.Value == null)
-                throw new ArgumentNullException(nameof(arrayArrayOfInteger), "Property is not nullable for class ArrayTest.");
+                throw new JsonException("Property is not nullable for class ArrayTest: array_array_of_integer.");
 
             if (arrayArrayOfModel.IsSet && arrayArrayOfModel.Value == null)
-                throw new ArgumentNullException(nameof(arrayArrayOfModel), "Property is not nullable for class ArrayTest.");
+                throw new JsonException("Property is not nullable for class ArrayTest: array_array_of_model.");
 
             if (arrayOfString.IsSet && arrayOfString.Value == null)
-                throw new ArgumentNullException(nameof(arrayOfString), "Property is not nullable for class ArrayTest.");
+                throw new JsonException("Property is not nullable for class ArrayTest: array_of_string.");
 
             return new ArrayTest(arrayArrayOfInteger, arrayArrayOfModel, arrayOfString);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Banana.cs
@@ -148,7 +148,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (lengthCm.IsSet && lengthCm.Value == null)
-                throw new ArgumentNullException(nameof(lengthCm), "Property is not nullable for class Banana.");
+                throw new JsonException("Property is not nullable for class Banana: lengthCm.");
 
             return new Banana(lengthCm);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -154,13 +154,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!lengthCm.IsSet)
-                throw new ArgumentException("Property is required for class BananaReq.", nameof(lengthCm));
+                throw new JsonException("Property is required for class BananaReq: lengthCm.");
 
             if (lengthCm.IsSet && lengthCm.Value == null)
-                throw new ArgumentNullException(nameof(lengthCm), "Property is not nullable for class BananaReq.");
+                throw new JsonException("Property is not nullable for class BananaReq: lengthCm.");
 
             if (sweet.IsSet && sweet.Value == null)
-                throw new ArgumentNullException(nameof(sweet), "Property is not nullable for class BananaReq.");
+                throw new JsonException("Property is not nullable for class BananaReq: sweet.");
 
             return new BananaReq(lengthCm.Value!.Value!, sweet);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/BasquePig.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/BasquePig.cs
@@ -141,10 +141,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class BasquePig.", nameof(className));
+                throw new JsonException("Property is required for class BasquePig: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class BasquePig.");
+                throw new JsonException("Property is not nullable for class BasquePig: className.");
 
             return new BasquePig(className.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -249,22 +249,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (aTTNAME.IsSet && aTTNAME.Value == null)
-                throw new ArgumentNullException(nameof(aTTNAME), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: ATT_NAME.");
 
             if (capitalCamel.IsSet && capitalCamel.Value == null)
-                throw new ArgumentNullException(nameof(capitalCamel), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: CapitalCamel.");
 
             if (capitalSnake.IsSet && capitalSnake.Value == null)
-                throw new ArgumentNullException(nameof(capitalSnake), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: Capital_Snake.");
 
             if (sCAETHFlowPoints.IsSet && sCAETHFlowPoints.Value == null)
-                throw new ArgumentNullException(nameof(sCAETHFlowPoints), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: SCA_ETH_Flow_Points.");
 
             if (smallCamel.IsSet && smallCamel.Value == null)
-                throw new ArgumentNullException(nameof(smallCamel), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: smallCamel.");
 
             if (smallSnake.IsSet && smallSnake.Value == null)
-                throw new ArgumentNullException(nameof(smallSnake), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: small_Snake.");
 
             return new Capitalization(aTTNAME, capitalCamel, capitalSnake, sCAETHFlowPoints, smallCamel, smallSnake);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Cat.cs
@@ -141,16 +141,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Cat.", nameof(className));
+                throw new JsonException("Property is required for class Cat: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Cat.");
+                throw new JsonException("Property is not nullable for class Cat: className.");
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Cat.");
+                throw new JsonException("Property is not nullable for class Cat: color.");
 
             if (declawed.IsSet && declawed.Value == null)
-                throw new ArgumentNullException(nameof(declawed), "Property is not nullable for class Cat.");
+                throw new JsonException("Property is not nullable for class Cat: declawed.");
 
             return new Cat(color, declawed);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Category.cs
@@ -161,13 +161,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!name.IsSet)
-                throw new ArgumentException("Property is required for class Category.", nameof(name));
+                throw new JsonException("Property is required for class Category: name.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Category.");
+                throw new JsonException("Property is not nullable for class Category: id.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Category.");
+                throw new JsonException("Property is not nullable for class Category: name.");
 
             return new Category(id, name.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -203,13 +203,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!petType.IsSet)
-                throw new ArgumentException("Property is required for class ChildCat.", nameof(petType));
+                throw new JsonException("Property is required for class ChildCat: pet_type.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class ChildCat.");
+                throw new JsonException("Property is not nullable for class ChildCat: name.");
 
             if (petType.IsSet && petType.Value == null)
-                throw new ArgumentNullException(nameof(petType), "Property is not nullable for class ChildCat.");
+                throw new JsonException("Property is not nullable for class ChildCat: pet_type.");
 
             return new ChildCat(name);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -148,7 +148,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varClass.IsSet && varClass.Value == null)
-                throw new ArgumentNullException(nameof(varClass), "Property is not nullable for class ClassModel.");
+                throw new JsonException("Property is not nullable for class ClassModel: _class.");
 
             return new ClassModel(varClass);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
@@ -154,16 +154,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class ComplexQuadrilateral.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class ComplexQuadrilateral: quadrilateralType.");
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ComplexQuadrilateral.", nameof(shapeType));
+                throw new JsonException("Property is required for class ComplexQuadrilateral: shapeType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class ComplexQuadrilateral.");
+                throw new JsonException("Property is not nullable for class ComplexQuadrilateral: quadrilateralType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ComplexQuadrilateral.");
+                throw new JsonException("Property is not nullable for class ComplexQuadrilateral: shapeType.");
 
             return new ComplexQuadrilateral(quadrilateralType.Value!, shapeType.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/CopyActivity.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/CopyActivity.cs
@@ -196,16 +196,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!copyActivitytt.IsSet)
-                throw new ArgumentException("Property is required for class CopyActivity.", nameof(copyActivitytt));
+                throw new JsonException("Property is required for class CopyActivity: copyActivitytt.");
 
             if (!schema.IsSet)
-                throw new ArgumentException("Property is required for class CopyActivity.", nameof(schema));
+                throw new JsonException("Property is required for class CopyActivity: $schema.");
 
             if (copyActivitytt.IsSet && copyActivitytt.Value == null)
-                throw new ArgumentNullException(nameof(copyActivitytt), "Property is not nullable for class CopyActivity.");
+                throw new JsonException("Property is not nullable for class CopyActivity: copyActivitytt.");
 
             if (schema.IsSet && schema.Value == null)
-                throw new ArgumentNullException(nameof(schema), "Property is not nullable for class CopyActivity.");
+                throw new JsonException("Property is not nullable for class CopyActivity: $schema.");
 
             return new CopyActivity(copyActivitytt.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/DanishPig.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/DanishPig.cs
@@ -141,10 +141,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class DanishPig.", nameof(className));
+                throw new JsonException("Property is required for class DanishPig: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class DanishPig.");
+                throw new JsonException("Property is not nullable for class DanishPig: className.");
 
             return new DanishPig(className.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -154,7 +154,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (dateOnlyProperty.IsSet && dateOnlyProperty.Value == null)
-                throw new ArgumentNullException(nameof(dateOnlyProperty), "Property is not nullable for class DateOnlyClass.");
+                throw new JsonException("Property is not nullable for class DateOnlyClass: dateOnlyProperty.");
 
             return new DateOnlyClass(dateOnlyProperty);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -148,7 +148,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class DeprecatedObject.");
+                throw new JsonException("Property is not nullable for class DeprecatedObject: name.");
 
             return new DeprecatedObject(name);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Descendant1.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Descendant1.cs
@@ -141,22 +141,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!alternativeName.IsSet)
-                throw new ArgumentException("Property is required for class Descendant1.", nameof(alternativeName));
+                throw new JsonException("Property is required for class Descendant1: alternativeName.");
 
             if (!descendantName.IsSet)
-                throw new ArgumentException("Property is required for class Descendant1.", nameof(descendantName));
+                throw new JsonException("Property is required for class Descendant1: descendantName.");
 
             if (!objectType.IsSet)
-                throw new ArgumentException("Property is required for class Descendant1.", nameof(objectType));
+                throw new JsonException("Property is required for class Descendant1: objectType.");
 
             if (alternativeName.IsSet && alternativeName.Value == null)
-                throw new ArgumentNullException(nameof(alternativeName), "Property is not nullable for class Descendant1.");
+                throw new JsonException("Property is not nullable for class Descendant1: alternativeName.");
 
             if (descendantName.IsSet && descendantName.Value == null)
-                throw new ArgumentNullException(nameof(descendantName), "Property is not nullable for class Descendant1.");
+                throw new JsonException("Property is not nullable for class Descendant1: descendantName.");
 
             if (objectType.IsSet && objectType.Value == null)
-                throw new ArgumentNullException(nameof(objectType), "Property is not nullable for class Descendant1.");
+                throw new JsonException("Property is not nullable for class Descendant1: objectType.");
 
             return new Descendant1(alternativeName.Value!, descendantName.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Descendant2.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Descendant2.cs
@@ -141,22 +141,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!alternativeName.IsSet)
-                throw new ArgumentException("Property is required for class Descendant2.", nameof(alternativeName));
+                throw new JsonException("Property is required for class Descendant2: alternativeName.");
 
             if (!confidentiality.IsSet)
-                throw new ArgumentException("Property is required for class Descendant2.", nameof(confidentiality));
+                throw new JsonException("Property is required for class Descendant2: confidentiality.");
 
             if (!objectType.IsSet)
-                throw new ArgumentException("Property is required for class Descendant2.", nameof(objectType));
+                throw new JsonException("Property is required for class Descendant2: objectType.");
 
             if (alternativeName.IsSet && alternativeName.Value == null)
-                throw new ArgumentNullException(nameof(alternativeName), "Property is not nullable for class Descendant2.");
+                throw new JsonException("Property is not nullable for class Descendant2: alternativeName.");
 
             if (confidentiality.IsSet && confidentiality.Value == null)
-                throw new ArgumentNullException(nameof(confidentiality), "Property is not nullable for class Descendant2.");
+                throw new JsonException("Property is not nullable for class Descendant2: confidentiality.");
 
             if (objectType.IsSet && objectType.Value == null)
-                throw new ArgumentNullException(nameof(objectType), "Property is not nullable for class Descendant2.");
+                throw new JsonException("Property is not nullable for class Descendant2: objectType.");
 
             return new Descendant2(alternativeName.Value!, confidentiality.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Dog.cs
@@ -141,16 +141,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Dog.", nameof(className));
+                throw new JsonException("Property is required for class Dog: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Dog.");
+                throw new JsonException("Property is not nullable for class Dog: className.");
 
             if (breed.IsSet && breed.Value == null)
-                throw new ArgumentNullException(nameof(breed), "Property is not nullable for class Dog.");
+                throw new JsonException("Property is not nullable for class Dog: breed.");
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Dog.");
+                throw new JsonException("Property is not nullable for class Dog: color.");
 
             return new Dog(breed, color);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Drawing.cs
@@ -208,10 +208,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (mainShape.IsSet && mainShape.Value == null)
-                throw new ArgumentNullException(nameof(mainShape), "Property is not nullable for class Drawing.");
+                throw new JsonException("Property is not nullable for class Drawing: mainShape.");
 
             if (shapes.IsSet && shapes.Value == null)
-                throw new ArgumentNullException(nameof(shapes), "Property is not nullable for class Drawing.");
+                throw new JsonException("Property is not nullable for class Drawing: shapes.");
 
             return new Drawing(mainShape, nullableShape, shapeOrNull, shapes);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/EntityBase.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/EntityBase.cs
@@ -155,10 +155,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!schema.IsSet)
-                throw new ArgumentException("Property is required for class EntityBase.", nameof(schema));
+                throw new JsonException("Property is required for class EntityBase: $schema.");
 
             if (schema.IsSet && schema.Value == null)
-                throw new ArgumentNullException(nameof(schema), "Property is not nullable for class EntityBase.");
+                throw new JsonException("Property is not nullable for class EntityBase: $schema.");
 
             return new EntityBase();
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -307,10 +307,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayEnum.IsSet && arrayEnum.Value == null)
-                throw new ArgumentNullException(nameof(arrayEnum), "Property is not nullable for class EnumArrays.");
+                throw new JsonException("Property is not nullable for class EnumArrays: array_enum.");
 
             if (justSymbol.IsSet && justSymbol.Value == null)
-                throw new ArgumentNullException(nameof(justSymbol), "Property is not nullable for class EnumArrays.");
+                throw new JsonException("Property is not nullable for class EnumArrays: just_symbol.");
 
             return new EnumArrays(arrayEnum, justSymbol);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -825,31 +825,31 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!enumStringRequired.IsSet)
-                throw new ArgumentException("Property is required for class EnumTest.", nameof(enumStringRequired));
+                throw new JsonException("Property is required for class EnumTest: enum_string_required.");
 
             if (enumStringRequired.IsSet && enumStringRequired.Value == null)
-                throw new ArgumentNullException(nameof(enumStringRequired), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_string_required.");
 
             if (enumInteger.IsSet && enumInteger.Value == null)
-                throw new ArgumentNullException(nameof(enumInteger), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_integer.");
 
             if (enumIntegerOnly.IsSet && enumIntegerOnly.Value == null)
-                throw new ArgumentNullException(nameof(enumIntegerOnly), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_integer_only.");
 
             if (enumNumber.IsSet && enumNumber.Value == null)
-                throw new ArgumentNullException(nameof(enumNumber), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_number.");
 
             if (enumString.IsSet && enumString.Value == null)
-                throw new ArgumentNullException(nameof(enumString), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_string.");
 
             if (outerEnumDefaultValue.IsSet && outerEnumDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(outerEnumDefaultValue), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: outerEnumDefaultValue.");
 
             if (outerEnumInteger.IsSet && outerEnumInteger.Value == null)
-                throw new ArgumentNullException(nameof(outerEnumInteger), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: outerEnumInteger.");
 
             if (outerEnumIntegerDefaultValue.IsSet && outerEnumIntegerDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(outerEnumIntegerDefaultValue), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: outerEnumIntegerDefaultValue.");
 
             return new EnumTest(enumStringRequired.Value!.Value!, enumInteger, enumIntegerOnly, enumNumber, enumString, outerEnum, outerEnumDefaultValue, outerEnumInteger, outerEnumIntegerDefaultValue);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
@@ -154,16 +154,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class EquilateralTriangle.", nameof(shapeType));
+                throw new JsonException("Property is required for class EquilateralTriangle: shapeType.");
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class EquilateralTriangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class EquilateralTriangle: triangleType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class EquilateralTriangle.");
+                throw new JsonException("Property is not nullable for class EquilateralTriangle: shapeType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class EquilateralTriangle.");
+                throw new JsonException("Property is not nullable for class EquilateralTriangle: triangleType.");
 
             return new EquilateralTriangle(shapeType.Value!, triangleType.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/File.cs
@@ -149,7 +149,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (sourceURI.IsSet && sourceURI.Value == null)
-                throw new ArgumentNullException(nameof(sourceURI), "Property is not nullable for class File.");
+                throw new JsonException("Property is not nullable for class File: sourceURI.");
 
             return new File(sourceURI);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -168,10 +168,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (file.IsSet && file.Value == null)
-                throw new ArgumentNullException(nameof(file), "Property is not nullable for class FileSchemaTestClass.");
+                throw new JsonException("Property is not nullable for class FileSchemaTestClass: file.");
 
             if (files.IsSet && files.Value == null)
-                throw new ArgumentNullException(nameof(files), "Property is not nullable for class FileSchemaTestClass.");
+                throw new JsonException("Property is not nullable for class FileSchemaTestClass: files.");
 
             return new FileSchemaTestClass(file, files);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Foo.cs
@@ -148,7 +148,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bar.IsSet && bar.Value == null)
-                throw new ArgumentNullException(nameof(bar), "Property is not nullable for class Foo.");
+                throw new JsonException("Property is not nullable for class Foo: bar.");
 
             return new Foo(bar);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -148,7 +148,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varString.IsSet && varString.Value == null)
-                throw new ArgumentNullException(nameof(varString), "Property is not nullable for class FooGetDefaultResponse.");
+                throw new JsonException("Property is not nullable for class FooGetDefaultResponse: string.");
 
             return new FooGetDefaultResponse(varString);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -829,103 +829,103 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!varByte.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(varByte));
+                throw new JsonException("Property is required for class FormatTest: byte.");
 
             if (!date.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(date));
+                throw new JsonException("Property is required for class FormatTest: date.");
 
             if (!number.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(number));
+                throw new JsonException("Property is required for class FormatTest: number.");
 
             if (!password.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(password));
+                throw new JsonException("Property is required for class FormatTest: password.");
 
             if (!stringFormattedAsDecimalRequired.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(stringFormattedAsDecimalRequired));
+                throw new JsonException("Property is required for class FormatTest: string_formatted_as_decimal_required.");
 
             if (varByte.IsSet && varByte.Value == null)
-                throw new ArgumentNullException(nameof(varByte), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: byte.");
 
             if (date.IsSet && date.Value == null)
-                throw new ArgumentNullException(nameof(date), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: date.");
 
             if (number.IsSet && number.Value == null)
-                throw new ArgumentNullException(nameof(number), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: number.");
 
             if (password.IsSet && password.Value == null)
-                throw new ArgumentNullException(nameof(password), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: password.");
 
             if (stringFormattedAsDecimalRequired.IsSet && stringFormattedAsDecimalRequired.Value == null)
-                throw new ArgumentNullException(nameof(stringFormattedAsDecimalRequired), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: string_formatted_as_decimal_required.");
 
             if (binary.IsSet && binary.Value == null)
-                throw new ArgumentNullException(nameof(binary), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: binary.");
 
             if (dateTime.IsSet && dateTime.Value == null)
-                throw new ArgumentNullException(nameof(dateTime), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: dateTime.");
 
             if (varDecimal.IsSet && varDecimal.Value == null)
-                throw new ArgumentNullException(nameof(varDecimal), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: decimal.");
 
             if (varDouble.IsSet && varDouble.Value == null)
-                throw new ArgumentNullException(nameof(varDouble), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: double.");
 
             if (duplicatePropertyName2.IsSet && duplicatePropertyName2.Value == null)
-                throw new ArgumentNullException(nameof(duplicatePropertyName2), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: duplicate_property_name.");
 
             if (duplicatePropertyName.IsSet && duplicatePropertyName.Value == null)
-                throw new ArgumentNullException(nameof(duplicatePropertyName), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: @duplicate_property_name.");
 
             if (varFloat.IsSet && varFloat.Value == null)
-                throw new ArgumentNullException(nameof(varFloat), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: float.");
 
             if (int32.IsSet && int32.Value == null)
-                throw new ArgumentNullException(nameof(int32), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int32.");
 
             if (int32Range.IsSet && int32Range.Value == null)
-                throw new ArgumentNullException(nameof(int32Range), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int32Range.");
 
             if (int64.IsSet && int64.Value == null)
-                throw new ArgumentNullException(nameof(int64), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64.");
 
             if (int64Negative.IsSet && int64Negative.Value == null)
-                throw new ArgumentNullException(nameof(int64Negative), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64Negative.");
 
             if (int64NegativeExclusive.IsSet && int64NegativeExclusive.Value == null)
-                throw new ArgumentNullException(nameof(int64NegativeExclusive), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64NegativeExclusive.");
 
             if (int64Positive.IsSet && int64Positive.Value == null)
-                throw new ArgumentNullException(nameof(int64Positive), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64Positive.");
 
             if (int64PositiveExclusive.IsSet && int64PositiveExclusive.Value == null)
-                throw new ArgumentNullException(nameof(int64PositiveExclusive), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64PositiveExclusive.");
 
             if (integer.IsSet && integer.Value == null)
-                throw new ArgumentNullException(nameof(integer), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: integer.");
 
             if (patternWithBackslash.IsSet && patternWithBackslash.Value == null)
-                throw new ArgumentNullException(nameof(patternWithBackslash), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: pattern_with_backslash.");
 
             if (patternWithDigits.IsSet && patternWithDigits.Value == null)
-                throw new ArgumentNullException(nameof(patternWithDigits), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: pattern_with_digits.");
 
             if (patternWithDigitsAndDelimiter.IsSet && patternWithDigitsAndDelimiter.Value == null)
-                throw new ArgumentNullException(nameof(patternWithDigitsAndDelimiter), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: pattern_with_digits_and_delimiter.");
 
             if (varString.IsSet && varString.Value == null)
-                throw new ArgumentNullException(nameof(varString), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: string.");
 
             if (stringFormattedAsDecimal.IsSet && stringFormattedAsDecimal.Value == null)
-                throw new ArgumentNullException(nameof(stringFormattedAsDecimal), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: string_formatted_as_decimal.");
 
             if (unsignedInteger.IsSet && unsignedInteger.Value == null)
-                throw new ArgumentNullException(nameof(unsignedInteger), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: unsigned_integer.");
 
             if (unsignedLong.IsSet && unsignedLong.Value == null)
-                throw new ArgumentNullException(nameof(unsignedLong), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: unsigned_long.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: uuid.");
 
             return new FormatTest(varByte.Value!, date.Value!.Value!, number.Value!.Value!, password.Value!, stringFormattedAsDecimalRequired.Value!.Value!, binary, dateTime, varDecimal, varDouble, duplicatePropertyName2, duplicatePropertyName, varFloat, int32, int32Range, int64, int64Negative, int64NegativeExclusive, int64Positive, int64PositiveExclusive, integer, patternWithBackslash, patternWithDigits, patternWithDigitsAndDelimiter, varString, stringFormattedAsDecimal, unsignedInteger, unsignedLong, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Fruit.cs
@@ -186,7 +186,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Fruit.");
+                throw new JsonException("Property is not nullable for class Fruit: color.");
 
             if (apple != null)
                 return new Fruit(apple, color);

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -190,7 +190,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class GmFruit.");
+                throw new JsonException("Property is not nullable for class GmFruit: color.");
 
             Option<Apple?> appleParsedValue = apple == null
                 ? default

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
@@ -158,10 +158,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!petType.IsSet)
-                throw new ArgumentException("Property is required for class GrandparentAnimal.", nameof(petType));
+                throw new JsonException("Property is required for class GrandparentAnimal: pet_type.");
 
             if (petType.IsSet && petType.Value == null)
-                throw new ArgumentNullException(nameof(petType), "Property is not nullable for class GrandparentAnimal.");
+                throw new JsonException("Property is not nullable for class GrandparentAnimal: pet_type.");
 
             return new GrandparentAnimal();
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -209,10 +209,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bar.IsSet && bar.Value == null)
-                throw new ArgumentNullException(nameof(bar), "Property is not nullable for class HasOnlyReadOnly.");
+                throw new JsonException("Property is not nullable for class HasOnlyReadOnly: bar.");
 
             if (foo.IsSet && foo.Value == null)
-                throw new ArgumentNullException(nameof(foo), "Property is not nullable for class HasOnlyReadOnly.");
+                throw new JsonException("Property is not nullable for class HasOnlyReadOnly: foo.");
 
             return new HasOnlyReadOnly(bar, foo);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
@@ -295,22 +295,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (potentiallyOverriddenPropertyAccessor.IsSet && potentiallyOverriddenPropertyAccessor.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyAccessor), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyAccessor.");
 
             if (potentiallyOverriddenPropertyToInternal.IsSet && potentiallyOverriddenPropertyToInternal.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyToInternal), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyToInternal.");
 
             if (potentiallyOverriddenPropertyToPrivate.IsSet && potentiallyOverriddenPropertyToPrivate.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyToPrivate), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyToPrivate.");
 
             if (potentiallyOverriddenPropertyToPublic.IsSet && potentiallyOverriddenPropertyToPublic.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyToPublic), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyToPublic.");
 
             if (unalteredProperty.IsSet && unalteredProperty.Value == null)
-                throw new ArgumentNullException(nameof(unalteredProperty), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: unalteredProperty.");
 
             if (unalteredPropertyAccessor.IsSet && unalteredPropertyAccessor.Value == null)
-                throw new ArgumentNullException(nameof(unalteredPropertyAccessor), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: unalteredPropertyAccessor.");
 
             return new InjectedVendorExtensionsTest(potentiallyOverriddenPropertyAccessor, potentiallyOverriddenPropertyToInternal, potentiallyOverriddenPropertyToPrivate, potentiallyOverriddenPropertyToPublic, unalteredProperty, unalteredPropertyAccessor);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
@@ -147,16 +147,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class IsoscelesTriangle.", nameof(shapeType));
+                throw new JsonException("Property is required for class IsoscelesTriangle: shapeType.");
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class IsoscelesTriangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class IsoscelesTriangle: triangleType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class IsoscelesTriangle.");
+                throw new JsonException("Property is not nullable for class IsoscelesTriangle: shapeType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class IsoscelesTriangle.");
+                throw new JsonException("Property is not nullable for class IsoscelesTriangle: triangleType.");
 
             return new IsoscelesTriangle(shapeType.Value!, triangleType.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/List.cs
@@ -148,7 +148,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (var123List.IsSet && var123List.Value == null)
-                throw new ArgumentNullException(nameof(var123List), "Property is not nullable for class List.");
+                throw new JsonException("Property is not nullable for class List: 123-list.");
 
             return new List(var123List);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -168,10 +168,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (escapedLiteralString.IsSet && escapedLiteralString.Value == null)
-                throw new ArgumentNullException(nameof(escapedLiteralString), "Property is not nullable for class LiteralStringClass.");
+                throw new JsonException("Property is not nullable for class LiteralStringClass: escapedLiteralString.");
 
             if (unescapedLiteralString.IsSet && unescapedLiteralString.Value == null)
-                throw new ArgumentNullException(nameof(unescapedLiteralString), "Property is not nullable for class LiteralStringClass.");
+                throw new JsonException("Property is not nullable for class LiteralStringClass: unescapedLiteralString.");
 
             return new LiteralStringClass(escapedLiteralString, unescapedLiteralString);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Mammal.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Mammal.cs
@@ -217,10 +217,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Mammal.", nameof(className));
+                throw new JsonException("Property is required for class Mammal: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Mammal.");
+                throw new JsonException("Property is not nullable for class Mammal: className.");
 
             if (pig != null)
                 return new Mammal(pig);

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/MapTest.cs
@@ -274,16 +274,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (directMap.IsSet && directMap.Value == null)
-                throw new ArgumentNullException(nameof(directMap), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: direct_map.");
 
             if (indirectMap.IsSet && indirectMap.Value == null)
-                throw new ArgumentNullException(nameof(indirectMap), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: indirect_map.");
 
             if (mapMapOfString.IsSet && mapMapOfString.Value == null)
-                throw new ArgumentNullException(nameof(mapMapOfString), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: map_map_of_string.");
 
             if (mapOfEnumString.IsSet && mapOfEnumString.Value == null)
-                throw new ArgumentNullException(nameof(mapOfEnumString), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: map_of_enum_string.");
 
             return new MapTest(directMap, indirectMap, mapMapOfString, mapOfEnumString);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/MixedAnyOf.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/MixedAnyOf.cs
@@ -148,7 +148,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (content.IsSet && content.Value == null)
-                throw new ArgumentNullException(nameof(content), "Property is not nullable for class MixedAnyOf.");
+                throw new JsonException("Property is not nullable for class MixedAnyOf: content.");
 
             return new MixedAnyOf(content);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/MixedOneOf.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/MixedOneOf.cs
@@ -148,7 +148,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (content.IsSet && content.Value == null)
-                throw new ArgumentNullException(nameof(content), "Property is not nullable for class MixedOneOf.");
+                throw new JsonException("Property is not nullable for class MixedOneOf: content.");
 
             return new MixedOneOf(content);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -220,16 +220,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (dateTime.IsSet && dateTime.Value == null)
-                throw new ArgumentNullException(nameof(dateTime), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: dateTime.");
 
             if (map.IsSet && map.Value == null)
-                throw new ArgumentNullException(nameof(map), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: map.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: uuid.");
 
             if (uuidWithPattern.IsSet && uuidWithPattern.Value == null)
-                throw new ArgumentNullException(nameof(uuidWithPattern), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: uuid_with_pattern.");
 
             return new MixedPropertiesAndAdditionalPropertiesClass(dateTime, map, uuid, uuidWithPattern);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/MixedSubId.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/MixedSubId.cs
@@ -148,7 +148,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class MixedSubId.");
+                throw new JsonException("Property is not nullable for class MixedSubId: id.");
 
             return new MixedSubId(id);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -168,10 +168,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varClass.IsSet && varClass.Value == null)
-                throw new ArgumentNullException(nameof(varClass), "Property is not nullable for class Model200Response.");
+                throw new JsonException("Property is not nullable for class Model200Response: class.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Model200Response.");
+                throw new JsonException("Property is not nullable for class Model200Response: name.");
 
             return new Model200Response(varClass, name);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -148,7 +148,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varClient.IsSet && varClient.Value == null)
-                throw new ArgumentNullException(nameof(varClient), "Property is not nullable for class ModelClient.");
+                throw new JsonException("Property is not nullable for class ModelClient: client.");
 
             return new ModelClient(varClient);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Name.cs
@@ -242,19 +242,19 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!varName.IsSet)
-                throw new ArgumentException("Property is required for class Name.", nameof(varName));
+                throw new JsonException("Property is required for class Name: name.");
 
             if (varName.IsSet && varName.Value == null)
-                throw new ArgumentNullException(nameof(varName), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: name.");
 
             if (property.IsSet && property.Value == null)
-                throw new ArgumentNullException(nameof(property), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: property.");
 
             if (snakeCase.IsSet && snakeCase.Value == null)
-                throw new ArgumentNullException(nameof(snakeCase), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: snake_case.");
 
             if (var123Number.IsSet && var123Number.Value == null)
-                throw new ArgumentNullException(nameof(var123Number), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: 123Number.");
 
             return new Name(varName.Value!.Value!, property, snakeCase, var123Number);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
@@ -154,16 +154,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!aObjVariableobject.IsSet)
-                throw new ArgumentException("Property is required for class NotificationtestGetElementsV1ResponseMPayload.", nameof(aObjVariableobject));
+                throw new JsonException("Property is required for class NotificationtestGetElementsV1ResponseMPayload: a_objVariableobject.");
 
             if (!pkiNotificationtestID.IsSet)
-                throw new ArgumentException("Property is required for class NotificationtestGetElementsV1ResponseMPayload.", nameof(pkiNotificationtestID));
+                throw new JsonException("Property is required for class NotificationtestGetElementsV1ResponseMPayload: pkiNotificationtestID.");
 
             if (aObjVariableobject.IsSet && aObjVariableobject.Value == null)
-                throw new ArgumentNullException(nameof(aObjVariableobject), "Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload.");
+                throw new JsonException("Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload: a_objVariableobject.");
 
             if (pkiNotificationtestID.IsSet && pkiNotificationtestID.Value == null)
-                throw new ArgumentNullException(nameof(pkiNotificationtestID), "Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload.");
+                throw new JsonException("Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload: pkiNotificationtestID.");
 
             return new NotificationtestGetElementsV1ResponseMPayload(aObjVariableobject.Value!, pkiNotificationtestID.Value!.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -378,10 +378,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayItemsNullable.IsSet && arrayItemsNullable.Value == null)
-                throw new ArgumentNullException(nameof(arrayItemsNullable), "Property is not nullable for class NullableClass.");
+                throw new JsonException("Property is not nullable for class NullableClass: array_items_nullable.");
 
             if (objectItemsNullable.IsSet && objectItemsNullable.Value == null)
-                throw new ArgumentNullException(nameof(objectItemsNullable), "Property is not nullable for class NullableClass.");
+                throw new JsonException("Property is not nullable for class NullableClass: object_items_nullable.");
 
             return new NullableClass(arrayAndItemsNullableProp, arrayItemsNullable, arrayNullableProp, booleanProp, dateProp, datetimeProp, integerProp, numberProp, objectAndItemsNullableProp, objectItemsNullable, objectNullableProp, stringProp);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/NullableShape.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/NullableShape.cs
@@ -196,10 +196,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class NullableShape.", nameof(shapeType));
+                throw new JsonException("Property is required for class NullableShape: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class NullableShape.");
+                throw new JsonException("Property is not nullable for class NullableShape: shapeType.");
 
             if (quadrilateral != null)
                 return new NullableShape(quadrilateral);

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -148,7 +148,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (justNumber.IsSet && justNumber.Value == null)
-                throw new ArgumentNullException(nameof(justNumber), "Property is not nullable for class NumberOnly.");
+                throw new JsonException("Property is not nullable for class NumberOnly: JustNumber.");
 
             return new NumberOnly(justNumber);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -211,16 +211,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bars.IsSet && bars.Value == null)
-                throw new ArgumentNullException(nameof(bars), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: bars.");
 
             if (deprecatedRef.IsSet && deprecatedRef.Value == null)
-                throw new ArgumentNullException(nameof(deprecatedRef), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: deprecatedRef.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: id.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: uuid.");
 
             return new ObjectWithDeprecatedFields(bars, deprecatedRef, id, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Order.cs
@@ -343,22 +343,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (complete.IsSet && complete.Value == null)
-                throw new ArgumentNullException(nameof(complete), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: complete.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: id.");
 
             if (petId.IsSet && petId.Value == null)
-                throw new ArgumentNullException(nameof(petId), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: petId.");
 
             if (quantity.IsSet && quantity.Value == null)
-                throw new ArgumentNullException(nameof(quantity), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: quantity.");
 
             if (shipDate.IsSet && shipDate.Value == null)
-                throw new ArgumentNullException(nameof(shipDate), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: shipDate.");
 
             if (status.IsSet && status.Value == null)
-                throw new ArgumentNullException(nameof(status), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: status.");
 
             return new Order(complete, id, petId, quantity, shipDate, status);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -188,13 +188,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (myBoolean.IsSet && myBoolean.Value == null)
-                throw new ArgumentNullException(nameof(myBoolean), "Property is not nullable for class OuterComposite.");
+                throw new JsonException("Property is not nullable for class OuterComposite: my_boolean.");
 
             if (myNumber.IsSet && myNumber.Value == null)
-                throw new ArgumentNullException(nameof(myNumber), "Property is not nullable for class OuterComposite.");
+                throw new JsonException("Property is not nullable for class OuterComposite: my_number.");
 
             if (myString.IsSet && myString.Value == null)
-                throw new ArgumentNullException(nameof(myString), "Property is not nullable for class OuterComposite.");
+                throw new JsonException("Property is not nullable for class OuterComposite: my_string.");
 
             return new OuterComposite(myBoolean, myNumber, myString);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ParentPet.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ParentPet.cs
@@ -121,10 +121,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!petType.IsSet)
-                throw new ArgumentException("Property is required for class ParentPet.", nameof(petType));
+                throw new JsonException("Property is required for class ParentPet: pet_type.");
 
             if (petType.IsSet && petType.Value == null)
-                throw new ArgumentNullException(nameof(petType), "Property is not nullable for class ParentPet.");
+                throw new JsonException("Property is not nullable for class ParentPet: pet_type.");
 
             return new ParentPet();
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Pet.cs
@@ -324,28 +324,28 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!name.IsSet)
-                throw new ArgumentException("Property is required for class Pet.", nameof(name));
+                throw new JsonException("Property is required for class Pet: name.");
 
             if (!photoUrls.IsSet)
-                throw new ArgumentException("Property is required for class Pet.", nameof(photoUrls));
+                throw new JsonException("Property is required for class Pet: photoUrls.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: name.");
 
             if (photoUrls.IsSet && photoUrls.Value == null)
-                throw new ArgumentNullException(nameof(photoUrls), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: photoUrls.");
 
             if (category.IsSet && category.Value == null)
-                throw new ArgumentNullException(nameof(category), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: category.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: id.");
 
             if (status.IsSet && status.Value == null)
-                throw new ArgumentNullException(nameof(status), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: status.");
 
             if (tags.IsSet && tags.Value == null)
-                throw new ArgumentNullException(nameof(tags), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: tags.");
 
             return new Pet(name.Value!, photoUrls.Value!, category, id, status, tags);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Pig.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Pig.cs
@@ -196,10 +196,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Pig.", nameof(className));
+                throw new JsonException("Property is required for class Pig: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Pig.");
+                throw new JsonException("Property is not nullable for class Pig: className.");
 
             if (basquePig != null)
                 return new Pig(basquePig);

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Quadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Quadrilateral.cs
@@ -196,10 +196,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class Quadrilateral.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class Quadrilateral: quadrilateralType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class Quadrilateral.");
+                throw new JsonException("Property is not nullable for class Quadrilateral: quadrilateralType.");
 
             if (complexQuadrilateral != null)
                 return new Quadrilateral(complexQuadrilateral);

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
@@ -141,10 +141,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class QuadrilateralInterface.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class QuadrilateralInterface: quadrilateralType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class QuadrilateralInterface.");
+                throw new JsonException("Property is not nullable for class QuadrilateralInterface: quadrilateralType.");
 
             return new QuadrilateralInterface(quadrilateralType.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -206,10 +206,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bar.IsSet && bar.Value == null)
-                throw new ArgumentNullException(nameof(bar), "Property is not nullable for class ReadOnlyFirst.");
+                throw new JsonException("Property is not nullable for class ReadOnlyFirst: bar.");
 
             if (baz.IsSet && baz.Value == null)
-                throw new ArgumentNullException(nameof(baz), "Property is not nullable for class ReadOnlyFirst.");
+                throw new JsonException("Property is not nullable for class ReadOnlyFirst: baz.");
 
             return new ReadOnlyFirst(bar, baz);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -2080,136 +2080,136 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!requiredNotNullableDateProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotNullableDateProp));
+                throw new JsonException("Property is required for class RequiredClass: required_not_nullable_date_prop.");
 
             if (!requiredNotnullableArrayOfString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableArrayOfString));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_array_of_string.");
 
             if (!requiredNotnullableBooleanProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableBooleanProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_boolean_prop.");
 
             if (!requiredNotnullableDatetimeProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableDatetimeProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_datetime_prop.");
 
             if (!requiredNotnullableEnumInteger.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableEnumInteger));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_enum_integer.");
 
             if (!requiredNotnullableEnumIntegerOnly.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableEnumIntegerOnly));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_enum_integer_only.");
 
             if (!requiredNotnullableEnumString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableEnumString));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_enum_string.");
 
             if (!requiredNotnullableOuterEnumDefaultValue.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableOuterEnumDefaultValue));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_outerEnumDefaultValue.");
 
             if (!requiredNotnullableStringProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableStringProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_string_prop.");
 
             if (!requiredNotnullableUuid.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableUuid));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_uuid.");
 
             if (!requiredNotnullableintegerProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableintegerProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullableinteger_prop.");
 
             if (!requiredNullableArrayOfString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableArrayOfString));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_array_of_string.");
 
             if (!requiredNullableBooleanProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableBooleanProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_boolean_prop.");
 
             if (!requiredNullableDateProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableDateProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_date_prop.");
 
             if (!requiredNullableDatetimeProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableDatetimeProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_datetime_prop.");
 
             if (!requiredNullableEnumInteger.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableEnumInteger));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_enum_integer.");
 
             if (!requiredNullableEnumIntegerOnly.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableEnumIntegerOnly));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_enum_integer_only.");
 
             if (!requiredNullableEnumString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableEnumString));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_enum_string.");
 
             if (!requiredNullableIntegerProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableIntegerProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_integer_prop.");
 
             if (!requiredNullableOuterEnumDefaultValue.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableOuterEnumDefaultValue));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_outerEnumDefaultValue.");
 
             if (!requiredNullableStringProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableStringProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_string_prop.");
 
             if (!requiredNullableUuid.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableUuid));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_uuid.");
 
             if (requiredNotNullableDateProp.IsSet && requiredNotNullableDateProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotNullableDateProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_not_nullable_date_prop.");
 
             if (requiredNotnullableArrayOfString.IsSet && requiredNotnullableArrayOfString.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableArrayOfString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_array_of_string.");
 
             if (requiredNotnullableBooleanProp.IsSet && requiredNotnullableBooleanProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableBooleanProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_boolean_prop.");
 
             if (requiredNotnullableDatetimeProp.IsSet && requiredNotnullableDatetimeProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableDatetimeProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_datetime_prop.");
 
             if (requiredNotnullableEnumInteger.IsSet && requiredNotnullableEnumInteger.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableEnumInteger), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_enum_integer.");
 
             if (requiredNotnullableEnumIntegerOnly.IsSet && requiredNotnullableEnumIntegerOnly.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableEnumIntegerOnly), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_enum_integer_only.");
 
             if (requiredNotnullableEnumString.IsSet && requiredNotnullableEnumString.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableEnumString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_enum_string.");
 
             if (requiredNotnullableOuterEnumDefaultValue.IsSet && requiredNotnullableOuterEnumDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableOuterEnumDefaultValue), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_outerEnumDefaultValue.");
 
             if (requiredNotnullableStringProp.IsSet && requiredNotnullableStringProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableStringProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_string_prop.");
 
             if (requiredNotnullableUuid.IsSet && requiredNotnullableUuid.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableUuid), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_uuid.");
 
             if (requiredNotnullableintegerProp.IsSet && requiredNotnullableintegerProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableintegerProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullableinteger_prop.");
 
             if (notRequiredNotnullableDateProp.IsSet && notRequiredNotnullableDateProp.Value == null)
-                throw new ArgumentNullException(nameof(notRequiredNotnullableDateProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: not_required_notnullable_date_prop.");
 
             if (notRequiredNotnullableintegerProp.IsSet && notRequiredNotnullableintegerProp.Value == null)
-                throw new ArgumentNullException(nameof(notRequiredNotnullableintegerProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: not_required_notnullableinteger_prop.");
 
             if (notrequiredNotnullableArrayOfString.IsSet && notrequiredNotnullableArrayOfString.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableArrayOfString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_array_of_string.");
 
             if (notrequiredNotnullableBooleanProp.IsSet && notrequiredNotnullableBooleanProp.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableBooleanProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_boolean_prop.");
 
             if (notrequiredNotnullableDatetimeProp.IsSet && notrequiredNotnullableDatetimeProp.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableDatetimeProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_datetime_prop.");
 
             if (notrequiredNotnullableEnumInteger.IsSet && notrequiredNotnullableEnumInteger.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableEnumInteger), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_enum_integer.");
 
             if (notrequiredNotnullableEnumIntegerOnly.IsSet && notrequiredNotnullableEnumIntegerOnly.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableEnumIntegerOnly), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_enum_integer_only.");
 
             if (notrequiredNotnullableEnumString.IsSet && notrequiredNotnullableEnumString.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableEnumString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_enum_string.");
 
             if (notrequiredNotnullableOuterEnumDefaultValue.IsSet && notrequiredNotnullableOuterEnumDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableOuterEnumDefaultValue), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_outerEnumDefaultValue.");
 
             if (notrequiredNotnullableStringProp.IsSet && notrequiredNotnullableStringProp.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableStringProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_string_prop.");
 
             if (notrequiredNotnullableUuid.IsSet && notrequiredNotnullableUuid.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableUuid), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_uuid.");
 
             return new RequiredClass(requiredNotNullableDateProp.Value!.Value!, requiredNotnullableArrayOfString.Value!, requiredNotnullableBooleanProp.Value!.Value!, requiredNotnullableDatetimeProp.Value!.Value!, requiredNotnullableEnumInteger.Value!.Value!, requiredNotnullableEnumIntegerOnly.Value!.Value!, requiredNotnullableEnumString.Value!.Value!, requiredNotnullableOuterEnumDefaultValue.Value!.Value!, requiredNotnullableStringProp.Value!, requiredNotnullableUuid.Value!.Value!, requiredNotnullableintegerProp.Value!.Value!, notRequiredNotnullableDateProp, notRequiredNotnullableintegerProp, notRequiredNullableDateProp, notRequiredNullableIntegerProp, notrequiredNotnullableArrayOfString, notrequiredNotnullableBooleanProp, notrequiredNotnullableDatetimeProp, notrequiredNotnullableEnumInteger, notrequiredNotnullableEnumIntegerOnly, notrequiredNotnullableEnumString, notrequiredNotnullableOuterEnumDefaultValue, notrequiredNotnullableStringProp, notrequiredNotnullableUuid, notrequiredNullableArrayOfString, notrequiredNullableBooleanProp, notrequiredNullableDatetimeProp, notrequiredNullableEnumInteger, notrequiredNullableEnumIntegerOnly, notrequiredNullableEnumString, notrequiredNullableOuterEnumDefaultValue, notrequiredNullableStringProp, notrequiredNullableUuid, requiredNullableArrayOfString.Value!, requiredNullableBooleanProp.Value!, requiredNullableDateProp.Value!, requiredNullableDatetimeProp.Value!, requiredNullableEnumInteger.Value!, requiredNullableEnumIntegerOnly.Value!, requiredNullableEnumString.Value!, requiredNullableIntegerProp.Value!, requiredNullableOuterEnumDefaultValue.Value!, requiredNullableStringProp.Value!, requiredNullableUuid.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Result.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Result.cs
@@ -191,13 +191,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (code.IsSet && code.Value == null)
-                throw new ArgumentNullException(nameof(code), "Property is not nullable for class Result.");
+                throw new JsonException("Property is not nullable for class Result: code.");
 
             if (data.IsSet && data.Value == null)
-                throw new ArgumentNullException(nameof(data), "Property is not nullable for class Result.");
+                throw new JsonException("Property is not nullable for class Result: data.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class Result.");
+                throw new JsonException("Property is not nullable for class Result: uuid.");
 
             return new Result(code, data, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Return.cs
@@ -194,19 +194,19 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!varLock.IsSet)
-                throw new ArgumentException("Property is required for class Return.", nameof(varLock));
+                throw new JsonException("Property is required for class Return: lock.");
 
             if (!varAbstract.IsSet)
-                throw new ArgumentException("Property is required for class Return.", nameof(varAbstract));
+                throw new JsonException("Property is required for class Return: abstract.");
 
             if (varLock.IsSet && varLock.Value == null)
-                throw new ArgumentNullException(nameof(varLock), "Property is not nullable for class Return.");
+                throw new JsonException("Property is not nullable for class Return: lock.");
 
             if (varReturn.IsSet && varReturn.Value == null)
-                throw new ArgumentNullException(nameof(varReturn), "Property is not nullable for class Return.");
+                throw new JsonException("Property is not nullable for class Return: return.");
 
             if (varUnsafe.IsSet && varUnsafe.Value == null)
-                throw new ArgumentNullException(nameof(varUnsafe), "Property is not nullable for class Return.");
+                throw new JsonException("Property is not nullable for class Return: unsafe.");
 
             return new Return(varLock.Value!, varAbstract.Value!, varReturn, varUnsafe);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -168,10 +168,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (role.IsSet && role.Value == null)
-                throw new ArgumentNullException(nameof(role), "Property is not nullable for class RolesReportsHash.");
+                throw new JsonException("Property is not nullable for class RolesReportsHash: role.");
 
             if (roleUuid.IsSet && roleUuid.Value == null)
-                throw new ArgumentNullException(nameof(roleUuid), "Property is not nullable for class RolesReportsHash.");
+                throw new JsonException("Property is not nullable for class RolesReportsHash: role_uuid.");
 
             return new RolesReportsHash(role, roleUuid);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
@@ -148,7 +148,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class RolesReportsHashRole.");
+                throw new JsonException("Property is not nullable for class RolesReportsHashRole: name.");
 
             return new RolesReportsHashRole(name);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
@@ -154,16 +154,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ScaleneTriangle.", nameof(shapeType));
+                throw new JsonException("Property is required for class ScaleneTriangle: shapeType.");
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class ScaleneTriangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class ScaleneTriangle: triangleType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ScaleneTriangle.");
+                throw new JsonException("Property is not nullable for class ScaleneTriangle: shapeType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class ScaleneTriangle.");
+                throw new JsonException("Property is not nullable for class ScaleneTriangle: triangleType.");
 
             return new ScaleneTriangle(shapeType.Value!, triangleType.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Shape.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Shape.cs
@@ -196,10 +196,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class Shape.", nameof(shapeType));
+                throw new JsonException("Property is required for class Shape: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class Shape.");
+                throw new JsonException("Property is not nullable for class Shape: shapeType.");
 
             if (quadrilateral != null)
                 return new Shape(quadrilateral);

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ShapeInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ShapeInterface.cs
@@ -141,10 +141,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ShapeInterface.", nameof(shapeType));
+                throw new JsonException("Property is required for class ShapeInterface: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ShapeInterface.");
+                throw new JsonException("Property is not nullable for class ShapeInterface: shapeType.");
 
             return new ShapeInterface(shapeType.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ShapeOrNull.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ShapeOrNull.cs
@@ -196,10 +196,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ShapeOrNull.", nameof(shapeType));
+                throw new JsonException("Property is required for class ShapeOrNull: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ShapeOrNull.");
+                throw new JsonException("Property is not nullable for class ShapeOrNull: shapeType.");
 
             if (quadrilateral != null)
                 return new ShapeOrNull(quadrilateral);

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
@@ -154,16 +154,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class SimpleQuadrilateral.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class SimpleQuadrilateral: quadrilateralType.");
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class SimpleQuadrilateral.", nameof(shapeType));
+                throw new JsonException("Property is required for class SimpleQuadrilateral: shapeType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class SimpleQuadrilateral.");
+                throw new JsonException("Property is not nullable for class SimpleQuadrilateral: quadrilateralType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class SimpleQuadrilateral.");
+                throw new JsonException("Property is not nullable for class SimpleQuadrilateral: shapeType.");
 
             return new SimpleQuadrilateral(quadrilateralType.Value!, shapeType.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -168,10 +168,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varSpecialModelName.IsSet && varSpecialModelName.Value == null)
-                throw new ArgumentNullException(nameof(varSpecialModelName), "Property is not nullable for class SpecialModelName.");
+                throw new JsonException("Property is not nullable for class SpecialModelName: _special_model.name_.");
 
             if (specialPropertyName.IsSet && specialPropertyName.Value == null)
-                throw new ArgumentNullException(nameof(specialPropertyName), "Property is not nullable for class SpecialModelName.");
+                throw new JsonException("Property is not nullable for class SpecialModelName: $special[property.name].");
 
             return new SpecialModelName(varSpecialModelName, specialPropertyName);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Tag.cs
@@ -168,10 +168,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Tag.");
+                throw new JsonException("Property is not nullable for class Tag: id.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Tag.");
+                throw new JsonException("Property is not nullable for class Tag: name.");
 
             return new Tag(id, name);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -148,7 +148,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (value.IsSet && value.Value == null)
-                throw new ArgumentNullException(nameof(value), "Property is not nullable for class TestCollectionEndingWithWordList.");
+                throw new JsonException("Property is not nullable for class TestCollectionEndingWithWordList: value.");
 
             return new TestCollectionEndingWithWordList(value);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -148,7 +148,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (testCollectionEndingWithWordList.IsSet && testCollectionEndingWithWordList.Value == null)
-                throw new ArgumentNullException(nameof(testCollectionEndingWithWordList), "Property is not nullable for class TestCollectionEndingWithWordListObject.");
+                throw new JsonException("Property is not nullable for class TestCollectionEndingWithWordListObject: TestCollectionEndingWithWordList.");
 
             return new TestCollectionEndingWithWordListObject(testCollectionEndingWithWordList);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/TestDescendants.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/TestDescendants.cs
@@ -244,16 +244,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!alternativeName.IsSet)
-                throw new ArgumentException("Property is required for class TestDescendants.", nameof(alternativeName));
+                throw new JsonException("Property is required for class TestDescendants: alternativeName.");
 
             if (!objectType.IsSet)
-                throw new ArgumentException("Property is required for class TestDescendants.", nameof(objectType));
+                throw new JsonException("Property is required for class TestDescendants: objectType.");
 
             if (alternativeName.IsSet && alternativeName.Value == null)
-                throw new ArgumentNullException(nameof(alternativeName), "Property is not nullable for class TestDescendants.");
+                throw new JsonException("Property is not nullable for class TestDescendants: alternativeName.");
 
             if (objectType.IsSet && objectType.Value == null)
-                throw new ArgumentNullException(nameof(objectType), "Property is not nullable for class TestDescendants.");
+                throw new JsonException("Property is not nullable for class TestDescendants: objectType.");
 
             return new TestDescendants(alternativeName.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
@@ -148,7 +148,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (someProperty.IsSet && someProperty.Value == null)
-                throw new ArgumentNullException(nameof(someProperty), "Property is not nullable for class TestInlineFreeformAdditionalPropertiesRequest.");
+                throw new JsonException("Property is not nullable for class TestInlineFreeformAdditionalPropertiesRequest: someProperty.");
 
             return new TestInlineFreeformAdditionalPropertiesRequest(someProperty);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/TestResult.cs
@@ -190,13 +190,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (code.IsSet && code.Value == null)
-                throw new ArgumentNullException(nameof(code), "Property is not nullable for class TestResult.");
+                throw new JsonException("Property is not nullable for class TestResult: code.");
 
             if (data.IsSet && data.Value == null)
-                throw new ArgumentNullException(nameof(data), "Property is not nullable for class TestResult.");
+                throw new JsonException("Property is not nullable for class TestResult: data.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class TestResult.");
+                throw new JsonException("Property is not nullable for class TestResult: uuid.");
 
             return new TestResult(code, data, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Triangle.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Triangle.cs
@@ -217,10 +217,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class Triangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class Triangle: triangleType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class Triangle.");
+                throw new JsonException("Property is not nullable for class Triangle: triangleType.");
 
             if (equilateralTriangle != null)
                 return new Triangle(equilateralTriangle);

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/TriangleInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/TriangleInterface.cs
@@ -141,10 +141,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class TriangleInterface.", nameof(triangleType));
+                throw new JsonException("Property is required for class TriangleInterface: triangleType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class TriangleInterface.");
+                throw new JsonException("Property is not nullable for class TriangleInterface: triangleType.");
 
             return new TriangleInterface(triangleType.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/User.cs
@@ -373,31 +373,31 @@ namespace Org.OpenAPITools.Model
             }
 
             if (email.IsSet && email.Value == null)
-                throw new ArgumentNullException(nameof(email), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: email.");
 
             if (firstName.IsSet && firstName.Value == null)
-                throw new ArgumentNullException(nameof(firstName), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: firstName.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: id.");
 
             if (lastName.IsSet && lastName.Value == null)
-                throw new ArgumentNullException(nameof(lastName), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: lastName.");
 
             if (objectWithNoDeclaredProps.IsSet && objectWithNoDeclaredProps.Value == null)
-                throw new ArgumentNullException(nameof(objectWithNoDeclaredProps), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: objectWithNoDeclaredProps.");
 
             if (password.IsSet && password.Value == null)
-                throw new ArgumentNullException(nameof(password), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: password.");
 
             if (phone.IsSet && phone.Value == null)
-                throw new ArgumentNullException(nameof(phone), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: phone.");
 
             if (userStatus.IsSet && userStatus.Value == null)
-                throw new ArgumentNullException(nameof(userStatus), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: userStatus.");
 
             if (username.IsSet && username.Value == null)
-                throw new ArgumentNullException(nameof(username), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: username.");
 
             return new User(anyTypeProp, anyTypePropNullable, email, firstName, id, lastName, objectWithNoDeclaredProps, objectWithNoDeclaredPropsNullable, password, phone, userStatus, username);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Whale.cs
@@ -181,16 +181,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Whale.", nameof(className));
+                throw new JsonException("Property is required for class Whale: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Whale.");
+                throw new JsonException("Property is not nullable for class Whale: className.");
 
             if (hasBaleen.IsSet && hasBaleen.Value == null)
-                throw new ArgumentNullException(nameof(hasBaleen), "Property is not nullable for class Whale.");
+                throw new JsonException("Property is not nullable for class Whale: hasBaleen.");
 
             if (hasTeeth.IsSet && hasTeeth.Value == null)
-                throw new ArgumentNullException(nameof(hasTeeth), "Property is not nullable for class Whale.");
+                throw new JsonException("Property is not nullable for class Whale: hasTeeth.");
 
             return new Whale(className.Value!, hasBaleen, hasTeeth);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Zebra.cs
@@ -248,13 +248,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Zebra.", nameof(className));
+                throw new JsonException("Property is required for class Zebra: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Zebra.");
+                throw new JsonException("Property is not nullable for class Zebra: className.");
 
             if (type.IsSet && type.Value == null)
-                throw new ArgumentNullException(nameof(type), "Property is not nullable for class Zebra.");
+                throw new JsonException("Property is not nullable for class Zebra: type.");
 
             return new Zebra(className.Value!, type);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
@@ -221,7 +221,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (zeroBasedEnum.IsSet && zeroBasedEnum.Value == null)
-                throw new ArgumentNullException(nameof(zeroBasedEnum), "Property is not nullable for class ZeroBasedEnumClass.");
+                throw new JsonException("Property is not nullable for class ZeroBasedEnumClass: ZeroBasedEnum.");
 
             return new ZeroBasedEnumClass(zeroBasedEnum);
         }

--- a/samples/client/petstore/csharp/generichost/net10/UseDateTimeForDate/src/Org.OpenAPITools/Model/NowGet200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net10/UseDateTimeForDate/src/Org.OpenAPITools/Model/NowGet200Response.cs
@@ -169,10 +169,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (now.IsSet && now.Value == null)
-                throw new ArgumentNullException(nameof(now), "Property is not nullable for class NowGet200Response.");
+                throw new JsonException("Property is not nullable for class NowGet200Response: now.");
 
             if (today.IsSet && today.Value == null)
-                throw new ArgumentNullException(nameof(today), "Property is not nullable for class NowGet200Response.");
+                throw new JsonException("Property is not nullable for class NowGet200Response: today.");
 
             return new NowGet200Response(now, today);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/AllOf/src/Org.OpenAPITools/Model/Adult.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/AllOf/src/Org.OpenAPITools/Model/Adult.cs
@@ -143,16 +143,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (children.IsSet && children.Value == null)
-                throw new ArgumentNullException(nameof(children), "Property is not nullable for class Adult.");
+                throw new JsonException("Property is not nullable for class Adult: children.");
 
             if (firstName.IsSet && firstName.Value == null)
-                throw new ArgumentNullException(nameof(firstName), "Property is not nullable for class Adult.");
+                throw new JsonException("Property is not nullable for class Adult: firstName.");
 
             if (lastName.IsSet && lastName.Value == null)
-                throw new ArgumentNullException(nameof(lastName), "Property is not nullable for class Adult.");
+                throw new JsonException("Property is not nullable for class Adult: lastName.");
 
             if (type.IsSet && type.Value == null)
-                throw new ArgumentNullException(nameof(type), "Property is not nullable for class Adult.");
+                throw new JsonException("Property is not nullable for class Adult: $_type.");
 
             return new Adult(children, firstName, lastName);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/AllOf/src/Org.OpenAPITools/Model/Child.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/AllOf/src/Org.OpenAPITools/Model/Child.cs
@@ -163,19 +163,19 @@ namespace Org.OpenAPITools.Model
             }
 
             if (age.IsSet && age.Value == null)
-                throw new ArgumentNullException(nameof(age), "Property is not nullable for class Child.");
+                throw new JsonException("Property is not nullable for class Child: age.");
 
             if (boosterSeat.IsSet && boosterSeat.Value == null)
-                throw new ArgumentNullException(nameof(boosterSeat), "Property is not nullable for class Child.");
+                throw new JsonException("Property is not nullable for class Child: boosterSeat.");
 
             if (firstName.IsSet && firstName.Value == null)
-                throw new ArgumentNullException(nameof(firstName), "Property is not nullable for class Child.");
+                throw new JsonException("Property is not nullable for class Child: firstName.");
 
             if (lastName.IsSet && lastName.Value == null)
-                throw new ArgumentNullException(nameof(lastName), "Property is not nullable for class Child.");
+                throw new JsonException("Property is not nullable for class Child: lastName.");
 
             if (type.IsSet && type.Value == null)
-                throw new ArgumentNullException(nameof(type), "Property is not nullable for class Child.");
+                throw new JsonException("Property is not nullable for class Child: $_type.");
 
             return new Child(age, boosterSeat, firstName, lastName);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/AllOf/src/Org.OpenAPITools/Model/Person.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/AllOf/src/Org.OpenAPITools/Model/Person.cs
@@ -195,13 +195,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (firstName.IsSet && firstName.Value == null)
-                throw new ArgumentNullException(nameof(firstName), "Property is not nullable for class Person.");
+                throw new JsonException("Property is not nullable for class Person: firstName.");
 
             if (lastName.IsSet && lastName.Value == null)
-                throw new ArgumentNullException(nameof(lastName), "Property is not nullable for class Person.");
+                throw new JsonException("Property is not nullable for class Person: lastName.");
 
             if (type.IsSet && type.Value == null)
-                throw new ArgumentNullException(nameof(type), "Property is not nullable for class Person.");
+                throw new JsonException("Property is not nullable for class Person: $_type.");
 
             return new Person(firstName, lastName);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/AnyOf/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/AnyOf/src/Org.OpenAPITools/Model/Apple.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (kind.IsSet && kind.Value == null)
-                throw new ArgumentNullException(nameof(kind), "Property is not nullable for class Apple.");
+                throw new JsonException("Property is not nullable for class Apple: kind.");
 
             return new Apple(kind);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/AnyOf/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/AnyOf/src/Org.OpenAPITools/Model/Banana.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (count.IsSet && count.Value == null)
-                throw new ArgumentNullException(nameof(count), "Property is not nullable for class Banana.");
+                throw new JsonException("Property is not nullable for class Banana: count.");
 
             return new Banana(count);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/AnyOf/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/AnyOf/src/Org.OpenAPITools/Model/Fruit.cs
@@ -194,7 +194,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Fruit.");
+                throw new JsonException("Property is not nullable for class Fruit: color.");
 
             Option<Apple> appleParsedValue = apple == null
                 ? default

--- a/samples/client/petstore/csharp/generichost/net4.7/AnyOfNoCompare/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/AnyOfNoCompare/src/Org.OpenAPITools/Model/Apple.cs
@@ -144,7 +144,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (kind.IsSet && kind.Value == null)
-                throw new ArgumentNullException(nameof(kind), "Property is not nullable for class Apple.");
+                throw new JsonException("Property is not nullable for class Apple: kind.");
 
             return new Apple(kind);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/AnyOfNoCompare/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/AnyOfNoCompare/src/Org.OpenAPITools/Model/Banana.cs
@@ -144,7 +144,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (count.IsSet && count.Value == null)
-                throw new ArgumentNullException(nameof(count), "Property is not nullable for class Banana.");
+                throw new JsonException("Property is not nullable for class Banana: count.");
 
             return new Banana(count);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/AnyOfNoCompare/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/AnyOfNoCompare/src/Org.OpenAPITools/Model/Fruit.cs
@@ -193,7 +193,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Fruit.");
+                throw new JsonException("Property is not nullable for class Fruit: color.");
 
             Option<Apple> appleParsedValue = apple == null
                 ? default

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Activity.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (activityOutputs.IsSet && activityOutputs.Value == null)
-                throw new ArgumentNullException(nameof(activityOutputs), "Property is not nullable for class Activity.");
+                throw new JsonException("Property is not nullable for class Activity: activity_outputs.");
 
             return new Activity(activityOutputs);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (prop1.IsSet && prop1.Value == null)
-                throw new ArgumentNullException(nameof(prop1), "Property is not nullable for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Property is not nullable for class ActivityOutputElementRepresentation: prop1.");
 
             if (prop2.IsSet && prop2.Value == null)
-                throw new ArgumentNullException(nameof(prop2), "Property is not nullable for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Property is not nullable for class ActivityOutputElementRepresentation: prop2.");
 
             return new ActivityOutputElementRepresentation(prop1, prop2);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -286,25 +286,25 @@ namespace Org.OpenAPITools.Model
             }
 
             if (emptyMap.IsSet && emptyMap.Value == null)
-                throw new ArgumentNullException(nameof(emptyMap), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: empty_map.");
 
             if (mapOfMapProperty.IsSet && mapOfMapProperty.Value == null)
-                throw new ArgumentNullException(nameof(mapOfMapProperty), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_of_map_property.");
 
             if (mapProperty.IsSet && mapProperty.Value == null)
-                throw new ArgumentNullException(nameof(mapProperty), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_property.");
 
             if (mapWithUndeclaredPropertiesAnytype1.IsSet && mapWithUndeclaredPropertiesAnytype1.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesAnytype1), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_anytype_1.");
 
             if (mapWithUndeclaredPropertiesAnytype2.IsSet && mapWithUndeclaredPropertiesAnytype2.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesAnytype2), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_anytype_2.");
 
             if (mapWithUndeclaredPropertiesAnytype3.IsSet && mapWithUndeclaredPropertiesAnytype3.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesAnytype3), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_anytype_3.");
 
             if (mapWithUndeclaredPropertiesString.IsSet && mapWithUndeclaredPropertiesString.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesString), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_string.");
 
             return new AdditionalPropertiesClass(anytype1, emptyMap, mapOfMapProperty, mapProperty, mapWithUndeclaredPropertiesAnytype1, mapWithUndeclaredPropertiesAnytype2, mapWithUndeclaredPropertiesAnytype3, mapWithUndeclaredPropertiesString);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Animal.cs
@@ -175,13 +175,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Animal.", nameof(className));
+                throw new JsonException("Property is required for class Animal: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Animal.");
+                throw new JsonException("Property is not nullable for class Animal: className.");
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Animal.");
+                throw new JsonException("Property is not nullable for class Animal: color.");
 
             return new Animal(color);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -185,13 +185,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (code.IsSet && code.Value == null)
-                throw new ArgumentNullException(nameof(code), "Property is not nullable for class ApiResponse.");
+                throw new JsonException("Property is not nullable for class ApiResponse: code.");
 
             if (message.IsSet && message.Value == null)
-                throw new ArgumentNullException(nameof(message), "Property is not nullable for class ApiResponse.");
+                throw new JsonException("Property is not nullable for class ApiResponse: message.");
 
             if (type.IsSet && type.Value == null)
-                throw new ArgumentNullException(nameof(type), "Property is not nullable for class ApiResponse.");
+                throw new JsonException("Property is not nullable for class ApiResponse: type.");
 
             return new ApiResponse(code, message, type);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Apple.cs
@@ -215,13 +215,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (colorCode.IsSet && colorCode.Value == null)
-                throw new ArgumentNullException(nameof(colorCode), "Property is not nullable for class Apple.");
+                throw new JsonException("Property is not nullable for class Apple: color_code.");
 
             if (cultivar.IsSet && cultivar.Value == null)
-                throw new ArgumentNullException(nameof(cultivar), "Property is not nullable for class Apple.");
+                throw new JsonException("Property is not nullable for class Apple: cultivar.");
 
             if (origin.IsSet && origin.Value == null)
-                throw new ArgumentNullException(nameof(origin), "Property is not nullable for class Apple.");
+                throw new JsonException("Property is not nullable for class Apple: origin.");
 
             return new Apple(colorCode, cultivar, origin);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -151,13 +151,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!cultivar.IsSet)
-                throw new ArgumentException("Property is required for class AppleReq.", nameof(cultivar));
+                throw new JsonException("Property is required for class AppleReq: cultivar.");
 
             if (cultivar.IsSet && cultivar.Value == null)
-                throw new ArgumentNullException(nameof(cultivar), "Property is not nullable for class AppleReq.");
+                throw new JsonException("Property is not nullable for class AppleReq: cultivar.");
 
             if (mealy.IsSet && mealy.Value == null)
-                throw new ArgumentNullException(nameof(mealy), "Property is not nullable for class AppleReq.");
+                throw new JsonException("Property is not nullable for class AppleReq: mealy.");
 
             return new AppleReq(cultivar.Value, mealy);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayArrayNumber.IsSet && arrayArrayNumber.Value == null)
-                throw new ArgumentNullException(nameof(arrayArrayNumber), "Property is not nullable for class ArrayOfArrayOfNumberOnly.");
+                throw new JsonException("Property is not nullable for class ArrayOfArrayOfNumberOnly: ArrayArrayNumber.");
 
             return new ArrayOfArrayOfNumberOnly(arrayArrayNumber);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayNumber.IsSet && arrayNumber.Value == null)
-                throw new ArgumentNullException(nameof(arrayNumber), "Property is not nullable for class ArrayOfNumberOnly.");
+                throw new JsonException("Property is not nullable for class ArrayOfNumberOnly: ArrayNumber.");
 
             return new ArrayOfNumberOnly(arrayNumber);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -185,13 +185,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayArrayOfInteger.IsSet && arrayArrayOfInteger.Value == null)
-                throw new ArgumentNullException(nameof(arrayArrayOfInteger), "Property is not nullable for class ArrayTest.");
+                throw new JsonException("Property is not nullable for class ArrayTest: array_array_of_integer.");
 
             if (arrayArrayOfModel.IsSet && arrayArrayOfModel.Value == null)
-                throw new ArgumentNullException(nameof(arrayArrayOfModel), "Property is not nullable for class ArrayTest.");
+                throw new JsonException("Property is not nullable for class ArrayTest: array_array_of_model.");
 
             if (arrayOfString.IsSet && arrayOfString.Value == null)
-                throw new ArgumentNullException(nameof(arrayOfString), "Property is not nullable for class ArrayTest.");
+                throw new JsonException("Property is not nullable for class ArrayTest: array_of_string.");
 
             return new ArrayTest(arrayArrayOfInteger, arrayArrayOfModel, arrayOfString);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Banana.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (lengthCm.IsSet && lengthCm.Value == null)
-                throw new ArgumentNullException(nameof(lengthCm), "Property is not nullable for class Banana.");
+                throw new JsonException("Property is not nullable for class Banana: lengthCm.");
 
             return new Banana(lengthCm);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -151,13 +151,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!lengthCm.IsSet)
-                throw new ArgumentException("Property is required for class BananaReq.", nameof(lengthCm));
+                throw new JsonException("Property is required for class BananaReq: lengthCm.");
 
             if (lengthCm.IsSet && lengthCm.Value == null)
-                throw new ArgumentNullException(nameof(lengthCm), "Property is not nullable for class BananaReq.");
+                throw new JsonException("Property is not nullable for class BananaReq: lengthCm.");
 
             if (sweet.IsSet && sweet.Value == null)
-                throw new ArgumentNullException(nameof(sweet), "Property is not nullable for class BananaReq.");
+                throw new JsonException("Property is not nullable for class BananaReq: sweet.");
 
             return new BananaReq(lengthCm.Value.Value, sweet);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/BasquePig.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/BasquePig.cs
@@ -138,10 +138,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class BasquePig.", nameof(className));
+                throw new JsonException("Property is required for class BasquePig: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class BasquePig.");
+                throw new JsonException("Property is not nullable for class BasquePig: className.");
 
             return new BasquePig(className.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -246,22 +246,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (aTTNAME.IsSet && aTTNAME.Value == null)
-                throw new ArgumentNullException(nameof(aTTNAME), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: ATT_NAME.");
 
             if (capitalCamel.IsSet && capitalCamel.Value == null)
-                throw new ArgumentNullException(nameof(capitalCamel), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: CapitalCamel.");
 
             if (capitalSnake.IsSet && capitalSnake.Value == null)
-                throw new ArgumentNullException(nameof(capitalSnake), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: Capital_Snake.");
 
             if (sCAETHFlowPoints.IsSet && sCAETHFlowPoints.Value == null)
-                throw new ArgumentNullException(nameof(sCAETHFlowPoints), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: SCA_ETH_Flow_Points.");
 
             if (smallCamel.IsSet && smallCamel.Value == null)
-                throw new ArgumentNullException(nameof(smallCamel), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: smallCamel.");
 
             if (smallSnake.IsSet && smallSnake.Value == null)
-                throw new ArgumentNullException(nameof(smallSnake), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: small_Snake.");
 
             return new Capitalization(aTTNAME, capitalCamel, capitalSnake, sCAETHFlowPoints, smallCamel, smallSnake);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Cat.cs
@@ -138,16 +138,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Cat.", nameof(className));
+                throw new JsonException("Property is required for class Cat: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Cat.");
+                throw new JsonException("Property is not nullable for class Cat: className.");
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Cat.");
+                throw new JsonException("Property is not nullable for class Cat: color.");
 
             if (declawed.IsSet && declawed.Value == null)
-                throw new ArgumentNullException(nameof(declawed), "Property is not nullable for class Cat.");
+                throw new JsonException("Property is not nullable for class Cat: declawed.");
 
             return new Cat(color, declawed);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Category.cs
@@ -158,13 +158,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!name.IsSet)
-                throw new ArgumentException("Property is required for class Category.", nameof(name));
+                throw new JsonException("Property is required for class Category: name.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Category.");
+                throw new JsonException("Property is not nullable for class Category: id.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Category.");
+                throw new JsonException("Property is not nullable for class Category: name.");
 
             return new Category(id, name.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -141,13 +141,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!petType.IsSet)
-                throw new ArgumentException("Property is required for class ChildCat.", nameof(petType));
+                throw new JsonException("Property is required for class ChildCat: pet_type.");
 
             if (petType.IsSet && petType.Value == null)
-                throw new ArgumentNullException(nameof(petType), "Property is not nullable for class ChildCat.");
+                throw new JsonException("Property is not nullable for class ChildCat: pet_type.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class ChildCat.");
+                throw new JsonException("Property is not nullable for class ChildCat: name.");
 
             return new ChildCat(name);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varClass.IsSet && varClass.Value == null)
-                throw new ArgumentNullException(nameof(varClass), "Property is not nullable for class ClassModel.");
+                throw new JsonException("Property is not nullable for class ClassModel: _class.");
 
             return new ClassModel(varClass);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
@@ -151,16 +151,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class ComplexQuadrilateral.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class ComplexQuadrilateral: quadrilateralType.");
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ComplexQuadrilateral.", nameof(shapeType));
+                throw new JsonException("Property is required for class ComplexQuadrilateral: shapeType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class ComplexQuadrilateral.");
+                throw new JsonException("Property is not nullable for class ComplexQuadrilateral: quadrilateralType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ComplexQuadrilateral.");
+                throw new JsonException("Property is not nullable for class ComplexQuadrilateral: shapeType.");
 
             return new ComplexQuadrilateral(quadrilateralType.Value, shapeType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/CopyActivity.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/CopyActivity.cs
@@ -134,16 +134,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!copyActivitytt.IsSet)
-                throw new ArgumentException("Property is required for class CopyActivity.", nameof(copyActivitytt));
+                throw new JsonException("Property is required for class CopyActivity: copyActivitytt.");
 
             if (!schema.IsSet)
-                throw new ArgumentException("Property is required for class CopyActivity.", nameof(schema));
+                throw new JsonException("Property is required for class CopyActivity: $schema.");
 
             if (copyActivitytt.IsSet && copyActivitytt.Value == null)
-                throw new ArgumentNullException(nameof(copyActivitytt), "Property is not nullable for class CopyActivity.");
+                throw new JsonException("Property is not nullable for class CopyActivity: copyActivitytt.");
 
             if (schema.IsSet && schema.Value == null)
-                throw new ArgumentNullException(nameof(schema), "Property is not nullable for class CopyActivity.");
+                throw new JsonException("Property is not nullable for class CopyActivity: $schema.");
 
             return new CopyActivity(copyActivitytt.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/DanishPig.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/DanishPig.cs
@@ -138,10 +138,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class DanishPig.", nameof(className));
+                throw new JsonException("Property is required for class DanishPig: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class DanishPig.");
+                throw new JsonException("Property is not nullable for class DanishPig: className.");
 
             return new DanishPig(className.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -151,7 +151,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (dateOnlyProperty.IsSet && dateOnlyProperty.Value == null)
-                throw new ArgumentNullException(nameof(dateOnlyProperty), "Property is not nullable for class DateOnlyClass.");
+                throw new JsonException("Property is not nullable for class DateOnlyClass: dateOnlyProperty.");
 
             return new DateOnlyClass(dateOnlyProperty);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class DeprecatedObject.");
+                throw new JsonException("Property is not nullable for class DeprecatedObject: name.");
 
             return new DeprecatedObject(name);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Descendant1.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Descendant1.cs
@@ -131,22 +131,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!alternativeName.IsSet)
-                throw new ArgumentException("Property is required for class Descendant1.", nameof(alternativeName));
+                throw new JsonException("Property is required for class Descendant1: alternativeName.");
 
             if (!descendantName.IsSet)
-                throw new ArgumentException("Property is required for class Descendant1.", nameof(descendantName));
+                throw new JsonException("Property is required for class Descendant1: descendantName.");
 
             if (!objectType.IsSet)
-                throw new ArgumentException("Property is required for class Descendant1.", nameof(objectType));
+                throw new JsonException("Property is required for class Descendant1: objectType.");
 
             if (alternativeName.IsSet && alternativeName.Value == null)
-                throw new ArgumentNullException(nameof(alternativeName), "Property is not nullable for class Descendant1.");
+                throw new JsonException("Property is not nullable for class Descendant1: alternativeName.");
 
             if (descendantName.IsSet && descendantName.Value == null)
-                throw new ArgumentNullException(nameof(descendantName), "Property is not nullable for class Descendant1.");
+                throw new JsonException("Property is not nullable for class Descendant1: descendantName.");
 
             if (objectType.IsSet && objectType.Value == null)
-                throw new ArgumentNullException(nameof(objectType), "Property is not nullable for class Descendant1.");
+                throw new JsonException("Property is not nullable for class Descendant1: objectType.");
 
             return new Descendant1(alternativeName.Value, descendantName.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Descendant2.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Descendant2.cs
@@ -131,22 +131,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!alternativeName.IsSet)
-                throw new ArgumentException("Property is required for class Descendant2.", nameof(alternativeName));
+                throw new JsonException("Property is required for class Descendant2: alternativeName.");
 
             if (!confidentiality.IsSet)
-                throw new ArgumentException("Property is required for class Descendant2.", nameof(confidentiality));
+                throw new JsonException("Property is required for class Descendant2: confidentiality.");
 
             if (!objectType.IsSet)
-                throw new ArgumentException("Property is required for class Descendant2.", nameof(objectType));
+                throw new JsonException("Property is required for class Descendant2: objectType.");
 
             if (alternativeName.IsSet && alternativeName.Value == null)
-                throw new ArgumentNullException(nameof(alternativeName), "Property is not nullable for class Descendant2.");
+                throw new JsonException("Property is not nullable for class Descendant2: alternativeName.");
 
             if (confidentiality.IsSet && confidentiality.Value == null)
-                throw new ArgumentNullException(nameof(confidentiality), "Property is not nullable for class Descendant2.");
+                throw new JsonException("Property is not nullable for class Descendant2: confidentiality.");
 
             if (objectType.IsSet && objectType.Value == null)
-                throw new ArgumentNullException(nameof(objectType), "Property is not nullable for class Descendant2.");
+                throw new JsonException("Property is not nullable for class Descendant2: objectType.");
 
             return new Descendant2(alternativeName.Value, confidentiality.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Dog.cs
@@ -138,16 +138,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Dog.", nameof(className));
+                throw new JsonException("Property is required for class Dog: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Dog.");
+                throw new JsonException("Property is not nullable for class Dog: className.");
 
             if (breed.IsSet && breed.Value == null)
-                throw new ArgumentNullException(nameof(breed), "Property is not nullable for class Dog.");
+                throw new JsonException("Property is not nullable for class Dog: breed.");
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Dog.");
+                throw new JsonException("Property is not nullable for class Dog: color.");
 
             return new Dog(breed, color);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Drawing.cs
@@ -205,10 +205,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (mainShape.IsSet && mainShape.Value == null)
-                throw new ArgumentNullException(nameof(mainShape), "Property is not nullable for class Drawing.");
+                throw new JsonException("Property is not nullable for class Drawing: mainShape.");
 
             if (shapes.IsSet && shapes.Value == null)
-                throw new ArgumentNullException(nameof(shapes), "Property is not nullable for class Drawing.");
+                throw new JsonException("Property is not nullable for class Drawing: shapes.");
 
             return new Drawing(mainShape, nullableShape, shapeOrNull, shapes);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/EntityBase.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/EntityBase.cs
@@ -152,10 +152,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!schema.IsSet)
-                throw new ArgumentException("Property is required for class EntityBase.", nameof(schema));
+                throw new JsonException("Property is required for class EntityBase: $schema.");
 
             if (schema.IsSet && schema.Value == null)
-                throw new ArgumentNullException(nameof(schema), "Property is not nullable for class EntityBase.");
+                throw new JsonException("Property is not nullable for class EntityBase: $schema.");
 
             return new EntityBase();
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayEnum.IsSet && arrayEnum.Value == null)
-                throw new ArgumentNullException(nameof(arrayEnum), "Property is not nullable for class EnumArrays.");
+                throw new JsonException("Property is not nullable for class EnumArrays: array_enum.");
 
             if (justSymbol.IsSet && justSymbol.Value == null)
-                throw new ArgumentNullException(nameof(justSymbol), "Property is not nullable for class EnumArrays.");
+                throw new JsonException("Property is not nullable for class EnumArrays: just_symbol.");
 
             return new EnumArrays(arrayEnum, justSymbol);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -298,31 +298,31 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!enumStringRequired.IsSet)
-                throw new ArgumentException("Property is required for class EnumTest.", nameof(enumStringRequired));
+                throw new JsonException("Property is required for class EnumTest: enum_string_required.");
 
             if (enumStringRequired.IsSet && enumStringRequired.Value == null)
-                throw new ArgumentNullException(nameof(enumStringRequired), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_string_required.");
 
             if (enumInteger.IsSet && enumInteger.Value == null)
-                throw new ArgumentNullException(nameof(enumInteger), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_integer.");
 
             if (enumIntegerOnly.IsSet && enumIntegerOnly.Value == null)
-                throw new ArgumentNullException(nameof(enumIntegerOnly), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_integer_only.");
 
             if (enumNumber.IsSet && enumNumber.Value == null)
-                throw new ArgumentNullException(nameof(enumNumber), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_number.");
 
             if (enumString.IsSet && enumString.Value == null)
-                throw new ArgumentNullException(nameof(enumString), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_string.");
 
             if (outerEnumDefaultValue.IsSet && outerEnumDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(outerEnumDefaultValue), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: outerEnumDefaultValue.");
 
             if (outerEnumInteger.IsSet && outerEnumInteger.Value == null)
-                throw new ArgumentNullException(nameof(outerEnumInteger), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: outerEnumInteger.");
 
             if (outerEnumIntegerDefaultValue.IsSet && outerEnumIntegerDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(outerEnumIntegerDefaultValue), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: outerEnumIntegerDefaultValue.");
 
             return new EnumTest(enumStringRequired.Value.Value, enumInteger, enumIntegerOnly, enumNumber, enumString, outerEnum, outerEnumDefaultValue, outerEnumInteger, outerEnumIntegerDefaultValue);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
@@ -151,16 +151,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class EquilateralTriangle.", nameof(shapeType));
+                throw new JsonException("Property is required for class EquilateralTriangle: shapeType.");
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class EquilateralTriangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class EquilateralTriangle: triangleType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class EquilateralTriangle.");
+                throw new JsonException("Property is not nullable for class EquilateralTriangle: shapeType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class EquilateralTriangle.");
+                throw new JsonException("Property is not nullable for class EquilateralTriangle: triangleType.");
 
             return new EquilateralTriangle(shapeType.Value, triangleType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/File.cs
@@ -146,7 +146,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (sourceURI.IsSet && sourceURI.Value == null)
-                throw new ArgumentNullException(nameof(sourceURI), "Property is not nullable for class File.");
+                throw new JsonException("Property is not nullable for class File: sourceURI.");
 
             return new File(sourceURI);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (file.IsSet && file.Value == null)
-                throw new ArgumentNullException(nameof(file), "Property is not nullable for class FileSchemaTestClass.");
+                throw new JsonException("Property is not nullable for class FileSchemaTestClass: file.");
 
             if (files.IsSet && files.Value == null)
-                throw new ArgumentNullException(nameof(files), "Property is not nullable for class FileSchemaTestClass.");
+                throw new JsonException("Property is not nullable for class FileSchemaTestClass: files.");
 
             return new FileSchemaTestClass(file, files);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Foo.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bar.IsSet && bar.Value == null)
-                throw new ArgumentNullException(nameof(bar), "Property is not nullable for class Foo.");
+                throw new JsonException("Property is not nullable for class Foo: bar.");
 
             return new Foo(bar);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varString.IsSet && varString.Value == null)
-                throw new ArgumentNullException(nameof(varString), "Property is not nullable for class FooGetDefaultResponse.");
+                throw new JsonException("Property is not nullable for class FooGetDefaultResponse: string.");
 
             return new FooGetDefaultResponse(varString);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -826,103 +826,103 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!varByte.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(varByte));
+                throw new JsonException("Property is required for class FormatTest: byte.");
 
             if (!date.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(date));
+                throw new JsonException("Property is required for class FormatTest: date.");
 
             if (!number.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(number));
+                throw new JsonException("Property is required for class FormatTest: number.");
 
             if (!password.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(password));
+                throw new JsonException("Property is required for class FormatTest: password.");
 
             if (!stringFormattedAsDecimalRequired.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(stringFormattedAsDecimalRequired));
+                throw new JsonException("Property is required for class FormatTest: string_formatted_as_decimal_required.");
 
             if (varByte.IsSet && varByte.Value == null)
-                throw new ArgumentNullException(nameof(varByte), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: byte.");
 
             if (date.IsSet && date.Value == null)
-                throw new ArgumentNullException(nameof(date), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: date.");
 
             if (number.IsSet && number.Value == null)
-                throw new ArgumentNullException(nameof(number), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: number.");
 
             if (password.IsSet && password.Value == null)
-                throw new ArgumentNullException(nameof(password), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: password.");
 
             if (stringFormattedAsDecimalRequired.IsSet && stringFormattedAsDecimalRequired.Value == null)
-                throw new ArgumentNullException(nameof(stringFormattedAsDecimalRequired), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: string_formatted_as_decimal_required.");
 
             if (binary.IsSet && binary.Value == null)
-                throw new ArgumentNullException(nameof(binary), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: binary.");
 
             if (dateTime.IsSet && dateTime.Value == null)
-                throw new ArgumentNullException(nameof(dateTime), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: dateTime.");
 
             if (varDecimal.IsSet && varDecimal.Value == null)
-                throw new ArgumentNullException(nameof(varDecimal), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: decimal.");
 
             if (varDouble.IsSet && varDouble.Value == null)
-                throw new ArgumentNullException(nameof(varDouble), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: double.");
 
             if (duplicatePropertyName2.IsSet && duplicatePropertyName2.Value == null)
-                throw new ArgumentNullException(nameof(duplicatePropertyName2), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: duplicate_property_name.");
 
             if (duplicatePropertyName.IsSet && duplicatePropertyName.Value == null)
-                throw new ArgumentNullException(nameof(duplicatePropertyName), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: @duplicate_property_name.");
 
             if (varFloat.IsSet && varFloat.Value == null)
-                throw new ArgumentNullException(nameof(varFloat), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: float.");
 
             if (int32.IsSet && int32.Value == null)
-                throw new ArgumentNullException(nameof(int32), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int32.");
 
             if (int32Range.IsSet && int32Range.Value == null)
-                throw new ArgumentNullException(nameof(int32Range), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int32Range.");
 
             if (int64.IsSet && int64.Value == null)
-                throw new ArgumentNullException(nameof(int64), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64.");
 
             if (int64Negative.IsSet && int64Negative.Value == null)
-                throw new ArgumentNullException(nameof(int64Negative), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64Negative.");
 
             if (int64NegativeExclusive.IsSet && int64NegativeExclusive.Value == null)
-                throw new ArgumentNullException(nameof(int64NegativeExclusive), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64NegativeExclusive.");
 
             if (int64Positive.IsSet && int64Positive.Value == null)
-                throw new ArgumentNullException(nameof(int64Positive), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64Positive.");
 
             if (int64PositiveExclusive.IsSet && int64PositiveExclusive.Value == null)
-                throw new ArgumentNullException(nameof(int64PositiveExclusive), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64PositiveExclusive.");
 
             if (integer.IsSet && integer.Value == null)
-                throw new ArgumentNullException(nameof(integer), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: integer.");
 
             if (patternWithBackslash.IsSet && patternWithBackslash.Value == null)
-                throw new ArgumentNullException(nameof(patternWithBackslash), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: pattern_with_backslash.");
 
             if (patternWithDigits.IsSet && patternWithDigits.Value == null)
-                throw new ArgumentNullException(nameof(patternWithDigits), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: pattern_with_digits.");
 
             if (patternWithDigitsAndDelimiter.IsSet && patternWithDigitsAndDelimiter.Value == null)
-                throw new ArgumentNullException(nameof(patternWithDigitsAndDelimiter), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: pattern_with_digits_and_delimiter.");
 
             if (varString.IsSet && varString.Value == null)
-                throw new ArgumentNullException(nameof(varString), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: string.");
 
             if (stringFormattedAsDecimal.IsSet && stringFormattedAsDecimal.Value == null)
-                throw new ArgumentNullException(nameof(stringFormattedAsDecimal), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: string_formatted_as_decimal.");
 
             if (unsignedInteger.IsSet && unsignedInteger.Value == null)
-                throw new ArgumentNullException(nameof(unsignedInteger), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: unsigned_integer.");
 
             if (unsignedLong.IsSet && unsignedLong.Value == null)
-                throw new ArgumentNullException(nameof(unsignedLong), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: unsigned_long.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: uuid.");
 
             return new FormatTest(varByte.Value, date.Value.Value, number.Value.Value, password.Value, stringFormattedAsDecimalRequired.Value.Value, binary, dateTime, varDecimal, varDouble, duplicatePropertyName2, duplicatePropertyName, varFloat, int32, int32Range, int64, int64Negative, int64NegativeExclusive, int64Positive, int64PositiveExclusive, integer, patternWithBackslash, patternWithDigits, patternWithDigitsAndDelimiter, varString, stringFormattedAsDecimal, unsignedInteger, unsignedLong, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Fruit.cs
@@ -183,7 +183,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Fruit.");
+                throw new JsonException("Property is not nullable for class Fruit: color.");
 
             if (apple != null)
                 return new Fruit(apple, color);

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -187,7 +187,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class GmFruit.");
+                throw new JsonException("Property is not nullable for class GmFruit: color.");
 
             Option<Apple> appleParsedValue = apple == null
                 ? default

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
@@ -155,10 +155,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!petType.IsSet)
-                throw new ArgumentException("Property is required for class GrandparentAnimal.", nameof(petType));
+                throw new JsonException("Property is required for class GrandparentAnimal: pet_type.");
 
             if (petType.IsSet && petType.Value == null)
-                throw new ArgumentNullException(nameof(petType), "Property is not nullable for class GrandparentAnimal.");
+                throw new JsonException("Property is not nullable for class GrandparentAnimal: pet_type.");
 
             return new GrandparentAnimal();
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -206,10 +206,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bar.IsSet && bar.Value == null)
-                throw new ArgumentNullException(nameof(bar), "Property is not nullable for class HasOnlyReadOnly.");
+                throw new JsonException("Property is not nullable for class HasOnlyReadOnly: bar.");
 
             if (foo.IsSet && foo.Value == null)
-                throw new ArgumentNullException(nameof(foo), "Property is not nullable for class HasOnlyReadOnly.");
+                throw new JsonException("Property is not nullable for class HasOnlyReadOnly: foo.");
 
             return new HasOnlyReadOnly(bar, foo);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
@@ -292,22 +292,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (potentiallyOverriddenPropertyAccessor.IsSet && potentiallyOverriddenPropertyAccessor.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyAccessor), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyAccessor.");
 
             if (potentiallyOverriddenPropertyToInternal.IsSet && potentiallyOverriddenPropertyToInternal.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyToInternal), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyToInternal.");
 
             if (potentiallyOverriddenPropertyToPrivate.IsSet && potentiallyOverriddenPropertyToPrivate.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyToPrivate), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyToPrivate.");
 
             if (potentiallyOverriddenPropertyToPublic.IsSet && potentiallyOverriddenPropertyToPublic.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyToPublic), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyToPublic.");
 
             if (unalteredProperty.IsSet && unalteredProperty.Value == null)
-                throw new ArgumentNullException(nameof(unalteredProperty), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: unalteredProperty.");
 
             if (unalteredPropertyAccessor.IsSet && unalteredPropertyAccessor.Value == null)
-                throw new ArgumentNullException(nameof(unalteredPropertyAccessor), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: unalteredPropertyAccessor.");
 
             return new InjectedVendorExtensionsTest(potentiallyOverriddenPropertyAccessor, potentiallyOverriddenPropertyToInternal, potentiallyOverriddenPropertyToPrivate, potentiallyOverriddenPropertyToPublic, unalteredProperty, unalteredPropertyAccessor);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
@@ -144,16 +144,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class IsoscelesTriangle.", nameof(shapeType));
+                throw new JsonException("Property is required for class IsoscelesTriangle: shapeType.");
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class IsoscelesTriangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class IsoscelesTriangle: triangleType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class IsoscelesTriangle.");
+                throw new JsonException("Property is not nullable for class IsoscelesTriangle: shapeType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class IsoscelesTriangle.");
+                throw new JsonException("Property is not nullable for class IsoscelesTriangle: triangleType.");
 
             return new IsoscelesTriangle(shapeType.Value, triangleType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/List.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (var123List.IsSet && var123List.Value == null)
-                throw new ArgumentNullException(nameof(var123List), "Property is not nullable for class List.");
+                throw new JsonException("Property is not nullable for class List: 123-list.");
 
             return new List(var123List);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (escapedLiteralString.IsSet && escapedLiteralString.Value == null)
-                throw new ArgumentNullException(nameof(escapedLiteralString), "Property is not nullable for class LiteralStringClass.");
+                throw new JsonException("Property is not nullable for class LiteralStringClass: escapedLiteralString.");
 
             if (unescapedLiteralString.IsSet && unescapedLiteralString.Value == null)
-                throw new ArgumentNullException(nameof(unescapedLiteralString), "Property is not nullable for class LiteralStringClass.");
+                throw new JsonException("Property is not nullable for class LiteralStringClass: unescapedLiteralString.");
 
             return new LiteralStringClass(escapedLiteralString, unescapedLiteralString);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Mammal.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Mammal.cs
@@ -214,10 +214,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Mammal.", nameof(className));
+                throw new JsonException("Property is required for class Mammal: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Mammal.");
+                throw new JsonException("Property is not nullable for class Mammal: className.");
 
             if (pig != null)
                 return new Mammal(pig);

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/MapTest.cs
@@ -205,16 +205,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (directMap.IsSet && directMap.Value == null)
-                throw new ArgumentNullException(nameof(directMap), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: direct_map.");
 
             if (indirectMap.IsSet && indirectMap.Value == null)
-                throw new ArgumentNullException(nameof(indirectMap), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: indirect_map.");
 
             if (mapMapOfString.IsSet && mapMapOfString.Value == null)
-                throw new ArgumentNullException(nameof(mapMapOfString), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: map_map_of_string.");
 
             if (mapOfEnumString.IsSet && mapOfEnumString.Value == null)
-                throw new ArgumentNullException(nameof(mapOfEnumString), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: map_of_enum_string.");
 
             return new MapTest(directMap, indirectMap, mapMapOfString, mapOfEnumString);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/MixedAnyOf.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/MixedAnyOf.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (content.IsSet && content.Value == null)
-                throw new ArgumentNullException(nameof(content), "Property is not nullable for class MixedAnyOf.");
+                throw new JsonException("Property is not nullable for class MixedAnyOf: content.");
 
             return new MixedAnyOf(content);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/MixedOneOf.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/MixedOneOf.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (content.IsSet && content.Value == null)
-                throw new ArgumentNullException(nameof(content), "Property is not nullable for class MixedOneOf.");
+                throw new JsonException("Property is not nullable for class MixedOneOf: content.");
 
             return new MixedOneOf(content);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -217,16 +217,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (dateTime.IsSet && dateTime.Value == null)
-                throw new ArgumentNullException(nameof(dateTime), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: dateTime.");
 
             if (map.IsSet && map.Value == null)
-                throw new ArgumentNullException(nameof(map), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: map.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: uuid.");
 
             if (uuidWithPattern.IsSet && uuidWithPattern.Value == null)
-                throw new ArgumentNullException(nameof(uuidWithPattern), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: uuid_with_pattern.");
 
             return new MixedPropertiesAndAdditionalPropertiesClass(dateTime, map, uuid, uuidWithPattern);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/MixedSubId.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/MixedSubId.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class MixedSubId.");
+                throw new JsonException("Property is not nullable for class MixedSubId: id.");
 
             return new MixedSubId(id);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varClass.IsSet && varClass.Value == null)
-                throw new ArgumentNullException(nameof(varClass), "Property is not nullable for class Model200Response.");
+                throw new JsonException("Property is not nullable for class Model200Response: class.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Model200Response.");
+                throw new JsonException("Property is not nullable for class Model200Response: name.");
 
             return new Model200Response(varClass, name);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varClient.IsSet && varClient.Value == null)
-                throw new ArgumentNullException(nameof(varClient), "Property is not nullable for class ModelClient.");
+                throw new JsonException("Property is not nullable for class ModelClient: client.");
 
             return new ModelClient(varClient);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Name.cs
@@ -239,19 +239,19 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!varName.IsSet)
-                throw new ArgumentException("Property is required for class Name.", nameof(varName));
+                throw new JsonException("Property is required for class Name: name.");
 
             if (varName.IsSet && varName.Value == null)
-                throw new ArgumentNullException(nameof(varName), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: name.");
 
             if (property.IsSet && property.Value == null)
-                throw new ArgumentNullException(nameof(property), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: property.");
 
             if (snakeCase.IsSet && snakeCase.Value == null)
-                throw new ArgumentNullException(nameof(snakeCase), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: snake_case.");
 
             if (var123Number.IsSet && var123Number.Value == null)
-                throw new ArgumentNullException(nameof(var123Number), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: 123Number.");
 
             return new Name(varName.Value.Value, property, snakeCase, var123Number);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
@@ -151,16 +151,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!aObjVariableobject.IsSet)
-                throw new ArgumentException("Property is required for class NotificationtestGetElementsV1ResponseMPayload.", nameof(aObjVariableobject));
+                throw new JsonException("Property is required for class NotificationtestGetElementsV1ResponseMPayload: a_objVariableobject.");
 
             if (!pkiNotificationtestID.IsSet)
-                throw new ArgumentException("Property is required for class NotificationtestGetElementsV1ResponseMPayload.", nameof(pkiNotificationtestID));
+                throw new JsonException("Property is required for class NotificationtestGetElementsV1ResponseMPayload: pkiNotificationtestID.");
 
             if (aObjVariableobject.IsSet && aObjVariableobject.Value == null)
-                throw new ArgumentNullException(nameof(aObjVariableobject), "Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload.");
+                throw new JsonException("Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload: a_objVariableobject.");
 
             if (pkiNotificationtestID.IsSet && pkiNotificationtestID.Value == null)
-                throw new ArgumentNullException(nameof(pkiNotificationtestID), "Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload.");
+                throw new JsonException("Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload: pkiNotificationtestID.");
 
             return new NotificationtestGetElementsV1ResponseMPayload(aObjVariableobject.Value, pkiNotificationtestID.Value.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -375,10 +375,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayItemsNullable.IsSet && arrayItemsNullable.Value == null)
-                throw new ArgumentNullException(nameof(arrayItemsNullable), "Property is not nullable for class NullableClass.");
+                throw new JsonException("Property is not nullable for class NullableClass: array_items_nullable.");
 
             if (objectItemsNullable.IsSet && objectItemsNullable.Value == null)
-                throw new ArgumentNullException(nameof(objectItemsNullable), "Property is not nullable for class NullableClass.");
+                throw new JsonException("Property is not nullable for class NullableClass: object_items_nullable.");
 
             return new NullableClass(arrayAndItemsNullableProp, arrayItemsNullable, arrayNullableProp, booleanProp, dateProp, datetimeProp, integerProp, numberProp, objectAndItemsNullableProp, objectItemsNullable, objectNullableProp, stringProp);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/NullableShape.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/NullableShape.cs
@@ -193,10 +193,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class NullableShape.", nameof(shapeType));
+                throw new JsonException("Property is required for class NullableShape: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class NullableShape.");
+                throw new JsonException("Property is not nullable for class NullableShape: shapeType.");
 
             if (quadrilateral != null)
                 return new NullableShape(quadrilateral);

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (justNumber.IsSet && justNumber.Value == null)
-                throw new ArgumentNullException(nameof(justNumber), "Property is not nullable for class NumberOnly.");
+                throw new JsonException("Property is not nullable for class NumberOnly: JustNumber.");
 
             return new NumberOnly(justNumber);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -208,16 +208,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bars.IsSet && bars.Value == null)
-                throw new ArgumentNullException(nameof(bars), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: bars.");
 
             if (deprecatedRef.IsSet && deprecatedRef.Value == null)
-                throw new ArgumentNullException(nameof(deprecatedRef), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: deprecatedRef.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: id.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: uuid.");
 
             return new ObjectWithDeprecatedFields(bars, deprecatedRef, id, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Order.cs
@@ -251,22 +251,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (complete.IsSet && complete.Value == null)
-                throw new ArgumentNullException(nameof(complete), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: complete.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: id.");
 
             if (petId.IsSet && petId.Value == null)
-                throw new ArgumentNullException(nameof(petId), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: petId.");
 
             if (quantity.IsSet && quantity.Value == null)
-                throw new ArgumentNullException(nameof(quantity), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: quantity.");
 
             if (shipDate.IsSet && shipDate.Value == null)
-                throw new ArgumentNullException(nameof(shipDate), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: shipDate.");
 
             if (status.IsSet && status.Value == null)
-                throw new ArgumentNullException(nameof(status), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: status.");
 
             return new Order(complete, id, petId, quantity, shipDate, status);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -185,13 +185,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (myBoolean.IsSet && myBoolean.Value == null)
-                throw new ArgumentNullException(nameof(myBoolean), "Property is not nullable for class OuterComposite.");
+                throw new JsonException("Property is not nullable for class OuterComposite: my_boolean.");
 
             if (myNumber.IsSet && myNumber.Value == null)
-                throw new ArgumentNullException(nameof(myNumber), "Property is not nullable for class OuterComposite.");
+                throw new JsonException("Property is not nullable for class OuterComposite: my_number.");
 
             if (myString.IsSet && myString.Value == null)
-                throw new ArgumentNullException(nameof(myString), "Property is not nullable for class OuterComposite.");
+                throw new JsonException("Property is not nullable for class OuterComposite: my_string.");
 
             return new OuterComposite(myBoolean, myNumber, myString);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ParentPet.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ParentPet.cs
@@ -118,10 +118,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!petType.IsSet)
-                throw new ArgumentException("Property is required for class ParentPet.", nameof(petType));
+                throw new JsonException("Property is required for class ParentPet: pet_type.");
 
             if (petType.IsSet && petType.Value == null)
-                throw new ArgumentNullException(nameof(petType), "Property is not nullable for class ParentPet.");
+                throw new JsonException("Property is not nullable for class ParentPet: pet_type.");
 
             return new ParentPet();
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Pet.cs
@@ -232,28 +232,28 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!name.IsSet)
-                throw new ArgumentException("Property is required for class Pet.", nameof(name));
+                throw new JsonException("Property is required for class Pet: name.");
 
             if (!photoUrls.IsSet)
-                throw new ArgumentException("Property is required for class Pet.", nameof(photoUrls));
+                throw new JsonException("Property is required for class Pet: photoUrls.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: name.");
 
             if (photoUrls.IsSet && photoUrls.Value == null)
-                throw new ArgumentNullException(nameof(photoUrls), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: photoUrls.");
 
             if (category.IsSet && category.Value == null)
-                throw new ArgumentNullException(nameof(category), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: category.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: id.");
 
             if (status.IsSet && status.Value == null)
-                throw new ArgumentNullException(nameof(status), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: status.");
 
             if (tags.IsSet && tags.Value == null)
-                throw new ArgumentNullException(nameof(tags), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: tags.");
 
             return new Pet(name.Value, photoUrls.Value, category, id, status, tags);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Pig.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Pig.cs
@@ -193,10 +193,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Pig.", nameof(className));
+                throw new JsonException("Property is required for class Pig: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Pig.");
+                throw new JsonException("Property is not nullable for class Pig: className.");
 
             if (basquePig != null)
                 return new Pig(basquePig);

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Quadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Quadrilateral.cs
@@ -193,10 +193,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class Quadrilateral.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class Quadrilateral: quadrilateralType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class Quadrilateral.");
+                throw new JsonException("Property is not nullable for class Quadrilateral: quadrilateralType.");
 
             if (complexQuadrilateral != null)
                 return new Quadrilateral(complexQuadrilateral);

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
@@ -138,10 +138,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class QuadrilateralInterface.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class QuadrilateralInterface: quadrilateralType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class QuadrilateralInterface.");
+                throw new JsonException("Property is not nullable for class QuadrilateralInterface: quadrilateralType.");
 
             return new QuadrilateralInterface(quadrilateralType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -203,10 +203,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bar.IsSet && bar.Value == null)
-                throw new ArgumentNullException(nameof(bar), "Property is not nullable for class ReadOnlyFirst.");
+                throw new JsonException("Property is not nullable for class ReadOnlyFirst: bar.");
 
             if (baz.IsSet && baz.Value == null)
-                throw new ArgumentNullException(nameof(baz), "Property is not nullable for class ReadOnlyFirst.");
+                throw new JsonException("Property is not nullable for class ReadOnlyFirst: baz.");
 
             return new ReadOnlyFirst(bar, baz);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -895,136 +895,136 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!requiredNotNullableDateProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotNullableDateProp));
+                throw new JsonException("Property is required for class RequiredClass: required_not_nullable_date_prop.");
 
             if (!requiredNotnullableArrayOfString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableArrayOfString));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_array_of_string.");
 
             if (!requiredNotnullableBooleanProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableBooleanProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_boolean_prop.");
 
             if (!requiredNotnullableDatetimeProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableDatetimeProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_datetime_prop.");
 
             if (!requiredNotnullableEnumInteger.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableEnumInteger));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_enum_integer.");
 
             if (!requiredNotnullableEnumIntegerOnly.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableEnumIntegerOnly));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_enum_integer_only.");
 
             if (!requiredNotnullableEnumString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableEnumString));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_enum_string.");
 
             if (!requiredNotnullableOuterEnumDefaultValue.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableOuterEnumDefaultValue));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_outerEnumDefaultValue.");
 
             if (!requiredNotnullableStringProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableStringProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_string_prop.");
 
             if (!requiredNotnullableUuid.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableUuid));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_uuid.");
 
             if (!requiredNotnullableintegerProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableintegerProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullableinteger_prop.");
 
             if (!requiredNullableArrayOfString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableArrayOfString));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_array_of_string.");
 
             if (!requiredNullableBooleanProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableBooleanProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_boolean_prop.");
 
             if (!requiredNullableDateProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableDateProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_date_prop.");
 
             if (!requiredNullableDatetimeProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableDatetimeProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_datetime_prop.");
 
             if (!requiredNullableEnumInteger.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableEnumInteger));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_enum_integer.");
 
             if (!requiredNullableEnumIntegerOnly.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableEnumIntegerOnly));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_enum_integer_only.");
 
             if (!requiredNullableEnumString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableEnumString));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_enum_string.");
 
             if (!requiredNullableIntegerProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableIntegerProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_integer_prop.");
 
             if (!requiredNullableOuterEnumDefaultValue.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableOuterEnumDefaultValue));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_outerEnumDefaultValue.");
 
             if (!requiredNullableStringProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableStringProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_string_prop.");
 
             if (!requiredNullableUuid.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableUuid));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_uuid.");
 
             if (requiredNotNullableDateProp.IsSet && requiredNotNullableDateProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotNullableDateProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_not_nullable_date_prop.");
 
             if (requiredNotnullableArrayOfString.IsSet && requiredNotnullableArrayOfString.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableArrayOfString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_array_of_string.");
 
             if (requiredNotnullableBooleanProp.IsSet && requiredNotnullableBooleanProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableBooleanProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_boolean_prop.");
 
             if (requiredNotnullableDatetimeProp.IsSet && requiredNotnullableDatetimeProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableDatetimeProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_datetime_prop.");
 
             if (requiredNotnullableEnumInteger.IsSet && requiredNotnullableEnumInteger.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableEnumInteger), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_enum_integer.");
 
             if (requiredNotnullableEnumIntegerOnly.IsSet && requiredNotnullableEnumIntegerOnly.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableEnumIntegerOnly), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_enum_integer_only.");
 
             if (requiredNotnullableEnumString.IsSet && requiredNotnullableEnumString.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableEnumString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_enum_string.");
 
             if (requiredNotnullableOuterEnumDefaultValue.IsSet && requiredNotnullableOuterEnumDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableOuterEnumDefaultValue), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_outerEnumDefaultValue.");
 
             if (requiredNotnullableStringProp.IsSet && requiredNotnullableStringProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableStringProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_string_prop.");
 
             if (requiredNotnullableUuid.IsSet && requiredNotnullableUuid.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableUuid), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_uuid.");
 
             if (requiredNotnullableintegerProp.IsSet && requiredNotnullableintegerProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableintegerProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullableinteger_prop.");
 
             if (notRequiredNotnullableDateProp.IsSet && notRequiredNotnullableDateProp.Value == null)
-                throw new ArgumentNullException(nameof(notRequiredNotnullableDateProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: not_required_notnullable_date_prop.");
 
             if (notRequiredNotnullableintegerProp.IsSet && notRequiredNotnullableintegerProp.Value == null)
-                throw new ArgumentNullException(nameof(notRequiredNotnullableintegerProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: not_required_notnullableinteger_prop.");
 
             if (notrequiredNotnullableArrayOfString.IsSet && notrequiredNotnullableArrayOfString.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableArrayOfString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_array_of_string.");
 
             if (notrequiredNotnullableBooleanProp.IsSet && notrequiredNotnullableBooleanProp.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableBooleanProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_boolean_prop.");
 
             if (notrequiredNotnullableDatetimeProp.IsSet && notrequiredNotnullableDatetimeProp.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableDatetimeProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_datetime_prop.");
 
             if (notrequiredNotnullableEnumInteger.IsSet && notrequiredNotnullableEnumInteger.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableEnumInteger), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_enum_integer.");
 
             if (notrequiredNotnullableEnumIntegerOnly.IsSet && notrequiredNotnullableEnumIntegerOnly.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableEnumIntegerOnly), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_enum_integer_only.");
 
             if (notrequiredNotnullableEnumString.IsSet && notrequiredNotnullableEnumString.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableEnumString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_enum_string.");
 
             if (notrequiredNotnullableOuterEnumDefaultValue.IsSet && notrequiredNotnullableOuterEnumDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableOuterEnumDefaultValue), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_outerEnumDefaultValue.");
 
             if (notrequiredNotnullableStringProp.IsSet && notrequiredNotnullableStringProp.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableStringProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_string_prop.");
 
             if (notrequiredNotnullableUuid.IsSet && notrequiredNotnullableUuid.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableUuid), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_uuid.");
 
             return new RequiredClass(requiredNotNullableDateProp.Value.Value, requiredNotnullableArrayOfString.Value, requiredNotnullableBooleanProp.Value.Value, requiredNotnullableDatetimeProp.Value.Value, requiredNotnullableEnumInteger.Value.Value, requiredNotnullableEnumIntegerOnly.Value.Value, requiredNotnullableEnumString.Value.Value, requiredNotnullableOuterEnumDefaultValue.Value.Value, requiredNotnullableStringProp.Value, requiredNotnullableUuid.Value.Value, requiredNotnullableintegerProp.Value.Value, notRequiredNotnullableDateProp, notRequiredNotnullableintegerProp, notRequiredNullableDateProp, notRequiredNullableIntegerProp, notrequiredNotnullableArrayOfString, notrequiredNotnullableBooleanProp, notrequiredNotnullableDatetimeProp, notrequiredNotnullableEnumInteger, notrequiredNotnullableEnumIntegerOnly, notrequiredNotnullableEnumString, notrequiredNotnullableOuterEnumDefaultValue, notrequiredNotnullableStringProp, notrequiredNotnullableUuid, notrequiredNullableArrayOfString, notrequiredNullableBooleanProp, notrequiredNullableDatetimeProp, notrequiredNullableEnumInteger, notrequiredNullableEnumIntegerOnly, notrequiredNullableEnumString, notrequiredNullableOuterEnumDefaultValue, notrequiredNullableStringProp, notrequiredNullableUuid, requiredNullableArrayOfString.Value, requiredNullableBooleanProp.Value, requiredNullableDateProp.Value, requiredNullableDatetimeProp.Value, requiredNullableEnumInteger.Value, requiredNullableEnumIntegerOnly.Value, requiredNullableEnumString.Value, requiredNullableIntegerProp.Value, requiredNullableOuterEnumDefaultValue.Value, requiredNullableStringProp.Value, requiredNullableUuid.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Result.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Result.cs
@@ -188,13 +188,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (code.IsSet && code.Value == null)
-                throw new ArgumentNullException(nameof(code), "Property is not nullable for class Result.");
+                throw new JsonException("Property is not nullable for class Result: code.");
 
             if (data.IsSet && data.Value == null)
-                throw new ArgumentNullException(nameof(data), "Property is not nullable for class Result.");
+                throw new JsonException("Property is not nullable for class Result: data.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class Result.");
+                throw new JsonException("Property is not nullable for class Result: uuid.");
 
             return new Result(code, data, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Return.cs
@@ -191,19 +191,19 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!varLock.IsSet)
-                throw new ArgumentException("Property is required for class Return.", nameof(varLock));
+                throw new JsonException("Property is required for class Return: lock.");
 
             if (!varAbstract.IsSet)
-                throw new ArgumentException("Property is required for class Return.", nameof(varAbstract));
+                throw new JsonException("Property is required for class Return: abstract.");
 
             if (varLock.IsSet && varLock.Value == null)
-                throw new ArgumentNullException(nameof(varLock), "Property is not nullable for class Return.");
+                throw new JsonException("Property is not nullable for class Return: lock.");
 
             if (varReturn.IsSet && varReturn.Value == null)
-                throw new ArgumentNullException(nameof(varReturn), "Property is not nullable for class Return.");
+                throw new JsonException("Property is not nullable for class Return: return.");
 
             if (varUnsafe.IsSet && varUnsafe.Value == null)
-                throw new ArgumentNullException(nameof(varUnsafe), "Property is not nullable for class Return.");
+                throw new JsonException("Property is not nullable for class Return: unsafe.");
 
             return new Return(varLock.Value, varAbstract.Value, varReturn, varUnsafe);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (role.IsSet && role.Value == null)
-                throw new ArgumentNullException(nameof(role), "Property is not nullable for class RolesReportsHash.");
+                throw new JsonException("Property is not nullable for class RolesReportsHash: role.");
 
             if (roleUuid.IsSet && roleUuid.Value == null)
-                throw new ArgumentNullException(nameof(roleUuid), "Property is not nullable for class RolesReportsHash.");
+                throw new JsonException("Property is not nullable for class RolesReportsHash: role_uuid.");
 
             return new RolesReportsHash(role, roleUuid);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class RolesReportsHashRole.");
+                throw new JsonException("Property is not nullable for class RolesReportsHashRole: name.");
 
             return new RolesReportsHashRole(name);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
@@ -151,16 +151,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ScaleneTriangle.", nameof(shapeType));
+                throw new JsonException("Property is required for class ScaleneTriangle: shapeType.");
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class ScaleneTriangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class ScaleneTriangle: triangleType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ScaleneTriangle.");
+                throw new JsonException("Property is not nullable for class ScaleneTriangle: shapeType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class ScaleneTriangle.");
+                throw new JsonException("Property is not nullable for class ScaleneTriangle: triangleType.");
 
             return new ScaleneTriangle(shapeType.Value, triangleType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Shape.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Shape.cs
@@ -193,10 +193,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class Shape.", nameof(shapeType));
+                throw new JsonException("Property is required for class Shape: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class Shape.");
+                throw new JsonException("Property is not nullable for class Shape: shapeType.");
 
             if (quadrilateral != null)
                 return new Shape(quadrilateral);

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ShapeInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ShapeInterface.cs
@@ -138,10 +138,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ShapeInterface.", nameof(shapeType));
+                throw new JsonException("Property is required for class ShapeInterface: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ShapeInterface.");
+                throw new JsonException("Property is not nullable for class ShapeInterface: shapeType.");
 
             return new ShapeInterface(shapeType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ShapeOrNull.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ShapeOrNull.cs
@@ -193,10 +193,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ShapeOrNull.", nameof(shapeType));
+                throw new JsonException("Property is required for class ShapeOrNull: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ShapeOrNull.");
+                throw new JsonException("Property is not nullable for class ShapeOrNull: shapeType.");
 
             if (quadrilateral != null)
                 return new ShapeOrNull(quadrilateral);

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
@@ -151,16 +151,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class SimpleQuadrilateral.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class SimpleQuadrilateral: quadrilateralType.");
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class SimpleQuadrilateral.", nameof(shapeType));
+                throw new JsonException("Property is required for class SimpleQuadrilateral: shapeType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class SimpleQuadrilateral.");
+                throw new JsonException("Property is not nullable for class SimpleQuadrilateral: quadrilateralType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class SimpleQuadrilateral.");
+                throw new JsonException("Property is not nullable for class SimpleQuadrilateral: shapeType.");
 
             return new SimpleQuadrilateral(quadrilateralType.Value, shapeType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varSpecialModelName.IsSet && varSpecialModelName.Value == null)
-                throw new ArgumentNullException(nameof(varSpecialModelName), "Property is not nullable for class SpecialModelName.");
+                throw new JsonException("Property is not nullable for class SpecialModelName: _special_model.name_.");
 
             if (specialPropertyName.IsSet && specialPropertyName.Value == null)
-                throw new ArgumentNullException(nameof(specialPropertyName), "Property is not nullable for class SpecialModelName.");
+                throw new JsonException("Property is not nullable for class SpecialModelName: $special[property.name].");
 
             return new SpecialModelName(varSpecialModelName, specialPropertyName);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Tag.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Tag.");
+                throw new JsonException("Property is not nullable for class Tag: id.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Tag.");
+                throw new JsonException("Property is not nullable for class Tag: name.");
 
             return new Tag(id, name);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (value.IsSet && value.Value == null)
-                throw new ArgumentNullException(nameof(value), "Property is not nullable for class TestCollectionEndingWithWordList.");
+                throw new JsonException("Property is not nullable for class TestCollectionEndingWithWordList: value.");
 
             return new TestCollectionEndingWithWordList(value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (testCollectionEndingWithWordList.IsSet && testCollectionEndingWithWordList.Value == null)
-                throw new ArgumentNullException(nameof(testCollectionEndingWithWordList), "Property is not nullable for class TestCollectionEndingWithWordListObject.");
+                throw new JsonException("Property is not nullable for class TestCollectionEndingWithWordListObject: TestCollectionEndingWithWordList.");
 
             return new TestCollectionEndingWithWordListObject(testCollectionEndingWithWordList);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/TestDescendants.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/TestDescendants.cs
@@ -168,16 +168,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!alternativeName.IsSet)
-                throw new ArgumentException("Property is required for class TestDescendants.", nameof(alternativeName));
+                throw new JsonException("Property is required for class TestDescendants: alternativeName.");
 
             if (!objectType.IsSet)
-                throw new ArgumentException("Property is required for class TestDescendants.", nameof(objectType));
+                throw new JsonException("Property is required for class TestDescendants: objectType.");
 
             if (alternativeName.IsSet && alternativeName.Value == null)
-                throw new ArgumentNullException(nameof(alternativeName), "Property is not nullable for class TestDescendants.");
+                throw new JsonException("Property is not nullable for class TestDescendants: alternativeName.");
 
             if (objectType.IsSet && objectType.Value == null)
-                throw new ArgumentNullException(nameof(objectType), "Property is not nullable for class TestDescendants.");
+                throw new JsonException("Property is not nullable for class TestDescendants: objectType.");
 
             return new TestDescendants(alternativeName.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (someProperty.IsSet && someProperty.Value == null)
-                throw new ArgumentNullException(nameof(someProperty), "Property is not nullable for class TestInlineFreeformAdditionalPropertiesRequest.");
+                throw new JsonException("Property is not nullable for class TestInlineFreeformAdditionalPropertiesRequest: someProperty.");
 
             return new TestInlineFreeformAdditionalPropertiesRequest(someProperty);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/TestResult.cs
@@ -187,13 +187,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (code.IsSet && code.Value == null)
-                throw new ArgumentNullException(nameof(code), "Property is not nullable for class TestResult.");
+                throw new JsonException("Property is not nullable for class TestResult: code.");
 
             if (data.IsSet && data.Value == null)
-                throw new ArgumentNullException(nameof(data), "Property is not nullable for class TestResult.");
+                throw new JsonException("Property is not nullable for class TestResult: data.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class TestResult.");
+                throw new JsonException("Property is not nullable for class TestResult: uuid.");
 
             return new TestResult(code, data, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Triangle.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Triangle.cs
@@ -214,10 +214,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class Triangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class Triangle: triangleType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class Triangle.");
+                throw new JsonException("Property is not nullable for class Triangle: triangleType.");
 
             if (equilateralTriangle != null)
                 return new Triangle(equilateralTriangle);

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/TriangleInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/TriangleInterface.cs
@@ -138,10 +138,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class TriangleInterface.", nameof(triangleType));
+                throw new JsonException("Property is required for class TriangleInterface: triangleType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class TriangleInterface.");
+                throw new JsonException("Property is not nullable for class TriangleInterface: triangleType.");
 
             return new TriangleInterface(triangleType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/User.cs
@@ -370,31 +370,31 @@ namespace Org.OpenAPITools.Model
             }
 
             if (email.IsSet && email.Value == null)
-                throw new ArgumentNullException(nameof(email), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: email.");
 
             if (firstName.IsSet && firstName.Value == null)
-                throw new ArgumentNullException(nameof(firstName), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: firstName.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: id.");
 
             if (lastName.IsSet && lastName.Value == null)
-                throw new ArgumentNullException(nameof(lastName), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: lastName.");
 
             if (objectWithNoDeclaredProps.IsSet && objectWithNoDeclaredProps.Value == null)
-                throw new ArgumentNullException(nameof(objectWithNoDeclaredProps), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: objectWithNoDeclaredProps.");
 
             if (password.IsSet && password.Value == null)
-                throw new ArgumentNullException(nameof(password), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: password.");
 
             if (phone.IsSet && phone.Value == null)
-                throw new ArgumentNullException(nameof(phone), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: phone.");
 
             if (userStatus.IsSet && userStatus.Value == null)
-                throw new ArgumentNullException(nameof(userStatus), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: userStatus.");
 
             if (username.IsSet && username.Value == null)
-                throw new ArgumentNullException(nameof(username), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: username.");
 
             return new User(anyTypeProp, anyTypePropNullable, email, firstName, id, lastName, objectWithNoDeclaredProps, objectWithNoDeclaredPropsNullable, password, phone, userStatus, username);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Whale.cs
@@ -178,16 +178,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Whale.", nameof(className));
+                throw new JsonException("Property is required for class Whale: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Whale.");
+                throw new JsonException("Property is not nullable for class Whale: className.");
 
             if (hasBaleen.IsSet && hasBaleen.Value == null)
-                throw new ArgumentNullException(nameof(hasBaleen), "Property is not nullable for class Whale.");
+                throw new JsonException("Property is not nullable for class Whale: hasBaleen.");
 
             if (hasTeeth.IsSet && hasTeeth.Value == null)
-                throw new ArgumentNullException(nameof(hasTeeth), "Property is not nullable for class Whale.");
+                throw new JsonException("Property is not nullable for class Whale: hasTeeth.");
 
             return new Whale(className.Value, hasBaleen, hasTeeth);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Zebra.cs
@@ -158,13 +158,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Zebra.", nameof(className));
+                throw new JsonException("Property is required for class Zebra: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Zebra.");
+                throw new JsonException("Property is not nullable for class Zebra: className.");
 
             if (type.IsSet && type.Value == null)
-                throw new ArgumentNullException(nameof(type), "Property is not nullable for class Zebra.");
+                throw new JsonException("Property is not nullable for class Zebra: type.");
 
             return new Zebra(className.Value, type);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (zeroBasedEnum.IsSet && zeroBasedEnum.Value == null)
-                throw new ArgumentNullException(nameof(zeroBasedEnum), "Property is not nullable for class ZeroBasedEnumClass.");
+                throw new JsonException("Property is not nullable for class ZeroBasedEnumClass: ZeroBasedEnum.");
 
             return new ZeroBasedEnumClass(zeroBasedEnum);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/OneOf/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/OneOf/src/Org.OpenAPITools/Model/Apple.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (kind.IsSet && kind.Value == null)
-                throw new ArgumentNullException(nameof(kind), "Property is not nullable for class Apple.");
+                throw new JsonException("Property is not nullable for class Apple: kind.");
 
             return new Apple(kind);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/OneOf/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/OneOf/src/Org.OpenAPITools/Model/Banana.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (count.IsSet && count.Value == null)
-                throw new ArgumentNullException(nameof(count), "Property is not nullable for class Banana.");
+                throw new JsonException("Property is not nullable for class Banana: count.");
 
             return new Banana(count);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/OneOf/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/OneOf/src/Org.OpenAPITools/Model/Fruit.cs
@@ -211,7 +211,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Fruit.");
+                throw new JsonException("Property is not nullable for class Fruit: color.");
 
             if (apple != null)
                 return new Fruit(apple, color);

--- a/samples/client/petstore/csharp/generichost/net4.7/OneOf/src/Org.OpenAPITools/Model/Orange.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/OneOf/src/Org.OpenAPITools/Model/Orange.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (sweet.IsSet && sweet.Value == null)
-                throw new ArgumentNullException(nameof(sweet), "Property is not nullable for class Orange.");
+                throw new JsonException("Property is not nullable for class Orange: sweet.");
 
             return new Orange(sweet);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Activity.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (activityOutputs.IsSet && activityOutputs.Value == null)
-                throw new ArgumentNullException(nameof(activityOutputs), "Property is not nullable for class Activity.");
+                throw new JsonException("Property is not nullable for class Activity: activity_outputs.");
 
             return new Activity(activityOutputs);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (prop1.IsSet && prop1.Value == null)
-                throw new ArgumentNullException(nameof(prop1), "Property is not nullable for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Property is not nullable for class ActivityOutputElementRepresentation: prop1.");
 
             if (prop2.IsSet && prop2.Value == null)
-                throw new ArgumentNullException(nameof(prop2), "Property is not nullable for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Property is not nullable for class ActivityOutputElementRepresentation: prop2.");
 
             return new ActivityOutputElementRepresentation(prop1, prop2);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -286,25 +286,25 @@ namespace Org.OpenAPITools.Model
             }
 
             if (emptyMap.IsSet && emptyMap.Value == null)
-                throw new ArgumentNullException(nameof(emptyMap), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: empty_map.");
 
             if (mapOfMapProperty.IsSet && mapOfMapProperty.Value == null)
-                throw new ArgumentNullException(nameof(mapOfMapProperty), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_of_map_property.");
 
             if (mapProperty.IsSet && mapProperty.Value == null)
-                throw new ArgumentNullException(nameof(mapProperty), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_property.");
 
             if (mapWithUndeclaredPropertiesAnytype1.IsSet && mapWithUndeclaredPropertiesAnytype1.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesAnytype1), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_anytype_1.");
 
             if (mapWithUndeclaredPropertiesAnytype2.IsSet && mapWithUndeclaredPropertiesAnytype2.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesAnytype2), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_anytype_2.");
 
             if (mapWithUndeclaredPropertiesAnytype3.IsSet && mapWithUndeclaredPropertiesAnytype3.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesAnytype3), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_anytype_3.");
 
             if (mapWithUndeclaredPropertiesString.IsSet && mapWithUndeclaredPropertiesString.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesString), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_string.");
 
             return new AdditionalPropertiesClass(anytype1, emptyMap, mapOfMapProperty, mapProperty, mapWithUndeclaredPropertiesAnytype1, mapWithUndeclaredPropertiesAnytype2, mapWithUndeclaredPropertiesAnytype3, mapWithUndeclaredPropertiesString);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Animal.cs
@@ -175,13 +175,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Animal.", nameof(className));
+                throw new JsonException("Property is required for class Animal: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Animal.");
+                throw new JsonException("Property is not nullable for class Animal: className.");
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Animal.");
+                throw new JsonException("Property is not nullable for class Animal: color.");
 
             return new Animal(color);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -185,13 +185,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (code.IsSet && code.Value == null)
-                throw new ArgumentNullException(nameof(code), "Property is not nullable for class ApiResponse.");
+                throw new JsonException("Property is not nullable for class ApiResponse: code.");
 
             if (message.IsSet && message.Value == null)
-                throw new ArgumentNullException(nameof(message), "Property is not nullable for class ApiResponse.");
+                throw new JsonException("Property is not nullable for class ApiResponse: message.");
 
             if (type.IsSet && type.Value == null)
-                throw new ArgumentNullException(nameof(type), "Property is not nullable for class ApiResponse.");
+                throw new JsonException("Property is not nullable for class ApiResponse: type.");
 
             return new ApiResponse(code, message, type);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Apple.cs
@@ -215,13 +215,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (colorCode.IsSet && colorCode.Value == null)
-                throw new ArgumentNullException(nameof(colorCode), "Property is not nullable for class Apple.");
+                throw new JsonException("Property is not nullable for class Apple: color_code.");
 
             if (cultivar.IsSet && cultivar.Value == null)
-                throw new ArgumentNullException(nameof(cultivar), "Property is not nullable for class Apple.");
+                throw new JsonException("Property is not nullable for class Apple: cultivar.");
 
             if (origin.IsSet && origin.Value == null)
-                throw new ArgumentNullException(nameof(origin), "Property is not nullable for class Apple.");
+                throw new JsonException("Property is not nullable for class Apple: origin.");
 
             return new Apple(colorCode, cultivar, origin);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -151,13 +151,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!cultivar.IsSet)
-                throw new ArgumentException("Property is required for class AppleReq.", nameof(cultivar));
+                throw new JsonException("Property is required for class AppleReq: cultivar.");
 
             if (cultivar.IsSet && cultivar.Value == null)
-                throw new ArgumentNullException(nameof(cultivar), "Property is not nullable for class AppleReq.");
+                throw new JsonException("Property is not nullable for class AppleReq: cultivar.");
 
             if (mealy.IsSet && mealy.Value == null)
-                throw new ArgumentNullException(nameof(mealy), "Property is not nullable for class AppleReq.");
+                throw new JsonException("Property is not nullable for class AppleReq: mealy.");
 
             return new AppleReq(cultivar.Value, mealy);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayArrayNumber.IsSet && arrayArrayNumber.Value == null)
-                throw new ArgumentNullException(nameof(arrayArrayNumber), "Property is not nullable for class ArrayOfArrayOfNumberOnly.");
+                throw new JsonException("Property is not nullable for class ArrayOfArrayOfNumberOnly: ArrayArrayNumber.");
 
             return new ArrayOfArrayOfNumberOnly(arrayArrayNumber);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayNumber.IsSet && arrayNumber.Value == null)
-                throw new ArgumentNullException(nameof(arrayNumber), "Property is not nullable for class ArrayOfNumberOnly.");
+                throw new JsonException("Property is not nullable for class ArrayOfNumberOnly: ArrayNumber.");
 
             return new ArrayOfNumberOnly(arrayNumber);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -185,13 +185,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayArrayOfInteger.IsSet && arrayArrayOfInteger.Value == null)
-                throw new ArgumentNullException(nameof(arrayArrayOfInteger), "Property is not nullable for class ArrayTest.");
+                throw new JsonException("Property is not nullable for class ArrayTest: array_array_of_integer.");
 
             if (arrayArrayOfModel.IsSet && arrayArrayOfModel.Value == null)
-                throw new ArgumentNullException(nameof(arrayArrayOfModel), "Property is not nullable for class ArrayTest.");
+                throw new JsonException("Property is not nullable for class ArrayTest: array_array_of_model.");
 
             if (arrayOfString.IsSet && arrayOfString.Value == null)
-                throw new ArgumentNullException(nameof(arrayOfString), "Property is not nullable for class ArrayTest.");
+                throw new JsonException("Property is not nullable for class ArrayTest: array_of_string.");
 
             return new ArrayTest(arrayArrayOfInteger, arrayArrayOfModel, arrayOfString);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Banana.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (lengthCm.IsSet && lengthCm.Value == null)
-                throw new ArgumentNullException(nameof(lengthCm), "Property is not nullable for class Banana.");
+                throw new JsonException("Property is not nullable for class Banana: lengthCm.");
 
             return new Banana(lengthCm);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -151,13 +151,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!lengthCm.IsSet)
-                throw new ArgumentException("Property is required for class BananaReq.", nameof(lengthCm));
+                throw new JsonException("Property is required for class BananaReq: lengthCm.");
 
             if (lengthCm.IsSet && lengthCm.Value == null)
-                throw new ArgumentNullException(nameof(lengthCm), "Property is not nullable for class BananaReq.");
+                throw new JsonException("Property is not nullable for class BananaReq: lengthCm.");
 
             if (sweet.IsSet && sweet.Value == null)
-                throw new ArgumentNullException(nameof(sweet), "Property is not nullable for class BananaReq.");
+                throw new JsonException("Property is not nullable for class BananaReq: sweet.");
 
             return new BananaReq(lengthCm.Value.Value, sweet);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/BasquePig.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/BasquePig.cs
@@ -138,10 +138,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class BasquePig.", nameof(className));
+                throw new JsonException("Property is required for class BasquePig: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class BasquePig.");
+                throw new JsonException("Property is not nullable for class BasquePig: className.");
 
             return new BasquePig(className.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -246,22 +246,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (aTTNAME.IsSet && aTTNAME.Value == null)
-                throw new ArgumentNullException(nameof(aTTNAME), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: ATT_NAME.");
 
             if (capitalCamel.IsSet && capitalCamel.Value == null)
-                throw new ArgumentNullException(nameof(capitalCamel), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: CapitalCamel.");
 
             if (capitalSnake.IsSet && capitalSnake.Value == null)
-                throw new ArgumentNullException(nameof(capitalSnake), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: Capital_Snake.");
 
             if (sCAETHFlowPoints.IsSet && sCAETHFlowPoints.Value == null)
-                throw new ArgumentNullException(nameof(sCAETHFlowPoints), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: SCA_ETH_Flow_Points.");
 
             if (smallCamel.IsSet && smallCamel.Value == null)
-                throw new ArgumentNullException(nameof(smallCamel), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: smallCamel.");
 
             if (smallSnake.IsSet && smallSnake.Value == null)
-                throw new ArgumentNullException(nameof(smallSnake), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: small_Snake.");
 
             return new Capitalization(aTTNAME, capitalCamel, capitalSnake, sCAETHFlowPoints, smallCamel, smallSnake);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Cat.cs
@@ -138,16 +138,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Cat.", nameof(className));
+                throw new JsonException("Property is required for class Cat: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Cat.");
+                throw new JsonException("Property is not nullable for class Cat: className.");
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Cat.");
+                throw new JsonException("Property is not nullable for class Cat: color.");
 
             if (declawed.IsSet && declawed.Value == null)
-                throw new ArgumentNullException(nameof(declawed), "Property is not nullable for class Cat.");
+                throw new JsonException("Property is not nullable for class Cat: declawed.");
 
             return new Cat(color, declawed);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Category.cs
@@ -158,13 +158,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!name.IsSet)
-                throw new ArgumentException("Property is required for class Category.", nameof(name));
+                throw new JsonException("Property is required for class Category: name.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Category.");
+                throw new JsonException("Property is not nullable for class Category: id.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Category.");
+                throw new JsonException("Property is not nullable for class Category: name.");
 
             return new Category(id, name.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -200,13 +200,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!petType.IsSet)
-                throw new ArgumentException("Property is required for class ChildCat.", nameof(petType));
+                throw new JsonException("Property is required for class ChildCat: pet_type.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class ChildCat.");
+                throw new JsonException("Property is not nullable for class ChildCat: name.");
 
             if (petType.IsSet && petType.Value == null)
-                throw new ArgumentNullException(nameof(petType), "Property is not nullable for class ChildCat.");
+                throw new JsonException("Property is not nullable for class ChildCat: pet_type.");
 
             return new ChildCat(name);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varClass.IsSet && varClass.Value == null)
-                throw new ArgumentNullException(nameof(varClass), "Property is not nullable for class ClassModel.");
+                throw new JsonException("Property is not nullable for class ClassModel: _class.");
 
             return new ClassModel(varClass);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
@@ -151,16 +151,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class ComplexQuadrilateral.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class ComplexQuadrilateral: quadrilateralType.");
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ComplexQuadrilateral.", nameof(shapeType));
+                throw new JsonException("Property is required for class ComplexQuadrilateral: shapeType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class ComplexQuadrilateral.");
+                throw new JsonException("Property is not nullable for class ComplexQuadrilateral: quadrilateralType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ComplexQuadrilateral.");
+                throw new JsonException("Property is not nullable for class ComplexQuadrilateral: shapeType.");
 
             return new ComplexQuadrilateral(quadrilateralType.Value, shapeType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/CopyActivity.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/CopyActivity.cs
@@ -193,16 +193,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!copyActivitytt.IsSet)
-                throw new ArgumentException("Property is required for class CopyActivity.", nameof(copyActivitytt));
+                throw new JsonException("Property is required for class CopyActivity: copyActivitytt.");
 
             if (!schema.IsSet)
-                throw new ArgumentException("Property is required for class CopyActivity.", nameof(schema));
+                throw new JsonException("Property is required for class CopyActivity: $schema.");
 
             if (copyActivitytt.IsSet && copyActivitytt.Value == null)
-                throw new ArgumentNullException(nameof(copyActivitytt), "Property is not nullable for class CopyActivity.");
+                throw new JsonException("Property is not nullable for class CopyActivity: copyActivitytt.");
 
             if (schema.IsSet && schema.Value == null)
-                throw new ArgumentNullException(nameof(schema), "Property is not nullable for class CopyActivity.");
+                throw new JsonException("Property is not nullable for class CopyActivity: $schema.");
 
             return new CopyActivity(copyActivitytt.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/DanishPig.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/DanishPig.cs
@@ -138,10 +138,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class DanishPig.", nameof(className));
+                throw new JsonException("Property is required for class DanishPig: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class DanishPig.");
+                throw new JsonException("Property is not nullable for class DanishPig: className.");
 
             return new DanishPig(className.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -151,7 +151,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (dateOnlyProperty.IsSet && dateOnlyProperty.Value == null)
-                throw new ArgumentNullException(nameof(dateOnlyProperty), "Property is not nullable for class DateOnlyClass.");
+                throw new JsonException("Property is not nullable for class DateOnlyClass: dateOnlyProperty.");
 
             return new DateOnlyClass(dateOnlyProperty);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class DeprecatedObject.");
+                throw new JsonException("Property is not nullable for class DeprecatedObject: name.");
 
             return new DeprecatedObject(name);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Descendant1.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Descendant1.cs
@@ -138,22 +138,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!alternativeName.IsSet)
-                throw new ArgumentException("Property is required for class Descendant1.", nameof(alternativeName));
+                throw new JsonException("Property is required for class Descendant1: alternativeName.");
 
             if (!descendantName.IsSet)
-                throw new ArgumentException("Property is required for class Descendant1.", nameof(descendantName));
+                throw new JsonException("Property is required for class Descendant1: descendantName.");
 
             if (!objectType.IsSet)
-                throw new ArgumentException("Property is required for class Descendant1.", nameof(objectType));
+                throw new JsonException("Property is required for class Descendant1: objectType.");
 
             if (alternativeName.IsSet && alternativeName.Value == null)
-                throw new ArgumentNullException(nameof(alternativeName), "Property is not nullable for class Descendant1.");
+                throw new JsonException("Property is not nullable for class Descendant1: alternativeName.");
 
             if (descendantName.IsSet && descendantName.Value == null)
-                throw new ArgumentNullException(nameof(descendantName), "Property is not nullable for class Descendant1.");
+                throw new JsonException("Property is not nullable for class Descendant1: descendantName.");
 
             if (objectType.IsSet && objectType.Value == null)
-                throw new ArgumentNullException(nameof(objectType), "Property is not nullable for class Descendant1.");
+                throw new JsonException("Property is not nullable for class Descendant1: objectType.");
 
             return new Descendant1(alternativeName.Value, descendantName.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Descendant2.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Descendant2.cs
@@ -138,22 +138,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!alternativeName.IsSet)
-                throw new ArgumentException("Property is required for class Descendant2.", nameof(alternativeName));
+                throw new JsonException("Property is required for class Descendant2: alternativeName.");
 
             if (!confidentiality.IsSet)
-                throw new ArgumentException("Property is required for class Descendant2.", nameof(confidentiality));
+                throw new JsonException("Property is required for class Descendant2: confidentiality.");
 
             if (!objectType.IsSet)
-                throw new ArgumentException("Property is required for class Descendant2.", nameof(objectType));
+                throw new JsonException("Property is required for class Descendant2: objectType.");
 
             if (alternativeName.IsSet && alternativeName.Value == null)
-                throw new ArgumentNullException(nameof(alternativeName), "Property is not nullable for class Descendant2.");
+                throw new JsonException("Property is not nullable for class Descendant2: alternativeName.");
 
             if (confidentiality.IsSet && confidentiality.Value == null)
-                throw new ArgumentNullException(nameof(confidentiality), "Property is not nullable for class Descendant2.");
+                throw new JsonException("Property is not nullable for class Descendant2: confidentiality.");
 
             if (objectType.IsSet && objectType.Value == null)
-                throw new ArgumentNullException(nameof(objectType), "Property is not nullable for class Descendant2.");
+                throw new JsonException("Property is not nullable for class Descendant2: objectType.");
 
             return new Descendant2(alternativeName.Value, confidentiality.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Dog.cs
@@ -138,16 +138,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Dog.", nameof(className));
+                throw new JsonException("Property is required for class Dog: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Dog.");
+                throw new JsonException("Property is not nullable for class Dog: className.");
 
             if (breed.IsSet && breed.Value == null)
-                throw new ArgumentNullException(nameof(breed), "Property is not nullable for class Dog.");
+                throw new JsonException("Property is not nullable for class Dog: breed.");
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Dog.");
+                throw new JsonException("Property is not nullable for class Dog: color.");
 
             return new Dog(breed, color);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Drawing.cs
@@ -205,10 +205,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (mainShape.IsSet && mainShape.Value == null)
-                throw new ArgumentNullException(nameof(mainShape), "Property is not nullable for class Drawing.");
+                throw new JsonException("Property is not nullable for class Drawing: mainShape.");
 
             if (shapes.IsSet && shapes.Value == null)
-                throw new ArgumentNullException(nameof(shapes), "Property is not nullable for class Drawing.");
+                throw new JsonException("Property is not nullable for class Drawing: shapes.");
 
             return new Drawing(mainShape, nullableShape, shapeOrNull, shapes);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/EntityBase.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/EntityBase.cs
@@ -152,10 +152,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!schema.IsSet)
-                throw new ArgumentException("Property is required for class EntityBase.", nameof(schema));
+                throw new JsonException("Property is required for class EntityBase: $schema.");
 
             if (schema.IsSet && schema.Value == null)
-                throw new ArgumentNullException(nameof(schema), "Property is not nullable for class EntityBase.");
+                throw new JsonException("Property is not nullable for class EntityBase: $schema.");
 
             return new EntityBase();
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -304,10 +304,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayEnum.IsSet && arrayEnum.Value == null)
-                throw new ArgumentNullException(nameof(arrayEnum), "Property is not nullable for class EnumArrays.");
+                throw new JsonException("Property is not nullable for class EnumArrays: array_enum.");
 
             if (justSymbol.IsSet && justSymbol.Value == null)
-                throw new ArgumentNullException(nameof(justSymbol), "Property is not nullable for class EnumArrays.");
+                throw new JsonException("Property is not nullable for class EnumArrays: just_symbol.");
 
             return new EnumArrays(arrayEnum, justSymbol);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -822,31 +822,31 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!enumStringRequired.IsSet)
-                throw new ArgumentException("Property is required for class EnumTest.", nameof(enumStringRequired));
+                throw new JsonException("Property is required for class EnumTest: enum_string_required.");
 
             if (enumStringRequired.IsSet && enumStringRequired.Value == null)
-                throw new ArgumentNullException(nameof(enumStringRequired), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_string_required.");
 
             if (enumInteger.IsSet && enumInteger.Value == null)
-                throw new ArgumentNullException(nameof(enumInteger), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_integer.");
 
             if (enumIntegerOnly.IsSet && enumIntegerOnly.Value == null)
-                throw new ArgumentNullException(nameof(enumIntegerOnly), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_integer_only.");
 
             if (enumNumber.IsSet && enumNumber.Value == null)
-                throw new ArgumentNullException(nameof(enumNumber), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_number.");
 
             if (enumString.IsSet && enumString.Value == null)
-                throw new ArgumentNullException(nameof(enumString), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_string.");
 
             if (outerEnumDefaultValue.IsSet && outerEnumDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(outerEnumDefaultValue), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: outerEnumDefaultValue.");
 
             if (outerEnumInteger.IsSet && outerEnumInteger.Value == null)
-                throw new ArgumentNullException(nameof(outerEnumInteger), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: outerEnumInteger.");
 
             if (outerEnumIntegerDefaultValue.IsSet && outerEnumIntegerDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(outerEnumIntegerDefaultValue), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: outerEnumIntegerDefaultValue.");
 
             return new EnumTest(enumStringRequired.Value.Value, enumInteger, enumIntegerOnly, enumNumber, enumString, outerEnum, outerEnumDefaultValue, outerEnumInteger, outerEnumIntegerDefaultValue);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
@@ -151,16 +151,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class EquilateralTriangle.", nameof(shapeType));
+                throw new JsonException("Property is required for class EquilateralTriangle: shapeType.");
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class EquilateralTriangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class EquilateralTriangle: triangleType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class EquilateralTriangle.");
+                throw new JsonException("Property is not nullable for class EquilateralTriangle: shapeType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class EquilateralTriangle.");
+                throw new JsonException("Property is not nullable for class EquilateralTriangle: triangleType.");
 
             return new EquilateralTriangle(shapeType.Value, triangleType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/File.cs
@@ -146,7 +146,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (sourceURI.IsSet && sourceURI.Value == null)
-                throw new ArgumentNullException(nameof(sourceURI), "Property is not nullable for class File.");
+                throw new JsonException("Property is not nullable for class File: sourceURI.");
 
             return new File(sourceURI);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (file.IsSet && file.Value == null)
-                throw new ArgumentNullException(nameof(file), "Property is not nullable for class FileSchemaTestClass.");
+                throw new JsonException("Property is not nullable for class FileSchemaTestClass: file.");
 
             if (files.IsSet && files.Value == null)
-                throw new ArgumentNullException(nameof(files), "Property is not nullable for class FileSchemaTestClass.");
+                throw new JsonException("Property is not nullable for class FileSchemaTestClass: files.");
 
             return new FileSchemaTestClass(file, files);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Foo.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bar.IsSet && bar.Value == null)
-                throw new ArgumentNullException(nameof(bar), "Property is not nullable for class Foo.");
+                throw new JsonException("Property is not nullable for class Foo: bar.");
 
             return new Foo(bar);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varString.IsSet && varString.Value == null)
-                throw new ArgumentNullException(nameof(varString), "Property is not nullable for class FooGetDefaultResponse.");
+                throw new JsonException("Property is not nullable for class FooGetDefaultResponse: string.");
 
             return new FooGetDefaultResponse(varString);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -826,103 +826,103 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!varByte.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(varByte));
+                throw new JsonException("Property is required for class FormatTest: byte.");
 
             if (!date.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(date));
+                throw new JsonException("Property is required for class FormatTest: date.");
 
             if (!number.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(number));
+                throw new JsonException("Property is required for class FormatTest: number.");
 
             if (!password.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(password));
+                throw new JsonException("Property is required for class FormatTest: password.");
 
             if (!stringFormattedAsDecimalRequired.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(stringFormattedAsDecimalRequired));
+                throw new JsonException("Property is required for class FormatTest: string_formatted_as_decimal_required.");
 
             if (varByte.IsSet && varByte.Value == null)
-                throw new ArgumentNullException(nameof(varByte), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: byte.");
 
             if (date.IsSet && date.Value == null)
-                throw new ArgumentNullException(nameof(date), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: date.");
 
             if (number.IsSet && number.Value == null)
-                throw new ArgumentNullException(nameof(number), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: number.");
 
             if (password.IsSet && password.Value == null)
-                throw new ArgumentNullException(nameof(password), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: password.");
 
             if (stringFormattedAsDecimalRequired.IsSet && stringFormattedAsDecimalRequired.Value == null)
-                throw new ArgumentNullException(nameof(stringFormattedAsDecimalRequired), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: string_formatted_as_decimal_required.");
 
             if (binary.IsSet && binary.Value == null)
-                throw new ArgumentNullException(nameof(binary), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: binary.");
 
             if (dateTime.IsSet && dateTime.Value == null)
-                throw new ArgumentNullException(nameof(dateTime), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: dateTime.");
 
             if (varDecimal.IsSet && varDecimal.Value == null)
-                throw new ArgumentNullException(nameof(varDecimal), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: decimal.");
 
             if (varDouble.IsSet && varDouble.Value == null)
-                throw new ArgumentNullException(nameof(varDouble), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: double.");
 
             if (duplicatePropertyName2.IsSet && duplicatePropertyName2.Value == null)
-                throw new ArgumentNullException(nameof(duplicatePropertyName2), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: duplicate_property_name.");
 
             if (duplicatePropertyName.IsSet && duplicatePropertyName.Value == null)
-                throw new ArgumentNullException(nameof(duplicatePropertyName), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: @duplicate_property_name.");
 
             if (varFloat.IsSet && varFloat.Value == null)
-                throw new ArgumentNullException(nameof(varFloat), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: float.");
 
             if (int32.IsSet && int32.Value == null)
-                throw new ArgumentNullException(nameof(int32), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int32.");
 
             if (int32Range.IsSet && int32Range.Value == null)
-                throw new ArgumentNullException(nameof(int32Range), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int32Range.");
 
             if (int64.IsSet && int64.Value == null)
-                throw new ArgumentNullException(nameof(int64), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64.");
 
             if (int64Negative.IsSet && int64Negative.Value == null)
-                throw new ArgumentNullException(nameof(int64Negative), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64Negative.");
 
             if (int64NegativeExclusive.IsSet && int64NegativeExclusive.Value == null)
-                throw new ArgumentNullException(nameof(int64NegativeExclusive), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64NegativeExclusive.");
 
             if (int64Positive.IsSet && int64Positive.Value == null)
-                throw new ArgumentNullException(nameof(int64Positive), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64Positive.");
 
             if (int64PositiveExclusive.IsSet && int64PositiveExclusive.Value == null)
-                throw new ArgumentNullException(nameof(int64PositiveExclusive), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64PositiveExclusive.");
 
             if (integer.IsSet && integer.Value == null)
-                throw new ArgumentNullException(nameof(integer), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: integer.");
 
             if (patternWithBackslash.IsSet && patternWithBackslash.Value == null)
-                throw new ArgumentNullException(nameof(patternWithBackslash), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: pattern_with_backslash.");
 
             if (patternWithDigits.IsSet && patternWithDigits.Value == null)
-                throw new ArgumentNullException(nameof(patternWithDigits), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: pattern_with_digits.");
 
             if (patternWithDigitsAndDelimiter.IsSet && patternWithDigitsAndDelimiter.Value == null)
-                throw new ArgumentNullException(nameof(patternWithDigitsAndDelimiter), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: pattern_with_digits_and_delimiter.");
 
             if (varString.IsSet && varString.Value == null)
-                throw new ArgumentNullException(nameof(varString), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: string.");
 
             if (stringFormattedAsDecimal.IsSet && stringFormattedAsDecimal.Value == null)
-                throw new ArgumentNullException(nameof(stringFormattedAsDecimal), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: string_formatted_as_decimal.");
 
             if (unsignedInteger.IsSet && unsignedInteger.Value == null)
-                throw new ArgumentNullException(nameof(unsignedInteger), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: unsigned_integer.");
 
             if (unsignedLong.IsSet && unsignedLong.Value == null)
-                throw new ArgumentNullException(nameof(unsignedLong), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: unsigned_long.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: uuid.");
 
             return new FormatTest(varByte.Value, date.Value.Value, number.Value.Value, password.Value, stringFormattedAsDecimalRequired.Value.Value, binary, dateTime, varDecimal, varDouble, duplicatePropertyName2, duplicatePropertyName, varFloat, int32, int32Range, int64, int64Negative, int64NegativeExclusive, int64Positive, int64PositiveExclusive, integer, patternWithBackslash, patternWithDigits, patternWithDigitsAndDelimiter, varString, stringFormattedAsDecimal, unsignedInteger, unsignedLong, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
@@ -183,7 +183,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Fruit.");
+                throw new JsonException("Property is not nullable for class Fruit: color.");
 
             if (apple != null)
                 return new Fruit(apple, color);

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -187,7 +187,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class GmFruit.");
+                throw new JsonException("Property is not nullable for class GmFruit: color.");
 
             Option<Apple> appleParsedValue = apple == null
                 ? default

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
@@ -155,10 +155,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!petType.IsSet)
-                throw new ArgumentException("Property is required for class GrandparentAnimal.", nameof(petType));
+                throw new JsonException("Property is required for class GrandparentAnimal: pet_type.");
 
             if (petType.IsSet && petType.Value == null)
-                throw new ArgumentNullException(nameof(petType), "Property is not nullable for class GrandparentAnimal.");
+                throw new JsonException("Property is not nullable for class GrandparentAnimal: pet_type.");
 
             return new GrandparentAnimal();
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -206,10 +206,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bar.IsSet && bar.Value == null)
-                throw new ArgumentNullException(nameof(bar), "Property is not nullable for class HasOnlyReadOnly.");
+                throw new JsonException("Property is not nullable for class HasOnlyReadOnly: bar.");
 
             if (foo.IsSet && foo.Value == null)
-                throw new ArgumentNullException(nameof(foo), "Property is not nullable for class HasOnlyReadOnly.");
+                throw new JsonException("Property is not nullable for class HasOnlyReadOnly: foo.");
 
             return new HasOnlyReadOnly(bar, foo);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
@@ -292,22 +292,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (potentiallyOverriddenPropertyAccessor.IsSet && potentiallyOverriddenPropertyAccessor.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyAccessor), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyAccessor.");
 
             if (potentiallyOverriddenPropertyToInternal.IsSet && potentiallyOverriddenPropertyToInternal.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyToInternal), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyToInternal.");
 
             if (potentiallyOverriddenPropertyToPrivate.IsSet && potentiallyOverriddenPropertyToPrivate.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyToPrivate), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyToPrivate.");
 
             if (potentiallyOverriddenPropertyToPublic.IsSet && potentiallyOverriddenPropertyToPublic.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyToPublic), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyToPublic.");
 
             if (unalteredProperty.IsSet && unalteredProperty.Value == null)
-                throw new ArgumentNullException(nameof(unalteredProperty), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: unalteredProperty.");
 
             if (unalteredPropertyAccessor.IsSet && unalteredPropertyAccessor.Value == null)
-                throw new ArgumentNullException(nameof(unalteredPropertyAccessor), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: unalteredPropertyAccessor.");
 
             return new InjectedVendorExtensionsTest(potentiallyOverriddenPropertyAccessor, potentiallyOverriddenPropertyToInternal, potentiallyOverriddenPropertyToPrivate, potentiallyOverriddenPropertyToPublic, unalteredProperty, unalteredPropertyAccessor);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
@@ -144,16 +144,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class IsoscelesTriangle.", nameof(shapeType));
+                throw new JsonException("Property is required for class IsoscelesTriangle: shapeType.");
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class IsoscelesTriangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class IsoscelesTriangle: triangleType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class IsoscelesTriangle.");
+                throw new JsonException("Property is not nullable for class IsoscelesTriangle: shapeType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class IsoscelesTriangle.");
+                throw new JsonException("Property is not nullable for class IsoscelesTriangle: triangleType.");
 
             return new IsoscelesTriangle(shapeType.Value, triangleType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/List.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (var123List.IsSet && var123List.Value == null)
-                throw new ArgumentNullException(nameof(var123List), "Property is not nullable for class List.");
+                throw new JsonException("Property is not nullable for class List: 123-list.");
 
             return new List(var123List);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (escapedLiteralString.IsSet && escapedLiteralString.Value == null)
-                throw new ArgumentNullException(nameof(escapedLiteralString), "Property is not nullable for class LiteralStringClass.");
+                throw new JsonException("Property is not nullable for class LiteralStringClass: escapedLiteralString.");
 
             if (unescapedLiteralString.IsSet && unescapedLiteralString.Value == null)
-                throw new ArgumentNullException(nameof(unescapedLiteralString), "Property is not nullable for class LiteralStringClass.");
+                throw new JsonException("Property is not nullable for class LiteralStringClass: unescapedLiteralString.");
 
             return new LiteralStringClass(escapedLiteralString, unescapedLiteralString);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Mammal.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Mammal.cs
@@ -214,10 +214,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Mammal.", nameof(className));
+                throw new JsonException("Property is required for class Mammal: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Mammal.");
+                throw new JsonException("Property is not nullable for class Mammal: className.");
 
             if (pig != null)
                 return new Mammal(pig);

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/MapTest.cs
@@ -271,16 +271,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (directMap.IsSet && directMap.Value == null)
-                throw new ArgumentNullException(nameof(directMap), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: direct_map.");
 
             if (indirectMap.IsSet && indirectMap.Value == null)
-                throw new ArgumentNullException(nameof(indirectMap), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: indirect_map.");
 
             if (mapMapOfString.IsSet && mapMapOfString.Value == null)
-                throw new ArgumentNullException(nameof(mapMapOfString), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: map_map_of_string.");
 
             if (mapOfEnumString.IsSet && mapOfEnumString.Value == null)
-                throw new ArgumentNullException(nameof(mapOfEnumString), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: map_of_enum_string.");
 
             return new MapTest(directMap, indirectMap, mapMapOfString, mapOfEnumString);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/MixedAnyOf.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/MixedAnyOf.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (content.IsSet && content.Value == null)
-                throw new ArgumentNullException(nameof(content), "Property is not nullable for class MixedAnyOf.");
+                throw new JsonException("Property is not nullable for class MixedAnyOf: content.");
 
             return new MixedAnyOf(content);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/MixedOneOf.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/MixedOneOf.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (content.IsSet && content.Value == null)
-                throw new ArgumentNullException(nameof(content), "Property is not nullable for class MixedOneOf.");
+                throw new JsonException("Property is not nullable for class MixedOneOf: content.");
 
             return new MixedOneOf(content);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -217,16 +217,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (dateTime.IsSet && dateTime.Value == null)
-                throw new ArgumentNullException(nameof(dateTime), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: dateTime.");
 
             if (map.IsSet && map.Value == null)
-                throw new ArgumentNullException(nameof(map), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: map.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: uuid.");
 
             if (uuidWithPattern.IsSet && uuidWithPattern.Value == null)
-                throw new ArgumentNullException(nameof(uuidWithPattern), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: uuid_with_pattern.");
 
             return new MixedPropertiesAndAdditionalPropertiesClass(dateTime, map, uuid, uuidWithPattern);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/MixedSubId.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/MixedSubId.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class MixedSubId.");
+                throw new JsonException("Property is not nullable for class MixedSubId: id.");
 
             return new MixedSubId(id);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varClass.IsSet && varClass.Value == null)
-                throw new ArgumentNullException(nameof(varClass), "Property is not nullable for class Model200Response.");
+                throw new JsonException("Property is not nullable for class Model200Response: class.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Model200Response.");
+                throw new JsonException("Property is not nullable for class Model200Response: name.");
 
             return new Model200Response(varClass, name);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varClient.IsSet && varClient.Value == null)
-                throw new ArgumentNullException(nameof(varClient), "Property is not nullable for class ModelClient.");
+                throw new JsonException("Property is not nullable for class ModelClient: client.");
 
             return new ModelClient(varClient);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Name.cs
@@ -239,19 +239,19 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!varName.IsSet)
-                throw new ArgumentException("Property is required for class Name.", nameof(varName));
+                throw new JsonException("Property is required for class Name: name.");
 
             if (varName.IsSet && varName.Value == null)
-                throw new ArgumentNullException(nameof(varName), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: name.");
 
             if (property.IsSet && property.Value == null)
-                throw new ArgumentNullException(nameof(property), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: property.");
 
             if (snakeCase.IsSet && snakeCase.Value == null)
-                throw new ArgumentNullException(nameof(snakeCase), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: snake_case.");
 
             if (var123Number.IsSet && var123Number.Value == null)
-                throw new ArgumentNullException(nameof(var123Number), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: 123Number.");
 
             return new Name(varName.Value.Value, property, snakeCase, var123Number);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
@@ -151,16 +151,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!aObjVariableobject.IsSet)
-                throw new ArgumentException("Property is required for class NotificationtestGetElementsV1ResponseMPayload.", nameof(aObjVariableobject));
+                throw new JsonException("Property is required for class NotificationtestGetElementsV1ResponseMPayload: a_objVariableobject.");
 
             if (!pkiNotificationtestID.IsSet)
-                throw new ArgumentException("Property is required for class NotificationtestGetElementsV1ResponseMPayload.", nameof(pkiNotificationtestID));
+                throw new JsonException("Property is required for class NotificationtestGetElementsV1ResponseMPayload: pkiNotificationtestID.");
 
             if (aObjVariableobject.IsSet && aObjVariableobject.Value == null)
-                throw new ArgumentNullException(nameof(aObjVariableobject), "Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload.");
+                throw new JsonException("Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload: a_objVariableobject.");
 
             if (pkiNotificationtestID.IsSet && pkiNotificationtestID.Value == null)
-                throw new ArgumentNullException(nameof(pkiNotificationtestID), "Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload.");
+                throw new JsonException("Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload: pkiNotificationtestID.");
 
             return new NotificationtestGetElementsV1ResponseMPayload(aObjVariableobject.Value, pkiNotificationtestID.Value.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -375,10 +375,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayItemsNullable.IsSet && arrayItemsNullable.Value == null)
-                throw new ArgumentNullException(nameof(arrayItemsNullable), "Property is not nullable for class NullableClass.");
+                throw new JsonException("Property is not nullable for class NullableClass: array_items_nullable.");
 
             if (objectItemsNullable.IsSet && objectItemsNullable.Value == null)
-                throw new ArgumentNullException(nameof(objectItemsNullable), "Property is not nullable for class NullableClass.");
+                throw new JsonException("Property is not nullable for class NullableClass: object_items_nullable.");
 
             return new NullableClass(arrayAndItemsNullableProp, arrayItemsNullable, arrayNullableProp, booleanProp, dateProp, datetimeProp, integerProp, numberProp, objectAndItemsNullableProp, objectItemsNullable, objectNullableProp, stringProp);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/NullableShape.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/NullableShape.cs
@@ -193,10 +193,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class NullableShape.", nameof(shapeType));
+                throw new JsonException("Property is required for class NullableShape: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class NullableShape.");
+                throw new JsonException("Property is not nullable for class NullableShape: shapeType.");
 
             if (quadrilateral != null)
                 return new NullableShape(quadrilateral);

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (justNumber.IsSet && justNumber.Value == null)
-                throw new ArgumentNullException(nameof(justNumber), "Property is not nullable for class NumberOnly.");
+                throw new JsonException("Property is not nullable for class NumberOnly: JustNumber.");
 
             return new NumberOnly(justNumber);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -208,16 +208,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bars.IsSet && bars.Value == null)
-                throw new ArgumentNullException(nameof(bars), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: bars.");
 
             if (deprecatedRef.IsSet && deprecatedRef.Value == null)
-                throw new ArgumentNullException(nameof(deprecatedRef), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: deprecatedRef.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: id.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: uuid.");
 
             return new ObjectWithDeprecatedFields(bars, deprecatedRef, id, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Order.cs
@@ -340,22 +340,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (complete.IsSet && complete.Value == null)
-                throw new ArgumentNullException(nameof(complete), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: complete.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: id.");
 
             if (petId.IsSet && petId.Value == null)
-                throw new ArgumentNullException(nameof(petId), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: petId.");
 
             if (quantity.IsSet && quantity.Value == null)
-                throw new ArgumentNullException(nameof(quantity), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: quantity.");
 
             if (shipDate.IsSet && shipDate.Value == null)
-                throw new ArgumentNullException(nameof(shipDate), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: shipDate.");
 
             if (status.IsSet && status.Value == null)
-                throw new ArgumentNullException(nameof(status), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: status.");
 
             return new Order(complete, id, petId, quantity, shipDate, status);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -185,13 +185,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (myBoolean.IsSet && myBoolean.Value == null)
-                throw new ArgumentNullException(nameof(myBoolean), "Property is not nullable for class OuterComposite.");
+                throw new JsonException("Property is not nullable for class OuterComposite: my_boolean.");
 
             if (myNumber.IsSet && myNumber.Value == null)
-                throw new ArgumentNullException(nameof(myNumber), "Property is not nullable for class OuterComposite.");
+                throw new JsonException("Property is not nullable for class OuterComposite: my_number.");
 
             if (myString.IsSet && myString.Value == null)
-                throw new ArgumentNullException(nameof(myString), "Property is not nullable for class OuterComposite.");
+                throw new JsonException("Property is not nullable for class OuterComposite: my_string.");
 
             return new OuterComposite(myBoolean, myNumber, myString);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ParentPet.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ParentPet.cs
@@ -118,10 +118,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!petType.IsSet)
-                throw new ArgumentException("Property is required for class ParentPet.", nameof(petType));
+                throw new JsonException("Property is required for class ParentPet: pet_type.");
 
             if (petType.IsSet && petType.Value == null)
-                throw new ArgumentNullException(nameof(petType), "Property is not nullable for class ParentPet.");
+                throw new JsonException("Property is not nullable for class ParentPet: pet_type.");
 
             return new ParentPet();
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Pet.cs
@@ -321,28 +321,28 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!name.IsSet)
-                throw new ArgumentException("Property is required for class Pet.", nameof(name));
+                throw new JsonException("Property is required for class Pet: name.");
 
             if (!photoUrls.IsSet)
-                throw new ArgumentException("Property is required for class Pet.", nameof(photoUrls));
+                throw new JsonException("Property is required for class Pet: photoUrls.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: name.");
 
             if (photoUrls.IsSet && photoUrls.Value == null)
-                throw new ArgumentNullException(nameof(photoUrls), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: photoUrls.");
 
             if (category.IsSet && category.Value == null)
-                throw new ArgumentNullException(nameof(category), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: category.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: id.");
 
             if (status.IsSet && status.Value == null)
-                throw new ArgumentNullException(nameof(status), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: status.");
 
             if (tags.IsSet && tags.Value == null)
-                throw new ArgumentNullException(nameof(tags), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: tags.");
 
             return new Pet(name.Value, photoUrls.Value, category, id, status, tags);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Pig.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Pig.cs
@@ -193,10 +193,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Pig.", nameof(className));
+                throw new JsonException("Property is required for class Pig: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Pig.");
+                throw new JsonException("Property is not nullable for class Pig: className.");
 
             if (basquePig != null)
                 return new Pig(basquePig);

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Quadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Quadrilateral.cs
@@ -193,10 +193,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class Quadrilateral.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class Quadrilateral: quadrilateralType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class Quadrilateral.");
+                throw new JsonException("Property is not nullable for class Quadrilateral: quadrilateralType.");
 
             if (complexQuadrilateral != null)
                 return new Quadrilateral(complexQuadrilateral);

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
@@ -138,10 +138,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class QuadrilateralInterface.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class QuadrilateralInterface: quadrilateralType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class QuadrilateralInterface.");
+                throw new JsonException("Property is not nullable for class QuadrilateralInterface: quadrilateralType.");
 
             return new QuadrilateralInterface(quadrilateralType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -203,10 +203,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bar.IsSet && bar.Value == null)
-                throw new ArgumentNullException(nameof(bar), "Property is not nullable for class ReadOnlyFirst.");
+                throw new JsonException("Property is not nullable for class ReadOnlyFirst: bar.");
 
             if (baz.IsSet && baz.Value == null)
-                throw new ArgumentNullException(nameof(baz), "Property is not nullable for class ReadOnlyFirst.");
+                throw new JsonException("Property is not nullable for class ReadOnlyFirst: baz.");
 
             return new ReadOnlyFirst(bar, baz);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -2077,136 +2077,136 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!requiredNotNullableDateProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotNullableDateProp));
+                throw new JsonException("Property is required for class RequiredClass: required_not_nullable_date_prop.");
 
             if (!requiredNotnullableArrayOfString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableArrayOfString));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_array_of_string.");
 
             if (!requiredNotnullableBooleanProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableBooleanProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_boolean_prop.");
 
             if (!requiredNotnullableDatetimeProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableDatetimeProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_datetime_prop.");
 
             if (!requiredNotnullableEnumInteger.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableEnumInteger));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_enum_integer.");
 
             if (!requiredNotnullableEnumIntegerOnly.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableEnumIntegerOnly));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_enum_integer_only.");
 
             if (!requiredNotnullableEnumString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableEnumString));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_enum_string.");
 
             if (!requiredNotnullableOuterEnumDefaultValue.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableOuterEnumDefaultValue));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_outerEnumDefaultValue.");
 
             if (!requiredNotnullableStringProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableStringProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_string_prop.");
 
             if (!requiredNotnullableUuid.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableUuid));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_uuid.");
 
             if (!requiredNotnullableintegerProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableintegerProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullableinteger_prop.");
 
             if (!requiredNullableArrayOfString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableArrayOfString));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_array_of_string.");
 
             if (!requiredNullableBooleanProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableBooleanProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_boolean_prop.");
 
             if (!requiredNullableDateProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableDateProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_date_prop.");
 
             if (!requiredNullableDatetimeProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableDatetimeProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_datetime_prop.");
 
             if (!requiredNullableEnumInteger.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableEnumInteger));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_enum_integer.");
 
             if (!requiredNullableEnumIntegerOnly.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableEnumIntegerOnly));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_enum_integer_only.");
 
             if (!requiredNullableEnumString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableEnumString));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_enum_string.");
 
             if (!requiredNullableIntegerProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableIntegerProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_integer_prop.");
 
             if (!requiredNullableOuterEnumDefaultValue.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableOuterEnumDefaultValue));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_outerEnumDefaultValue.");
 
             if (!requiredNullableStringProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableStringProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_string_prop.");
 
             if (!requiredNullableUuid.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableUuid));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_uuid.");
 
             if (requiredNotNullableDateProp.IsSet && requiredNotNullableDateProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotNullableDateProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_not_nullable_date_prop.");
 
             if (requiredNotnullableArrayOfString.IsSet && requiredNotnullableArrayOfString.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableArrayOfString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_array_of_string.");
 
             if (requiredNotnullableBooleanProp.IsSet && requiredNotnullableBooleanProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableBooleanProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_boolean_prop.");
 
             if (requiredNotnullableDatetimeProp.IsSet && requiredNotnullableDatetimeProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableDatetimeProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_datetime_prop.");
 
             if (requiredNotnullableEnumInteger.IsSet && requiredNotnullableEnumInteger.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableEnumInteger), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_enum_integer.");
 
             if (requiredNotnullableEnumIntegerOnly.IsSet && requiredNotnullableEnumIntegerOnly.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableEnumIntegerOnly), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_enum_integer_only.");
 
             if (requiredNotnullableEnumString.IsSet && requiredNotnullableEnumString.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableEnumString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_enum_string.");
 
             if (requiredNotnullableOuterEnumDefaultValue.IsSet && requiredNotnullableOuterEnumDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableOuterEnumDefaultValue), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_outerEnumDefaultValue.");
 
             if (requiredNotnullableStringProp.IsSet && requiredNotnullableStringProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableStringProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_string_prop.");
 
             if (requiredNotnullableUuid.IsSet && requiredNotnullableUuid.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableUuid), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_uuid.");
 
             if (requiredNotnullableintegerProp.IsSet && requiredNotnullableintegerProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableintegerProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullableinteger_prop.");
 
             if (notRequiredNotnullableDateProp.IsSet && notRequiredNotnullableDateProp.Value == null)
-                throw new ArgumentNullException(nameof(notRequiredNotnullableDateProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: not_required_notnullable_date_prop.");
 
             if (notRequiredNotnullableintegerProp.IsSet && notRequiredNotnullableintegerProp.Value == null)
-                throw new ArgumentNullException(nameof(notRequiredNotnullableintegerProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: not_required_notnullableinteger_prop.");
 
             if (notrequiredNotnullableArrayOfString.IsSet && notrequiredNotnullableArrayOfString.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableArrayOfString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_array_of_string.");
 
             if (notrequiredNotnullableBooleanProp.IsSet && notrequiredNotnullableBooleanProp.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableBooleanProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_boolean_prop.");
 
             if (notrequiredNotnullableDatetimeProp.IsSet && notrequiredNotnullableDatetimeProp.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableDatetimeProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_datetime_prop.");
 
             if (notrequiredNotnullableEnumInteger.IsSet && notrequiredNotnullableEnumInteger.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableEnumInteger), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_enum_integer.");
 
             if (notrequiredNotnullableEnumIntegerOnly.IsSet && notrequiredNotnullableEnumIntegerOnly.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableEnumIntegerOnly), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_enum_integer_only.");
 
             if (notrequiredNotnullableEnumString.IsSet && notrequiredNotnullableEnumString.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableEnumString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_enum_string.");
 
             if (notrequiredNotnullableOuterEnumDefaultValue.IsSet && notrequiredNotnullableOuterEnumDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableOuterEnumDefaultValue), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_outerEnumDefaultValue.");
 
             if (notrequiredNotnullableStringProp.IsSet && notrequiredNotnullableStringProp.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableStringProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_string_prop.");
 
             if (notrequiredNotnullableUuid.IsSet && notrequiredNotnullableUuid.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableUuid), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_uuid.");
 
             return new RequiredClass(requiredNotNullableDateProp.Value.Value, requiredNotnullableArrayOfString.Value, requiredNotnullableBooleanProp.Value.Value, requiredNotnullableDatetimeProp.Value.Value, requiredNotnullableEnumInteger.Value.Value, requiredNotnullableEnumIntegerOnly.Value.Value, requiredNotnullableEnumString.Value.Value, requiredNotnullableOuterEnumDefaultValue.Value.Value, requiredNotnullableStringProp.Value, requiredNotnullableUuid.Value.Value, requiredNotnullableintegerProp.Value.Value, notRequiredNotnullableDateProp, notRequiredNotnullableintegerProp, notRequiredNullableDateProp, notRequiredNullableIntegerProp, notrequiredNotnullableArrayOfString, notrequiredNotnullableBooleanProp, notrequiredNotnullableDatetimeProp, notrequiredNotnullableEnumInteger, notrequiredNotnullableEnumIntegerOnly, notrequiredNotnullableEnumString, notrequiredNotnullableOuterEnumDefaultValue, notrequiredNotnullableStringProp, notrequiredNotnullableUuid, notrequiredNullableArrayOfString, notrequiredNullableBooleanProp, notrequiredNullableDatetimeProp, notrequiredNullableEnumInteger, notrequiredNullableEnumIntegerOnly, notrequiredNullableEnumString, notrequiredNullableOuterEnumDefaultValue, notrequiredNullableStringProp, notrequiredNullableUuid, requiredNullableArrayOfString.Value, requiredNullableBooleanProp.Value, requiredNullableDateProp.Value, requiredNullableDatetimeProp.Value, requiredNullableEnumInteger.Value, requiredNullableEnumIntegerOnly.Value, requiredNullableEnumString.Value, requiredNullableIntegerProp.Value, requiredNullableOuterEnumDefaultValue.Value, requiredNullableStringProp.Value, requiredNullableUuid.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Result.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Result.cs
@@ -188,13 +188,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (code.IsSet && code.Value == null)
-                throw new ArgumentNullException(nameof(code), "Property is not nullable for class Result.");
+                throw new JsonException("Property is not nullable for class Result: code.");
 
             if (data.IsSet && data.Value == null)
-                throw new ArgumentNullException(nameof(data), "Property is not nullable for class Result.");
+                throw new JsonException("Property is not nullable for class Result: data.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class Result.");
+                throw new JsonException("Property is not nullable for class Result: uuid.");
 
             return new Result(code, data, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Return.cs
@@ -191,19 +191,19 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!varLock.IsSet)
-                throw new ArgumentException("Property is required for class Return.", nameof(varLock));
+                throw new JsonException("Property is required for class Return: lock.");
 
             if (!varAbstract.IsSet)
-                throw new ArgumentException("Property is required for class Return.", nameof(varAbstract));
+                throw new JsonException("Property is required for class Return: abstract.");
 
             if (varLock.IsSet && varLock.Value == null)
-                throw new ArgumentNullException(nameof(varLock), "Property is not nullable for class Return.");
+                throw new JsonException("Property is not nullable for class Return: lock.");
 
             if (varReturn.IsSet && varReturn.Value == null)
-                throw new ArgumentNullException(nameof(varReturn), "Property is not nullable for class Return.");
+                throw new JsonException("Property is not nullable for class Return: return.");
 
             if (varUnsafe.IsSet && varUnsafe.Value == null)
-                throw new ArgumentNullException(nameof(varUnsafe), "Property is not nullable for class Return.");
+                throw new JsonException("Property is not nullable for class Return: unsafe.");
 
             return new Return(varLock.Value, varAbstract.Value, varReturn, varUnsafe);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (role.IsSet && role.Value == null)
-                throw new ArgumentNullException(nameof(role), "Property is not nullable for class RolesReportsHash.");
+                throw new JsonException("Property is not nullable for class RolesReportsHash: role.");
 
             if (roleUuid.IsSet && roleUuid.Value == null)
-                throw new ArgumentNullException(nameof(roleUuid), "Property is not nullable for class RolesReportsHash.");
+                throw new JsonException("Property is not nullable for class RolesReportsHash: role_uuid.");
 
             return new RolesReportsHash(role, roleUuid);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class RolesReportsHashRole.");
+                throw new JsonException("Property is not nullable for class RolesReportsHashRole: name.");
 
             return new RolesReportsHashRole(name);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
@@ -151,16 +151,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ScaleneTriangle.", nameof(shapeType));
+                throw new JsonException("Property is required for class ScaleneTriangle: shapeType.");
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class ScaleneTriangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class ScaleneTriangle: triangleType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ScaleneTriangle.");
+                throw new JsonException("Property is not nullable for class ScaleneTriangle: shapeType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class ScaleneTriangle.");
+                throw new JsonException("Property is not nullable for class ScaleneTriangle: triangleType.");
 
             return new ScaleneTriangle(shapeType.Value, triangleType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Shape.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Shape.cs
@@ -193,10 +193,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class Shape.", nameof(shapeType));
+                throw new JsonException("Property is required for class Shape: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class Shape.");
+                throw new JsonException("Property is not nullable for class Shape: shapeType.");
 
             if (quadrilateral != null)
                 return new Shape(quadrilateral);

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ShapeInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ShapeInterface.cs
@@ -138,10 +138,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ShapeInterface.", nameof(shapeType));
+                throw new JsonException("Property is required for class ShapeInterface: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ShapeInterface.");
+                throw new JsonException("Property is not nullable for class ShapeInterface: shapeType.");
 
             return new ShapeInterface(shapeType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ShapeOrNull.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ShapeOrNull.cs
@@ -193,10 +193,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ShapeOrNull.", nameof(shapeType));
+                throw new JsonException("Property is required for class ShapeOrNull: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ShapeOrNull.");
+                throw new JsonException("Property is not nullable for class ShapeOrNull: shapeType.");
 
             if (quadrilateral != null)
                 return new ShapeOrNull(quadrilateral);

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
@@ -151,16 +151,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class SimpleQuadrilateral.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class SimpleQuadrilateral: quadrilateralType.");
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class SimpleQuadrilateral.", nameof(shapeType));
+                throw new JsonException("Property is required for class SimpleQuadrilateral: shapeType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class SimpleQuadrilateral.");
+                throw new JsonException("Property is not nullable for class SimpleQuadrilateral: quadrilateralType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class SimpleQuadrilateral.");
+                throw new JsonException("Property is not nullable for class SimpleQuadrilateral: shapeType.");
 
             return new SimpleQuadrilateral(quadrilateralType.Value, shapeType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varSpecialModelName.IsSet && varSpecialModelName.Value == null)
-                throw new ArgumentNullException(nameof(varSpecialModelName), "Property is not nullable for class SpecialModelName.");
+                throw new JsonException("Property is not nullable for class SpecialModelName: _special_model.name_.");
 
             if (specialPropertyName.IsSet && specialPropertyName.Value == null)
-                throw new ArgumentNullException(nameof(specialPropertyName), "Property is not nullable for class SpecialModelName.");
+                throw new JsonException("Property is not nullable for class SpecialModelName: $special[property.name].");
 
             return new SpecialModelName(varSpecialModelName, specialPropertyName);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Tag.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Tag.");
+                throw new JsonException("Property is not nullable for class Tag: id.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Tag.");
+                throw new JsonException("Property is not nullable for class Tag: name.");
 
             return new Tag(id, name);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (value.IsSet && value.Value == null)
-                throw new ArgumentNullException(nameof(value), "Property is not nullable for class TestCollectionEndingWithWordList.");
+                throw new JsonException("Property is not nullable for class TestCollectionEndingWithWordList: value.");
 
             return new TestCollectionEndingWithWordList(value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (testCollectionEndingWithWordList.IsSet && testCollectionEndingWithWordList.Value == null)
-                throw new ArgumentNullException(nameof(testCollectionEndingWithWordList), "Property is not nullable for class TestCollectionEndingWithWordListObject.");
+                throw new JsonException("Property is not nullable for class TestCollectionEndingWithWordListObject: TestCollectionEndingWithWordList.");
 
             return new TestCollectionEndingWithWordListObject(testCollectionEndingWithWordList);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/TestDescendants.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/TestDescendants.cs
@@ -241,16 +241,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!alternativeName.IsSet)
-                throw new ArgumentException("Property is required for class TestDescendants.", nameof(alternativeName));
+                throw new JsonException("Property is required for class TestDescendants: alternativeName.");
 
             if (!objectType.IsSet)
-                throw new ArgumentException("Property is required for class TestDescendants.", nameof(objectType));
+                throw new JsonException("Property is required for class TestDescendants: objectType.");
 
             if (alternativeName.IsSet && alternativeName.Value == null)
-                throw new ArgumentNullException(nameof(alternativeName), "Property is not nullable for class TestDescendants.");
+                throw new JsonException("Property is not nullable for class TestDescendants: alternativeName.");
 
             if (objectType.IsSet && objectType.Value == null)
-                throw new ArgumentNullException(nameof(objectType), "Property is not nullable for class TestDescendants.");
+                throw new JsonException("Property is not nullable for class TestDescendants: objectType.");
 
             return new TestDescendants(alternativeName.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (someProperty.IsSet && someProperty.Value == null)
-                throw new ArgumentNullException(nameof(someProperty), "Property is not nullable for class TestInlineFreeformAdditionalPropertiesRequest.");
+                throw new JsonException("Property is not nullable for class TestInlineFreeformAdditionalPropertiesRequest: someProperty.");
 
             return new TestInlineFreeformAdditionalPropertiesRequest(someProperty);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/TestResult.cs
@@ -187,13 +187,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (code.IsSet && code.Value == null)
-                throw new ArgumentNullException(nameof(code), "Property is not nullable for class TestResult.");
+                throw new JsonException("Property is not nullable for class TestResult: code.");
 
             if (data.IsSet && data.Value == null)
-                throw new ArgumentNullException(nameof(data), "Property is not nullable for class TestResult.");
+                throw new JsonException("Property is not nullable for class TestResult: data.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class TestResult.");
+                throw new JsonException("Property is not nullable for class TestResult: uuid.");
 
             return new TestResult(code, data, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Triangle.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Triangle.cs
@@ -214,10 +214,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class Triangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class Triangle: triangleType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class Triangle.");
+                throw new JsonException("Property is not nullable for class Triangle: triangleType.");
 
             if (equilateralTriangle != null)
                 return new Triangle(equilateralTriangle);

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/TriangleInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/TriangleInterface.cs
@@ -138,10 +138,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class TriangleInterface.", nameof(triangleType));
+                throw new JsonException("Property is required for class TriangleInterface: triangleType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class TriangleInterface.");
+                throw new JsonException("Property is not nullable for class TriangleInterface: triangleType.");
 
             return new TriangleInterface(triangleType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/User.cs
@@ -370,31 +370,31 @@ namespace Org.OpenAPITools.Model
             }
 
             if (email.IsSet && email.Value == null)
-                throw new ArgumentNullException(nameof(email), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: email.");
 
             if (firstName.IsSet && firstName.Value == null)
-                throw new ArgumentNullException(nameof(firstName), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: firstName.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: id.");
 
             if (lastName.IsSet && lastName.Value == null)
-                throw new ArgumentNullException(nameof(lastName), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: lastName.");
 
             if (objectWithNoDeclaredProps.IsSet && objectWithNoDeclaredProps.Value == null)
-                throw new ArgumentNullException(nameof(objectWithNoDeclaredProps), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: objectWithNoDeclaredProps.");
 
             if (password.IsSet && password.Value == null)
-                throw new ArgumentNullException(nameof(password), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: password.");
 
             if (phone.IsSet && phone.Value == null)
-                throw new ArgumentNullException(nameof(phone), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: phone.");
 
             if (userStatus.IsSet && userStatus.Value == null)
-                throw new ArgumentNullException(nameof(userStatus), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: userStatus.");
 
             if (username.IsSet && username.Value == null)
-                throw new ArgumentNullException(nameof(username), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: username.");
 
             return new User(anyTypeProp, anyTypePropNullable, email, firstName, id, lastName, objectWithNoDeclaredProps, objectWithNoDeclaredPropsNullable, password, phone, userStatus, username);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Whale.cs
@@ -178,16 +178,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Whale.", nameof(className));
+                throw new JsonException("Property is required for class Whale: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Whale.");
+                throw new JsonException("Property is not nullable for class Whale: className.");
 
             if (hasBaleen.IsSet && hasBaleen.Value == null)
-                throw new ArgumentNullException(nameof(hasBaleen), "Property is not nullable for class Whale.");
+                throw new JsonException("Property is not nullable for class Whale: hasBaleen.");
 
             if (hasTeeth.IsSet && hasTeeth.Value == null)
-                throw new ArgumentNullException(nameof(hasTeeth), "Property is not nullable for class Whale.");
+                throw new JsonException("Property is not nullable for class Whale: hasTeeth.");
 
             return new Whale(className.Value, hasBaleen, hasTeeth);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Zebra.cs
@@ -245,13 +245,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Zebra.", nameof(className));
+                throw new JsonException("Property is required for class Zebra: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Zebra.");
+                throw new JsonException("Property is not nullable for class Zebra: className.");
 
             if (type.IsSet && type.Value == null)
-                throw new ArgumentNullException(nameof(type), "Property is not nullable for class Zebra.");
+                throw new JsonException("Property is not nullable for class Zebra: type.");
 
             return new Zebra(className.Value, type);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
@@ -218,7 +218,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (zeroBasedEnum.IsSet && zeroBasedEnum.Value == null)
-                throw new ArgumentNullException(nameof(zeroBasedEnum), "Property is not nullable for class ZeroBasedEnumClass.");
+                throw new JsonException("Property is not nullable for class ZeroBasedEnumClass: ZeroBasedEnum.");
 
             return new ZeroBasedEnumClass(zeroBasedEnum);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/UseDateTimeForDate/src/Org.OpenAPITools/Model/NowGet200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/UseDateTimeForDate/src/Org.OpenAPITools/Model/NowGet200Response.cs
@@ -167,10 +167,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (now.IsSet && now.Value == null)
-                throw new ArgumentNullException(nameof(now), "Property is not nullable for class NowGet200Response.");
+                throw new JsonException("Property is not nullable for class NowGet200Response: now.");
 
             if (today.IsSet && today.Value == null)
-                throw new ArgumentNullException(nameof(today), "Property is not nullable for class NowGet200Response.");
+                throw new JsonException("Property is not nullable for class NowGet200Response: today.");
 
             return new NowGet200Response(now, today);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/AllOf/src/Org.OpenAPITools/Model/Adult.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/AllOf/src/Org.OpenAPITools/Model/Adult.cs
@@ -143,16 +143,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (children.IsSet && children.Value == null)
-                throw new ArgumentNullException(nameof(children), "Property is not nullable for class Adult.");
+                throw new JsonException("Property is not nullable for class Adult: children.");
 
             if (firstName.IsSet && firstName.Value == null)
-                throw new ArgumentNullException(nameof(firstName), "Property is not nullable for class Adult.");
+                throw new JsonException("Property is not nullable for class Adult: firstName.");
 
             if (lastName.IsSet && lastName.Value == null)
-                throw new ArgumentNullException(nameof(lastName), "Property is not nullable for class Adult.");
+                throw new JsonException("Property is not nullable for class Adult: lastName.");
 
             if (type.IsSet && type.Value == null)
-                throw new ArgumentNullException(nameof(type), "Property is not nullable for class Adult.");
+                throw new JsonException("Property is not nullable for class Adult: $_type.");
 
             return new Adult(children, firstName, lastName);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/AllOf/src/Org.OpenAPITools/Model/Child.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/AllOf/src/Org.OpenAPITools/Model/Child.cs
@@ -163,19 +163,19 @@ namespace Org.OpenAPITools.Model
             }
 
             if (age.IsSet && age.Value == null)
-                throw new ArgumentNullException(nameof(age), "Property is not nullable for class Child.");
+                throw new JsonException("Property is not nullable for class Child: age.");
 
             if (boosterSeat.IsSet && boosterSeat.Value == null)
-                throw new ArgumentNullException(nameof(boosterSeat), "Property is not nullable for class Child.");
+                throw new JsonException("Property is not nullable for class Child: boosterSeat.");
 
             if (firstName.IsSet && firstName.Value == null)
-                throw new ArgumentNullException(nameof(firstName), "Property is not nullable for class Child.");
+                throw new JsonException("Property is not nullable for class Child: firstName.");
 
             if (lastName.IsSet && lastName.Value == null)
-                throw new ArgumentNullException(nameof(lastName), "Property is not nullable for class Child.");
+                throw new JsonException("Property is not nullable for class Child: lastName.");
 
             if (type.IsSet && type.Value == null)
-                throw new ArgumentNullException(nameof(type), "Property is not nullable for class Child.");
+                throw new JsonException("Property is not nullable for class Child: $_type.");
 
             return new Child(age, boosterSeat, firstName, lastName);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/AllOf/src/Org.OpenAPITools/Model/Person.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/AllOf/src/Org.OpenAPITools/Model/Person.cs
@@ -195,13 +195,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (firstName.IsSet && firstName.Value == null)
-                throw new ArgumentNullException(nameof(firstName), "Property is not nullable for class Person.");
+                throw new JsonException("Property is not nullable for class Person: firstName.");
 
             if (lastName.IsSet && lastName.Value == null)
-                throw new ArgumentNullException(nameof(lastName), "Property is not nullable for class Person.");
+                throw new JsonException("Property is not nullable for class Person: lastName.");
 
             if (type.IsSet && type.Value == null)
-                throw new ArgumentNullException(nameof(type), "Property is not nullable for class Person.");
+                throw new JsonException("Property is not nullable for class Person: $_type.");
 
             return new Person(firstName, lastName);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/AnyOf/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/AnyOf/src/Org.OpenAPITools/Model/Apple.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (kind.IsSet && kind.Value == null)
-                throw new ArgumentNullException(nameof(kind), "Property is not nullable for class Apple.");
+                throw new JsonException("Property is not nullable for class Apple: kind.");
 
             return new Apple(kind);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/AnyOf/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/AnyOf/src/Org.OpenAPITools/Model/Banana.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (count.IsSet && count.Value == null)
-                throw new ArgumentNullException(nameof(count), "Property is not nullable for class Banana.");
+                throw new JsonException("Property is not nullable for class Banana: count.");
 
             return new Banana(count);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/AnyOf/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/AnyOf/src/Org.OpenAPITools/Model/Fruit.cs
@@ -194,7 +194,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Fruit.");
+                throw new JsonException("Property is not nullable for class Fruit: color.");
 
             Option<Apple> appleParsedValue = apple == null
                 ? default

--- a/samples/client/petstore/csharp/generichost/net4.8/AnyOfNoCompare/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/AnyOfNoCompare/src/Org.OpenAPITools/Model/Apple.cs
@@ -144,7 +144,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (kind.IsSet && kind.Value == null)
-                throw new ArgumentNullException(nameof(kind), "Property is not nullable for class Apple.");
+                throw new JsonException("Property is not nullable for class Apple: kind.");
 
             return new Apple(kind);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/AnyOfNoCompare/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/AnyOfNoCompare/src/Org.OpenAPITools/Model/Banana.cs
@@ -144,7 +144,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (count.IsSet && count.Value == null)
-                throw new ArgumentNullException(nameof(count), "Property is not nullable for class Banana.");
+                throw new JsonException("Property is not nullable for class Banana: count.");
 
             return new Banana(count);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/AnyOfNoCompare/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/AnyOfNoCompare/src/Org.OpenAPITools/Model/Fruit.cs
@@ -193,7 +193,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Fruit.");
+                throw new JsonException("Property is not nullable for class Fruit: color.");
 
             Option<Apple> appleParsedValue = apple == null
                 ? default

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Activity.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (activityOutputs.IsSet && activityOutputs.Value == null)
-                throw new ArgumentNullException(nameof(activityOutputs), "Property is not nullable for class Activity.");
+                throw new JsonException("Property is not nullable for class Activity: activity_outputs.");
 
             return new Activity(activityOutputs);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (prop1.IsSet && prop1.Value == null)
-                throw new ArgumentNullException(nameof(prop1), "Property is not nullable for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Property is not nullable for class ActivityOutputElementRepresentation: prop1.");
 
             if (prop2.IsSet && prop2.Value == null)
-                throw new ArgumentNullException(nameof(prop2), "Property is not nullable for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Property is not nullable for class ActivityOutputElementRepresentation: prop2.");
 
             return new ActivityOutputElementRepresentation(prop1, prop2);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -286,25 +286,25 @@ namespace Org.OpenAPITools.Model
             }
 
             if (emptyMap.IsSet && emptyMap.Value == null)
-                throw new ArgumentNullException(nameof(emptyMap), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: empty_map.");
 
             if (mapOfMapProperty.IsSet && mapOfMapProperty.Value == null)
-                throw new ArgumentNullException(nameof(mapOfMapProperty), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_of_map_property.");
 
             if (mapProperty.IsSet && mapProperty.Value == null)
-                throw new ArgumentNullException(nameof(mapProperty), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_property.");
 
             if (mapWithUndeclaredPropertiesAnytype1.IsSet && mapWithUndeclaredPropertiesAnytype1.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesAnytype1), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_anytype_1.");
 
             if (mapWithUndeclaredPropertiesAnytype2.IsSet && mapWithUndeclaredPropertiesAnytype2.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesAnytype2), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_anytype_2.");
 
             if (mapWithUndeclaredPropertiesAnytype3.IsSet && mapWithUndeclaredPropertiesAnytype3.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesAnytype3), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_anytype_3.");
 
             if (mapWithUndeclaredPropertiesString.IsSet && mapWithUndeclaredPropertiesString.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesString), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_string.");
 
             return new AdditionalPropertiesClass(anytype1, emptyMap, mapOfMapProperty, mapProperty, mapWithUndeclaredPropertiesAnytype1, mapWithUndeclaredPropertiesAnytype2, mapWithUndeclaredPropertiesAnytype3, mapWithUndeclaredPropertiesString);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Animal.cs
@@ -175,13 +175,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Animal.", nameof(className));
+                throw new JsonException("Property is required for class Animal: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Animal.");
+                throw new JsonException("Property is not nullable for class Animal: className.");
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Animal.");
+                throw new JsonException("Property is not nullable for class Animal: color.");
 
             return new Animal(color);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -185,13 +185,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (code.IsSet && code.Value == null)
-                throw new ArgumentNullException(nameof(code), "Property is not nullable for class ApiResponse.");
+                throw new JsonException("Property is not nullable for class ApiResponse: code.");
 
             if (message.IsSet && message.Value == null)
-                throw new ArgumentNullException(nameof(message), "Property is not nullable for class ApiResponse.");
+                throw new JsonException("Property is not nullable for class ApiResponse: message.");
 
             if (type.IsSet && type.Value == null)
-                throw new ArgumentNullException(nameof(type), "Property is not nullable for class ApiResponse.");
+                throw new JsonException("Property is not nullable for class ApiResponse: type.");
 
             return new ApiResponse(code, message, type);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Apple.cs
@@ -215,13 +215,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (colorCode.IsSet && colorCode.Value == null)
-                throw new ArgumentNullException(nameof(colorCode), "Property is not nullable for class Apple.");
+                throw new JsonException("Property is not nullable for class Apple: color_code.");
 
             if (cultivar.IsSet && cultivar.Value == null)
-                throw new ArgumentNullException(nameof(cultivar), "Property is not nullable for class Apple.");
+                throw new JsonException("Property is not nullable for class Apple: cultivar.");
 
             if (origin.IsSet && origin.Value == null)
-                throw new ArgumentNullException(nameof(origin), "Property is not nullable for class Apple.");
+                throw new JsonException("Property is not nullable for class Apple: origin.");
 
             return new Apple(colorCode, cultivar, origin);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -151,13 +151,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!cultivar.IsSet)
-                throw new ArgumentException("Property is required for class AppleReq.", nameof(cultivar));
+                throw new JsonException("Property is required for class AppleReq: cultivar.");
 
             if (cultivar.IsSet && cultivar.Value == null)
-                throw new ArgumentNullException(nameof(cultivar), "Property is not nullable for class AppleReq.");
+                throw new JsonException("Property is not nullable for class AppleReq: cultivar.");
 
             if (mealy.IsSet && mealy.Value == null)
-                throw new ArgumentNullException(nameof(mealy), "Property is not nullable for class AppleReq.");
+                throw new JsonException("Property is not nullable for class AppleReq: mealy.");
 
             return new AppleReq(cultivar.Value, mealy);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayArrayNumber.IsSet && arrayArrayNumber.Value == null)
-                throw new ArgumentNullException(nameof(arrayArrayNumber), "Property is not nullable for class ArrayOfArrayOfNumberOnly.");
+                throw new JsonException("Property is not nullable for class ArrayOfArrayOfNumberOnly: ArrayArrayNumber.");
 
             return new ArrayOfArrayOfNumberOnly(arrayArrayNumber);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayNumber.IsSet && arrayNumber.Value == null)
-                throw new ArgumentNullException(nameof(arrayNumber), "Property is not nullable for class ArrayOfNumberOnly.");
+                throw new JsonException("Property is not nullable for class ArrayOfNumberOnly: ArrayNumber.");
 
             return new ArrayOfNumberOnly(arrayNumber);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -185,13 +185,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayArrayOfInteger.IsSet && arrayArrayOfInteger.Value == null)
-                throw new ArgumentNullException(nameof(arrayArrayOfInteger), "Property is not nullable for class ArrayTest.");
+                throw new JsonException("Property is not nullable for class ArrayTest: array_array_of_integer.");
 
             if (arrayArrayOfModel.IsSet && arrayArrayOfModel.Value == null)
-                throw new ArgumentNullException(nameof(arrayArrayOfModel), "Property is not nullable for class ArrayTest.");
+                throw new JsonException("Property is not nullable for class ArrayTest: array_array_of_model.");
 
             if (arrayOfString.IsSet && arrayOfString.Value == null)
-                throw new ArgumentNullException(nameof(arrayOfString), "Property is not nullable for class ArrayTest.");
+                throw new JsonException("Property is not nullable for class ArrayTest: array_of_string.");
 
             return new ArrayTest(arrayArrayOfInteger, arrayArrayOfModel, arrayOfString);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Banana.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (lengthCm.IsSet && lengthCm.Value == null)
-                throw new ArgumentNullException(nameof(lengthCm), "Property is not nullable for class Banana.");
+                throw new JsonException("Property is not nullable for class Banana: lengthCm.");
 
             return new Banana(lengthCm);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -151,13 +151,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!lengthCm.IsSet)
-                throw new ArgumentException("Property is required for class BananaReq.", nameof(lengthCm));
+                throw new JsonException("Property is required for class BananaReq: lengthCm.");
 
             if (lengthCm.IsSet && lengthCm.Value == null)
-                throw new ArgumentNullException(nameof(lengthCm), "Property is not nullable for class BananaReq.");
+                throw new JsonException("Property is not nullable for class BananaReq: lengthCm.");
 
             if (sweet.IsSet && sweet.Value == null)
-                throw new ArgumentNullException(nameof(sweet), "Property is not nullable for class BananaReq.");
+                throw new JsonException("Property is not nullable for class BananaReq: sweet.");
 
             return new BananaReq(lengthCm.Value.Value, sweet);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/BasquePig.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/BasquePig.cs
@@ -138,10 +138,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class BasquePig.", nameof(className));
+                throw new JsonException("Property is required for class BasquePig: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class BasquePig.");
+                throw new JsonException("Property is not nullable for class BasquePig: className.");
 
             return new BasquePig(className.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -246,22 +246,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (aTTNAME.IsSet && aTTNAME.Value == null)
-                throw new ArgumentNullException(nameof(aTTNAME), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: ATT_NAME.");
 
             if (capitalCamel.IsSet && capitalCamel.Value == null)
-                throw new ArgumentNullException(nameof(capitalCamel), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: CapitalCamel.");
 
             if (capitalSnake.IsSet && capitalSnake.Value == null)
-                throw new ArgumentNullException(nameof(capitalSnake), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: Capital_Snake.");
 
             if (sCAETHFlowPoints.IsSet && sCAETHFlowPoints.Value == null)
-                throw new ArgumentNullException(nameof(sCAETHFlowPoints), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: SCA_ETH_Flow_Points.");
 
             if (smallCamel.IsSet && smallCamel.Value == null)
-                throw new ArgumentNullException(nameof(smallCamel), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: smallCamel.");
 
             if (smallSnake.IsSet && smallSnake.Value == null)
-                throw new ArgumentNullException(nameof(smallSnake), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: small_Snake.");
 
             return new Capitalization(aTTNAME, capitalCamel, capitalSnake, sCAETHFlowPoints, smallCamel, smallSnake);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Cat.cs
@@ -138,16 +138,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Cat.", nameof(className));
+                throw new JsonException("Property is required for class Cat: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Cat.");
+                throw new JsonException("Property is not nullable for class Cat: className.");
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Cat.");
+                throw new JsonException("Property is not nullable for class Cat: color.");
 
             if (declawed.IsSet && declawed.Value == null)
-                throw new ArgumentNullException(nameof(declawed), "Property is not nullable for class Cat.");
+                throw new JsonException("Property is not nullable for class Cat: declawed.");
 
             return new Cat(color, declawed);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Category.cs
@@ -158,13 +158,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!name.IsSet)
-                throw new ArgumentException("Property is required for class Category.", nameof(name));
+                throw new JsonException("Property is required for class Category: name.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Category.");
+                throw new JsonException("Property is not nullable for class Category: id.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Category.");
+                throw new JsonException("Property is not nullable for class Category: name.");
 
             return new Category(id, name.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -141,13 +141,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!petType.IsSet)
-                throw new ArgumentException("Property is required for class ChildCat.", nameof(petType));
+                throw new JsonException("Property is required for class ChildCat: pet_type.");
 
             if (petType.IsSet && petType.Value == null)
-                throw new ArgumentNullException(nameof(petType), "Property is not nullable for class ChildCat.");
+                throw new JsonException("Property is not nullable for class ChildCat: pet_type.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class ChildCat.");
+                throw new JsonException("Property is not nullable for class ChildCat: name.");
 
             return new ChildCat(name);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varClass.IsSet && varClass.Value == null)
-                throw new ArgumentNullException(nameof(varClass), "Property is not nullable for class ClassModel.");
+                throw new JsonException("Property is not nullable for class ClassModel: _class.");
 
             return new ClassModel(varClass);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
@@ -151,16 +151,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class ComplexQuadrilateral.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class ComplexQuadrilateral: quadrilateralType.");
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ComplexQuadrilateral.", nameof(shapeType));
+                throw new JsonException("Property is required for class ComplexQuadrilateral: shapeType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class ComplexQuadrilateral.");
+                throw new JsonException("Property is not nullable for class ComplexQuadrilateral: quadrilateralType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ComplexQuadrilateral.");
+                throw new JsonException("Property is not nullable for class ComplexQuadrilateral: shapeType.");
 
             return new ComplexQuadrilateral(quadrilateralType.Value, shapeType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/CopyActivity.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/CopyActivity.cs
@@ -134,16 +134,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!copyActivitytt.IsSet)
-                throw new ArgumentException("Property is required for class CopyActivity.", nameof(copyActivitytt));
+                throw new JsonException("Property is required for class CopyActivity: copyActivitytt.");
 
             if (!schema.IsSet)
-                throw new ArgumentException("Property is required for class CopyActivity.", nameof(schema));
+                throw new JsonException("Property is required for class CopyActivity: $schema.");
 
             if (copyActivitytt.IsSet && copyActivitytt.Value == null)
-                throw new ArgumentNullException(nameof(copyActivitytt), "Property is not nullable for class CopyActivity.");
+                throw new JsonException("Property is not nullable for class CopyActivity: copyActivitytt.");
 
             if (schema.IsSet && schema.Value == null)
-                throw new ArgumentNullException(nameof(schema), "Property is not nullable for class CopyActivity.");
+                throw new JsonException("Property is not nullable for class CopyActivity: $schema.");
 
             return new CopyActivity(copyActivitytt.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/DanishPig.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/DanishPig.cs
@@ -138,10 +138,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class DanishPig.", nameof(className));
+                throw new JsonException("Property is required for class DanishPig: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class DanishPig.");
+                throw new JsonException("Property is not nullable for class DanishPig: className.");
 
             return new DanishPig(className.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -151,7 +151,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (dateOnlyProperty.IsSet && dateOnlyProperty.Value == null)
-                throw new ArgumentNullException(nameof(dateOnlyProperty), "Property is not nullable for class DateOnlyClass.");
+                throw new JsonException("Property is not nullable for class DateOnlyClass: dateOnlyProperty.");
 
             return new DateOnlyClass(dateOnlyProperty);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class DeprecatedObject.");
+                throw new JsonException("Property is not nullable for class DeprecatedObject: name.");
 
             return new DeprecatedObject(name);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Descendant1.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Descendant1.cs
@@ -131,22 +131,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!alternativeName.IsSet)
-                throw new ArgumentException("Property is required for class Descendant1.", nameof(alternativeName));
+                throw new JsonException("Property is required for class Descendant1: alternativeName.");
 
             if (!descendantName.IsSet)
-                throw new ArgumentException("Property is required for class Descendant1.", nameof(descendantName));
+                throw new JsonException("Property is required for class Descendant1: descendantName.");
 
             if (!objectType.IsSet)
-                throw new ArgumentException("Property is required for class Descendant1.", nameof(objectType));
+                throw new JsonException("Property is required for class Descendant1: objectType.");
 
             if (alternativeName.IsSet && alternativeName.Value == null)
-                throw new ArgumentNullException(nameof(alternativeName), "Property is not nullable for class Descendant1.");
+                throw new JsonException("Property is not nullable for class Descendant1: alternativeName.");
 
             if (descendantName.IsSet && descendantName.Value == null)
-                throw new ArgumentNullException(nameof(descendantName), "Property is not nullable for class Descendant1.");
+                throw new JsonException("Property is not nullable for class Descendant1: descendantName.");
 
             if (objectType.IsSet && objectType.Value == null)
-                throw new ArgumentNullException(nameof(objectType), "Property is not nullable for class Descendant1.");
+                throw new JsonException("Property is not nullable for class Descendant1: objectType.");
 
             return new Descendant1(alternativeName.Value, descendantName.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Descendant2.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Descendant2.cs
@@ -131,22 +131,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!alternativeName.IsSet)
-                throw new ArgumentException("Property is required for class Descendant2.", nameof(alternativeName));
+                throw new JsonException("Property is required for class Descendant2: alternativeName.");
 
             if (!confidentiality.IsSet)
-                throw new ArgumentException("Property is required for class Descendant2.", nameof(confidentiality));
+                throw new JsonException("Property is required for class Descendant2: confidentiality.");
 
             if (!objectType.IsSet)
-                throw new ArgumentException("Property is required for class Descendant2.", nameof(objectType));
+                throw new JsonException("Property is required for class Descendant2: objectType.");
 
             if (alternativeName.IsSet && alternativeName.Value == null)
-                throw new ArgumentNullException(nameof(alternativeName), "Property is not nullable for class Descendant2.");
+                throw new JsonException("Property is not nullable for class Descendant2: alternativeName.");
 
             if (confidentiality.IsSet && confidentiality.Value == null)
-                throw new ArgumentNullException(nameof(confidentiality), "Property is not nullable for class Descendant2.");
+                throw new JsonException("Property is not nullable for class Descendant2: confidentiality.");
 
             if (objectType.IsSet && objectType.Value == null)
-                throw new ArgumentNullException(nameof(objectType), "Property is not nullable for class Descendant2.");
+                throw new JsonException("Property is not nullable for class Descendant2: objectType.");
 
             return new Descendant2(alternativeName.Value, confidentiality.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Dog.cs
@@ -138,16 +138,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Dog.", nameof(className));
+                throw new JsonException("Property is required for class Dog: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Dog.");
+                throw new JsonException("Property is not nullable for class Dog: className.");
 
             if (breed.IsSet && breed.Value == null)
-                throw new ArgumentNullException(nameof(breed), "Property is not nullable for class Dog.");
+                throw new JsonException("Property is not nullable for class Dog: breed.");
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Dog.");
+                throw new JsonException("Property is not nullable for class Dog: color.");
 
             return new Dog(breed, color);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Drawing.cs
@@ -205,10 +205,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (mainShape.IsSet && mainShape.Value == null)
-                throw new ArgumentNullException(nameof(mainShape), "Property is not nullable for class Drawing.");
+                throw new JsonException("Property is not nullable for class Drawing: mainShape.");
 
             if (shapes.IsSet && shapes.Value == null)
-                throw new ArgumentNullException(nameof(shapes), "Property is not nullable for class Drawing.");
+                throw new JsonException("Property is not nullable for class Drawing: shapes.");
 
             return new Drawing(mainShape, nullableShape, shapeOrNull, shapes);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/EntityBase.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/EntityBase.cs
@@ -152,10 +152,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!schema.IsSet)
-                throw new ArgumentException("Property is required for class EntityBase.", nameof(schema));
+                throw new JsonException("Property is required for class EntityBase: $schema.");
 
             if (schema.IsSet && schema.Value == null)
-                throw new ArgumentNullException(nameof(schema), "Property is not nullable for class EntityBase.");
+                throw new JsonException("Property is not nullable for class EntityBase: $schema.");
 
             return new EntityBase();
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayEnum.IsSet && arrayEnum.Value == null)
-                throw new ArgumentNullException(nameof(arrayEnum), "Property is not nullable for class EnumArrays.");
+                throw new JsonException("Property is not nullable for class EnumArrays: array_enum.");
 
             if (justSymbol.IsSet && justSymbol.Value == null)
-                throw new ArgumentNullException(nameof(justSymbol), "Property is not nullable for class EnumArrays.");
+                throw new JsonException("Property is not nullable for class EnumArrays: just_symbol.");
 
             return new EnumArrays(arrayEnum, justSymbol);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -298,31 +298,31 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!enumStringRequired.IsSet)
-                throw new ArgumentException("Property is required for class EnumTest.", nameof(enumStringRequired));
+                throw new JsonException("Property is required for class EnumTest: enum_string_required.");
 
             if (enumStringRequired.IsSet && enumStringRequired.Value == null)
-                throw new ArgumentNullException(nameof(enumStringRequired), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_string_required.");
 
             if (enumInteger.IsSet && enumInteger.Value == null)
-                throw new ArgumentNullException(nameof(enumInteger), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_integer.");
 
             if (enumIntegerOnly.IsSet && enumIntegerOnly.Value == null)
-                throw new ArgumentNullException(nameof(enumIntegerOnly), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_integer_only.");
 
             if (enumNumber.IsSet && enumNumber.Value == null)
-                throw new ArgumentNullException(nameof(enumNumber), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_number.");
 
             if (enumString.IsSet && enumString.Value == null)
-                throw new ArgumentNullException(nameof(enumString), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_string.");
 
             if (outerEnumDefaultValue.IsSet && outerEnumDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(outerEnumDefaultValue), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: outerEnumDefaultValue.");
 
             if (outerEnumInteger.IsSet && outerEnumInteger.Value == null)
-                throw new ArgumentNullException(nameof(outerEnumInteger), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: outerEnumInteger.");
 
             if (outerEnumIntegerDefaultValue.IsSet && outerEnumIntegerDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(outerEnumIntegerDefaultValue), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: outerEnumIntegerDefaultValue.");
 
             return new EnumTest(enumStringRequired.Value.Value, enumInteger, enumIntegerOnly, enumNumber, enumString, outerEnum, outerEnumDefaultValue, outerEnumInteger, outerEnumIntegerDefaultValue);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
@@ -151,16 +151,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class EquilateralTriangle.", nameof(shapeType));
+                throw new JsonException("Property is required for class EquilateralTriangle: shapeType.");
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class EquilateralTriangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class EquilateralTriangle: triangleType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class EquilateralTriangle.");
+                throw new JsonException("Property is not nullable for class EquilateralTriangle: shapeType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class EquilateralTriangle.");
+                throw new JsonException("Property is not nullable for class EquilateralTriangle: triangleType.");
 
             return new EquilateralTriangle(shapeType.Value, triangleType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/File.cs
@@ -146,7 +146,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (sourceURI.IsSet && sourceURI.Value == null)
-                throw new ArgumentNullException(nameof(sourceURI), "Property is not nullable for class File.");
+                throw new JsonException("Property is not nullable for class File: sourceURI.");
 
             return new File(sourceURI);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (file.IsSet && file.Value == null)
-                throw new ArgumentNullException(nameof(file), "Property is not nullable for class FileSchemaTestClass.");
+                throw new JsonException("Property is not nullable for class FileSchemaTestClass: file.");
 
             if (files.IsSet && files.Value == null)
-                throw new ArgumentNullException(nameof(files), "Property is not nullable for class FileSchemaTestClass.");
+                throw new JsonException("Property is not nullable for class FileSchemaTestClass: files.");
 
             return new FileSchemaTestClass(file, files);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Foo.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bar.IsSet && bar.Value == null)
-                throw new ArgumentNullException(nameof(bar), "Property is not nullable for class Foo.");
+                throw new JsonException("Property is not nullable for class Foo: bar.");
 
             return new Foo(bar);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varString.IsSet && varString.Value == null)
-                throw new ArgumentNullException(nameof(varString), "Property is not nullable for class FooGetDefaultResponse.");
+                throw new JsonException("Property is not nullable for class FooGetDefaultResponse: string.");
 
             return new FooGetDefaultResponse(varString);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -826,103 +826,103 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!varByte.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(varByte));
+                throw new JsonException("Property is required for class FormatTest: byte.");
 
             if (!date.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(date));
+                throw new JsonException("Property is required for class FormatTest: date.");
 
             if (!number.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(number));
+                throw new JsonException("Property is required for class FormatTest: number.");
 
             if (!password.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(password));
+                throw new JsonException("Property is required for class FormatTest: password.");
 
             if (!stringFormattedAsDecimalRequired.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(stringFormattedAsDecimalRequired));
+                throw new JsonException("Property is required for class FormatTest: string_formatted_as_decimal_required.");
 
             if (varByte.IsSet && varByte.Value == null)
-                throw new ArgumentNullException(nameof(varByte), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: byte.");
 
             if (date.IsSet && date.Value == null)
-                throw new ArgumentNullException(nameof(date), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: date.");
 
             if (number.IsSet && number.Value == null)
-                throw new ArgumentNullException(nameof(number), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: number.");
 
             if (password.IsSet && password.Value == null)
-                throw new ArgumentNullException(nameof(password), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: password.");
 
             if (stringFormattedAsDecimalRequired.IsSet && stringFormattedAsDecimalRequired.Value == null)
-                throw new ArgumentNullException(nameof(stringFormattedAsDecimalRequired), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: string_formatted_as_decimal_required.");
 
             if (binary.IsSet && binary.Value == null)
-                throw new ArgumentNullException(nameof(binary), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: binary.");
 
             if (dateTime.IsSet && dateTime.Value == null)
-                throw new ArgumentNullException(nameof(dateTime), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: dateTime.");
 
             if (varDecimal.IsSet && varDecimal.Value == null)
-                throw new ArgumentNullException(nameof(varDecimal), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: decimal.");
 
             if (varDouble.IsSet && varDouble.Value == null)
-                throw new ArgumentNullException(nameof(varDouble), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: double.");
 
             if (duplicatePropertyName2.IsSet && duplicatePropertyName2.Value == null)
-                throw new ArgumentNullException(nameof(duplicatePropertyName2), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: duplicate_property_name.");
 
             if (duplicatePropertyName.IsSet && duplicatePropertyName.Value == null)
-                throw new ArgumentNullException(nameof(duplicatePropertyName), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: @duplicate_property_name.");
 
             if (varFloat.IsSet && varFloat.Value == null)
-                throw new ArgumentNullException(nameof(varFloat), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: float.");
 
             if (int32.IsSet && int32.Value == null)
-                throw new ArgumentNullException(nameof(int32), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int32.");
 
             if (int32Range.IsSet && int32Range.Value == null)
-                throw new ArgumentNullException(nameof(int32Range), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int32Range.");
 
             if (int64.IsSet && int64.Value == null)
-                throw new ArgumentNullException(nameof(int64), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64.");
 
             if (int64Negative.IsSet && int64Negative.Value == null)
-                throw new ArgumentNullException(nameof(int64Negative), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64Negative.");
 
             if (int64NegativeExclusive.IsSet && int64NegativeExclusive.Value == null)
-                throw new ArgumentNullException(nameof(int64NegativeExclusive), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64NegativeExclusive.");
 
             if (int64Positive.IsSet && int64Positive.Value == null)
-                throw new ArgumentNullException(nameof(int64Positive), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64Positive.");
 
             if (int64PositiveExclusive.IsSet && int64PositiveExclusive.Value == null)
-                throw new ArgumentNullException(nameof(int64PositiveExclusive), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64PositiveExclusive.");
 
             if (integer.IsSet && integer.Value == null)
-                throw new ArgumentNullException(nameof(integer), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: integer.");
 
             if (patternWithBackslash.IsSet && patternWithBackslash.Value == null)
-                throw new ArgumentNullException(nameof(patternWithBackslash), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: pattern_with_backslash.");
 
             if (patternWithDigits.IsSet && patternWithDigits.Value == null)
-                throw new ArgumentNullException(nameof(patternWithDigits), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: pattern_with_digits.");
 
             if (patternWithDigitsAndDelimiter.IsSet && patternWithDigitsAndDelimiter.Value == null)
-                throw new ArgumentNullException(nameof(patternWithDigitsAndDelimiter), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: pattern_with_digits_and_delimiter.");
 
             if (varString.IsSet && varString.Value == null)
-                throw new ArgumentNullException(nameof(varString), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: string.");
 
             if (stringFormattedAsDecimal.IsSet && stringFormattedAsDecimal.Value == null)
-                throw new ArgumentNullException(nameof(stringFormattedAsDecimal), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: string_formatted_as_decimal.");
 
             if (unsignedInteger.IsSet && unsignedInteger.Value == null)
-                throw new ArgumentNullException(nameof(unsignedInteger), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: unsigned_integer.");
 
             if (unsignedLong.IsSet && unsignedLong.Value == null)
-                throw new ArgumentNullException(nameof(unsignedLong), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: unsigned_long.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: uuid.");
 
             return new FormatTest(varByte.Value, date.Value.Value, number.Value.Value, password.Value, stringFormattedAsDecimalRequired.Value.Value, binary, dateTime, varDecimal, varDouble, duplicatePropertyName2, duplicatePropertyName, varFloat, int32, int32Range, int64, int64Negative, int64NegativeExclusive, int64Positive, int64PositiveExclusive, integer, patternWithBackslash, patternWithDigits, patternWithDigitsAndDelimiter, varString, stringFormattedAsDecimal, unsignedInteger, unsignedLong, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Fruit.cs
@@ -183,7 +183,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Fruit.");
+                throw new JsonException("Property is not nullable for class Fruit: color.");
 
             if (apple != null)
                 return new Fruit(apple, color);

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -187,7 +187,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class GmFruit.");
+                throw new JsonException("Property is not nullable for class GmFruit: color.");
 
             Option<Apple> appleParsedValue = apple == null
                 ? default

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
@@ -155,10 +155,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!petType.IsSet)
-                throw new ArgumentException("Property is required for class GrandparentAnimal.", nameof(petType));
+                throw new JsonException("Property is required for class GrandparentAnimal: pet_type.");
 
             if (petType.IsSet && petType.Value == null)
-                throw new ArgumentNullException(nameof(petType), "Property is not nullable for class GrandparentAnimal.");
+                throw new JsonException("Property is not nullable for class GrandparentAnimal: pet_type.");
 
             return new GrandparentAnimal();
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -206,10 +206,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bar.IsSet && bar.Value == null)
-                throw new ArgumentNullException(nameof(bar), "Property is not nullable for class HasOnlyReadOnly.");
+                throw new JsonException("Property is not nullable for class HasOnlyReadOnly: bar.");
 
             if (foo.IsSet && foo.Value == null)
-                throw new ArgumentNullException(nameof(foo), "Property is not nullable for class HasOnlyReadOnly.");
+                throw new JsonException("Property is not nullable for class HasOnlyReadOnly: foo.");
 
             return new HasOnlyReadOnly(bar, foo);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
@@ -292,22 +292,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (potentiallyOverriddenPropertyAccessor.IsSet && potentiallyOverriddenPropertyAccessor.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyAccessor), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyAccessor.");
 
             if (potentiallyOverriddenPropertyToInternal.IsSet && potentiallyOverriddenPropertyToInternal.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyToInternal), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyToInternal.");
 
             if (potentiallyOverriddenPropertyToPrivate.IsSet && potentiallyOverriddenPropertyToPrivate.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyToPrivate), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyToPrivate.");
 
             if (potentiallyOverriddenPropertyToPublic.IsSet && potentiallyOverriddenPropertyToPublic.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyToPublic), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyToPublic.");
 
             if (unalteredProperty.IsSet && unalteredProperty.Value == null)
-                throw new ArgumentNullException(nameof(unalteredProperty), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: unalteredProperty.");
 
             if (unalteredPropertyAccessor.IsSet && unalteredPropertyAccessor.Value == null)
-                throw new ArgumentNullException(nameof(unalteredPropertyAccessor), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: unalteredPropertyAccessor.");
 
             return new InjectedVendorExtensionsTest(potentiallyOverriddenPropertyAccessor, potentiallyOverriddenPropertyToInternal, potentiallyOverriddenPropertyToPrivate, potentiallyOverriddenPropertyToPublic, unalteredProperty, unalteredPropertyAccessor);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
@@ -144,16 +144,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class IsoscelesTriangle.", nameof(shapeType));
+                throw new JsonException("Property is required for class IsoscelesTriangle: shapeType.");
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class IsoscelesTriangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class IsoscelesTriangle: triangleType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class IsoscelesTriangle.");
+                throw new JsonException("Property is not nullable for class IsoscelesTriangle: shapeType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class IsoscelesTriangle.");
+                throw new JsonException("Property is not nullable for class IsoscelesTriangle: triangleType.");
 
             return new IsoscelesTriangle(shapeType.Value, triangleType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/List.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (var123List.IsSet && var123List.Value == null)
-                throw new ArgumentNullException(nameof(var123List), "Property is not nullable for class List.");
+                throw new JsonException("Property is not nullable for class List: 123-list.");
 
             return new List(var123List);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (escapedLiteralString.IsSet && escapedLiteralString.Value == null)
-                throw new ArgumentNullException(nameof(escapedLiteralString), "Property is not nullable for class LiteralStringClass.");
+                throw new JsonException("Property is not nullable for class LiteralStringClass: escapedLiteralString.");
 
             if (unescapedLiteralString.IsSet && unescapedLiteralString.Value == null)
-                throw new ArgumentNullException(nameof(unescapedLiteralString), "Property is not nullable for class LiteralStringClass.");
+                throw new JsonException("Property is not nullable for class LiteralStringClass: unescapedLiteralString.");
 
             return new LiteralStringClass(escapedLiteralString, unescapedLiteralString);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Mammal.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Mammal.cs
@@ -214,10 +214,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Mammal.", nameof(className));
+                throw new JsonException("Property is required for class Mammal: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Mammal.");
+                throw new JsonException("Property is not nullable for class Mammal: className.");
 
             if (pig != null)
                 return new Mammal(pig);

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/MapTest.cs
@@ -205,16 +205,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (directMap.IsSet && directMap.Value == null)
-                throw new ArgumentNullException(nameof(directMap), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: direct_map.");
 
             if (indirectMap.IsSet && indirectMap.Value == null)
-                throw new ArgumentNullException(nameof(indirectMap), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: indirect_map.");
 
             if (mapMapOfString.IsSet && mapMapOfString.Value == null)
-                throw new ArgumentNullException(nameof(mapMapOfString), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: map_map_of_string.");
 
             if (mapOfEnumString.IsSet && mapOfEnumString.Value == null)
-                throw new ArgumentNullException(nameof(mapOfEnumString), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: map_of_enum_string.");
 
             return new MapTest(directMap, indirectMap, mapMapOfString, mapOfEnumString);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/MixedAnyOf.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/MixedAnyOf.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (content.IsSet && content.Value == null)
-                throw new ArgumentNullException(nameof(content), "Property is not nullable for class MixedAnyOf.");
+                throw new JsonException("Property is not nullable for class MixedAnyOf: content.");
 
             return new MixedAnyOf(content);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/MixedOneOf.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/MixedOneOf.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (content.IsSet && content.Value == null)
-                throw new ArgumentNullException(nameof(content), "Property is not nullable for class MixedOneOf.");
+                throw new JsonException("Property is not nullable for class MixedOneOf: content.");
 
             return new MixedOneOf(content);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -217,16 +217,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (dateTime.IsSet && dateTime.Value == null)
-                throw new ArgumentNullException(nameof(dateTime), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: dateTime.");
 
             if (map.IsSet && map.Value == null)
-                throw new ArgumentNullException(nameof(map), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: map.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: uuid.");
 
             if (uuidWithPattern.IsSet && uuidWithPattern.Value == null)
-                throw new ArgumentNullException(nameof(uuidWithPattern), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: uuid_with_pattern.");
 
             return new MixedPropertiesAndAdditionalPropertiesClass(dateTime, map, uuid, uuidWithPattern);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/MixedSubId.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/MixedSubId.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class MixedSubId.");
+                throw new JsonException("Property is not nullable for class MixedSubId: id.");
 
             return new MixedSubId(id);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varClass.IsSet && varClass.Value == null)
-                throw new ArgumentNullException(nameof(varClass), "Property is not nullable for class Model200Response.");
+                throw new JsonException("Property is not nullable for class Model200Response: class.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Model200Response.");
+                throw new JsonException("Property is not nullable for class Model200Response: name.");
 
             return new Model200Response(varClass, name);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varClient.IsSet && varClient.Value == null)
-                throw new ArgumentNullException(nameof(varClient), "Property is not nullable for class ModelClient.");
+                throw new JsonException("Property is not nullable for class ModelClient: client.");
 
             return new ModelClient(varClient);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Name.cs
@@ -239,19 +239,19 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!varName.IsSet)
-                throw new ArgumentException("Property is required for class Name.", nameof(varName));
+                throw new JsonException("Property is required for class Name: name.");
 
             if (varName.IsSet && varName.Value == null)
-                throw new ArgumentNullException(nameof(varName), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: name.");
 
             if (property.IsSet && property.Value == null)
-                throw new ArgumentNullException(nameof(property), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: property.");
 
             if (snakeCase.IsSet && snakeCase.Value == null)
-                throw new ArgumentNullException(nameof(snakeCase), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: snake_case.");
 
             if (var123Number.IsSet && var123Number.Value == null)
-                throw new ArgumentNullException(nameof(var123Number), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: 123Number.");
 
             return new Name(varName.Value.Value, property, snakeCase, var123Number);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
@@ -151,16 +151,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!aObjVariableobject.IsSet)
-                throw new ArgumentException("Property is required for class NotificationtestGetElementsV1ResponseMPayload.", nameof(aObjVariableobject));
+                throw new JsonException("Property is required for class NotificationtestGetElementsV1ResponseMPayload: a_objVariableobject.");
 
             if (!pkiNotificationtestID.IsSet)
-                throw new ArgumentException("Property is required for class NotificationtestGetElementsV1ResponseMPayload.", nameof(pkiNotificationtestID));
+                throw new JsonException("Property is required for class NotificationtestGetElementsV1ResponseMPayload: pkiNotificationtestID.");
 
             if (aObjVariableobject.IsSet && aObjVariableobject.Value == null)
-                throw new ArgumentNullException(nameof(aObjVariableobject), "Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload.");
+                throw new JsonException("Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload: a_objVariableobject.");
 
             if (pkiNotificationtestID.IsSet && pkiNotificationtestID.Value == null)
-                throw new ArgumentNullException(nameof(pkiNotificationtestID), "Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload.");
+                throw new JsonException("Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload: pkiNotificationtestID.");
 
             return new NotificationtestGetElementsV1ResponseMPayload(aObjVariableobject.Value, pkiNotificationtestID.Value.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -375,10 +375,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayItemsNullable.IsSet && arrayItemsNullable.Value == null)
-                throw new ArgumentNullException(nameof(arrayItemsNullable), "Property is not nullable for class NullableClass.");
+                throw new JsonException("Property is not nullable for class NullableClass: array_items_nullable.");
 
             if (objectItemsNullable.IsSet && objectItemsNullable.Value == null)
-                throw new ArgumentNullException(nameof(objectItemsNullable), "Property is not nullable for class NullableClass.");
+                throw new JsonException("Property is not nullable for class NullableClass: object_items_nullable.");
 
             return new NullableClass(arrayAndItemsNullableProp, arrayItemsNullable, arrayNullableProp, booleanProp, dateProp, datetimeProp, integerProp, numberProp, objectAndItemsNullableProp, objectItemsNullable, objectNullableProp, stringProp);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/NullableShape.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/NullableShape.cs
@@ -193,10 +193,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class NullableShape.", nameof(shapeType));
+                throw new JsonException("Property is required for class NullableShape: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class NullableShape.");
+                throw new JsonException("Property is not nullable for class NullableShape: shapeType.");
 
             if (quadrilateral != null)
                 return new NullableShape(quadrilateral);

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (justNumber.IsSet && justNumber.Value == null)
-                throw new ArgumentNullException(nameof(justNumber), "Property is not nullable for class NumberOnly.");
+                throw new JsonException("Property is not nullable for class NumberOnly: JustNumber.");
 
             return new NumberOnly(justNumber);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -208,16 +208,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bars.IsSet && bars.Value == null)
-                throw new ArgumentNullException(nameof(bars), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: bars.");
 
             if (deprecatedRef.IsSet && deprecatedRef.Value == null)
-                throw new ArgumentNullException(nameof(deprecatedRef), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: deprecatedRef.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: id.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: uuid.");
 
             return new ObjectWithDeprecatedFields(bars, deprecatedRef, id, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Order.cs
@@ -251,22 +251,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (complete.IsSet && complete.Value == null)
-                throw new ArgumentNullException(nameof(complete), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: complete.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: id.");
 
             if (petId.IsSet && petId.Value == null)
-                throw new ArgumentNullException(nameof(petId), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: petId.");
 
             if (quantity.IsSet && quantity.Value == null)
-                throw new ArgumentNullException(nameof(quantity), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: quantity.");
 
             if (shipDate.IsSet && shipDate.Value == null)
-                throw new ArgumentNullException(nameof(shipDate), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: shipDate.");
 
             if (status.IsSet && status.Value == null)
-                throw new ArgumentNullException(nameof(status), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: status.");
 
             return new Order(complete, id, petId, quantity, shipDate, status);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -185,13 +185,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (myBoolean.IsSet && myBoolean.Value == null)
-                throw new ArgumentNullException(nameof(myBoolean), "Property is not nullable for class OuterComposite.");
+                throw new JsonException("Property is not nullable for class OuterComposite: my_boolean.");
 
             if (myNumber.IsSet && myNumber.Value == null)
-                throw new ArgumentNullException(nameof(myNumber), "Property is not nullable for class OuterComposite.");
+                throw new JsonException("Property is not nullable for class OuterComposite: my_number.");
 
             if (myString.IsSet && myString.Value == null)
-                throw new ArgumentNullException(nameof(myString), "Property is not nullable for class OuterComposite.");
+                throw new JsonException("Property is not nullable for class OuterComposite: my_string.");
 
             return new OuterComposite(myBoolean, myNumber, myString);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ParentPet.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ParentPet.cs
@@ -118,10 +118,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!petType.IsSet)
-                throw new ArgumentException("Property is required for class ParentPet.", nameof(petType));
+                throw new JsonException("Property is required for class ParentPet: pet_type.");
 
             if (petType.IsSet && petType.Value == null)
-                throw new ArgumentNullException(nameof(petType), "Property is not nullable for class ParentPet.");
+                throw new JsonException("Property is not nullable for class ParentPet: pet_type.");
 
             return new ParentPet();
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Pet.cs
@@ -232,28 +232,28 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!name.IsSet)
-                throw new ArgumentException("Property is required for class Pet.", nameof(name));
+                throw new JsonException("Property is required for class Pet: name.");
 
             if (!photoUrls.IsSet)
-                throw new ArgumentException("Property is required for class Pet.", nameof(photoUrls));
+                throw new JsonException("Property is required for class Pet: photoUrls.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: name.");
 
             if (photoUrls.IsSet && photoUrls.Value == null)
-                throw new ArgumentNullException(nameof(photoUrls), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: photoUrls.");
 
             if (category.IsSet && category.Value == null)
-                throw new ArgumentNullException(nameof(category), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: category.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: id.");
 
             if (status.IsSet && status.Value == null)
-                throw new ArgumentNullException(nameof(status), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: status.");
 
             if (tags.IsSet && tags.Value == null)
-                throw new ArgumentNullException(nameof(tags), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: tags.");
 
             return new Pet(name.Value, photoUrls.Value, category, id, status, tags);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Pig.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Pig.cs
@@ -193,10 +193,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Pig.", nameof(className));
+                throw new JsonException("Property is required for class Pig: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Pig.");
+                throw new JsonException("Property is not nullable for class Pig: className.");
 
             if (basquePig != null)
                 return new Pig(basquePig);

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Quadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Quadrilateral.cs
@@ -193,10 +193,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class Quadrilateral.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class Quadrilateral: quadrilateralType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class Quadrilateral.");
+                throw new JsonException("Property is not nullable for class Quadrilateral: quadrilateralType.");
 
             if (complexQuadrilateral != null)
                 return new Quadrilateral(complexQuadrilateral);

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
@@ -138,10 +138,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class QuadrilateralInterface.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class QuadrilateralInterface: quadrilateralType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class QuadrilateralInterface.");
+                throw new JsonException("Property is not nullable for class QuadrilateralInterface: quadrilateralType.");
 
             return new QuadrilateralInterface(quadrilateralType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -203,10 +203,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bar.IsSet && bar.Value == null)
-                throw new ArgumentNullException(nameof(bar), "Property is not nullable for class ReadOnlyFirst.");
+                throw new JsonException("Property is not nullable for class ReadOnlyFirst: bar.");
 
             if (baz.IsSet && baz.Value == null)
-                throw new ArgumentNullException(nameof(baz), "Property is not nullable for class ReadOnlyFirst.");
+                throw new JsonException("Property is not nullable for class ReadOnlyFirst: baz.");
 
             return new ReadOnlyFirst(bar, baz);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -895,136 +895,136 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!requiredNotNullableDateProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotNullableDateProp));
+                throw new JsonException("Property is required for class RequiredClass: required_not_nullable_date_prop.");
 
             if (!requiredNotnullableArrayOfString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableArrayOfString));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_array_of_string.");
 
             if (!requiredNotnullableBooleanProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableBooleanProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_boolean_prop.");
 
             if (!requiredNotnullableDatetimeProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableDatetimeProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_datetime_prop.");
 
             if (!requiredNotnullableEnumInteger.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableEnumInteger));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_enum_integer.");
 
             if (!requiredNotnullableEnumIntegerOnly.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableEnumIntegerOnly));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_enum_integer_only.");
 
             if (!requiredNotnullableEnumString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableEnumString));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_enum_string.");
 
             if (!requiredNotnullableOuterEnumDefaultValue.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableOuterEnumDefaultValue));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_outerEnumDefaultValue.");
 
             if (!requiredNotnullableStringProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableStringProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_string_prop.");
 
             if (!requiredNotnullableUuid.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableUuid));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_uuid.");
 
             if (!requiredNotnullableintegerProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableintegerProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullableinteger_prop.");
 
             if (!requiredNullableArrayOfString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableArrayOfString));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_array_of_string.");
 
             if (!requiredNullableBooleanProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableBooleanProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_boolean_prop.");
 
             if (!requiredNullableDateProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableDateProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_date_prop.");
 
             if (!requiredNullableDatetimeProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableDatetimeProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_datetime_prop.");
 
             if (!requiredNullableEnumInteger.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableEnumInteger));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_enum_integer.");
 
             if (!requiredNullableEnumIntegerOnly.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableEnumIntegerOnly));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_enum_integer_only.");
 
             if (!requiredNullableEnumString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableEnumString));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_enum_string.");
 
             if (!requiredNullableIntegerProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableIntegerProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_integer_prop.");
 
             if (!requiredNullableOuterEnumDefaultValue.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableOuterEnumDefaultValue));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_outerEnumDefaultValue.");
 
             if (!requiredNullableStringProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableStringProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_string_prop.");
 
             if (!requiredNullableUuid.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableUuid));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_uuid.");
 
             if (requiredNotNullableDateProp.IsSet && requiredNotNullableDateProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotNullableDateProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_not_nullable_date_prop.");
 
             if (requiredNotnullableArrayOfString.IsSet && requiredNotnullableArrayOfString.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableArrayOfString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_array_of_string.");
 
             if (requiredNotnullableBooleanProp.IsSet && requiredNotnullableBooleanProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableBooleanProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_boolean_prop.");
 
             if (requiredNotnullableDatetimeProp.IsSet && requiredNotnullableDatetimeProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableDatetimeProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_datetime_prop.");
 
             if (requiredNotnullableEnumInteger.IsSet && requiredNotnullableEnumInteger.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableEnumInteger), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_enum_integer.");
 
             if (requiredNotnullableEnumIntegerOnly.IsSet && requiredNotnullableEnumIntegerOnly.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableEnumIntegerOnly), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_enum_integer_only.");
 
             if (requiredNotnullableEnumString.IsSet && requiredNotnullableEnumString.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableEnumString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_enum_string.");
 
             if (requiredNotnullableOuterEnumDefaultValue.IsSet && requiredNotnullableOuterEnumDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableOuterEnumDefaultValue), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_outerEnumDefaultValue.");
 
             if (requiredNotnullableStringProp.IsSet && requiredNotnullableStringProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableStringProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_string_prop.");
 
             if (requiredNotnullableUuid.IsSet && requiredNotnullableUuid.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableUuid), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_uuid.");
 
             if (requiredNotnullableintegerProp.IsSet && requiredNotnullableintegerProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableintegerProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullableinteger_prop.");
 
             if (notRequiredNotnullableDateProp.IsSet && notRequiredNotnullableDateProp.Value == null)
-                throw new ArgumentNullException(nameof(notRequiredNotnullableDateProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: not_required_notnullable_date_prop.");
 
             if (notRequiredNotnullableintegerProp.IsSet && notRequiredNotnullableintegerProp.Value == null)
-                throw new ArgumentNullException(nameof(notRequiredNotnullableintegerProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: not_required_notnullableinteger_prop.");
 
             if (notrequiredNotnullableArrayOfString.IsSet && notrequiredNotnullableArrayOfString.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableArrayOfString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_array_of_string.");
 
             if (notrequiredNotnullableBooleanProp.IsSet && notrequiredNotnullableBooleanProp.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableBooleanProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_boolean_prop.");
 
             if (notrequiredNotnullableDatetimeProp.IsSet && notrequiredNotnullableDatetimeProp.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableDatetimeProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_datetime_prop.");
 
             if (notrequiredNotnullableEnumInteger.IsSet && notrequiredNotnullableEnumInteger.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableEnumInteger), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_enum_integer.");
 
             if (notrequiredNotnullableEnumIntegerOnly.IsSet && notrequiredNotnullableEnumIntegerOnly.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableEnumIntegerOnly), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_enum_integer_only.");
 
             if (notrequiredNotnullableEnumString.IsSet && notrequiredNotnullableEnumString.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableEnumString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_enum_string.");
 
             if (notrequiredNotnullableOuterEnumDefaultValue.IsSet && notrequiredNotnullableOuterEnumDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableOuterEnumDefaultValue), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_outerEnumDefaultValue.");
 
             if (notrequiredNotnullableStringProp.IsSet && notrequiredNotnullableStringProp.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableStringProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_string_prop.");
 
             if (notrequiredNotnullableUuid.IsSet && notrequiredNotnullableUuid.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableUuid), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_uuid.");
 
             return new RequiredClass(requiredNotNullableDateProp.Value.Value, requiredNotnullableArrayOfString.Value, requiredNotnullableBooleanProp.Value.Value, requiredNotnullableDatetimeProp.Value.Value, requiredNotnullableEnumInteger.Value.Value, requiredNotnullableEnumIntegerOnly.Value.Value, requiredNotnullableEnumString.Value.Value, requiredNotnullableOuterEnumDefaultValue.Value.Value, requiredNotnullableStringProp.Value, requiredNotnullableUuid.Value.Value, requiredNotnullableintegerProp.Value.Value, notRequiredNotnullableDateProp, notRequiredNotnullableintegerProp, notRequiredNullableDateProp, notRequiredNullableIntegerProp, notrequiredNotnullableArrayOfString, notrequiredNotnullableBooleanProp, notrequiredNotnullableDatetimeProp, notrequiredNotnullableEnumInteger, notrequiredNotnullableEnumIntegerOnly, notrequiredNotnullableEnumString, notrequiredNotnullableOuterEnumDefaultValue, notrequiredNotnullableStringProp, notrequiredNotnullableUuid, notrequiredNullableArrayOfString, notrequiredNullableBooleanProp, notrequiredNullableDatetimeProp, notrequiredNullableEnumInteger, notrequiredNullableEnumIntegerOnly, notrequiredNullableEnumString, notrequiredNullableOuterEnumDefaultValue, notrequiredNullableStringProp, notrequiredNullableUuid, requiredNullableArrayOfString.Value, requiredNullableBooleanProp.Value, requiredNullableDateProp.Value, requiredNullableDatetimeProp.Value, requiredNullableEnumInteger.Value, requiredNullableEnumIntegerOnly.Value, requiredNullableEnumString.Value, requiredNullableIntegerProp.Value, requiredNullableOuterEnumDefaultValue.Value, requiredNullableStringProp.Value, requiredNullableUuid.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Result.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Result.cs
@@ -188,13 +188,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (code.IsSet && code.Value == null)
-                throw new ArgumentNullException(nameof(code), "Property is not nullable for class Result.");
+                throw new JsonException("Property is not nullable for class Result: code.");
 
             if (data.IsSet && data.Value == null)
-                throw new ArgumentNullException(nameof(data), "Property is not nullable for class Result.");
+                throw new JsonException("Property is not nullable for class Result: data.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class Result.");
+                throw new JsonException("Property is not nullable for class Result: uuid.");
 
             return new Result(code, data, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Return.cs
@@ -191,19 +191,19 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!varLock.IsSet)
-                throw new ArgumentException("Property is required for class Return.", nameof(varLock));
+                throw new JsonException("Property is required for class Return: lock.");
 
             if (!varAbstract.IsSet)
-                throw new ArgumentException("Property is required for class Return.", nameof(varAbstract));
+                throw new JsonException("Property is required for class Return: abstract.");
 
             if (varLock.IsSet && varLock.Value == null)
-                throw new ArgumentNullException(nameof(varLock), "Property is not nullable for class Return.");
+                throw new JsonException("Property is not nullable for class Return: lock.");
 
             if (varReturn.IsSet && varReturn.Value == null)
-                throw new ArgumentNullException(nameof(varReturn), "Property is not nullable for class Return.");
+                throw new JsonException("Property is not nullable for class Return: return.");
 
             if (varUnsafe.IsSet && varUnsafe.Value == null)
-                throw new ArgumentNullException(nameof(varUnsafe), "Property is not nullable for class Return.");
+                throw new JsonException("Property is not nullable for class Return: unsafe.");
 
             return new Return(varLock.Value, varAbstract.Value, varReturn, varUnsafe);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (role.IsSet && role.Value == null)
-                throw new ArgumentNullException(nameof(role), "Property is not nullable for class RolesReportsHash.");
+                throw new JsonException("Property is not nullable for class RolesReportsHash: role.");
 
             if (roleUuid.IsSet && roleUuid.Value == null)
-                throw new ArgumentNullException(nameof(roleUuid), "Property is not nullable for class RolesReportsHash.");
+                throw new JsonException("Property is not nullable for class RolesReportsHash: role_uuid.");
 
             return new RolesReportsHash(role, roleUuid);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class RolesReportsHashRole.");
+                throw new JsonException("Property is not nullable for class RolesReportsHashRole: name.");
 
             return new RolesReportsHashRole(name);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
@@ -151,16 +151,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ScaleneTriangle.", nameof(shapeType));
+                throw new JsonException("Property is required for class ScaleneTriangle: shapeType.");
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class ScaleneTriangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class ScaleneTriangle: triangleType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ScaleneTriangle.");
+                throw new JsonException("Property is not nullable for class ScaleneTriangle: shapeType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class ScaleneTriangle.");
+                throw new JsonException("Property is not nullable for class ScaleneTriangle: triangleType.");
 
             return new ScaleneTriangle(shapeType.Value, triangleType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Shape.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Shape.cs
@@ -193,10 +193,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class Shape.", nameof(shapeType));
+                throw new JsonException("Property is required for class Shape: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class Shape.");
+                throw new JsonException("Property is not nullable for class Shape: shapeType.");
 
             if (quadrilateral != null)
                 return new Shape(quadrilateral);

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ShapeInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ShapeInterface.cs
@@ -138,10 +138,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ShapeInterface.", nameof(shapeType));
+                throw new JsonException("Property is required for class ShapeInterface: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ShapeInterface.");
+                throw new JsonException("Property is not nullable for class ShapeInterface: shapeType.");
 
             return new ShapeInterface(shapeType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ShapeOrNull.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ShapeOrNull.cs
@@ -193,10 +193,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ShapeOrNull.", nameof(shapeType));
+                throw new JsonException("Property is required for class ShapeOrNull: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ShapeOrNull.");
+                throw new JsonException("Property is not nullable for class ShapeOrNull: shapeType.");
 
             if (quadrilateral != null)
                 return new ShapeOrNull(quadrilateral);

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
@@ -151,16 +151,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class SimpleQuadrilateral.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class SimpleQuadrilateral: quadrilateralType.");
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class SimpleQuadrilateral.", nameof(shapeType));
+                throw new JsonException("Property is required for class SimpleQuadrilateral: shapeType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class SimpleQuadrilateral.");
+                throw new JsonException("Property is not nullable for class SimpleQuadrilateral: quadrilateralType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class SimpleQuadrilateral.");
+                throw new JsonException("Property is not nullable for class SimpleQuadrilateral: shapeType.");
 
             return new SimpleQuadrilateral(quadrilateralType.Value, shapeType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varSpecialModelName.IsSet && varSpecialModelName.Value == null)
-                throw new ArgumentNullException(nameof(varSpecialModelName), "Property is not nullable for class SpecialModelName.");
+                throw new JsonException("Property is not nullable for class SpecialModelName: _special_model.name_.");
 
             if (specialPropertyName.IsSet && specialPropertyName.Value == null)
-                throw new ArgumentNullException(nameof(specialPropertyName), "Property is not nullable for class SpecialModelName.");
+                throw new JsonException("Property is not nullable for class SpecialModelName: $special[property.name].");
 
             return new SpecialModelName(varSpecialModelName, specialPropertyName);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Tag.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Tag.");
+                throw new JsonException("Property is not nullable for class Tag: id.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Tag.");
+                throw new JsonException("Property is not nullable for class Tag: name.");
 
             return new Tag(id, name);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (value.IsSet && value.Value == null)
-                throw new ArgumentNullException(nameof(value), "Property is not nullable for class TestCollectionEndingWithWordList.");
+                throw new JsonException("Property is not nullable for class TestCollectionEndingWithWordList: value.");
 
             return new TestCollectionEndingWithWordList(value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (testCollectionEndingWithWordList.IsSet && testCollectionEndingWithWordList.Value == null)
-                throw new ArgumentNullException(nameof(testCollectionEndingWithWordList), "Property is not nullable for class TestCollectionEndingWithWordListObject.");
+                throw new JsonException("Property is not nullable for class TestCollectionEndingWithWordListObject: TestCollectionEndingWithWordList.");
 
             return new TestCollectionEndingWithWordListObject(testCollectionEndingWithWordList);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/TestDescendants.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/TestDescendants.cs
@@ -168,16 +168,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!alternativeName.IsSet)
-                throw new ArgumentException("Property is required for class TestDescendants.", nameof(alternativeName));
+                throw new JsonException("Property is required for class TestDescendants: alternativeName.");
 
             if (!objectType.IsSet)
-                throw new ArgumentException("Property is required for class TestDescendants.", nameof(objectType));
+                throw new JsonException("Property is required for class TestDescendants: objectType.");
 
             if (alternativeName.IsSet && alternativeName.Value == null)
-                throw new ArgumentNullException(nameof(alternativeName), "Property is not nullable for class TestDescendants.");
+                throw new JsonException("Property is not nullable for class TestDescendants: alternativeName.");
 
             if (objectType.IsSet && objectType.Value == null)
-                throw new ArgumentNullException(nameof(objectType), "Property is not nullable for class TestDescendants.");
+                throw new JsonException("Property is not nullable for class TestDescendants: objectType.");
 
             return new TestDescendants(alternativeName.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (someProperty.IsSet && someProperty.Value == null)
-                throw new ArgumentNullException(nameof(someProperty), "Property is not nullable for class TestInlineFreeformAdditionalPropertiesRequest.");
+                throw new JsonException("Property is not nullable for class TestInlineFreeformAdditionalPropertiesRequest: someProperty.");
 
             return new TestInlineFreeformAdditionalPropertiesRequest(someProperty);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/TestResult.cs
@@ -187,13 +187,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (code.IsSet && code.Value == null)
-                throw new ArgumentNullException(nameof(code), "Property is not nullable for class TestResult.");
+                throw new JsonException("Property is not nullable for class TestResult: code.");
 
             if (data.IsSet && data.Value == null)
-                throw new ArgumentNullException(nameof(data), "Property is not nullable for class TestResult.");
+                throw new JsonException("Property is not nullable for class TestResult: data.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class TestResult.");
+                throw new JsonException("Property is not nullable for class TestResult: uuid.");
 
             return new TestResult(code, data, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Triangle.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Triangle.cs
@@ -214,10 +214,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class Triangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class Triangle: triangleType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class Triangle.");
+                throw new JsonException("Property is not nullable for class Triangle: triangleType.");
 
             if (equilateralTriangle != null)
                 return new Triangle(equilateralTriangle);

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/TriangleInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/TriangleInterface.cs
@@ -138,10 +138,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class TriangleInterface.", nameof(triangleType));
+                throw new JsonException("Property is required for class TriangleInterface: triangleType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class TriangleInterface.");
+                throw new JsonException("Property is not nullable for class TriangleInterface: triangleType.");
 
             return new TriangleInterface(triangleType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/User.cs
@@ -370,31 +370,31 @@ namespace Org.OpenAPITools.Model
             }
 
             if (email.IsSet && email.Value == null)
-                throw new ArgumentNullException(nameof(email), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: email.");
 
             if (firstName.IsSet && firstName.Value == null)
-                throw new ArgumentNullException(nameof(firstName), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: firstName.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: id.");
 
             if (lastName.IsSet && lastName.Value == null)
-                throw new ArgumentNullException(nameof(lastName), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: lastName.");
 
             if (objectWithNoDeclaredProps.IsSet && objectWithNoDeclaredProps.Value == null)
-                throw new ArgumentNullException(nameof(objectWithNoDeclaredProps), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: objectWithNoDeclaredProps.");
 
             if (password.IsSet && password.Value == null)
-                throw new ArgumentNullException(nameof(password), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: password.");
 
             if (phone.IsSet && phone.Value == null)
-                throw new ArgumentNullException(nameof(phone), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: phone.");
 
             if (userStatus.IsSet && userStatus.Value == null)
-                throw new ArgumentNullException(nameof(userStatus), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: userStatus.");
 
             if (username.IsSet && username.Value == null)
-                throw new ArgumentNullException(nameof(username), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: username.");
 
             return new User(anyTypeProp, anyTypePropNullable, email, firstName, id, lastName, objectWithNoDeclaredProps, objectWithNoDeclaredPropsNullable, password, phone, userStatus, username);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Whale.cs
@@ -178,16 +178,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Whale.", nameof(className));
+                throw new JsonException("Property is required for class Whale: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Whale.");
+                throw new JsonException("Property is not nullable for class Whale: className.");
 
             if (hasBaleen.IsSet && hasBaleen.Value == null)
-                throw new ArgumentNullException(nameof(hasBaleen), "Property is not nullable for class Whale.");
+                throw new JsonException("Property is not nullable for class Whale: hasBaleen.");
 
             if (hasTeeth.IsSet && hasTeeth.Value == null)
-                throw new ArgumentNullException(nameof(hasTeeth), "Property is not nullable for class Whale.");
+                throw new JsonException("Property is not nullable for class Whale: hasTeeth.");
 
             return new Whale(className.Value, hasBaleen, hasTeeth);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Zebra.cs
@@ -158,13 +158,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Zebra.", nameof(className));
+                throw new JsonException("Property is required for class Zebra: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Zebra.");
+                throw new JsonException("Property is not nullable for class Zebra: className.");
 
             if (type.IsSet && type.Value == null)
-                throw new ArgumentNullException(nameof(type), "Property is not nullable for class Zebra.");
+                throw new JsonException("Property is not nullable for class Zebra: type.");
 
             return new Zebra(className.Value, type);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (zeroBasedEnum.IsSet && zeroBasedEnum.Value == null)
-                throw new ArgumentNullException(nameof(zeroBasedEnum), "Property is not nullable for class ZeroBasedEnumClass.");
+                throw new JsonException("Property is not nullable for class ZeroBasedEnumClass: ZeroBasedEnum.");
 
             return new ZeroBasedEnumClass(zeroBasedEnum);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/OneOf/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/OneOf/src/Org.OpenAPITools/Model/Apple.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (kind.IsSet && kind.Value == null)
-                throw new ArgumentNullException(nameof(kind), "Property is not nullable for class Apple.");
+                throw new JsonException("Property is not nullable for class Apple: kind.");
 
             return new Apple(kind);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/OneOf/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/OneOf/src/Org.OpenAPITools/Model/Banana.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (count.IsSet && count.Value == null)
-                throw new ArgumentNullException(nameof(count), "Property is not nullable for class Banana.");
+                throw new JsonException("Property is not nullable for class Banana: count.");
 
             return new Banana(count);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/OneOf/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/OneOf/src/Org.OpenAPITools/Model/Fruit.cs
@@ -211,7 +211,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Fruit.");
+                throw new JsonException("Property is not nullable for class Fruit: color.");
 
             if (apple != null)
                 return new Fruit(apple, color);

--- a/samples/client/petstore/csharp/generichost/net4.8/OneOf/src/Org.OpenAPITools/Model/Orange.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/OneOf/src/Org.OpenAPITools/Model/Orange.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (sweet.IsSet && sweet.Value == null)
-                throw new ArgumentNullException(nameof(sweet), "Property is not nullable for class Orange.");
+                throw new JsonException("Property is not nullable for class Orange: sweet.");
 
             return new Orange(sweet);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Activity.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (activityOutputs.IsSet && activityOutputs.Value == null)
-                throw new ArgumentNullException(nameof(activityOutputs), "Property is not nullable for class Activity.");
+                throw new JsonException("Property is not nullable for class Activity: activity_outputs.");
 
             return new Activity(activityOutputs);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (prop1.IsSet && prop1.Value == null)
-                throw new ArgumentNullException(nameof(prop1), "Property is not nullable for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Property is not nullable for class ActivityOutputElementRepresentation: prop1.");
 
             if (prop2.IsSet && prop2.Value == null)
-                throw new ArgumentNullException(nameof(prop2), "Property is not nullable for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Property is not nullable for class ActivityOutputElementRepresentation: prop2.");
 
             return new ActivityOutputElementRepresentation(prop1, prop2);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -286,25 +286,25 @@ namespace Org.OpenAPITools.Model
             }
 
             if (emptyMap.IsSet && emptyMap.Value == null)
-                throw new ArgumentNullException(nameof(emptyMap), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: empty_map.");
 
             if (mapOfMapProperty.IsSet && mapOfMapProperty.Value == null)
-                throw new ArgumentNullException(nameof(mapOfMapProperty), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_of_map_property.");
 
             if (mapProperty.IsSet && mapProperty.Value == null)
-                throw new ArgumentNullException(nameof(mapProperty), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_property.");
 
             if (mapWithUndeclaredPropertiesAnytype1.IsSet && mapWithUndeclaredPropertiesAnytype1.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesAnytype1), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_anytype_1.");
 
             if (mapWithUndeclaredPropertiesAnytype2.IsSet && mapWithUndeclaredPropertiesAnytype2.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesAnytype2), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_anytype_2.");
 
             if (mapWithUndeclaredPropertiesAnytype3.IsSet && mapWithUndeclaredPropertiesAnytype3.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesAnytype3), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_anytype_3.");
 
             if (mapWithUndeclaredPropertiesString.IsSet && mapWithUndeclaredPropertiesString.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesString), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_string.");
 
             return new AdditionalPropertiesClass(anytype1, emptyMap, mapOfMapProperty, mapProperty, mapWithUndeclaredPropertiesAnytype1, mapWithUndeclaredPropertiesAnytype2, mapWithUndeclaredPropertiesAnytype3, mapWithUndeclaredPropertiesString);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Animal.cs
@@ -175,13 +175,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Animal.", nameof(className));
+                throw new JsonException("Property is required for class Animal: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Animal.");
+                throw new JsonException("Property is not nullable for class Animal: className.");
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Animal.");
+                throw new JsonException("Property is not nullable for class Animal: color.");
 
             return new Animal(color);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -185,13 +185,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (code.IsSet && code.Value == null)
-                throw new ArgumentNullException(nameof(code), "Property is not nullable for class ApiResponse.");
+                throw new JsonException("Property is not nullable for class ApiResponse: code.");
 
             if (message.IsSet && message.Value == null)
-                throw new ArgumentNullException(nameof(message), "Property is not nullable for class ApiResponse.");
+                throw new JsonException("Property is not nullable for class ApiResponse: message.");
 
             if (type.IsSet && type.Value == null)
-                throw new ArgumentNullException(nameof(type), "Property is not nullable for class ApiResponse.");
+                throw new JsonException("Property is not nullable for class ApiResponse: type.");
 
             return new ApiResponse(code, message, type);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Apple.cs
@@ -215,13 +215,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (colorCode.IsSet && colorCode.Value == null)
-                throw new ArgumentNullException(nameof(colorCode), "Property is not nullable for class Apple.");
+                throw new JsonException("Property is not nullable for class Apple: color_code.");
 
             if (cultivar.IsSet && cultivar.Value == null)
-                throw new ArgumentNullException(nameof(cultivar), "Property is not nullable for class Apple.");
+                throw new JsonException("Property is not nullable for class Apple: cultivar.");
 
             if (origin.IsSet && origin.Value == null)
-                throw new ArgumentNullException(nameof(origin), "Property is not nullable for class Apple.");
+                throw new JsonException("Property is not nullable for class Apple: origin.");
 
             return new Apple(colorCode, cultivar, origin);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -151,13 +151,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!cultivar.IsSet)
-                throw new ArgumentException("Property is required for class AppleReq.", nameof(cultivar));
+                throw new JsonException("Property is required for class AppleReq: cultivar.");
 
             if (cultivar.IsSet && cultivar.Value == null)
-                throw new ArgumentNullException(nameof(cultivar), "Property is not nullable for class AppleReq.");
+                throw new JsonException("Property is not nullable for class AppleReq: cultivar.");
 
             if (mealy.IsSet && mealy.Value == null)
-                throw new ArgumentNullException(nameof(mealy), "Property is not nullable for class AppleReq.");
+                throw new JsonException("Property is not nullable for class AppleReq: mealy.");
 
             return new AppleReq(cultivar.Value, mealy);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayArrayNumber.IsSet && arrayArrayNumber.Value == null)
-                throw new ArgumentNullException(nameof(arrayArrayNumber), "Property is not nullable for class ArrayOfArrayOfNumberOnly.");
+                throw new JsonException("Property is not nullable for class ArrayOfArrayOfNumberOnly: ArrayArrayNumber.");
 
             return new ArrayOfArrayOfNumberOnly(arrayArrayNumber);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayNumber.IsSet && arrayNumber.Value == null)
-                throw new ArgumentNullException(nameof(arrayNumber), "Property is not nullable for class ArrayOfNumberOnly.");
+                throw new JsonException("Property is not nullable for class ArrayOfNumberOnly: ArrayNumber.");
 
             return new ArrayOfNumberOnly(arrayNumber);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -185,13 +185,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayArrayOfInteger.IsSet && arrayArrayOfInteger.Value == null)
-                throw new ArgumentNullException(nameof(arrayArrayOfInteger), "Property is not nullable for class ArrayTest.");
+                throw new JsonException("Property is not nullable for class ArrayTest: array_array_of_integer.");
 
             if (arrayArrayOfModel.IsSet && arrayArrayOfModel.Value == null)
-                throw new ArgumentNullException(nameof(arrayArrayOfModel), "Property is not nullable for class ArrayTest.");
+                throw new JsonException("Property is not nullable for class ArrayTest: array_array_of_model.");
 
             if (arrayOfString.IsSet && arrayOfString.Value == null)
-                throw new ArgumentNullException(nameof(arrayOfString), "Property is not nullable for class ArrayTest.");
+                throw new JsonException("Property is not nullable for class ArrayTest: array_of_string.");
 
             return new ArrayTest(arrayArrayOfInteger, arrayArrayOfModel, arrayOfString);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Banana.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (lengthCm.IsSet && lengthCm.Value == null)
-                throw new ArgumentNullException(nameof(lengthCm), "Property is not nullable for class Banana.");
+                throw new JsonException("Property is not nullable for class Banana: lengthCm.");
 
             return new Banana(lengthCm);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -151,13 +151,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!lengthCm.IsSet)
-                throw new ArgumentException("Property is required for class BananaReq.", nameof(lengthCm));
+                throw new JsonException("Property is required for class BananaReq: lengthCm.");
 
             if (lengthCm.IsSet && lengthCm.Value == null)
-                throw new ArgumentNullException(nameof(lengthCm), "Property is not nullable for class BananaReq.");
+                throw new JsonException("Property is not nullable for class BananaReq: lengthCm.");
 
             if (sweet.IsSet && sweet.Value == null)
-                throw new ArgumentNullException(nameof(sweet), "Property is not nullable for class BananaReq.");
+                throw new JsonException("Property is not nullable for class BananaReq: sweet.");
 
             return new BananaReq(lengthCm.Value.Value, sweet);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/BasquePig.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/BasquePig.cs
@@ -138,10 +138,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class BasquePig.", nameof(className));
+                throw new JsonException("Property is required for class BasquePig: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class BasquePig.");
+                throw new JsonException("Property is not nullable for class BasquePig: className.");
 
             return new BasquePig(className.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -246,22 +246,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (aTTNAME.IsSet && aTTNAME.Value == null)
-                throw new ArgumentNullException(nameof(aTTNAME), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: ATT_NAME.");
 
             if (capitalCamel.IsSet && capitalCamel.Value == null)
-                throw new ArgumentNullException(nameof(capitalCamel), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: CapitalCamel.");
 
             if (capitalSnake.IsSet && capitalSnake.Value == null)
-                throw new ArgumentNullException(nameof(capitalSnake), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: Capital_Snake.");
 
             if (sCAETHFlowPoints.IsSet && sCAETHFlowPoints.Value == null)
-                throw new ArgumentNullException(nameof(sCAETHFlowPoints), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: SCA_ETH_Flow_Points.");
 
             if (smallCamel.IsSet && smallCamel.Value == null)
-                throw new ArgumentNullException(nameof(smallCamel), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: smallCamel.");
 
             if (smallSnake.IsSet && smallSnake.Value == null)
-                throw new ArgumentNullException(nameof(smallSnake), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: small_Snake.");
 
             return new Capitalization(aTTNAME, capitalCamel, capitalSnake, sCAETHFlowPoints, smallCamel, smallSnake);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Cat.cs
@@ -138,16 +138,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Cat.", nameof(className));
+                throw new JsonException("Property is required for class Cat: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Cat.");
+                throw new JsonException("Property is not nullable for class Cat: className.");
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Cat.");
+                throw new JsonException("Property is not nullable for class Cat: color.");
 
             if (declawed.IsSet && declawed.Value == null)
-                throw new ArgumentNullException(nameof(declawed), "Property is not nullable for class Cat.");
+                throw new JsonException("Property is not nullable for class Cat: declawed.");
 
             return new Cat(color, declawed);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Category.cs
@@ -158,13 +158,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!name.IsSet)
-                throw new ArgumentException("Property is required for class Category.", nameof(name));
+                throw new JsonException("Property is required for class Category: name.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Category.");
+                throw new JsonException("Property is not nullable for class Category: id.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Category.");
+                throw new JsonException("Property is not nullable for class Category: name.");
 
             return new Category(id, name.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -200,13 +200,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!petType.IsSet)
-                throw new ArgumentException("Property is required for class ChildCat.", nameof(petType));
+                throw new JsonException("Property is required for class ChildCat: pet_type.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class ChildCat.");
+                throw new JsonException("Property is not nullable for class ChildCat: name.");
 
             if (petType.IsSet && petType.Value == null)
-                throw new ArgumentNullException(nameof(petType), "Property is not nullable for class ChildCat.");
+                throw new JsonException("Property is not nullable for class ChildCat: pet_type.");
 
             return new ChildCat(name);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varClass.IsSet && varClass.Value == null)
-                throw new ArgumentNullException(nameof(varClass), "Property is not nullable for class ClassModel.");
+                throw new JsonException("Property is not nullable for class ClassModel: _class.");
 
             return new ClassModel(varClass);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
@@ -151,16 +151,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class ComplexQuadrilateral.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class ComplexQuadrilateral: quadrilateralType.");
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ComplexQuadrilateral.", nameof(shapeType));
+                throw new JsonException("Property is required for class ComplexQuadrilateral: shapeType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class ComplexQuadrilateral.");
+                throw new JsonException("Property is not nullable for class ComplexQuadrilateral: quadrilateralType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ComplexQuadrilateral.");
+                throw new JsonException("Property is not nullable for class ComplexQuadrilateral: shapeType.");
 
             return new ComplexQuadrilateral(quadrilateralType.Value, shapeType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/CopyActivity.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/CopyActivity.cs
@@ -193,16 +193,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!copyActivitytt.IsSet)
-                throw new ArgumentException("Property is required for class CopyActivity.", nameof(copyActivitytt));
+                throw new JsonException("Property is required for class CopyActivity: copyActivitytt.");
 
             if (!schema.IsSet)
-                throw new ArgumentException("Property is required for class CopyActivity.", nameof(schema));
+                throw new JsonException("Property is required for class CopyActivity: $schema.");
 
             if (copyActivitytt.IsSet && copyActivitytt.Value == null)
-                throw new ArgumentNullException(nameof(copyActivitytt), "Property is not nullable for class CopyActivity.");
+                throw new JsonException("Property is not nullable for class CopyActivity: copyActivitytt.");
 
             if (schema.IsSet && schema.Value == null)
-                throw new ArgumentNullException(nameof(schema), "Property is not nullable for class CopyActivity.");
+                throw new JsonException("Property is not nullable for class CopyActivity: $schema.");
 
             return new CopyActivity(copyActivitytt.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/DanishPig.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/DanishPig.cs
@@ -138,10 +138,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class DanishPig.", nameof(className));
+                throw new JsonException("Property is required for class DanishPig: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class DanishPig.");
+                throw new JsonException("Property is not nullable for class DanishPig: className.");
 
             return new DanishPig(className.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -151,7 +151,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (dateOnlyProperty.IsSet && dateOnlyProperty.Value == null)
-                throw new ArgumentNullException(nameof(dateOnlyProperty), "Property is not nullable for class DateOnlyClass.");
+                throw new JsonException("Property is not nullable for class DateOnlyClass: dateOnlyProperty.");
 
             return new DateOnlyClass(dateOnlyProperty);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class DeprecatedObject.");
+                throw new JsonException("Property is not nullable for class DeprecatedObject: name.");
 
             return new DeprecatedObject(name);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Descendant1.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Descendant1.cs
@@ -138,22 +138,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!alternativeName.IsSet)
-                throw new ArgumentException("Property is required for class Descendant1.", nameof(alternativeName));
+                throw new JsonException("Property is required for class Descendant1: alternativeName.");
 
             if (!descendantName.IsSet)
-                throw new ArgumentException("Property is required for class Descendant1.", nameof(descendantName));
+                throw new JsonException("Property is required for class Descendant1: descendantName.");
 
             if (!objectType.IsSet)
-                throw new ArgumentException("Property is required for class Descendant1.", nameof(objectType));
+                throw new JsonException("Property is required for class Descendant1: objectType.");
 
             if (alternativeName.IsSet && alternativeName.Value == null)
-                throw new ArgumentNullException(nameof(alternativeName), "Property is not nullable for class Descendant1.");
+                throw new JsonException("Property is not nullable for class Descendant1: alternativeName.");
 
             if (descendantName.IsSet && descendantName.Value == null)
-                throw new ArgumentNullException(nameof(descendantName), "Property is not nullable for class Descendant1.");
+                throw new JsonException("Property is not nullable for class Descendant1: descendantName.");
 
             if (objectType.IsSet && objectType.Value == null)
-                throw new ArgumentNullException(nameof(objectType), "Property is not nullable for class Descendant1.");
+                throw new JsonException("Property is not nullable for class Descendant1: objectType.");
 
             return new Descendant1(alternativeName.Value, descendantName.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Descendant2.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Descendant2.cs
@@ -138,22 +138,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!alternativeName.IsSet)
-                throw new ArgumentException("Property is required for class Descendant2.", nameof(alternativeName));
+                throw new JsonException("Property is required for class Descendant2: alternativeName.");
 
             if (!confidentiality.IsSet)
-                throw new ArgumentException("Property is required for class Descendant2.", nameof(confidentiality));
+                throw new JsonException("Property is required for class Descendant2: confidentiality.");
 
             if (!objectType.IsSet)
-                throw new ArgumentException("Property is required for class Descendant2.", nameof(objectType));
+                throw new JsonException("Property is required for class Descendant2: objectType.");
 
             if (alternativeName.IsSet && alternativeName.Value == null)
-                throw new ArgumentNullException(nameof(alternativeName), "Property is not nullable for class Descendant2.");
+                throw new JsonException("Property is not nullable for class Descendant2: alternativeName.");
 
             if (confidentiality.IsSet && confidentiality.Value == null)
-                throw new ArgumentNullException(nameof(confidentiality), "Property is not nullable for class Descendant2.");
+                throw new JsonException("Property is not nullable for class Descendant2: confidentiality.");
 
             if (objectType.IsSet && objectType.Value == null)
-                throw new ArgumentNullException(nameof(objectType), "Property is not nullable for class Descendant2.");
+                throw new JsonException("Property is not nullable for class Descendant2: objectType.");
 
             return new Descendant2(alternativeName.Value, confidentiality.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Dog.cs
@@ -138,16 +138,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Dog.", nameof(className));
+                throw new JsonException("Property is required for class Dog: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Dog.");
+                throw new JsonException("Property is not nullable for class Dog: className.");
 
             if (breed.IsSet && breed.Value == null)
-                throw new ArgumentNullException(nameof(breed), "Property is not nullable for class Dog.");
+                throw new JsonException("Property is not nullable for class Dog: breed.");
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Dog.");
+                throw new JsonException("Property is not nullable for class Dog: color.");
 
             return new Dog(breed, color);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Drawing.cs
@@ -205,10 +205,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (mainShape.IsSet && mainShape.Value == null)
-                throw new ArgumentNullException(nameof(mainShape), "Property is not nullable for class Drawing.");
+                throw new JsonException("Property is not nullable for class Drawing: mainShape.");
 
             if (shapes.IsSet && shapes.Value == null)
-                throw new ArgumentNullException(nameof(shapes), "Property is not nullable for class Drawing.");
+                throw new JsonException("Property is not nullable for class Drawing: shapes.");
 
             return new Drawing(mainShape, nullableShape, shapeOrNull, shapes);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/EntityBase.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/EntityBase.cs
@@ -152,10 +152,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!schema.IsSet)
-                throw new ArgumentException("Property is required for class EntityBase.", nameof(schema));
+                throw new JsonException("Property is required for class EntityBase: $schema.");
 
             if (schema.IsSet && schema.Value == null)
-                throw new ArgumentNullException(nameof(schema), "Property is not nullable for class EntityBase.");
+                throw new JsonException("Property is not nullable for class EntityBase: $schema.");
 
             return new EntityBase();
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -304,10 +304,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayEnum.IsSet && arrayEnum.Value == null)
-                throw new ArgumentNullException(nameof(arrayEnum), "Property is not nullable for class EnumArrays.");
+                throw new JsonException("Property is not nullable for class EnumArrays: array_enum.");
 
             if (justSymbol.IsSet && justSymbol.Value == null)
-                throw new ArgumentNullException(nameof(justSymbol), "Property is not nullable for class EnumArrays.");
+                throw new JsonException("Property is not nullable for class EnumArrays: just_symbol.");
 
             return new EnumArrays(arrayEnum, justSymbol);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -822,31 +822,31 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!enumStringRequired.IsSet)
-                throw new ArgumentException("Property is required for class EnumTest.", nameof(enumStringRequired));
+                throw new JsonException("Property is required for class EnumTest: enum_string_required.");
 
             if (enumStringRequired.IsSet && enumStringRequired.Value == null)
-                throw new ArgumentNullException(nameof(enumStringRequired), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_string_required.");
 
             if (enumInteger.IsSet && enumInteger.Value == null)
-                throw new ArgumentNullException(nameof(enumInteger), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_integer.");
 
             if (enumIntegerOnly.IsSet && enumIntegerOnly.Value == null)
-                throw new ArgumentNullException(nameof(enumIntegerOnly), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_integer_only.");
 
             if (enumNumber.IsSet && enumNumber.Value == null)
-                throw new ArgumentNullException(nameof(enumNumber), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_number.");
 
             if (enumString.IsSet && enumString.Value == null)
-                throw new ArgumentNullException(nameof(enumString), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_string.");
 
             if (outerEnumDefaultValue.IsSet && outerEnumDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(outerEnumDefaultValue), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: outerEnumDefaultValue.");
 
             if (outerEnumInteger.IsSet && outerEnumInteger.Value == null)
-                throw new ArgumentNullException(nameof(outerEnumInteger), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: outerEnumInteger.");
 
             if (outerEnumIntegerDefaultValue.IsSet && outerEnumIntegerDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(outerEnumIntegerDefaultValue), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: outerEnumIntegerDefaultValue.");
 
             return new EnumTest(enumStringRequired.Value.Value, enumInteger, enumIntegerOnly, enumNumber, enumString, outerEnum, outerEnumDefaultValue, outerEnumInteger, outerEnumIntegerDefaultValue);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
@@ -151,16 +151,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class EquilateralTriangle.", nameof(shapeType));
+                throw new JsonException("Property is required for class EquilateralTriangle: shapeType.");
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class EquilateralTriangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class EquilateralTriangle: triangleType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class EquilateralTriangle.");
+                throw new JsonException("Property is not nullable for class EquilateralTriangle: shapeType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class EquilateralTriangle.");
+                throw new JsonException("Property is not nullable for class EquilateralTriangle: triangleType.");
 
             return new EquilateralTriangle(shapeType.Value, triangleType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/File.cs
@@ -146,7 +146,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (sourceURI.IsSet && sourceURI.Value == null)
-                throw new ArgumentNullException(nameof(sourceURI), "Property is not nullable for class File.");
+                throw new JsonException("Property is not nullable for class File: sourceURI.");
 
             return new File(sourceURI);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (file.IsSet && file.Value == null)
-                throw new ArgumentNullException(nameof(file), "Property is not nullable for class FileSchemaTestClass.");
+                throw new JsonException("Property is not nullable for class FileSchemaTestClass: file.");
 
             if (files.IsSet && files.Value == null)
-                throw new ArgumentNullException(nameof(files), "Property is not nullable for class FileSchemaTestClass.");
+                throw new JsonException("Property is not nullable for class FileSchemaTestClass: files.");
 
             return new FileSchemaTestClass(file, files);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Foo.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bar.IsSet && bar.Value == null)
-                throw new ArgumentNullException(nameof(bar), "Property is not nullable for class Foo.");
+                throw new JsonException("Property is not nullable for class Foo: bar.");
 
             return new Foo(bar);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varString.IsSet && varString.Value == null)
-                throw new ArgumentNullException(nameof(varString), "Property is not nullable for class FooGetDefaultResponse.");
+                throw new JsonException("Property is not nullable for class FooGetDefaultResponse: string.");
 
             return new FooGetDefaultResponse(varString);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -826,103 +826,103 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!varByte.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(varByte));
+                throw new JsonException("Property is required for class FormatTest: byte.");
 
             if (!date.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(date));
+                throw new JsonException("Property is required for class FormatTest: date.");
 
             if (!number.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(number));
+                throw new JsonException("Property is required for class FormatTest: number.");
 
             if (!password.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(password));
+                throw new JsonException("Property is required for class FormatTest: password.");
 
             if (!stringFormattedAsDecimalRequired.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(stringFormattedAsDecimalRequired));
+                throw new JsonException("Property is required for class FormatTest: string_formatted_as_decimal_required.");
 
             if (varByte.IsSet && varByte.Value == null)
-                throw new ArgumentNullException(nameof(varByte), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: byte.");
 
             if (date.IsSet && date.Value == null)
-                throw new ArgumentNullException(nameof(date), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: date.");
 
             if (number.IsSet && number.Value == null)
-                throw new ArgumentNullException(nameof(number), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: number.");
 
             if (password.IsSet && password.Value == null)
-                throw new ArgumentNullException(nameof(password), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: password.");
 
             if (stringFormattedAsDecimalRequired.IsSet && stringFormattedAsDecimalRequired.Value == null)
-                throw new ArgumentNullException(nameof(stringFormattedAsDecimalRequired), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: string_formatted_as_decimal_required.");
 
             if (binary.IsSet && binary.Value == null)
-                throw new ArgumentNullException(nameof(binary), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: binary.");
 
             if (dateTime.IsSet && dateTime.Value == null)
-                throw new ArgumentNullException(nameof(dateTime), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: dateTime.");
 
             if (varDecimal.IsSet && varDecimal.Value == null)
-                throw new ArgumentNullException(nameof(varDecimal), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: decimal.");
 
             if (varDouble.IsSet && varDouble.Value == null)
-                throw new ArgumentNullException(nameof(varDouble), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: double.");
 
             if (duplicatePropertyName2.IsSet && duplicatePropertyName2.Value == null)
-                throw new ArgumentNullException(nameof(duplicatePropertyName2), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: duplicate_property_name.");
 
             if (duplicatePropertyName.IsSet && duplicatePropertyName.Value == null)
-                throw new ArgumentNullException(nameof(duplicatePropertyName), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: @duplicate_property_name.");
 
             if (varFloat.IsSet && varFloat.Value == null)
-                throw new ArgumentNullException(nameof(varFloat), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: float.");
 
             if (int32.IsSet && int32.Value == null)
-                throw new ArgumentNullException(nameof(int32), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int32.");
 
             if (int32Range.IsSet && int32Range.Value == null)
-                throw new ArgumentNullException(nameof(int32Range), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int32Range.");
 
             if (int64.IsSet && int64.Value == null)
-                throw new ArgumentNullException(nameof(int64), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64.");
 
             if (int64Negative.IsSet && int64Negative.Value == null)
-                throw new ArgumentNullException(nameof(int64Negative), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64Negative.");
 
             if (int64NegativeExclusive.IsSet && int64NegativeExclusive.Value == null)
-                throw new ArgumentNullException(nameof(int64NegativeExclusive), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64NegativeExclusive.");
 
             if (int64Positive.IsSet && int64Positive.Value == null)
-                throw new ArgumentNullException(nameof(int64Positive), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64Positive.");
 
             if (int64PositiveExclusive.IsSet && int64PositiveExclusive.Value == null)
-                throw new ArgumentNullException(nameof(int64PositiveExclusive), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64PositiveExclusive.");
 
             if (integer.IsSet && integer.Value == null)
-                throw new ArgumentNullException(nameof(integer), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: integer.");
 
             if (patternWithBackslash.IsSet && patternWithBackslash.Value == null)
-                throw new ArgumentNullException(nameof(patternWithBackslash), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: pattern_with_backslash.");
 
             if (patternWithDigits.IsSet && patternWithDigits.Value == null)
-                throw new ArgumentNullException(nameof(patternWithDigits), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: pattern_with_digits.");
 
             if (patternWithDigitsAndDelimiter.IsSet && patternWithDigitsAndDelimiter.Value == null)
-                throw new ArgumentNullException(nameof(patternWithDigitsAndDelimiter), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: pattern_with_digits_and_delimiter.");
 
             if (varString.IsSet && varString.Value == null)
-                throw new ArgumentNullException(nameof(varString), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: string.");
 
             if (stringFormattedAsDecimal.IsSet && stringFormattedAsDecimal.Value == null)
-                throw new ArgumentNullException(nameof(stringFormattedAsDecimal), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: string_formatted_as_decimal.");
 
             if (unsignedInteger.IsSet && unsignedInteger.Value == null)
-                throw new ArgumentNullException(nameof(unsignedInteger), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: unsigned_integer.");
 
             if (unsignedLong.IsSet && unsignedLong.Value == null)
-                throw new ArgumentNullException(nameof(unsignedLong), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: unsigned_long.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: uuid.");
 
             return new FormatTest(varByte.Value, date.Value.Value, number.Value.Value, password.Value, stringFormattedAsDecimalRequired.Value.Value, binary, dateTime, varDecimal, varDouble, duplicatePropertyName2, duplicatePropertyName, varFloat, int32, int32Range, int64, int64Negative, int64NegativeExclusive, int64Positive, int64PositiveExclusive, integer, patternWithBackslash, patternWithDigits, patternWithDigitsAndDelimiter, varString, stringFormattedAsDecimal, unsignedInteger, unsignedLong, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
@@ -183,7 +183,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Fruit.");
+                throw new JsonException("Property is not nullable for class Fruit: color.");
 
             if (apple != null)
                 return new Fruit(apple, color);

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -187,7 +187,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class GmFruit.");
+                throw new JsonException("Property is not nullable for class GmFruit: color.");
 
             Option<Apple> appleParsedValue = apple == null
                 ? default

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
@@ -155,10 +155,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!petType.IsSet)
-                throw new ArgumentException("Property is required for class GrandparentAnimal.", nameof(petType));
+                throw new JsonException("Property is required for class GrandparentAnimal: pet_type.");
 
             if (petType.IsSet && petType.Value == null)
-                throw new ArgumentNullException(nameof(petType), "Property is not nullable for class GrandparentAnimal.");
+                throw new JsonException("Property is not nullable for class GrandparentAnimal: pet_type.");
 
             return new GrandparentAnimal();
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -206,10 +206,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bar.IsSet && bar.Value == null)
-                throw new ArgumentNullException(nameof(bar), "Property is not nullable for class HasOnlyReadOnly.");
+                throw new JsonException("Property is not nullable for class HasOnlyReadOnly: bar.");
 
             if (foo.IsSet && foo.Value == null)
-                throw new ArgumentNullException(nameof(foo), "Property is not nullable for class HasOnlyReadOnly.");
+                throw new JsonException("Property is not nullable for class HasOnlyReadOnly: foo.");
 
             return new HasOnlyReadOnly(bar, foo);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
@@ -292,22 +292,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (potentiallyOverriddenPropertyAccessor.IsSet && potentiallyOverriddenPropertyAccessor.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyAccessor), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyAccessor.");
 
             if (potentiallyOverriddenPropertyToInternal.IsSet && potentiallyOverriddenPropertyToInternal.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyToInternal), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyToInternal.");
 
             if (potentiallyOverriddenPropertyToPrivate.IsSet && potentiallyOverriddenPropertyToPrivate.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyToPrivate), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyToPrivate.");
 
             if (potentiallyOverriddenPropertyToPublic.IsSet && potentiallyOverriddenPropertyToPublic.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyToPublic), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyToPublic.");
 
             if (unalteredProperty.IsSet && unalteredProperty.Value == null)
-                throw new ArgumentNullException(nameof(unalteredProperty), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: unalteredProperty.");
 
             if (unalteredPropertyAccessor.IsSet && unalteredPropertyAccessor.Value == null)
-                throw new ArgumentNullException(nameof(unalteredPropertyAccessor), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: unalteredPropertyAccessor.");
 
             return new InjectedVendorExtensionsTest(potentiallyOverriddenPropertyAccessor, potentiallyOverriddenPropertyToInternal, potentiallyOverriddenPropertyToPrivate, potentiallyOverriddenPropertyToPublic, unalteredProperty, unalteredPropertyAccessor);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
@@ -144,16 +144,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class IsoscelesTriangle.", nameof(shapeType));
+                throw new JsonException("Property is required for class IsoscelesTriangle: shapeType.");
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class IsoscelesTriangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class IsoscelesTriangle: triangleType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class IsoscelesTriangle.");
+                throw new JsonException("Property is not nullable for class IsoscelesTriangle: shapeType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class IsoscelesTriangle.");
+                throw new JsonException("Property is not nullable for class IsoscelesTriangle: triangleType.");
 
             return new IsoscelesTriangle(shapeType.Value, triangleType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/List.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (var123List.IsSet && var123List.Value == null)
-                throw new ArgumentNullException(nameof(var123List), "Property is not nullable for class List.");
+                throw new JsonException("Property is not nullable for class List: 123-list.");
 
             return new List(var123List);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (escapedLiteralString.IsSet && escapedLiteralString.Value == null)
-                throw new ArgumentNullException(nameof(escapedLiteralString), "Property is not nullable for class LiteralStringClass.");
+                throw new JsonException("Property is not nullable for class LiteralStringClass: escapedLiteralString.");
 
             if (unescapedLiteralString.IsSet && unescapedLiteralString.Value == null)
-                throw new ArgumentNullException(nameof(unescapedLiteralString), "Property is not nullable for class LiteralStringClass.");
+                throw new JsonException("Property is not nullable for class LiteralStringClass: unescapedLiteralString.");
 
             return new LiteralStringClass(escapedLiteralString, unescapedLiteralString);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Mammal.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Mammal.cs
@@ -214,10 +214,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Mammal.", nameof(className));
+                throw new JsonException("Property is required for class Mammal: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Mammal.");
+                throw new JsonException("Property is not nullable for class Mammal: className.");
 
             if (pig != null)
                 return new Mammal(pig);

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/MapTest.cs
@@ -271,16 +271,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (directMap.IsSet && directMap.Value == null)
-                throw new ArgumentNullException(nameof(directMap), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: direct_map.");
 
             if (indirectMap.IsSet && indirectMap.Value == null)
-                throw new ArgumentNullException(nameof(indirectMap), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: indirect_map.");
 
             if (mapMapOfString.IsSet && mapMapOfString.Value == null)
-                throw new ArgumentNullException(nameof(mapMapOfString), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: map_map_of_string.");
 
             if (mapOfEnumString.IsSet && mapOfEnumString.Value == null)
-                throw new ArgumentNullException(nameof(mapOfEnumString), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: map_of_enum_string.");
 
             return new MapTest(directMap, indirectMap, mapMapOfString, mapOfEnumString);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/MixedAnyOf.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/MixedAnyOf.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (content.IsSet && content.Value == null)
-                throw new ArgumentNullException(nameof(content), "Property is not nullable for class MixedAnyOf.");
+                throw new JsonException("Property is not nullable for class MixedAnyOf: content.");
 
             return new MixedAnyOf(content);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/MixedOneOf.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/MixedOneOf.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (content.IsSet && content.Value == null)
-                throw new ArgumentNullException(nameof(content), "Property is not nullable for class MixedOneOf.");
+                throw new JsonException("Property is not nullable for class MixedOneOf: content.");
 
             return new MixedOneOf(content);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -217,16 +217,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (dateTime.IsSet && dateTime.Value == null)
-                throw new ArgumentNullException(nameof(dateTime), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: dateTime.");
 
             if (map.IsSet && map.Value == null)
-                throw new ArgumentNullException(nameof(map), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: map.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: uuid.");
 
             if (uuidWithPattern.IsSet && uuidWithPattern.Value == null)
-                throw new ArgumentNullException(nameof(uuidWithPattern), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: uuid_with_pattern.");
 
             return new MixedPropertiesAndAdditionalPropertiesClass(dateTime, map, uuid, uuidWithPattern);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/MixedSubId.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/MixedSubId.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class MixedSubId.");
+                throw new JsonException("Property is not nullable for class MixedSubId: id.");
 
             return new MixedSubId(id);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varClass.IsSet && varClass.Value == null)
-                throw new ArgumentNullException(nameof(varClass), "Property is not nullable for class Model200Response.");
+                throw new JsonException("Property is not nullable for class Model200Response: class.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Model200Response.");
+                throw new JsonException("Property is not nullable for class Model200Response: name.");
 
             return new Model200Response(varClass, name);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varClient.IsSet && varClient.Value == null)
-                throw new ArgumentNullException(nameof(varClient), "Property is not nullable for class ModelClient.");
+                throw new JsonException("Property is not nullable for class ModelClient: client.");
 
             return new ModelClient(varClient);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Name.cs
@@ -239,19 +239,19 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!varName.IsSet)
-                throw new ArgumentException("Property is required for class Name.", nameof(varName));
+                throw new JsonException("Property is required for class Name: name.");
 
             if (varName.IsSet && varName.Value == null)
-                throw new ArgumentNullException(nameof(varName), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: name.");
 
             if (property.IsSet && property.Value == null)
-                throw new ArgumentNullException(nameof(property), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: property.");
 
             if (snakeCase.IsSet && snakeCase.Value == null)
-                throw new ArgumentNullException(nameof(snakeCase), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: snake_case.");
 
             if (var123Number.IsSet && var123Number.Value == null)
-                throw new ArgumentNullException(nameof(var123Number), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: 123Number.");
 
             return new Name(varName.Value.Value, property, snakeCase, var123Number);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
@@ -151,16 +151,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!aObjVariableobject.IsSet)
-                throw new ArgumentException("Property is required for class NotificationtestGetElementsV1ResponseMPayload.", nameof(aObjVariableobject));
+                throw new JsonException("Property is required for class NotificationtestGetElementsV1ResponseMPayload: a_objVariableobject.");
 
             if (!pkiNotificationtestID.IsSet)
-                throw new ArgumentException("Property is required for class NotificationtestGetElementsV1ResponseMPayload.", nameof(pkiNotificationtestID));
+                throw new JsonException("Property is required for class NotificationtestGetElementsV1ResponseMPayload: pkiNotificationtestID.");
 
             if (aObjVariableobject.IsSet && aObjVariableobject.Value == null)
-                throw new ArgumentNullException(nameof(aObjVariableobject), "Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload.");
+                throw new JsonException("Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload: a_objVariableobject.");
 
             if (pkiNotificationtestID.IsSet && pkiNotificationtestID.Value == null)
-                throw new ArgumentNullException(nameof(pkiNotificationtestID), "Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload.");
+                throw new JsonException("Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload: pkiNotificationtestID.");
 
             return new NotificationtestGetElementsV1ResponseMPayload(aObjVariableobject.Value, pkiNotificationtestID.Value.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -375,10 +375,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayItemsNullable.IsSet && arrayItemsNullable.Value == null)
-                throw new ArgumentNullException(nameof(arrayItemsNullable), "Property is not nullable for class NullableClass.");
+                throw new JsonException("Property is not nullable for class NullableClass: array_items_nullable.");
 
             if (objectItemsNullable.IsSet && objectItemsNullable.Value == null)
-                throw new ArgumentNullException(nameof(objectItemsNullable), "Property is not nullable for class NullableClass.");
+                throw new JsonException("Property is not nullable for class NullableClass: object_items_nullable.");
 
             return new NullableClass(arrayAndItemsNullableProp, arrayItemsNullable, arrayNullableProp, booleanProp, dateProp, datetimeProp, integerProp, numberProp, objectAndItemsNullableProp, objectItemsNullable, objectNullableProp, stringProp);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/NullableShape.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/NullableShape.cs
@@ -193,10 +193,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class NullableShape.", nameof(shapeType));
+                throw new JsonException("Property is required for class NullableShape: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class NullableShape.");
+                throw new JsonException("Property is not nullable for class NullableShape: shapeType.");
 
             if (quadrilateral != null)
                 return new NullableShape(quadrilateral);

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (justNumber.IsSet && justNumber.Value == null)
-                throw new ArgumentNullException(nameof(justNumber), "Property is not nullable for class NumberOnly.");
+                throw new JsonException("Property is not nullable for class NumberOnly: JustNumber.");
 
             return new NumberOnly(justNumber);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -208,16 +208,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bars.IsSet && bars.Value == null)
-                throw new ArgumentNullException(nameof(bars), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: bars.");
 
             if (deprecatedRef.IsSet && deprecatedRef.Value == null)
-                throw new ArgumentNullException(nameof(deprecatedRef), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: deprecatedRef.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: id.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: uuid.");
 
             return new ObjectWithDeprecatedFields(bars, deprecatedRef, id, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Order.cs
@@ -340,22 +340,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (complete.IsSet && complete.Value == null)
-                throw new ArgumentNullException(nameof(complete), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: complete.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: id.");
 
             if (petId.IsSet && petId.Value == null)
-                throw new ArgumentNullException(nameof(petId), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: petId.");
 
             if (quantity.IsSet && quantity.Value == null)
-                throw new ArgumentNullException(nameof(quantity), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: quantity.");
 
             if (shipDate.IsSet && shipDate.Value == null)
-                throw new ArgumentNullException(nameof(shipDate), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: shipDate.");
 
             if (status.IsSet && status.Value == null)
-                throw new ArgumentNullException(nameof(status), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: status.");
 
             return new Order(complete, id, petId, quantity, shipDate, status);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -185,13 +185,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (myBoolean.IsSet && myBoolean.Value == null)
-                throw new ArgumentNullException(nameof(myBoolean), "Property is not nullable for class OuterComposite.");
+                throw new JsonException("Property is not nullable for class OuterComposite: my_boolean.");
 
             if (myNumber.IsSet && myNumber.Value == null)
-                throw new ArgumentNullException(nameof(myNumber), "Property is not nullable for class OuterComposite.");
+                throw new JsonException("Property is not nullable for class OuterComposite: my_number.");
 
             if (myString.IsSet && myString.Value == null)
-                throw new ArgumentNullException(nameof(myString), "Property is not nullable for class OuterComposite.");
+                throw new JsonException("Property is not nullable for class OuterComposite: my_string.");
 
             return new OuterComposite(myBoolean, myNumber, myString);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ParentPet.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ParentPet.cs
@@ -118,10 +118,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!petType.IsSet)
-                throw new ArgumentException("Property is required for class ParentPet.", nameof(petType));
+                throw new JsonException("Property is required for class ParentPet: pet_type.");
 
             if (petType.IsSet && petType.Value == null)
-                throw new ArgumentNullException(nameof(petType), "Property is not nullable for class ParentPet.");
+                throw new JsonException("Property is not nullable for class ParentPet: pet_type.");
 
             return new ParentPet();
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Pet.cs
@@ -321,28 +321,28 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!name.IsSet)
-                throw new ArgumentException("Property is required for class Pet.", nameof(name));
+                throw new JsonException("Property is required for class Pet: name.");
 
             if (!photoUrls.IsSet)
-                throw new ArgumentException("Property is required for class Pet.", nameof(photoUrls));
+                throw new JsonException("Property is required for class Pet: photoUrls.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: name.");
 
             if (photoUrls.IsSet && photoUrls.Value == null)
-                throw new ArgumentNullException(nameof(photoUrls), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: photoUrls.");
 
             if (category.IsSet && category.Value == null)
-                throw new ArgumentNullException(nameof(category), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: category.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: id.");
 
             if (status.IsSet && status.Value == null)
-                throw new ArgumentNullException(nameof(status), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: status.");
 
             if (tags.IsSet && tags.Value == null)
-                throw new ArgumentNullException(nameof(tags), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: tags.");
 
             return new Pet(name.Value, photoUrls.Value, category, id, status, tags);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Pig.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Pig.cs
@@ -193,10 +193,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Pig.", nameof(className));
+                throw new JsonException("Property is required for class Pig: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Pig.");
+                throw new JsonException("Property is not nullable for class Pig: className.");
 
             if (basquePig != null)
                 return new Pig(basquePig);

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Quadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Quadrilateral.cs
@@ -193,10 +193,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class Quadrilateral.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class Quadrilateral: quadrilateralType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class Quadrilateral.");
+                throw new JsonException("Property is not nullable for class Quadrilateral: quadrilateralType.");
 
             if (complexQuadrilateral != null)
                 return new Quadrilateral(complexQuadrilateral);

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
@@ -138,10 +138,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class QuadrilateralInterface.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class QuadrilateralInterface: quadrilateralType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class QuadrilateralInterface.");
+                throw new JsonException("Property is not nullable for class QuadrilateralInterface: quadrilateralType.");
 
             return new QuadrilateralInterface(quadrilateralType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -203,10 +203,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bar.IsSet && bar.Value == null)
-                throw new ArgumentNullException(nameof(bar), "Property is not nullable for class ReadOnlyFirst.");
+                throw new JsonException("Property is not nullable for class ReadOnlyFirst: bar.");
 
             if (baz.IsSet && baz.Value == null)
-                throw new ArgumentNullException(nameof(baz), "Property is not nullable for class ReadOnlyFirst.");
+                throw new JsonException("Property is not nullable for class ReadOnlyFirst: baz.");
 
             return new ReadOnlyFirst(bar, baz);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -2077,136 +2077,136 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!requiredNotNullableDateProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotNullableDateProp));
+                throw new JsonException("Property is required for class RequiredClass: required_not_nullable_date_prop.");
 
             if (!requiredNotnullableArrayOfString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableArrayOfString));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_array_of_string.");
 
             if (!requiredNotnullableBooleanProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableBooleanProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_boolean_prop.");
 
             if (!requiredNotnullableDatetimeProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableDatetimeProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_datetime_prop.");
 
             if (!requiredNotnullableEnumInteger.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableEnumInteger));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_enum_integer.");
 
             if (!requiredNotnullableEnumIntegerOnly.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableEnumIntegerOnly));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_enum_integer_only.");
 
             if (!requiredNotnullableEnumString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableEnumString));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_enum_string.");
 
             if (!requiredNotnullableOuterEnumDefaultValue.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableOuterEnumDefaultValue));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_outerEnumDefaultValue.");
 
             if (!requiredNotnullableStringProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableStringProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_string_prop.");
 
             if (!requiredNotnullableUuid.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableUuid));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_uuid.");
 
             if (!requiredNotnullableintegerProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableintegerProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullableinteger_prop.");
 
             if (!requiredNullableArrayOfString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableArrayOfString));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_array_of_string.");
 
             if (!requiredNullableBooleanProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableBooleanProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_boolean_prop.");
 
             if (!requiredNullableDateProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableDateProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_date_prop.");
 
             if (!requiredNullableDatetimeProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableDatetimeProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_datetime_prop.");
 
             if (!requiredNullableEnumInteger.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableEnumInteger));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_enum_integer.");
 
             if (!requiredNullableEnumIntegerOnly.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableEnumIntegerOnly));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_enum_integer_only.");
 
             if (!requiredNullableEnumString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableEnumString));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_enum_string.");
 
             if (!requiredNullableIntegerProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableIntegerProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_integer_prop.");
 
             if (!requiredNullableOuterEnumDefaultValue.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableOuterEnumDefaultValue));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_outerEnumDefaultValue.");
 
             if (!requiredNullableStringProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableStringProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_string_prop.");
 
             if (!requiredNullableUuid.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableUuid));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_uuid.");
 
             if (requiredNotNullableDateProp.IsSet && requiredNotNullableDateProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotNullableDateProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_not_nullable_date_prop.");
 
             if (requiredNotnullableArrayOfString.IsSet && requiredNotnullableArrayOfString.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableArrayOfString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_array_of_string.");
 
             if (requiredNotnullableBooleanProp.IsSet && requiredNotnullableBooleanProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableBooleanProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_boolean_prop.");
 
             if (requiredNotnullableDatetimeProp.IsSet && requiredNotnullableDatetimeProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableDatetimeProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_datetime_prop.");
 
             if (requiredNotnullableEnumInteger.IsSet && requiredNotnullableEnumInteger.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableEnumInteger), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_enum_integer.");
 
             if (requiredNotnullableEnumIntegerOnly.IsSet && requiredNotnullableEnumIntegerOnly.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableEnumIntegerOnly), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_enum_integer_only.");
 
             if (requiredNotnullableEnumString.IsSet && requiredNotnullableEnumString.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableEnumString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_enum_string.");
 
             if (requiredNotnullableOuterEnumDefaultValue.IsSet && requiredNotnullableOuterEnumDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableOuterEnumDefaultValue), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_outerEnumDefaultValue.");
 
             if (requiredNotnullableStringProp.IsSet && requiredNotnullableStringProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableStringProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_string_prop.");
 
             if (requiredNotnullableUuid.IsSet && requiredNotnullableUuid.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableUuid), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_uuid.");
 
             if (requiredNotnullableintegerProp.IsSet && requiredNotnullableintegerProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableintegerProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullableinteger_prop.");
 
             if (notRequiredNotnullableDateProp.IsSet && notRequiredNotnullableDateProp.Value == null)
-                throw new ArgumentNullException(nameof(notRequiredNotnullableDateProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: not_required_notnullable_date_prop.");
 
             if (notRequiredNotnullableintegerProp.IsSet && notRequiredNotnullableintegerProp.Value == null)
-                throw new ArgumentNullException(nameof(notRequiredNotnullableintegerProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: not_required_notnullableinteger_prop.");
 
             if (notrequiredNotnullableArrayOfString.IsSet && notrequiredNotnullableArrayOfString.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableArrayOfString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_array_of_string.");
 
             if (notrequiredNotnullableBooleanProp.IsSet && notrequiredNotnullableBooleanProp.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableBooleanProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_boolean_prop.");
 
             if (notrequiredNotnullableDatetimeProp.IsSet && notrequiredNotnullableDatetimeProp.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableDatetimeProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_datetime_prop.");
 
             if (notrequiredNotnullableEnumInteger.IsSet && notrequiredNotnullableEnumInteger.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableEnumInteger), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_enum_integer.");
 
             if (notrequiredNotnullableEnumIntegerOnly.IsSet && notrequiredNotnullableEnumIntegerOnly.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableEnumIntegerOnly), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_enum_integer_only.");
 
             if (notrequiredNotnullableEnumString.IsSet && notrequiredNotnullableEnumString.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableEnumString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_enum_string.");
 
             if (notrequiredNotnullableOuterEnumDefaultValue.IsSet && notrequiredNotnullableOuterEnumDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableOuterEnumDefaultValue), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_outerEnumDefaultValue.");
 
             if (notrequiredNotnullableStringProp.IsSet && notrequiredNotnullableStringProp.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableStringProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_string_prop.");
 
             if (notrequiredNotnullableUuid.IsSet && notrequiredNotnullableUuid.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableUuid), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_uuid.");
 
             return new RequiredClass(requiredNotNullableDateProp.Value.Value, requiredNotnullableArrayOfString.Value, requiredNotnullableBooleanProp.Value.Value, requiredNotnullableDatetimeProp.Value.Value, requiredNotnullableEnumInteger.Value.Value, requiredNotnullableEnumIntegerOnly.Value.Value, requiredNotnullableEnumString.Value.Value, requiredNotnullableOuterEnumDefaultValue.Value.Value, requiredNotnullableStringProp.Value, requiredNotnullableUuid.Value.Value, requiredNotnullableintegerProp.Value.Value, notRequiredNotnullableDateProp, notRequiredNotnullableintegerProp, notRequiredNullableDateProp, notRequiredNullableIntegerProp, notrequiredNotnullableArrayOfString, notrequiredNotnullableBooleanProp, notrequiredNotnullableDatetimeProp, notrequiredNotnullableEnumInteger, notrequiredNotnullableEnumIntegerOnly, notrequiredNotnullableEnumString, notrequiredNotnullableOuterEnumDefaultValue, notrequiredNotnullableStringProp, notrequiredNotnullableUuid, notrequiredNullableArrayOfString, notrequiredNullableBooleanProp, notrequiredNullableDatetimeProp, notrequiredNullableEnumInteger, notrequiredNullableEnumIntegerOnly, notrequiredNullableEnumString, notrequiredNullableOuterEnumDefaultValue, notrequiredNullableStringProp, notrequiredNullableUuid, requiredNullableArrayOfString.Value, requiredNullableBooleanProp.Value, requiredNullableDateProp.Value, requiredNullableDatetimeProp.Value, requiredNullableEnumInteger.Value, requiredNullableEnumIntegerOnly.Value, requiredNullableEnumString.Value, requiredNullableIntegerProp.Value, requiredNullableOuterEnumDefaultValue.Value, requiredNullableStringProp.Value, requiredNullableUuid.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Result.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Result.cs
@@ -188,13 +188,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (code.IsSet && code.Value == null)
-                throw new ArgumentNullException(nameof(code), "Property is not nullable for class Result.");
+                throw new JsonException("Property is not nullable for class Result: code.");
 
             if (data.IsSet && data.Value == null)
-                throw new ArgumentNullException(nameof(data), "Property is not nullable for class Result.");
+                throw new JsonException("Property is not nullable for class Result: data.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class Result.");
+                throw new JsonException("Property is not nullable for class Result: uuid.");
 
             return new Result(code, data, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Return.cs
@@ -191,19 +191,19 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!varLock.IsSet)
-                throw new ArgumentException("Property is required for class Return.", nameof(varLock));
+                throw new JsonException("Property is required for class Return: lock.");
 
             if (!varAbstract.IsSet)
-                throw new ArgumentException("Property is required for class Return.", nameof(varAbstract));
+                throw new JsonException("Property is required for class Return: abstract.");
 
             if (varLock.IsSet && varLock.Value == null)
-                throw new ArgumentNullException(nameof(varLock), "Property is not nullable for class Return.");
+                throw new JsonException("Property is not nullable for class Return: lock.");
 
             if (varReturn.IsSet && varReturn.Value == null)
-                throw new ArgumentNullException(nameof(varReturn), "Property is not nullable for class Return.");
+                throw new JsonException("Property is not nullable for class Return: return.");
 
             if (varUnsafe.IsSet && varUnsafe.Value == null)
-                throw new ArgumentNullException(nameof(varUnsafe), "Property is not nullable for class Return.");
+                throw new JsonException("Property is not nullable for class Return: unsafe.");
 
             return new Return(varLock.Value, varAbstract.Value, varReturn, varUnsafe);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (role.IsSet && role.Value == null)
-                throw new ArgumentNullException(nameof(role), "Property is not nullable for class RolesReportsHash.");
+                throw new JsonException("Property is not nullable for class RolesReportsHash: role.");
 
             if (roleUuid.IsSet && roleUuid.Value == null)
-                throw new ArgumentNullException(nameof(roleUuid), "Property is not nullable for class RolesReportsHash.");
+                throw new JsonException("Property is not nullable for class RolesReportsHash: role_uuid.");
 
             return new RolesReportsHash(role, roleUuid);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class RolesReportsHashRole.");
+                throw new JsonException("Property is not nullable for class RolesReportsHashRole: name.");
 
             return new RolesReportsHashRole(name);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
@@ -151,16 +151,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ScaleneTriangle.", nameof(shapeType));
+                throw new JsonException("Property is required for class ScaleneTriangle: shapeType.");
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class ScaleneTriangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class ScaleneTriangle: triangleType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ScaleneTriangle.");
+                throw new JsonException("Property is not nullable for class ScaleneTriangle: shapeType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class ScaleneTriangle.");
+                throw new JsonException("Property is not nullable for class ScaleneTriangle: triangleType.");
 
             return new ScaleneTriangle(shapeType.Value, triangleType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Shape.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Shape.cs
@@ -193,10 +193,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class Shape.", nameof(shapeType));
+                throw new JsonException("Property is required for class Shape: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class Shape.");
+                throw new JsonException("Property is not nullable for class Shape: shapeType.");
 
             if (quadrilateral != null)
                 return new Shape(quadrilateral);

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ShapeInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ShapeInterface.cs
@@ -138,10 +138,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ShapeInterface.", nameof(shapeType));
+                throw new JsonException("Property is required for class ShapeInterface: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ShapeInterface.");
+                throw new JsonException("Property is not nullable for class ShapeInterface: shapeType.");
 
             return new ShapeInterface(shapeType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ShapeOrNull.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ShapeOrNull.cs
@@ -193,10 +193,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ShapeOrNull.", nameof(shapeType));
+                throw new JsonException("Property is required for class ShapeOrNull: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ShapeOrNull.");
+                throw new JsonException("Property is not nullable for class ShapeOrNull: shapeType.");
 
             if (quadrilateral != null)
                 return new ShapeOrNull(quadrilateral);

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
@@ -151,16 +151,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class SimpleQuadrilateral.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class SimpleQuadrilateral: quadrilateralType.");
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class SimpleQuadrilateral.", nameof(shapeType));
+                throw new JsonException("Property is required for class SimpleQuadrilateral: shapeType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class SimpleQuadrilateral.");
+                throw new JsonException("Property is not nullable for class SimpleQuadrilateral: quadrilateralType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class SimpleQuadrilateral.");
+                throw new JsonException("Property is not nullable for class SimpleQuadrilateral: shapeType.");
 
             return new SimpleQuadrilateral(quadrilateralType.Value, shapeType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varSpecialModelName.IsSet && varSpecialModelName.Value == null)
-                throw new ArgumentNullException(nameof(varSpecialModelName), "Property is not nullable for class SpecialModelName.");
+                throw new JsonException("Property is not nullable for class SpecialModelName: _special_model.name_.");
 
             if (specialPropertyName.IsSet && specialPropertyName.Value == null)
-                throw new ArgumentNullException(nameof(specialPropertyName), "Property is not nullable for class SpecialModelName.");
+                throw new JsonException("Property is not nullable for class SpecialModelName: $special[property.name].");
 
             return new SpecialModelName(varSpecialModelName, specialPropertyName);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Tag.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Tag.");
+                throw new JsonException("Property is not nullable for class Tag: id.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Tag.");
+                throw new JsonException("Property is not nullable for class Tag: name.");
 
             return new Tag(id, name);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (value.IsSet && value.Value == null)
-                throw new ArgumentNullException(nameof(value), "Property is not nullable for class TestCollectionEndingWithWordList.");
+                throw new JsonException("Property is not nullable for class TestCollectionEndingWithWordList: value.");
 
             return new TestCollectionEndingWithWordList(value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (testCollectionEndingWithWordList.IsSet && testCollectionEndingWithWordList.Value == null)
-                throw new ArgumentNullException(nameof(testCollectionEndingWithWordList), "Property is not nullable for class TestCollectionEndingWithWordListObject.");
+                throw new JsonException("Property is not nullable for class TestCollectionEndingWithWordListObject: TestCollectionEndingWithWordList.");
 
             return new TestCollectionEndingWithWordListObject(testCollectionEndingWithWordList);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/TestDescendants.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/TestDescendants.cs
@@ -241,16 +241,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!alternativeName.IsSet)
-                throw new ArgumentException("Property is required for class TestDescendants.", nameof(alternativeName));
+                throw new JsonException("Property is required for class TestDescendants: alternativeName.");
 
             if (!objectType.IsSet)
-                throw new ArgumentException("Property is required for class TestDescendants.", nameof(objectType));
+                throw new JsonException("Property is required for class TestDescendants: objectType.");
 
             if (alternativeName.IsSet && alternativeName.Value == null)
-                throw new ArgumentNullException(nameof(alternativeName), "Property is not nullable for class TestDescendants.");
+                throw new JsonException("Property is not nullable for class TestDescendants: alternativeName.");
 
             if (objectType.IsSet && objectType.Value == null)
-                throw new ArgumentNullException(nameof(objectType), "Property is not nullable for class TestDescendants.");
+                throw new JsonException("Property is not nullable for class TestDescendants: objectType.");
 
             return new TestDescendants(alternativeName.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (someProperty.IsSet && someProperty.Value == null)
-                throw new ArgumentNullException(nameof(someProperty), "Property is not nullable for class TestInlineFreeformAdditionalPropertiesRequest.");
+                throw new JsonException("Property is not nullable for class TestInlineFreeformAdditionalPropertiesRequest: someProperty.");
 
             return new TestInlineFreeformAdditionalPropertiesRequest(someProperty);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/TestResult.cs
@@ -187,13 +187,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (code.IsSet && code.Value == null)
-                throw new ArgumentNullException(nameof(code), "Property is not nullable for class TestResult.");
+                throw new JsonException("Property is not nullable for class TestResult: code.");
 
             if (data.IsSet && data.Value == null)
-                throw new ArgumentNullException(nameof(data), "Property is not nullable for class TestResult.");
+                throw new JsonException("Property is not nullable for class TestResult: data.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class TestResult.");
+                throw new JsonException("Property is not nullable for class TestResult: uuid.");
 
             return new TestResult(code, data, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Triangle.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Triangle.cs
@@ -214,10 +214,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class Triangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class Triangle: triangleType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class Triangle.");
+                throw new JsonException("Property is not nullable for class Triangle: triangleType.");
 
             if (equilateralTriangle != null)
                 return new Triangle(equilateralTriangle);

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/TriangleInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/TriangleInterface.cs
@@ -138,10 +138,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class TriangleInterface.", nameof(triangleType));
+                throw new JsonException("Property is required for class TriangleInterface: triangleType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class TriangleInterface.");
+                throw new JsonException("Property is not nullable for class TriangleInterface: triangleType.");
 
             return new TriangleInterface(triangleType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/User.cs
@@ -370,31 +370,31 @@ namespace Org.OpenAPITools.Model
             }
 
             if (email.IsSet && email.Value == null)
-                throw new ArgumentNullException(nameof(email), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: email.");
 
             if (firstName.IsSet && firstName.Value == null)
-                throw new ArgumentNullException(nameof(firstName), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: firstName.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: id.");
 
             if (lastName.IsSet && lastName.Value == null)
-                throw new ArgumentNullException(nameof(lastName), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: lastName.");
 
             if (objectWithNoDeclaredProps.IsSet && objectWithNoDeclaredProps.Value == null)
-                throw new ArgumentNullException(nameof(objectWithNoDeclaredProps), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: objectWithNoDeclaredProps.");
 
             if (password.IsSet && password.Value == null)
-                throw new ArgumentNullException(nameof(password), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: password.");
 
             if (phone.IsSet && phone.Value == null)
-                throw new ArgumentNullException(nameof(phone), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: phone.");
 
             if (userStatus.IsSet && userStatus.Value == null)
-                throw new ArgumentNullException(nameof(userStatus), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: userStatus.");
 
             if (username.IsSet && username.Value == null)
-                throw new ArgumentNullException(nameof(username), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: username.");
 
             return new User(anyTypeProp, anyTypePropNullable, email, firstName, id, lastName, objectWithNoDeclaredProps, objectWithNoDeclaredPropsNullable, password, phone, userStatus, username);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Whale.cs
@@ -178,16 +178,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Whale.", nameof(className));
+                throw new JsonException("Property is required for class Whale: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Whale.");
+                throw new JsonException("Property is not nullable for class Whale: className.");
 
             if (hasBaleen.IsSet && hasBaleen.Value == null)
-                throw new ArgumentNullException(nameof(hasBaleen), "Property is not nullable for class Whale.");
+                throw new JsonException("Property is not nullable for class Whale: hasBaleen.");
 
             if (hasTeeth.IsSet && hasTeeth.Value == null)
-                throw new ArgumentNullException(nameof(hasTeeth), "Property is not nullable for class Whale.");
+                throw new JsonException("Property is not nullable for class Whale: hasTeeth.");
 
             return new Whale(className.Value, hasBaleen, hasTeeth);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Zebra.cs
@@ -245,13 +245,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Zebra.", nameof(className));
+                throw new JsonException("Property is required for class Zebra: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Zebra.");
+                throw new JsonException("Property is not nullable for class Zebra: className.");
 
             if (type.IsSet && type.Value == null)
-                throw new ArgumentNullException(nameof(type), "Property is not nullable for class Zebra.");
+                throw new JsonException("Property is not nullable for class Zebra: type.");
 
             return new Zebra(className.Value, type);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
@@ -218,7 +218,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (zeroBasedEnum.IsSet && zeroBasedEnum.Value == null)
-                throw new ArgumentNullException(nameof(zeroBasedEnum), "Property is not nullable for class ZeroBasedEnumClass.");
+                throw new JsonException("Property is not nullable for class ZeroBasedEnumClass: ZeroBasedEnum.");
 
             return new ZeroBasedEnumClass(zeroBasedEnum);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/UseDateTimeForDate/src/Org.OpenAPITools/Model/NowGet200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/UseDateTimeForDate/src/Org.OpenAPITools/Model/NowGet200Response.cs
@@ -167,10 +167,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (now.IsSet && now.Value == null)
-                throw new ArgumentNullException(nameof(now), "Property is not nullable for class NowGet200Response.");
+                throw new JsonException("Property is not nullable for class NowGet200Response: now.");
 
             if (today.IsSet && today.Value == null)
-                throw new ArgumentNullException(nameof(today), "Property is not nullable for class NowGet200Response.");
+                throw new JsonException("Property is not nullable for class NowGet200Response: today.");
 
             return new NowGet200Response(now, today);
         }

--- a/samples/client/petstore/csharp/generichost/net8/AllOf/src/Org.OpenAPITools/Model/Adult.cs
+++ b/samples/client/petstore/csharp/generichost/net8/AllOf/src/Org.OpenAPITools/Model/Adult.cs
@@ -145,16 +145,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (children.IsSet && children.Value == null)
-                throw new ArgumentNullException(nameof(children), "Property is not nullable for class Adult.");
+                throw new JsonException("Property is not nullable for class Adult: children.");
 
             if (firstName.IsSet && firstName.Value == null)
-                throw new ArgumentNullException(nameof(firstName), "Property is not nullable for class Adult.");
+                throw new JsonException("Property is not nullable for class Adult: firstName.");
 
             if (lastName.IsSet && lastName.Value == null)
-                throw new ArgumentNullException(nameof(lastName), "Property is not nullable for class Adult.");
+                throw new JsonException("Property is not nullable for class Adult: lastName.");
 
             if (type.IsSet && type.Value == null)
-                throw new ArgumentNullException(nameof(type), "Property is not nullable for class Adult.");
+                throw new JsonException("Property is not nullable for class Adult: $_type.");
 
             return new Adult(children, firstName, lastName);
         }

--- a/samples/client/petstore/csharp/generichost/net8/AllOf/src/Org.OpenAPITools/Model/Child.cs
+++ b/samples/client/petstore/csharp/generichost/net8/AllOf/src/Org.OpenAPITools/Model/Child.cs
@@ -165,19 +165,19 @@ namespace Org.OpenAPITools.Model
             }
 
             if (age.IsSet && age.Value == null)
-                throw new ArgumentNullException(nameof(age), "Property is not nullable for class Child.");
+                throw new JsonException("Property is not nullable for class Child: age.");
 
             if (boosterSeat.IsSet && boosterSeat.Value == null)
-                throw new ArgumentNullException(nameof(boosterSeat), "Property is not nullable for class Child.");
+                throw new JsonException("Property is not nullable for class Child: boosterSeat.");
 
             if (firstName.IsSet && firstName.Value == null)
-                throw new ArgumentNullException(nameof(firstName), "Property is not nullable for class Child.");
+                throw new JsonException("Property is not nullable for class Child: firstName.");
 
             if (lastName.IsSet && lastName.Value == null)
-                throw new ArgumentNullException(nameof(lastName), "Property is not nullable for class Child.");
+                throw new JsonException("Property is not nullable for class Child: lastName.");
 
             if (type.IsSet && type.Value == null)
-                throw new ArgumentNullException(nameof(type), "Property is not nullable for class Child.");
+                throw new JsonException("Property is not nullable for class Child: $_type.");
 
             return new Child(age, boosterSeat, firstName, lastName);
         }

--- a/samples/client/petstore/csharp/generichost/net8/AllOf/src/Org.OpenAPITools/Model/Person.cs
+++ b/samples/client/petstore/csharp/generichost/net8/AllOf/src/Org.OpenAPITools/Model/Person.cs
@@ -197,13 +197,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (firstName.IsSet && firstName.Value == null)
-                throw new ArgumentNullException(nameof(firstName), "Property is not nullable for class Person.");
+                throw new JsonException("Property is not nullable for class Person: firstName.");
 
             if (lastName.IsSet && lastName.Value == null)
-                throw new ArgumentNullException(nameof(lastName), "Property is not nullable for class Person.");
+                throw new JsonException("Property is not nullable for class Person: lastName.");
 
             if (type.IsSet && type.Value == null)
-                throw new ArgumentNullException(nameof(type), "Property is not nullable for class Person.");
+                throw new JsonException("Property is not nullable for class Person: $_type.");
 
             return new Person(firstName, lastName);
         }

--- a/samples/client/petstore/csharp/generichost/net8/AnyOf/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net8/AnyOf/src/Org.OpenAPITools/Model/Apple.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (kind.IsSet && kind.Value == null)
-                throw new ArgumentNullException(nameof(kind), "Property is not nullable for class Apple.");
+                throw new JsonException("Property is not nullable for class Apple: kind.");
 
             return new Apple(kind);
         }

--- a/samples/client/petstore/csharp/generichost/net8/AnyOf/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net8/AnyOf/src/Org.OpenAPITools/Model/Banana.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (count.IsSet && count.Value == null)
-                throw new ArgumentNullException(nameof(count), "Property is not nullable for class Banana.");
+                throw new JsonException("Property is not nullable for class Banana: count.");
 
             return new Banana(count);
         }

--- a/samples/client/petstore/csharp/generichost/net8/AnyOf/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net8/AnyOf/src/Org.OpenAPITools/Model/Fruit.cs
@@ -196,7 +196,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Fruit.");
+                throw new JsonException("Property is not nullable for class Fruit: color.");
 
             Option<Apple?> appleParsedValue = apple == null
                 ? default

--- a/samples/client/petstore/csharp/generichost/net8/AnyOfNoCompare/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net8/AnyOfNoCompare/src/Org.OpenAPITools/Model/Apple.cs
@@ -146,7 +146,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (kind.IsSet && kind.Value == null)
-                throw new ArgumentNullException(nameof(kind), "Property is not nullable for class Apple.");
+                throw new JsonException("Property is not nullable for class Apple: kind.");
 
             return new Apple(kind);
         }

--- a/samples/client/petstore/csharp/generichost/net8/AnyOfNoCompare/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net8/AnyOfNoCompare/src/Org.OpenAPITools/Model/Banana.cs
@@ -146,7 +146,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (count.IsSet && count.Value == null)
-                throw new ArgumentNullException(nameof(count), "Property is not nullable for class Banana.");
+                throw new JsonException("Property is not nullable for class Banana: count.");
 
             return new Banana(count);
         }

--- a/samples/client/petstore/csharp/generichost/net8/AnyOfNoCompare/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net8/AnyOfNoCompare/src/Org.OpenAPITools/Model/Fruit.cs
@@ -195,7 +195,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Fruit.");
+                throw new JsonException("Property is not nullable for class Fruit: color.");
 
             Option<Apple?> appleParsedValue = apple == null
                 ? default

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Activity.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (activityOutputs.IsSet && activityOutputs.Value == null)
-                throw new ArgumentNullException(nameof(activityOutputs), "Property is not nullable for class Activity.");
+                throw new JsonException("Property is not nullable for class Activity: activity_outputs.");
 
             return new Activity(activityOutputs);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (prop1.IsSet && prop1.Value == null)
-                throw new ArgumentNullException(nameof(prop1), "Property is not nullable for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Property is not nullable for class ActivityOutputElementRepresentation: prop1.");
 
             if (prop2.IsSet && prop2.Value == null)
-                throw new ArgumentNullException(nameof(prop2), "Property is not nullable for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Property is not nullable for class ActivityOutputElementRepresentation: prop2.");
 
             return new ActivityOutputElementRepresentation(prop1, prop2);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -286,25 +286,25 @@ namespace Org.OpenAPITools.Model
             }
 
             if (emptyMap.IsSet && emptyMap.Value == null)
-                throw new ArgumentNullException(nameof(emptyMap), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: empty_map.");
 
             if (mapOfMapProperty.IsSet && mapOfMapProperty.Value == null)
-                throw new ArgumentNullException(nameof(mapOfMapProperty), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_of_map_property.");
 
             if (mapProperty.IsSet && mapProperty.Value == null)
-                throw new ArgumentNullException(nameof(mapProperty), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_property.");
 
             if (mapWithUndeclaredPropertiesAnytype1.IsSet && mapWithUndeclaredPropertiesAnytype1.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesAnytype1), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_anytype_1.");
 
             if (mapWithUndeclaredPropertiesAnytype2.IsSet && mapWithUndeclaredPropertiesAnytype2.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesAnytype2), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_anytype_2.");
 
             if (mapWithUndeclaredPropertiesAnytype3.IsSet && mapWithUndeclaredPropertiesAnytype3.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesAnytype3), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_anytype_3.");
 
             if (mapWithUndeclaredPropertiesString.IsSet && mapWithUndeclaredPropertiesString.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesString), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_string.");
 
             return new AdditionalPropertiesClass(anytype1, emptyMap, mapOfMapProperty, mapProperty, mapWithUndeclaredPropertiesAnytype1, mapWithUndeclaredPropertiesAnytype2, mapWithUndeclaredPropertiesAnytype3, mapWithUndeclaredPropertiesString);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Animal.cs
@@ -175,13 +175,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Animal.", nameof(className));
+                throw new JsonException("Property is required for class Animal: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Animal.");
+                throw new JsonException("Property is not nullable for class Animal: className.");
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Animal.");
+                throw new JsonException("Property is not nullable for class Animal: color.");
 
             return new Animal(color);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -185,13 +185,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (code.IsSet && code.Value == null)
-                throw new ArgumentNullException(nameof(code), "Property is not nullable for class ApiResponse.");
+                throw new JsonException("Property is not nullable for class ApiResponse: code.");
 
             if (message.IsSet && message.Value == null)
-                throw new ArgumentNullException(nameof(message), "Property is not nullable for class ApiResponse.");
+                throw new JsonException("Property is not nullable for class ApiResponse: message.");
 
             if (type.IsSet && type.Value == null)
-                throw new ArgumentNullException(nameof(type), "Property is not nullable for class ApiResponse.");
+                throw new JsonException("Property is not nullable for class ApiResponse: type.");
 
             return new ApiResponse(code, message, type);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Apple.cs
@@ -215,13 +215,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (colorCode.IsSet && colorCode.Value == null)
-                throw new ArgumentNullException(nameof(colorCode), "Property is not nullable for class Apple.");
+                throw new JsonException("Property is not nullable for class Apple: color_code.");
 
             if (cultivar.IsSet && cultivar.Value == null)
-                throw new ArgumentNullException(nameof(cultivar), "Property is not nullable for class Apple.");
+                throw new JsonException("Property is not nullable for class Apple: cultivar.");
 
             if (origin.IsSet && origin.Value == null)
-                throw new ArgumentNullException(nameof(origin), "Property is not nullable for class Apple.");
+                throw new JsonException("Property is not nullable for class Apple: origin.");
 
             return new Apple(colorCode, cultivar, origin);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -151,13 +151,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!cultivar.IsSet)
-                throw new ArgumentException("Property is required for class AppleReq.", nameof(cultivar));
+                throw new JsonException("Property is required for class AppleReq: cultivar.");
 
             if (cultivar.IsSet && cultivar.Value == null)
-                throw new ArgumentNullException(nameof(cultivar), "Property is not nullable for class AppleReq.");
+                throw new JsonException("Property is not nullable for class AppleReq: cultivar.");
 
             if (mealy.IsSet && mealy.Value == null)
-                throw new ArgumentNullException(nameof(mealy), "Property is not nullable for class AppleReq.");
+                throw new JsonException("Property is not nullable for class AppleReq: mealy.");
 
             return new AppleReq(cultivar.Value, mealy);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayArrayNumber.IsSet && arrayArrayNumber.Value == null)
-                throw new ArgumentNullException(nameof(arrayArrayNumber), "Property is not nullable for class ArrayOfArrayOfNumberOnly.");
+                throw new JsonException("Property is not nullable for class ArrayOfArrayOfNumberOnly: ArrayArrayNumber.");
 
             return new ArrayOfArrayOfNumberOnly(arrayArrayNumber);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayNumber.IsSet && arrayNumber.Value == null)
-                throw new ArgumentNullException(nameof(arrayNumber), "Property is not nullable for class ArrayOfNumberOnly.");
+                throw new JsonException("Property is not nullable for class ArrayOfNumberOnly: ArrayNumber.");
 
             return new ArrayOfNumberOnly(arrayNumber);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -185,13 +185,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayArrayOfInteger.IsSet && arrayArrayOfInteger.Value == null)
-                throw new ArgumentNullException(nameof(arrayArrayOfInteger), "Property is not nullable for class ArrayTest.");
+                throw new JsonException("Property is not nullable for class ArrayTest: array_array_of_integer.");
 
             if (arrayArrayOfModel.IsSet && arrayArrayOfModel.Value == null)
-                throw new ArgumentNullException(nameof(arrayArrayOfModel), "Property is not nullable for class ArrayTest.");
+                throw new JsonException("Property is not nullable for class ArrayTest: array_array_of_model.");
 
             if (arrayOfString.IsSet && arrayOfString.Value == null)
-                throw new ArgumentNullException(nameof(arrayOfString), "Property is not nullable for class ArrayTest.");
+                throw new JsonException("Property is not nullable for class ArrayTest: array_of_string.");
 
             return new ArrayTest(arrayArrayOfInteger, arrayArrayOfModel, arrayOfString);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Banana.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (lengthCm.IsSet && lengthCm.Value == null)
-                throw new ArgumentNullException(nameof(lengthCm), "Property is not nullable for class Banana.");
+                throw new JsonException("Property is not nullable for class Banana: lengthCm.");
 
             return new Banana(lengthCm);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -151,13 +151,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!lengthCm.IsSet)
-                throw new ArgumentException("Property is required for class BananaReq.", nameof(lengthCm));
+                throw new JsonException("Property is required for class BananaReq: lengthCm.");
 
             if (lengthCm.IsSet && lengthCm.Value == null)
-                throw new ArgumentNullException(nameof(lengthCm), "Property is not nullable for class BananaReq.");
+                throw new JsonException("Property is not nullable for class BananaReq: lengthCm.");
 
             if (sweet.IsSet && sweet.Value == null)
-                throw new ArgumentNullException(nameof(sweet), "Property is not nullable for class BananaReq.");
+                throw new JsonException("Property is not nullable for class BananaReq: sweet.");
 
             return new BananaReq(lengthCm.Value.Value, sweet);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/BasquePig.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/BasquePig.cs
@@ -138,10 +138,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class BasquePig.", nameof(className));
+                throw new JsonException("Property is required for class BasquePig: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class BasquePig.");
+                throw new JsonException("Property is not nullable for class BasquePig: className.");
 
             return new BasquePig(className.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -246,22 +246,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (aTTNAME.IsSet && aTTNAME.Value == null)
-                throw new ArgumentNullException(nameof(aTTNAME), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: ATT_NAME.");
 
             if (capitalCamel.IsSet && capitalCamel.Value == null)
-                throw new ArgumentNullException(nameof(capitalCamel), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: CapitalCamel.");
 
             if (capitalSnake.IsSet && capitalSnake.Value == null)
-                throw new ArgumentNullException(nameof(capitalSnake), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: Capital_Snake.");
 
             if (sCAETHFlowPoints.IsSet && sCAETHFlowPoints.Value == null)
-                throw new ArgumentNullException(nameof(sCAETHFlowPoints), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: SCA_ETH_Flow_Points.");
 
             if (smallCamel.IsSet && smallCamel.Value == null)
-                throw new ArgumentNullException(nameof(smallCamel), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: smallCamel.");
 
             if (smallSnake.IsSet && smallSnake.Value == null)
-                throw new ArgumentNullException(nameof(smallSnake), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: small_Snake.");
 
             return new Capitalization(aTTNAME, capitalCamel, capitalSnake, sCAETHFlowPoints, smallCamel, smallSnake);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Cat.cs
@@ -138,16 +138,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Cat.", nameof(className));
+                throw new JsonException("Property is required for class Cat: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Cat.");
+                throw new JsonException("Property is not nullable for class Cat: className.");
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Cat.");
+                throw new JsonException("Property is not nullable for class Cat: color.");
 
             if (declawed.IsSet && declawed.Value == null)
-                throw new ArgumentNullException(nameof(declawed), "Property is not nullable for class Cat.");
+                throw new JsonException("Property is not nullable for class Cat: declawed.");
 
             return new Cat(color, declawed);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Category.cs
@@ -158,13 +158,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!name.IsSet)
-                throw new ArgumentException("Property is required for class Category.", nameof(name));
+                throw new JsonException("Property is required for class Category: name.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Category.");
+                throw new JsonException("Property is not nullable for class Category: id.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Category.");
+                throw new JsonException("Property is not nullable for class Category: name.");
 
             return new Category(id, name.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -141,13 +141,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!petType.IsSet)
-                throw new ArgumentException("Property is required for class ChildCat.", nameof(petType));
+                throw new JsonException("Property is required for class ChildCat: pet_type.");
 
             if (petType.IsSet && petType.Value == null)
-                throw new ArgumentNullException(nameof(petType), "Property is not nullable for class ChildCat.");
+                throw new JsonException("Property is not nullable for class ChildCat: pet_type.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class ChildCat.");
+                throw new JsonException("Property is not nullable for class ChildCat: name.");
 
             return new ChildCat(name);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varClass.IsSet && varClass.Value == null)
-                throw new ArgumentNullException(nameof(varClass), "Property is not nullable for class ClassModel.");
+                throw new JsonException("Property is not nullable for class ClassModel: _class.");
 
             return new ClassModel(varClass);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
@@ -151,16 +151,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class ComplexQuadrilateral.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class ComplexQuadrilateral: quadrilateralType.");
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ComplexQuadrilateral.", nameof(shapeType));
+                throw new JsonException("Property is required for class ComplexQuadrilateral: shapeType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class ComplexQuadrilateral.");
+                throw new JsonException("Property is not nullable for class ComplexQuadrilateral: quadrilateralType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ComplexQuadrilateral.");
+                throw new JsonException("Property is not nullable for class ComplexQuadrilateral: shapeType.");
 
             return new ComplexQuadrilateral(quadrilateralType.Value, shapeType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/CopyActivity.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/CopyActivity.cs
@@ -134,16 +134,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!copyActivitytt.IsSet)
-                throw new ArgumentException("Property is required for class CopyActivity.", nameof(copyActivitytt));
+                throw new JsonException("Property is required for class CopyActivity: copyActivitytt.");
 
             if (!schema.IsSet)
-                throw new ArgumentException("Property is required for class CopyActivity.", nameof(schema));
+                throw new JsonException("Property is required for class CopyActivity: $schema.");
 
             if (copyActivitytt.IsSet && copyActivitytt.Value == null)
-                throw new ArgumentNullException(nameof(copyActivitytt), "Property is not nullable for class CopyActivity.");
+                throw new JsonException("Property is not nullable for class CopyActivity: copyActivitytt.");
 
             if (schema.IsSet && schema.Value == null)
-                throw new ArgumentNullException(nameof(schema), "Property is not nullable for class CopyActivity.");
+                throw new JsonException("Property is not nullable for class CopyActivity: $schema.");
 
             return new CopyActivity(copyActivitytt.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/DanishPig.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/DanishPig.cs
@@ -138,10 +138,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class DanishPig.", nameof(className));
+                throw new JsonException("Property is required for class DanishPig: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class DanishPig.");
+                throw new JsonException("Property is not nullable for class DanishPig: className.");
 
             return new DanishPig(className.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -151,7 +151,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (dateOnlyProperty.IsSet && dateOnlyProperty.Value == null)
-                throw new ArgumentNullException(nameof(dateOnlyProperty), "Property is not nullable for class DateOnlyClass.");
+                throw new JsonException("Property is not nullable for class DateOnlyClass: dateOnlyProperty.");
 
             return new DateOnlyClass(dateOnlyProperty);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class DeprecatedObject.");
+                throw new JsonException("Property is not nullable for class DeprecatedObject: name.");
 
             return new DeprecatedObject(name);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Descendant1.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Descendant1.cs
@@ -131,22 +131,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!alternativeName.IsSet)
-                throw new ArgumentException("Property is required for class Descendant1.", nameof(alternativeName));
+                throw new JsonException("Property is required for class Descendant1: alternativeName.");
 
             if (!descendantName.IsSet)
-                throw new ArgumentException("Property is required for class Descendant1.", nameof(descendantName));
+                throw new JsonException("Property is required for class Descendant1: descendantName.");
 
             if (!objectType.IsSet)
-                throw new ArgumentException("Property is required for class Descendant1.", nameof(objectType));
+                throw new JsonException("Property is required for class Descendant1: objectType.");
 
             if (alternativeName.IsSet && alternativeName.Value == null)
-                throw new ArgumentNullException(nameof(alternativeName), "Property is not nullable for class Descendant1.");
+                throw new JsonException("Property is not nullable for class Descendant1: alternativeName.");
 
             if (descendantName.IsSet && descendantName.Value == null)
-                throw new ArgumentNullException(nameof(descendantName), "Property is not nullable for class Descendant1.");
+                throw new JsonException("Property is not nullable for class Descendant1: descendantName.");
 
             if (objectType.IsSet && objectType.Value == null)
-                throw new ArgumentNullException(nameof(objectType), "Property is not nullable for class Descendant1.");
+                throw new JsonException("Property is not nullable for class Descendant1: objectType.");
 
             return new Descendant1(alternativeName.Value, descendantName.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Descendant2.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Descendant2.cs
@@ -131,22 +131,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!alternativeName.IsSet)
-                throw new ArgumentException("Property is required for class Descendant2.", nameof(alternativeName));
+                throw new JsonException("Property is required for class Descendant2: alternativeName.");
 
             if (!confidentiality.IsSet)
-                throw new ArgumentException("Property is required for class Descendant2.", nameof(confidentiality));
+                throw new JsonException("Property is required for class Descendant2: confidentiality.");
 
             if (!objectType.IsSet)
-                throw new ArgumentException("Property is required for class Descendant2.", nameof(objectType));
+                throw new JsonException("Property is required for class Descendant2: objectType.");
 
             if (alternativeName.IsSet && alternativeName.Value == null)
-                throw new ArgumentNullException(nameof(alternativeName), "Property is not nullable for class Descendant2.");
+                throw new JsonException("Property is not nullable for class Descendant2: alternativeName.");
 
             if (confidentiality.IsSet && confidentiality.Value == null)
-                throw new ArgumentNullException(nameof(confidentiality), "Property is not nullable for class Descendant2.");
+                throw new JsonException("Property is not nullable for class Descendant2: confidentiality.");
 
             if (objectType.IsSet && objectType.Value == null)
-                throw new ArgumentNullException(nameof(objectType), "Property is not nullable for class Descendant2.");
+                throw new JsonException("Property is not nullable for class Descendant2: objectType.");
 
             return new Descendant2(alternativeName.Value, confidentiality.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Dog.cs
@@ -138,16 +138,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Dog.", nameof(className));
+                throw new JsonException("Property is required for class Dog: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Dog.");
+                throw new JsonException("Property is not nullable for class Dog: className.");
 
             if (breed.IsSet && breed.Value == null)
-                throw new ArgumentNullException(nameof(breed), "Property is not nullable for class Dog.");
+                throw new JsonException("Property is not nullable for class Dog: breed.");
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Dog.");
+                throw new JsonException("Property is not nullable for class Dog: color.");
 
             return new Dog(breed, color);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Drawing.cs
@@ -205,10 +205,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (mainShape.IsSet && mainShape.Value == null)
-                throw new ArgumentNullException(nameof(mainShape), "Property is not nullable for class Drawing.");
+                throw new JsonException("Property is not nullable for class Drawing: mainShape.");
 
             if (shapes.IsSet && shapes.Value == null)
-                throw new ArgumentNullException(nameof(shapes), "Property is not nullable for class Drawing.");
+                throw new JsonException("Property is not nullable for class Drawing: shapes.");
 
             return new Drawing(mainShape, nullableShape, shapeOrNull, shapes);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/EntityBase.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/EntityBase.cs
@@ -152,10 +152,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!schema.IsSet)
-                throw new ArgumentException("Property is required for class EntityBase.", nameof(schema));
+                throw new JsonException("Property is required for class EntityBase: $schema.");
 
             if (schema.IsSet && schema.Value == null)
-                throw new ArgumentNullException(nameof(schema), "Property is not nullable for class EntityBase.");
+                throw new JsonException("Property is not nullable for class EntityBase: $schema.");
 
             return new EntityBase();
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayEnum.IsSet && arrayEnum.Value == null)
-                throw new ArgumentNullException(nameof(arrayEnum), "Property is not nullable for class EnumArrays.");
+                throw new JsonException("Property is not nullable for class EnumArrays: array_enum.");
 
             if (justSymbol.IsSet && justSymbol.Value == null)
-                throw new ArgumentNullException(nameof(justSymbol), "Property is not nullable for class EnumArrays.");
+                throw new JsonException("Property is not nullable for class EnumArrays: just_symbol.");
 
             return new EnumArrays(arrayEnum, justSymbol);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -298,31 +298,31 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!enumStringRequired.IsSet)
-                throw new ArgumentException("Property is required for class EnumTest.", nameof(enumStringRequired));
+                throw new JsonException("Property is required for class EnumTest: enum_string_required.");
 
             if (enumStringRequired.IsSet && enumStringRequired.Value == null)
-                throw new ArgumentNullException(nameof(enumStringRequired), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_string_required.");
 
             if (enumInteger.IsSet && enumInteger.Value == null)
-                throw new ArgumentNullException(nameof(enumInteger), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_integer.");
 
             if (enumIntegerOnly.IsSet && enumIntegerOnly.Value == null)
-                throw new ArgumentNullException(nameof(enumIntegerOnly), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_integer_only.");
 
             if (enumNumber.IsSet && enumNumber.Value == null)
-                throw new ArgumentNullException(nameof(enumNumber), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_number.");
 
             if (enumString.IsSet && enumString.Value == null)
-                throw new ArgumentNullException(nameof(enumString), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_string.");
 
             if (outerEnumDefaultValue.IsSet && outerEnumDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(outerEnumDefaultValue), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: outerEnumDefaultValue.");
 
             if (outerEnumInteger.IsSet && outerEnumInteger.Value == null)
-                throw new ArgumentNullException(nameof(outerEnumInteger), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: outerEnumInteger.");
 
             if (outerEnumIntegerDefaultValue.IsSet && outerEnumIntegerDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(outerEnumIntegerDefaultValue), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: outerEnumIntegerDefaultValue.");
 
             return new EnumTest(enumStringRequired.Value.Value, enumInteger, enumIntegerOnly, enumNumber, enumString, outerEnum, outerEnumDefaultValue, outerEnumInteger, outerEnumIntegerDefaultValue);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
@@ -151,16 +151,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class EquilateralTriangle.", nameof(shapeType));
+                throw new JsonException("Property is required for class EquilateralTriangle: shapeType.");
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class EquilateralTriangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class EquilateralTriangle: triangleType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class EquilateralTriangle.");
+                throw new JsonException("Property is not nullable for class EquilateralTriangle: shapeType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class EquilateralTriangle.");
+                throw new JsonException("Property is not nullable for class EquilateralTriangle: triangleType.");
 
             return new EquilateralTriangle(shapeType.Value, triangleType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/File.cs
@@ -146,7 +146,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (sourceURI.IsSet && sourceURI.Value == null)
-                throw new ArgumentNullException(nameof(sourceURI), "Property is not nullable for class File.");
+                throw new JsonException("Property is not nullable for class File: sourceURI.");
 
             return new File(sourceURI);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (file.IsSet && file.Value == null)
-                throw new ArgumentNullException(nameof(file), "Property is not nullable for class FileSchemaTestClass.");
+                throw new JsonException("Property is not nullable for class FileSchemaTestClass: file.");
 
             if (files.IsSet && files.Value == null)
-                throw new ArgumentNullException(nameof(files), "Property is not nullable for class FileSchemaTestClass.");
+                throw new JsonException("Property is not nullable for class FileSchemaTestClass: files.");
 
             return new FileSchemaTestClass(file, files);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Foo.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bar.IsSet && bar.Value == null)
-                throw new ArgumentNullException(nameof(bar), "Property is not nullable for class Foo.");
+                throw new JsonException("Property is not nullable for class Foo: bar.");
 
             return new Foo(bar);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varString.IsSet && varString.Value == null)
-                throw new ArgumentNullException(nameof(varString), "Property is not nullable for class FooGetDefaultResponse.");
+                throw new JsonException("Property is not nullable for class FooGetDefaultResponse: string.");
 
             return new FooGetDefaultResponse(varString);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -826,103 +826,103 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!varByte.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(varByte));
+                throw new JsonException("Property is required for class FormatTest: byte.");
 
             if (!date.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(date));
+                throw new JsonException("Property is required for class FormatTest: date.");
 
             if (!number.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(number));
+                throw new JsonException("Property is required for class FormatTest: number.");
 
             if (!password.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(password));
+                throw new JsonException("Property is required for class FormatTest: password.");
 
             if (!stringFormattedAsDecimalRequired.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(stringFormattedAsDecimalRequired));
+                throw new JsonException("Property is required for class FormatTest: string_formatted_as_decimal_required.");
 
             if (varByte.IsSet && varByte.Value == null)
-                throw new ArgumentNullException(nameof(varByte), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: byte.");
 
             if (date.IsSet && date.Value == null)
-                throw new ArgumentNullException(nameof(date), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: date.");
 
             if (number.IsSet && number.Value == null)
-                throw new ArgumentNullException(nameof(number), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: number.");
 
             if (password.IsSet && password.Value == null)
-                throw new ArgumentNullException(nameof(password), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: password.");
 
             if (stringFormattedAsDecimalRequired.IsSet && stringFormattedAsDecimalRequired.Value == null)
-                throw new ArgumentNullException(nameof(stringFormattedAsDecimalRequired), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: string_formatted_as_decimal_required.");
 
             if (binary.IsSet && binary.Value == null)
-                throw new ArgumentNullException(nameof(binary), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: binary.");
 
             if (dateTime.IsSet && dateTime.Value == null)
-                throw new ArgumentNullException(nameof(dateTime), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: dateTime.");
 
             if (varDecimal.IsSet && varDecimal.Value == null)
-                throw new ArgumentNullException(nameof(varDecimal), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: decimal.");
 
             if (varDouble.IsSet && varDouble.Value == null)
-                throw new ArgumentNullException(nameof(varDouble), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: double.");
 
             if (duplicatePropertyName2.IsSet && duplicatePropertyName2.Value == null)
-                throw new ArgumentNullException(nameof(duplicatePropertyName2), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: duplicate_property_name.");
 
             if (duplicatePropertyName.IsSet && duplicatePropertyName.Value == null)
-                throw new ArgumentNullException(nameof(duplicatePropertyName), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: @duplicate_property_name.");
 
             if (varFloat.IsSet && varFloat.Value == null)
-                throw new ArgumentNullException(nameof(varFloat), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: float.");
 
             if (int32.IsSet && int32.Value == null)
-                throw new ArgumentNullException(nameof(int32), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int32.");
 
             if (int32Range.IsSet && int32Range.Value == null)
-                throw new ArgumentNullException(nameof(int32Range), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int32Range.");
 
             if (int64.IsSet && int64.Value == null)
-                throw new ArgumentNullException(nameof(int64), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64.");
 
             if (int64Negative.IsSet && int64Negative.Value == null)
-                throw new ArgumentNullException(nameof(int64Negative), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64Negative.");
 
             if (int64NegativeExclusive.IsSet && int64NegativeExclusive.Value == null)
-                throw new ArgumentNullException(nameof(int64NegativeExclusive), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64NegativeExclusive.");
 
             if (int64Positive.IsSet && int64Positive.Value == null)
-                throw new ArgumentNullException(nameof(int64Positive), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64Positive.");
 
             if (int64PositiveExclusive.IsSet && int64PositiveExclusive.Value == null)
-                throw new ArgumentNullException(nameof(int64PositiveExclusive), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64PositiveExclusive.");
 
             if (integer.IsSet && integer.Value == null)
-                throw new ArgumentNullException(nameof(integer), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: integer.");
 
             if (patternWithBackslash.IsSet && patternWithBackslash.Value == null)
-                throw new ArgumentNullException(nameof(patternWithBackslash), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: pattern_with_backslash.");
 
             if (patternWithDigits.IsSet && patternWithDigits.Value == null)
-                throw new ArgumentNullException(nameof(patternWithDigits), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: pattern_with_digits.");
 
             if (patternWithDigitsAndDelimiter.IsSet && patternWithDigitsAndDelimiter.Value == null)
-                throw new ArgumentNullException(nameof(patternWithDigitsAndDelimiter), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: pattern_with_digits_and_delimiter.");
 
             if (varString.IsSet && varString.Value == null)
-                throw new ArgumentNullException(nameof(varString), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: string.");
 
             if (stringFormattedAsDecimal.IsSet && stringFormattedAsDecimal.Value == null)
-                throw new ArgumentNullException(nameof(stringFormattedAsDecimal), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: string_formatted_as_decimal.");
 
             if (unsignedInteger.IsSet && unsignedInteger.Value == null)
-                throw new ArgumentNullException(nameof(unsignedInteger), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: unsigned_integer.");
 
             if (unsignedLong.IsSet && unsignedLong.Value == null)
-                throw new ArgumentNullException(nameof(unsignedLong), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: unsigned_long.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: uuid.");
 
             return new FormatTest(varByte.Value, date.Value.Value, number.Value.Value, password.Value, stringFormattedAsDecimalRequired.Value.Value, binary, dateTime, varDecimal, varDouble, duplicatePropertyName2, duplicatePropertyName, varFloat, int32, int32Range, int64, int64Negative, int64NegativeExclusive, int64Positive, int64PositiveExclusive, integer, patternWithBackslash, patternWithDigits, patternWithDigitsAndDelimiter, varString, stringFormattedAsDecimal, unsignedInteger, unsignedLong, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Fruit.cs
@@ -183,7 +183,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Fruit.");
+                throw new JsonException("Property is not nullable for class Fruit: color.");
 
             if (apple != null)
                 return new Fruit(apple, color);

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -187,7 +187,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class GmFruit.");
+                throw new JsonException("Property is not nullable for class GmFruit: color.");
 
             Option<Apple> appleParsedValue = apple == null
                 ? default

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
@@ -155,10 +155,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!petType.IsSet)
-                throw new ArgumentException("Property is required for class GrandparentAnimal.", nameof(petType));
+                throw new JsonException("Property is required for class GrandparentAnimal: pet_type.");
 
             if (petType.IsSet && petType.Value == null)
-                throw new ArgumentNullException(nameof(petType), "Property is not nullable for class GrandparentAnimal.");
+                throw new JsonException("Property is not nullable for class GrandparentAnimal: pet_type.");
 
             return new GrandparentAnimal();
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -206,10 +206,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bar.IsSet && bar.Value == null)
-                throw new ArgumentNullException(nameof(bar), "Property is not nullable for class HasOnlyReadOnly.");
+                throw new JsonException("Property is not nullable for class HasOnlyReadOnly: bar.");
 
             if (foo.IsSet && foo.Value == null)
-                throw new ArgumentNullException(nameof(foo), "Property is not nullable for class HasOnlyReadOnly.");
+                throw new JsonException("Property is not nullable for class HasOnlyReadOnly: foo.");
 
             return new HasOnlyReadOnly(bar, foo);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
@@ -292,22 +292,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (potentiallyOverriddenPropertyAccessor.IsSet && potentiallyOverriddenPropertyAccessor.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyAccessor), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyAccessor.");
 
             if (potentiallyOverriddenPropertyToInternal.IsSet && potentiallyOverriddenPropertyToInternal.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyToInternal), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyToInternal.");
 
             if (potentiallyOverriddenPropertyToPrivate.IsSet && potentiallyOverriddenPropertyToPrivate.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyToPrivate), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyToPrivate.");
 
             if (potentiallyOverriddenPropertyToPublic.IsSet && potentiallyOverriddenPropertyToPublic.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyToPublic), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyToPublic.");
 
             if (unalteredProperty.IsSet && unalteredProperty.Value == null)
-                throw new ArgumentNullException(nameof(unalteredProperty), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: unalteredProperty.");
 
             if (unalteredPropertyAccessor.IsSet && unalteredPropertyAccessor.Value == null)
-                throw new ArgumentNullException(nameof(unalteredPropertyAccessor), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: unalteredPropertyAccessor.");
 
             return new InjectedVendorExtensionsTest(potentiallyOverriddenPropertyAccessor, potentiallyOverriddenPropertyToInternal, potentiallyOverriddenPropertyToPrivate, potentiallyOverriddenPropertyToPublic, unalteredProperty, unalteredPropertyAccessor);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
@@ -144,16 +144,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class IsoscelesTriangle.", nameof(shapeType));
+                throw new JsonException("Property is required for class IsoscelesTriangle: shapeType.");
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class IsoscelesTriangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class IsoscelesTriangle: triangleType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class IsoscelesTriangle.");
+                throw new JsonException("Property is not nullable for class IsoscelesTriangle: shapeType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class IsoscelesTriangle.");
+                throw new JsonException("Property is not nullable for class IsoscelesTriangle: triangleType.");
 
             return new IsoscelesTriangle(shapeType.Value, triangleType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/List.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (var123List.IsSet && var123List.Value == null)
-                throw new ArgumentNullException(nameof(var123List), "Property is not nullable for class List.");
+                throw new JsonException("Property is not nullable for class List: 123-list.");
 
             return new List(var123List);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (escapedLiteralString.IsSet && escapedLiteralString.Value == null)
-                throw new ArgumentNullException(nameof(escapedLiteralString), "Property is not nullable for class LiteralStringClass.");
+                throw new JsonException("Property is not nullable for class LiteralStringClass: escapedLiteralString.");
 
             if (unescapedLiteralString.IsSet && unescapedLiteralString.Value == null)
-                throw new ArgumentNullException(nameof(unescapedLiteralString), "Property is not nullable for class LiteralStringClass.");
+                throw new JsonException("Property is not nullable for class LiteralStringClass: unescapedLiteralString.");
 
             return new LiteralStringClass(escapedLiteralString, unescapedLiteralString);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Mammal.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Mammal.cs
@@ -214,10 +214,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Mammal.", nameof(className));
+                throw new JsonException("Property is required for class Mammal: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Mammal.");
+                throw new JsonException("Property is not nullable for class Mammal: className.");
 
             if (pig != null)
                 return new Mammal(pig);

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/MapTest.cs
@@ -205,16 +205,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (directMap.IsSet && directMap.Value == null)
-                throw new ArgumentNullException(nameof(directMap), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: direct_map.");
 
             if (indirectMap.IsSet && indirectMap.Value == null)
-                throw new ArgumentNullException(nameof(indirectMap), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: indirect_map.");
 
             if (mapMapOfString.IsSet && mapMapOfString.Value == null)
-                throw new ArgumentNullException(nameof(mapMapOfString), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: map_map_of_string.");
 
             if (mapOfEnumString.IsSet && mapOfEnumString.Value == null)
-                throw new ArgumentNullException(nameof(mapOfEnumString), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: map_of_enum_string.");
 
             return new MapTest(directMap, indirectMap, mapMapOfString, mapOfEnumString);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/MixedAnyOf.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/MixedAnyOf.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (content.IsSet && content.Value == null)
-                throw new ArgumentNullException(nameof(content), "Property is not nullable for class MixedAnyOf.");
+                throw new JsonException("Property is not nullable for class MixedAnyOf: content.");
 
             return new MixedAnyOf(content);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/MixedOneOf.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/MixedOneOf.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (content.IsSet && content.Value == null)
-                throw new ArgumentNullException(nameof(content), "Property is not nullable for class MixedOneOf.");
+                throw new JsonException("Property is not nullable for class MixedOneOf: content.");
 
             return new MixedOneOf(content);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -217,16 +217,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (dateTime.IsSet && dateTime.Value == null)
-                throw new ArgumentNullException(nameof(dateTime), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: dateTime.");
 
             if (map.IsSet && map.Value == null)
-                throw new ArgumentNullException(nameof(map), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: map.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: uuid.");
 
             if (uuidWithPattern.IsSet && uuidWithPattern.Value == null)
-                throw new ArgumentNullException(nameof(uuidWithPattern), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: uuid_with_pattern.");
 
             return new MixedPropertiesAndAdditionalPropertiesClass(dateTime, map, uuid, uuidWithPattern);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/MixedSubId.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/MixedSubId.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class MixedSubId.");
+                throw new JsonException("Property is not nullable for class MixedSubId: id.");
 
             return new MixedSubId(id);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varClass.IsSet && varClass.Value == null)
-                throw new ArgumentNullException(nameof(varClass), "Property is not nullable for class Model200Response.");
+                throw new JsonException("Property is not nullable for class Model200Response: class.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Model200Response.");
+                throw new JsonException("Property is not nullable for class Model200Response: name.");
 
             return new Model200Response(varClass, name);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varClient.IsSet && varClient.Value == null)
-                throw new ArgumentNullException(nameof(varClient), "Property is not nullable for class ModelClient.");
+                throw new JsonException("Property is not nullable for class ModelClient: client.");
 
             return new ModelClient(varClient);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Name.cs
@@ -239,19 +239,19 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!varName.IsSet)
-                throw new ArgumentException("Property is required for class Name.", nameof(varName));
+                throw new JsonException("Property is required for class Name: name.");
 
             if (varName.IsSet && varName.Value == null)
-                throw new ArgumentNullException(nameof(varName), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: name.");
 
             if (property.IsSet && property.Value == null)
-                throw new ArgumentNullException(nameof(property), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: property.");
 
             if (snakeCase.IsSet && snakeCase.Value == null)
-                throw new ArgumentNullException(nameof(snakeCase), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: snake_case.");
 
             if (var123Number.IsSet && var123Number.Value == null)
-                throw new ArgumentNullException(nameof(var123Number), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: 123Number.");
 
             return new Name(varName.Value.Value, property, snakeCase, var123Number);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
@@ -151,16 +151,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!aObjVariableobject.IsSet)
-                throw new ArgumentException("Property is required for class NotificationtestGetElementsV1ResponseMPayload.", nameof(aObjVariableobject));
+                throw new JsonException("Property is required for class NotificationtestGetElementsV1ResponseMPayload: a_objVariableobject.");
 
             if (!pkiNotificationtestID.IsSet)
-                throw new ArgumentException("Property is required for class NotificationtestGetElementsV1ResponseMPayload.", nameof(pkiNotificationtestID));
+                throw new JsonException("Property is required for class NotificationtestGetElementsV1ResponseMPayload: pkiNotificationtestID.");
 
             if (aObjVariableobject.IsSet && aObjVariableobject.Value == null)
-                throw new ArgumentNullException(nameof(aObjVariableobject), "Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload.");
+                throw new JsonException("Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload: a_objVariableobject.");
 
             if (pkiNotificationtestID.IsSet && pkiNotificationtestID.Value == null)
-                throw new ArgumentNullException(nameof(pkiNotificationtestID), "Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload.");
+                throw new JsonException("Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload: pkiNotificationtestID.");
 
             return new NotificationtestGetElementsV1ResponseMPayload(aObjVariableobject.Value, pkiNotificationtestID.Value.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -375,10 +375,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayItemsNullable.IsSet && arrayItemsNullable.Value == null)
-                throw new ArgumentNullException(nameof(arrayItemsNullable), "Property is not nullable for class NullableClass.");
+                throw new JsonException("Property is not nullable for class NullableClass: array_items_nullable.");
 
             if (objectItemsNullable.IsSet && objectItemsNullable.Value == null)
-                throw new ArgumentNullException(nameof(objectItemsNullable), "Property is not nullable for class NullableClass.");
+                throw new JsonException("Property is not nullable for class NullableClass: object_items_nullable.");
 
             return new NullableClass(arrayAndItemsNullableProp, arrayItemsNullable, arrayNullableProp, booleanProp, dateProp, datetimeProp, integerProp, numberProp, objectAndItemsNullableProp, objectItemsNullable, objectNullableProp, stringProp);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/NullableShape.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/NullableShape.cs
@@ -193,10 +193,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class NullableShape.", nameof(shapeType));
+                throw new JsonException("Property is required for class NullableShape: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class NullableShape.");
+                throw new JsonException("Property is not nullable for class NullableShape: shapeType.");
 
             if (quadrilateral != null)
                 return new NullableShape(quadrilateral);

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (justNumber.IsSet && justNumber.Value == null)
-                throw new ArgumentNullException(nameof(justNumber), "Property is not nullable for class NumberOnly.");
+                throw new JsonException("Property is not nullable for class NumberOnly: JustNumber.");
 
             return new NumberOnly(justNumber);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -208,16 +208,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bars.IsSet && bars.Value == null)
-                throw new ArgumentNullException(nameof(bars), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: bars.");
 
             if (deprecatedRef.IsSet && deprecatedRef.Value == null)
-                throw new ArgumentNullException(nameof(deprecatedRef), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: deprecatedRef.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: id.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: uuid.");
 
             return new ObjectWithDeprecatedFields(bars, deprecatedRef, id, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Order.cs
@@ -251,22 +251,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (complete.IsSet && complete.Value == null)
-                throw new ArgumentNullException(nameof(complete), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: complete.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: id.");
 
             if (petId.IsSet && petId.Value == null)
-                throw new ArgumentNullException(nameof(petId), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: petId.");
 
             if (quantity.IsSet && quantity.Value == null)
-                throw new ArgumentNullException(nameof(quantity), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: quantity.");
 
             if (shipDate.IsSet && shipDate.Value == null)
-                throw new ArgumentNullException(nameof(shipDate), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: shipDate.");
 
             if (status.IsSet && status.Value == null)
-                throw new ArgumentNullException(nameof(status), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: status.");
 
             return new Order(complete, id, petId, quantity, shipDate, status);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -185,13 +185,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (myBoolean.IsSet && myBoolean.Value == null)
-                throw new ArgumentNullException(nameof(myBoolean), "Property is not nullable for class OuterComposite.");
+                throw new JsonException("Property is not nullable for class OuterComposite: my_boolean.");
 
             if (myNumber.IsSet && myNumber.Value == null)
-                throw new ArgumentNullException(nameof(myNumber), "Property is not nullable for class OuterComposite.");
+                throw new JsonException("Property is not nullable for class OuterComposite: my_number.");
 
             if (myString.IsSet && myString.Value == null)
-                throw new ArgumentNullException(nameof(myString), "Property is not nullable for class OuterComposite.");
+                throw new JsonException("Property is not nullable for class OuterComposite: my_string.");
 
             return new OuterComposite(myBoolean, myNumber, myString);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ParentPet.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ParentPet.cs
@@ -118,10 +118,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!petType.IsSet)
-                throw new ArgumentException("Property is required for class ParentPet.", nameof(petType));
+                throw new JsonException("Property is required for class ParentPet: pet_type.");
 
             if (petType.IsSet && petType.Value == null)
-                throw new ArgumentNullException(nameof(petType), "Property is not nullable for class ParentPet.");
+                throw new JsonException("Property is not nullable for class ParentPet: pet_type.");
 
             return new ParentPet();
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Pet.cs
@@ -232,28 +232,28 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!name.IsSet)
-                throw new ArgumentException("Property is required for class Pet.", nameof(name));
+                throw new JsonException("Property is required for class Pet: name.");
 
             if (!photoUrls.IsSet)
-                throw new ArgumentException("Property is required for class Pet.", nameof(photoUrls));
+                throw new JsonException("Property is required for class Pet: photoUrls.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: name.");
 
             if (photoUrls.IsSet && photoUrls.Value == null)
-                throw new ArgumentNullException(nameof(photoUrls), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: photoUrls.");
 
             if (category.IsSet && category.Value == null)
-                throw new ArgumentNullException(nameof(category), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: category.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: id.");
 
             if (status.IsSet && status.Value == null)
-                throw new ArgumentNullException(nameof(status), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: status.");
 
             if (tags.IsSet && tags.Value == null)
-                throw new ArgumentNullException(nameof(tags), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: tags.");
 
             return new Pet(name.Value, photoUrls.Value, category, id, status, tags);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Pig.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Pig.cs
@@ -193,10 +193,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Pig.", nameof(className));
+                throw new JsonException("Property is required for class Pig: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Pig.");
+                throw new JsonException("Property is not nullable for class Pig: className.");
 
             if (basquePig != null)
                 return new Pig(basquePig);

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Quadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Quadrilateral.cs
@@ -193,10 +193,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class Quadrilateral.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class Quadrilateral: quadrilateralType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class Quadrilateral.");
+                throw new JsonException("Property is not nullable for class Quadrilateral: quadrilateralType.");
 
             if (complexQuadrilateral != null)
                 return new Quadrilateral(complexQuadrilateral);

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
@@ -138,10 +138,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class QuadrilateralInterface.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class QuadrilateralInterface: quadrilateralType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class QuadrilateralInterface.");
+                throw new JsonException("Property is not nullable for class QuadrilateralInterface: quadrilateralType.");
 
             return new QuadrilateralInterface(quadrilateralType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -203,10 +203,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bar.IsSet && bar.Value == null)
-                throw new ArgumentNullException(nameof(bar), "Property is not nullable for class ReadOnlyFirst.");
+                throw new JsonException("Property is not nullable for class ReadOnlyFirst: bar.");
 
             if (baz.IsSet && baz.Value == null)
-                throw new ArgumentNullException(nameof(baz), "Property is not nullable for class ReadOnlyFirst.");
+                throw new JsonException("Property is not nullable for class ReadOnlyFirst: baz.");
 
             return new ReadOnlyFirst(bar, baz);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -895,136 +895,136 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!requiredNotNullableDateProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotNullableDateProp));
+                throw new JsonException("Property is required for class RequiredClass: required_not_nullable_date_prop.");
 
             if (!requiredNotnullableArrayOfString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableArrayOfString));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_array_of_string.");
 
             if (!requiredNotnullableBooleanProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableBooleanProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_boolean_prop.");
 
             if (!requiredNotnullableDatetimeProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableDatetimeProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_datetime_prop.");
 
             if (!requiredNotnullableEnumInteger.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableEnumInteger));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_enum_integer.");
 
             if (!requiredNotnullableEnumIntegerOnly.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableEnumIntegerOnly));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_enum_integer_only.");
 
             if (!requiredNotnullableEnumString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableEnumString));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_enum_string.");
 
             if (!requiredNotnullableOuterEnumDefaultValue.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableOuterEnumDefaultValue));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_outerEnumDefaultValue.");
 
             if (!requiredNotnullableStringProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableStringProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_string_prop.");
 
             if (!requiredNotnullableUuid.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableUuid));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_uuid.");
 
             if (!requiredNotnullableintegerProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableintegerProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullableinteger_prop.");
 
             if (!requiredNullableArrayOfString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableArrayOfString));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_array_of_string.");
 
             if (!requiredNullableBooleanProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableBooleanProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_boolean_prop.");
 
             if (!requiredNullableDateProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableDateProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_date_prop.");
 
             if (!requiredNullableDatetimeProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableDatetimeProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_datetime_prop.");
 
             if (!requiredNullableEnumInteger.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableEnumInteger));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_enum_integer.");
 
             if (!requiredNullableEnumIntegerOnly.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableEnumIntegerOnly));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_enum_integer_only.");
 
             if (!requiredNullableEnumString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableEnumString));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_enum_string.");
 
             if (!requiredNullableIntegerProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableIntegerProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_integer_prop.");
 
             if (!requiredNullableOuterEnumDefaultValue.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableOuterEnumDefaultValue));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_outerEnumDefaultValue.");
 
             if (!requiredNullableStringProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableStringProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_string_prop.");
 
             if (!requiredNullableUuid.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableUuid));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_uuid.");
 
             if (requiredNotNullableDateProp.IsSet && requiredNotNullableDateProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotNullableDateProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_not_nullable_date_prop.");
 
             if (requiredNotnullableArrayOfString.IsSet && requiredNotnullableArrayOfString.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableArrayOfString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_array_of_string.");
 
             if (requiredNotnullableBooleanProp.IsSet && requiredNotnullableBooleanProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableBooleanProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_boolean_prop.");
 
             if (requiredNotnullableDatetimeProp.IsSet && requiredNotnullableDatetimeProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableDatetimeProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_datetime_prop.");
 
             if (requiredNotnullableEnumInteger.IsSet && requiredNotnullableEnumInteger.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableEnumInteger), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_enum_integer.");
 
             if (requiredNotnullableEnumIntegerOnly.IsSet && requiredNotnullableEnumIntegerOnly.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableEnumIntegerOnly), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_enum_integer_only.");
 
             if (requiredNotnullableEnumString.IsSet && requiredNotnullableEnumString.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableEnumString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_enum_string.");
 
             if (requiredNotnullableOuterEnumDefaultValue.IsSet && requiredNotnullableOuterEnumDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableOuterEnumDefaultValue), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_outerEnumDefaultValue.");
 
             if (requiredNotnullableStringProp.IsSet && requiredNotnullableStringProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableStringProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_string_prop.");
 
             if (requiredNotnullableUuid.IsSet && requiredNotnullableUuid.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableUuid), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_uuid.");
 
             if (requiredNotnullableintegerProp.IsSet && requiredNotnullableintegerProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableintegerProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullableinteger_prop.");
 
             if (notRequiredNotnullableDateProp.IsSet && notRequiredNotnullableDateProp.Value == null)
-                throw new ArgumentNullException(nameof(notRequiredNotnullableDateProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: not_required_notnullable_date_prop.");
 
             if (notRequiredNotnullableintegerProp.IsSet && notRequiredNotnullableintegerProp.Value == null)
-                throw new ArgumentNullException(nameof(notRequiredNotnullableintegerProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: not_required_notnullableinteger_prop.");
 
             if (notrequiredNotnullableArrayOfString.IsSet && notrequiredNotnullableArrayOfString.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableArrayOfString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_array_of_string.");
 
             if (notrequiredNotnullableBooleanProp.IsSet && notrequiredNotnullableBooleanProp.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableBooleanProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_boolean_prop.");
 
             if (notrequiredNotnullableDatetimeProp.IsSet && notrequiredNotnullableDatetimeProp.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableDatetimeProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_datetime_prop.");
 
             if (notrequiredNotnullableEnumInteger.IsSet && notrequiredNotnullableEnumInteger.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableEnumInteger), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_enum_integer.");
 
             if (notrequiredNotnullableEnumIntegerOnly.IsSet && notrequiredNotnullableEnumIntegerOnly.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableEnumIntegerOnly), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_enum_integer_only.");
 
             if (notrequiredNotnullableEnumString.IsSet && notrequiredNotnullableEnumString.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableEnumString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_enum_string.");
 
             if (notrequiredNotnullableOuterEnumDefaultValue.IsSet && notrequiredNotnullableOuterEnumDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableOuterEnumDefaultValue), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_outerEnumDefaultValue.");
 
             if (notrequiredNotnullableStringProp.IsSet && notrequiredNotnullableStringProp.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableStringProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_string_prop.");
 
             if (notrequiredNotnullableUuid.IsSet && notrequiredNotnullableUuid.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableUuid), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_uuid.");
 
             return new RequiredClass(requiredNotNullableDateProp.Value.Value, requiredNotnullableArrayOfString.Value, requiredNotnullableBooleanProp.Value.Value, requiredNotnullableDatetimeProp.Value.Value, requiredNotnullableEnumInteger.Value.Value, requiredNotnullableEnumIntegerOnly.Value.Value, requiredNotnullableEnumString.Value.Value, requiredNotnullableOuterEnumDefaultValue.Value.Value, requiredNotnullableStringProp.Value, requiredNotnullableUuid.Value.Value, requiredNotnullableintegerProp.Value.Value, notRequiredNotnullableDateProp, notRequiredNotnullableintegerProp, notRequiredNullableDateProp, notRequiredNullableIntegerProp, notrequiredNotnullableArrayOfString, notrequiredNotnullableBooleanProp, notrequiredNotnullableDatetimeProp, notrequiredNotnullableEnumInteger, notrequiredNotnullableEnumIntegerOnly, notrequiredNotnullableEnumString, notrequiredNotnullableOuterEnumDefaultValue, notrequiredNotnullableStringProp, notrequiredNotnullableUuid, notrequiredNullableArrayOfString, notrequiredNullableBooleanProp, notrequiredNullableDatetimeProp, notrequiredNullableEnumInteger, notrequiredNullableEnumIntegerOnly, notrequiredNullableEnumString, notrequiredNullableOuterEnumDefaultValue, notrequiredNullableStringProp, notrequiredNullableUuid, requiredNullableArrayOfString.Value, requiredNullableBooleanProp.Value, requiredNullableDateProp.Value, requiredNullableDatetimeProp.Value, requiredNullableEnumInteger.Value, requiredNullableEnumIntegerOnly.Value, requiredNullableEnumString.Value, requiredNullableIntegerProp.Value, requiredNullableOuterEnumDefaultValue.Value, requiredNullableStringProp.Value, requiredNullableUuid.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Result.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Result.cs
@@ -188,13 +188,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (code.IsSet && code.Value == null)
-                throw new ArgumentNullException(nameof(code), "Property is not nullable for class Result.");
+                throw new JsonException("Property is not nullable for class Result: code.");
 
             if (data.IsSet && data.Value == null)
-                throw new ArgumentNullException(nameof(data), "Property is not nullable for class Result.");
+                throw new JsonException("Property is not nullable for class Result: data.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class Result.");
+                throw new JsonException("Property is not nullable for class Result: uuid.");
 
             return new Result(code, data, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Return.cs
@@ -191,19 +191,19 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!varLock.IsSet)
-                throw new ArgumentException("Property is required for class Return.", nameof(varLock));
+                throw new JsonException("Property is required for class Return: lock.");
 
             if (!varAbstract.IsSet)
-                throw new ArgumentException("Property is required for class Return.", nameof(varAbstract));
+                throw new JsonException("Property is required for class Return: abstract.");
 
             if (varLock.IsSet && varLock.Value == null)
-                throw new ArgumentNullException(nameof(varLock), "Property is not nullable for class Return.");
+                throw new JsonException("Property is not nullable for class Return: lock.");
 
             if (varReturn.IsSet && varReturn.Value == null)
-                throw new ArgumentNullException(nameof(varReturn), "Property is not nullable for class Return.");
+                throw new JsonException("Property is not nullable for class Return: return.");
 
             if (varUnsafe.IsSet && varUnsafe.Value == null)
-                throw new ArgumentNullException(nameof(varUnsafe), "Property is not nullable for class Return.");
+                throw new JsonException("Property is not nullable for class Return: unsafe.");
 
             return new Return(varLock.Value, varAbstract.Value, varReturn, varUnsafe);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (role.IsSet && role.Value == null)
-                throw new ArgumentNullException(nameof(role), "Property is not nullable for class RolesReportsHash.");
+                throw new JsonException("Property is not nullable for class RolesReportsHash: role.");
 
             if (roleUuid.IsSet && roleUuid.Value == null)
-                throw new ArgumentNullException(nameof(roleUuid), "Property is not nullable for class RolesReportsHash.");
+                throw new JsonException("Property is not nullable for class RolesReportsHash: role_uuid.");
 
             return new RolesReportsHash(role, roleUuid);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class RolesReportsHashRole.");
+                throw new JsonException("Property is not nullable for class RolesReportsHashRole: name.");
 
             return new RolesReportsHashRole(name);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
@@ -151,16 +151,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ScaleneTriangle.", nameof(shapeType));
+                throw new JsonException("Property is required for class ScaleneTriangle: shapeType.");
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class ScaleneTriangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class ScaleneTriangle: triangleType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ScaleneTriangle.");
+                throw new JsonException("Property is not nullable for class ScaleneTriangle: shapeType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class ScaleneTriangle.");
+                throw new JsonException("Property is not nullable for class ScaleneTriangle: triangleType.");
 
             return new ScaleneTriangle(shapeType.Value, triangleType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Shape.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Shape.cs
@@ -193,10 +193,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class Shape.", nameof(shapeType));
+                throw new JsonException("Property is required for class Shape: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class Shape.");
+                throw new JsonException("Property is not nullable for class Shape: shapeType.");
 
             if (quadrilateral != null)
                 return new Shape(quadrilateral);

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ShapeInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ShapeInterface.cs
@@ -138,10 +138,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ShapeInterface.", nameof(shapeType));
+                throw new JsonException("Property is required for class ShapeInterface: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ShapeInterface.");
+                throw new JsonException("Property is not nullable for class ShapeInterface: shapeType.");
 
             return new ShapeInterface(shapeType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ShapeOrNull.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ShapeOrNull.cs
@@ -193,10 +193,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ShapeOrNull.", nameof(shapeType));
+                throw new JsonException("Property is required for class ShapeOrNull: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ShapeOrNull.");
+                throw new JsonException("Property is not nullable for class ShapeOrNull: shapeType.");
 
             if (quadrilateral != null)
                 return new ShapeOrNull(quadrilateral);

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
@@ -151,16 +151,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class SimpleQuadrilateral.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class SimpleQuadrilateral: quadrilateralType.");
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class SimpleQuadrilateral.", nameof(shapeType));
+                throw new JsonException("Property is required for class SimpleQuadrilateral: shapeType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class SimpleQuadrilateral.");
+                throw new JsonException("Property is not nullable for class SimpleQuadrilateral: quadrilateralType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class SimpleQuadrilateral.");
+                throw new JsonException("Property is not nullable for class SimpleQuadrilateral: shapeType.");
 
             return new SimpleQuadrilateral(quadrilateralType.Value, shapeType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varSpecialModelName.IsSet && varSpecialModelName.Value == null)
-                throw new ArgumentNullException(nameof(varSpecialModelName), "Property is not nullable for class SpecialModelName.");
+                throw new JsonException("Property is not nullable for class SpecialModelName: _special_model.name_.");
 
             if (specialPropertyName.IsSet && specialPropertyName.Value == null)
-                throw new ArgumentNullException(nameof(specialPropertyName), "Property is not nullable for class SpecialModelName.");
+                throw new JsonException("Property is not nullable for class SpecialModelName: $special[property.name].");
 
             return new SpecialModelName(varSpecialModelName, specialPropertyName);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Tag.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Tag.");
+                throw new JsonException("Property is not nullable for class Tag: id.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Tag.");
+                throw new JsonException("Property is not nullable for class Tag: name.");
 
             return new Tag(id, name);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (value.IsSet && value.Value == null)
-                throw new ArgumentNullException(nameof(value), "Property is not nullable for class TestCollectionEndingWithWordList.");
+                throw new JsonException("Property is not nullable for class TestCollectionEndingWithWordList: value.");
 
             return new TestCollectionEndingWithWordList(value);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (testCollectionEndingWithWordList.IsSet && testCollectionEndingWithWordList.Value == null)
-                throw new ArgumentNullException(nameof(testCollectionEndingWithWordList), "Property is not nullable for class TestCollectionEndingWithWordListObject.");
+                throw new JsonException("Property is not nullable for class TestCollectionEndingWithWordListObject: TestCollectionEndingWithWordList.");
 
             return new TestCollectionEndingWithWordListObject(testCollectionEndingWithWordList);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/TestDescendants.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/TestDescendants.cs
@@ -168,16 +168,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!alternativeName.IsSet)
-                throw new ArgumentException("Property is required for class TestDescendants.", nameof(alternativeName));
+                throw new JsonException("Property is required for class TestDescendants: alternativeName.");
 
             if (!objectType.IsSet)
-                throw new ArgumentException("Property is required for class TestDescendants.", nameof(objectType));
+                throw new JsonException("Property is required for class TestDescendants: objectType.");
 
             if (alternativeName.IsSet && alternativeName.Value == null)
-                throw new ArgumentNullException(nameof(alternativeName), "Property is not nullable for class TestDescendants.");
+                throw new JsonException("Property is not nullable for class TestDescendants: alternativeName.");
 
             if (objectType.IsSet && objectType.Value == null)
-                throw new ArgumentNullException(nameof(objectType), "Property is not nullable for class TestDescendants.");
+                throw new JsonException("Property is not nullable for class TestDescendants: objectType.");
 
             return new TestDescendants(alternativeName.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (someProperty.IsSet && someProperty.Value == null)
-                throw new ArgumentNullException(nameof(someProperty), "Property is not nullable for class TestInlineFreeformAdditionalPropertiesRequest.");
+                throw new JsonException("Property is not nullable for class TestInlineFreeformAdditionalPropertiesRequest: someProperty.");
 
             return new TestInlineFreeformAdditionalPropertiesRequest(someProperty);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/TestResult.cs
@@ -187,13 +187,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (code.IsSet && code.Value == null)
-                throw new ArgumentNullException(nameof(code), "Property is not nullable for class TestResult.");
+                throw new JsonException("Property is not nullable for class TestResult: code.");
 
             if (data.IsSet && data.Value == null)
-                throw new ArgumentNullException(nameof(data), "Property is not nullable for class TestResult.");
+                throw new JsonException("Property is not nullable for class TestResult: data.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class TestResult.");
+                throw new JsonException("Property is not nullable for class TestResult: uuid.");
 
             return new TestResult(code, data, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Triangle.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Triangle.cs
@@ -214,10 +214,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class Triangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class Triangle: triangleType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class Triangle.");
+                throw new JsonException("Property is not nullable for class Triangle: triangleType.");
 
             if (equilateralTriangle != null)
                 return new Triangle(equilateralTriangle);

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/TriangleInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/TriangleInterface.cs
@@ -138,10 +138,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class TriangleInterface.", nameof(triangleType));
+                throw new JsonException("Property is required for class TriangleInterface: triangleType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class TriangleInterface.");
+                throw new JsonException("Property is not nullable for class TriangleInterface: triangleType.");
 
             return new TriangleInterface(triangleType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/User.cs
@@ -370,31 +370,31 @@ namespace Org.OpenAPITools.Model
             }
 
             if (email.IsSet && email.Value == null)
-                throw new ArgumentNullException(nameof(email), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: email.");
 
             if (firstName.IsSet && firstName.Value == null)
-                throw new ArgumentNullException(nameof(firstName), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: firstName.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: id.");
 
             if (lastName.IsSet && lastName.Value == null)
-                throw new ArgumentNullException(nameof(lastName), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: lastName.");
 
             if (objectWithNoDeclaredProps.IsSet && objectWithNoDeclaredProps.Value == null)
-                throw new ArgumentNullException(nameof(objectWithNoDeclaredProps), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: objectWithNoDeclaredProps.");
 
             if (password.IsSet && password.Value == null)
-                throw new ArgumentNullException(nameof(password), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: password.");
 
             if (phone.IsSet && phone.Value == null)
-                throw new ArgumentNullException(nameof(phone), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: phone.");
 
             if (userStatus.IsSet && userStatus.Value == null)
-                throw new ArgumentNullException(nameof(userStatus), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: userStatus.");
 
             if (username.IsSet && username.Value == null)
-                throw new ArgumentNullException(nameof(username), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: username.");
 
             return new User(anyTypeProp, anyTypePropNullable, email, firstName, id, lastName, objectWithNoDeclaredProps, objectWithNoDeclaredPropsNullable, password, phone, userStatus, username);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Whale.cs
@@ -178,16 +178,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Whale.", nameof(className));
+                throw new JsonException("Property is required for class Whale: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Whale.");
+                throw new JsonException("Property is not nullable for class Whale: className.");
 
             if (hasBaleen.IsSet && hasBaleen.Value == null)
-                throw new ArgumentNullException(nameof(hasBaleen), "Property is not nullable for class Whale.");
+                throw new JsonException("Property is not nullable for class Whale: hasBaleen.");
 
             if (hasTeeth.IsSet && hasTeeth.Value == null)
-                throw new ArgumentNullException(nameof(hasTeeth), "Property is not nullable for class Whale.");
+                throw new JsonException("Property is not nullable for class Whale: hasTeeth.");
 
             return new Whale(className.Value, hasBaleen, hasTeeth);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Zebra.cs
@@ -158,13 +158,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Zebra.", nameof(className));
+                throw new JsonException("Property is required for class Zebra: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Zebra.");
+                throw new JsonException("Property is not nullable for class Zebra: className.");
 
             if (type.IsSet && type.Value == null)
-                throw new ArgumentNullException(nameof(type), "Property is not nullable for class Zebra.");
+                throw new JsonException("Property is not nullable for class Zebra: type.");
 
             return new Zebra(className.Value, type);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (zeroBasedEnum.IsSet && zeroBasedEnum.Value == null)
-                throw new ArgumentNullException(nameof(zeroBasedEnum), "Property is not nullable for class ZeroBasedEnumClass.");
+                throw new JsonException("Property is not nullable for class ZeroBasedEnumClass: ZeroBasedEnum.");
 
             return new ZeroBasedEnumClass(zeroBasedEnum);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Activity.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (activityOutputs.IsSet && activityOutputs.Value == null)
-                throw new ArgumentNullException(nameof(activityOutputs), "Property is not nullable for class Activity.");
+                throw new JsonException("Property is not nullable for class Activity: activity_outputs.");
 
             return new Activity(activityOutputs);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -167,10 +167,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (prop1.IsSet && prop1.Value == null)
-                throw new ArgumentNullException(nameof(prop1), "Property is not nullable for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Property is not nullable for class ActivityOutputElementRepresentation: prop1.");
 
             if (prop2.IsSet && prop2.Value == null)
-                throw new ArgumentNullException(nameof(prop2), "Property is not nullable for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Property is not nullable for class ActivityOutputElementRepresentation: prop2.");
 
             return new ActivityOutputElementRepresentation(prop1, prop2);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -288,25 +288,25 @@ namespace Org.OpenAPITools.Model
             }
 
             if (emptyMap.IsSet && emptyMap.Value == null)
-                throw new ArgumentNullException(nameof(emptyMap), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: empty_map.");
 
             if (mapOfMapProperty.IsSet && mapOfMapProperty.Value == null)
-                throw new ArgumentNullException(nameof(mapOfMapProperty), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_of_map_property.");
 
             if (mapProperty.IsSet && mapProperty.Value == null)
-                throw new ArgumentNullException(nameof(mapProperty), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_property.");
 
             if (mapWithUndeclaredPropertiesAnytype1.IsSet && mapWithUndeclaredPropertiesAnytype1.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesAnytype1), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_anytype_1.");
 
             if (mapWithUndeclaredPropertiesAnytype2.IsSet && mapWithUndeclaredPropertiesAnytype2.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesAnytype2), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_anytype_2.");
 
             if (mapWithUndeclaredPropertiesAnytype3.IsSet && mapWithUndeclaredPropertiesAnytype3.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesAnytype3), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_anytype_3.");
 
             if (mapWithUndeclaredPropertiesString.IsSet && mapWithUndeclaredPropertiesString.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesString), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_string.");
 
             return new AdditionalPropertiesClass(anytype1, emptyMap, mapOfMapProperty, mapProperty, mapWithUndeclaredPropertiesAnytype1, mapWithUndeclaredPropertiesAnytype2, mapWithUndeclaredPropertiesAnytype3, mapWithUndeclaredPropertiesString);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Animal.cs
@@ -177,13 +177,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Animal.", nameof(className));
+                throw new JsonException("Property is required for class Animal: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Animal.");
+                throw new JsonException("Property is not nullable for class Animal: className.");
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Animal.");
+                throw new JsonException("Property is not nullable for class Animal: color.");
 
             return new Animal(color);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -187,13 +187,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (code.IsSet && code.Value == null)
-                throw new ArgumentNullException(nameof(code), "Property is not nullable for class ApiResponse.");
+                throw new JsonException("Property is not nullable for class ApiResponse: code.");
 
             if (message.IsSet && message.Value == null)
-                throw new ArgumentNullException(nameof(message), "Property is not nullable for class ApiResponse.");
+                throw new JsonException("Property is not nullable for class ApiResponse: message.");
 
             if (type.IsSet && type.Value == null)
-                throw new ArgumentNullException(nameof(type), "Property is not nullable for class ApiResponse.");
+                throw new JsonException("Property is not nullable for class ApiResponse: type.");
 
             return new ApiResponse(code, message, type);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Apple.cs
@@ -217,13 +217,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (colorCode.IsSet && colorCode.Value == null)
-                throw new ArgumentNullException(nameof(colorCode), "Property is not nullable for class Apple.");
+                throw new JsonException("Property is not nullable for class Apple: color_code.");
 
             if (cultivar.IsSet && cultivar.Value == null)
-                throw new ArgumentNullException(nameof(cultivar), "Property is not nullable for class Apple.");
+                throw new JsonException("Property is not nullable for class Apple: cultivar.");
 
             if (origin.IsSet && origin.Value == null)
-                throw new ArgumentNullException(nameof(origin), "Property is not nullable for class Apple.");
+                throw new JsonException("Property is not nullable for class Apple: origin.");
 
             return new Apple(colorCode, cultivar, origin);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -153,13 +153,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!cultivar.IsSet)
-                throw new ArgumentException("Property is required for class AppleReq.", nameof(cultivar));
+                throw new JsonException("Property is required for class AppleReq: cultivar.");
 
             if (cultivar.IsSet && cultivar.Value == null)
-                throw new ArgumentNullException(nameof(cultivar), "Property is not nullable for class AppleReq.");
+                throw new JsonException("Property is not nullable for class AppleReq: cultivar.");
 
             if (mealy.IsSet && mealy.Value == null)
-                throw new ArgumentNullException(nameof(mealy), "Property is not nullable for class AppleReq.");
+                throw new JsonException("Property is not nullable for class AppleReq: mealy.");
 
             return new AppleReq(cultivar.Value!, mealy);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayArrayNumber.IsSet && arrayArrayNumber.Value == null)
-                throw new ArgumentNullException(nameof(arrayArrayNumber), "Property is not nullable for class ArrayOfArrayOfNumberOnly.");
+                throw new JsonException("Property is not nullable for class ArrayOfArrayOfNumberOnly: ArrayArrayNumber.");
 
             return new ArrayOfArrayOfNumberOnly(arrayArrayNumber);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayNumber.IsSet && arrayNumber.Value == null)
-                throw new ArgumentNullException(nameof(arrayNumber), "Property is not nullable for class ArrayOfNumberOnly.");
+                throw new JsonException("Property is not nullable for class ArrayOfNumberOnly: ArrayNumber.");
 
             return new ArrayOfNumberOnly(arrayNumber);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -187,13 +187,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayArrayOfInteger.IsSet && arrayArrayOfInteger.Value == null)
-                throw new ArgumentNullException(nameof(arrayArrayOfInteger), "Property is not nullable for class ArrayTest.");
+                throw new JsonException("Property is not nullable for class ArrayTest: array_array_of_integer.");
 
             if (arrayArrayOfModel.IsSet && arrayArrayOfModel.Value == null)
-                throw new ArgumentNullException(nameof(arrayArrayOfModel), "Property is not nullable for class ArrayTest.");
+                throw new JsonException("Property is not nullable for class ArrayTest: array_array_of_model.");
 
             if (arrayOfString.IsSet && arrayOfString.Value == null)
-                throw new ArgumentNullException(nameof(arrayOfString), "Property is not nullable for class ArrayTest.");
+                throw new JsonException("Property is not nullable for class ArrayTest: array_of_string.");
 
             return new ArrayTest(arrayArrayOfInteger, arrayArrayOfModel, arrayOfString);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Banana.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (lengthCm.IsSet && lengthCm.Value == null)
-                throw new ArgumentNullException(nameof(lengthCm), "Property is not nullable for class Banana.");
+                throw new JsonException("Property is not nullable for class Banana: lengthCm.");
 
             return new Banana(lengthCm);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -153,13 +153,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!lengthCm.IsSet)
-                throw new ArgumentException("Property is required for class BananaReq.", nameof(lengthCm));
+                throw new JsonException("Property is required for class BananaReq: lengthCm.");
 
             if (lengthCm.IsSet && lengthCm.Value == null)
-                throw new ArgumentNullException(nameof(lengthCm), "Property is not nullable for class BananaReq.");
+                throw new JsonException("Property is not nullable for class BananaReq: lengthCm.");
 
             if (sweet.IsSet && sweet.Value == null)
-                throw new ArgumentNullException(nameof(sweet), "Property is not nullable for class BananaReq.");
+                throw new JsonException("Property is not nullable for class BananaReq: sweet.");
 
             return new BananaReq(lengthCm.Value!.Value!, sweet);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/BasquePig.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/BasquePig.cs
@@ -140,10 +140,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class BasquePig.", nameof(className));
+                throw new JsonException("Property is required for class BasquePig: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class BasquePig.");
+                throw new JsonException("Property is not nullable for class BasquePig: className.");
 
             return new BasquePig(className.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -248,22 +248,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (aTTNAME.IsSet && aTTNAME.Value == null)
-                throw new ArgumentNullException(nameof(aTTNAME), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: ATT_NAME.");
 
             if (capitalCamel.IsSet && capitalCamel.Value == null)
-                throw new ArgumentNullException(nameof(capitalCamel), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: CapitalCamel.");
 
             if (capitalSnake.IsSet && capitalSnake.Value == null)
-                throw new ArgumentNullException(nameof(capitalSnake), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: Capital_Snake.");
 
             if (sCAETHFlowPoints.IsSet && sCAETHFlowPoints.Value == null)
-                throw new ArgumentNullException(nameof(sCAETHFlowPoints), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: SCA_ETH_Flow_Points.");
 
             if (smallCamel.IsSet && smallCamel.Value == null)
-                throw new ArgumentNullException(nameof(smallCamel), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: smallCamel.");
 
             if (smallSnake.IsSet && smallSnake.Value == null)
-                throw new ArgumentNullException(nameof(smallSnake), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: small_Snake.");
 
             return new Capitalization(aTTNAME, capitalCamel, capitalSnake, sCAETHFlowPoints, smallCamel, smallSnake);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Cat.cs
@@ -140,16 +140,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Cat.", nameof(className));
+                throw new JsonException("Property is required for class Cat: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Cat.");
+                throw new JsonException("Property is not nullable for class Cat: className.");
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Cat.");
+                throw new JsonException("Property is not nullable for class Cat: color.");
 
             if (declawed.IsSet && declawed.Value == null)
-                throw new ArgumentNullException(nameof(declawed), "Property is not nullable for class Cat.");
+                throw new JsonException("Property is not nullable for class Cat: declawed.");
 
             return new Cat(color, declawed);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Category.cs
@@ -160,13 +160,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!name.IsSet)
-                throw new ArgumentException("Property is required for class Category.", nameof(name));
+                throw new JsonException("Property is required for class Category: name.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Category.");
+                throw new JsonException("Property is not nullable for class Category: id.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Category.");
+                throw new JsonException("Property is not nullable for class Category: name.");
 
             return new Category(id, name.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -202,13 +202,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!petType.IsSet)
-                throw new ArgumentException("Property is required for class ChildCat.", nameof(petType));
+                throw new JsonException("Property is required for class ChildCat: pet_type.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class ChildCat.");
+                throw new JsonException("Property is not nullable for class ChildCat: name.");
 
             if (petType.IsSet && petType.Value == null)
-                throw new ArgumentNullException(nameof(petType), "Property is not nullable for class ChildCat.");
+                throw new JsonException("Property is not nullable for class ChildCat: pet_type.");
 
             return new ChildCat(name);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varClass.IsSet && varClass.Value == null)
-                throw new ArgumentNullException(nameof(varClass), "Property is not nullable for class ClassModel.");
+                throw new JsonException("Property is not nullable for class ClassModel: _class.");
 
             return new ClassModel(varClass);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
@@ -153,16 +153,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class ComplexQuadrilateral.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class ComplexQuadrilateral: quadrilateralType.");
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ComplexQuadrilateral.", nameof(shapeType));
+                throw new JsonException("Property is required for class ComplexQuadrilateral: shapeType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class ComplexQuadrilateral.");
+                throw new JsonException("Property is not nullable for class ComplexQuadrilateral: quadrilateralType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ComplexQuadrilateral.");
+                throw new JsonException("Property is not nullable for class ComplexQuadrilateral: shapeType.");
 
             return new ComplexQuadrilateral(quadrilateralType.Value!, shapeType.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/CopyActivity.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/CopyActivity.cs
@@ -195,16 +195,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!copyActivitytt.IsSet)
-                throw new ArgumentException("Property is required for class CopyActivity.", nameof(copyActivitytt));
+                throw new JsonException("Property is required for class CopyActivity: copyActivitytt.");
 
             if (!schema.IsSet)
-                throw new ArgumentException("Property is required for class CopyActivity.", nameof(schema));
+                throw new JsonException("Property is required for class CopyActivity: $schema.");
 
             if (copyActivitytt.IsSet && copyActivitytt.Value == null)
-                throw new ArgumentNullException(nameof(copyActivitytt), "Property is not nullable for class CopyActivity.");
+                throw new JsonException("Property is not nullable for class CopyActivity: copyActivitytt.");
 
             if (schema.IsSet && schema.Value == null)
-                throw new ArgumentNullException(nameof(schema), "Property is not nullable for class CopyActivity.");
+                throw new JsonException("Property is not nullable for class CopyActivity: $schema.");
 
             return new CopyActivity(copyActivitytt.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/DanishPig.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/DanishPig.cs
@@ -140,10 +140,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class DanishPig.", nameof(className));
+                throw new JsonException("Property is required for class DanishPig: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class DanishPig.");
+                throw new JsonException("Property is not nullable for class DanishPig: className.");
 
             return new DanishPig(className.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -153,7 +153,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (dateOnlyProperty.IsSet && dateOnlyProperty.Value == null)
-                throw new ArgumentNullException(nameof(dateOnlyProperty), "Property is not nullable for class DateOnlyClass.");
+                throw new JsonException("Property is not nullable for class DateOnlyClass: dateOnlyProperty.");
 
             return new DateOnlyClass(dateOnlyProperty);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class DeprecatedObject.");
+                throw new JsonException("Property is not nullable for class DeprecatedObject: name.");
 
             return new DeprecatedObject(name);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Descendant1.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Descendant1.cs
@@ -140,22 +140,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!alternativeName.IsSet)
-                throw new ArgumentException("Property is required for class Descendant1.", nameof(alternativeName));
+                throw new JsonException("Property is required for class Descendant1: alternativeName.");
 
             if (!descendantName.IsSet)
-                throw new ArgumentException("Property is required for class Descendant1.", nameof(descendantName));
+                throw new JsonException("Property is required for class Descendant1: descendantName.");
 
             if (!objectType.IsSet)
-                throw new ArgumentException("Property is required for class Descendant1.", nameof(objectType));
+                throw new JsonException("Property is required for class Descendant1: objectType.");
 
             if (alternativeName.IsSet && alternativeName.Value == null)
-                throw new ArgumentNullException(nameof(alternativeName), "Property is not nullable for class Descendant1.");
+                throw new JsonException("Property is not nullable for class Descendant1: alternativeName.");
 
             if (descendantName.IsSet && descendantName.Value == null)
-                throw new ArgumentNullException(nameof(descendantName), "Property is not nullable for class Descendant1.");
+                throw new JsonException("Property is not nullable for class Descendant1: descendantName.");
 
             if (objectType.IsSet && objectType.Value == null)
-                throw new ArgumentNullException(nameof(objectType), "Property is not nullable for class Descendant1.");
+                throw new JsonException("Property is not nullable for class Descendant1: objectType.");
 
             return new Descendant1(alternativeName.Value!, descendantName.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Descendant2.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Descendant2.cs
@@ -140,22 +140,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!alternativeName.IsSet)
-                throw new ArgumentException("Property is required for class Descendant2.", nameof(alternativeName));
+                throw new JsonException("Property is required for class Descendant2: alternativeName.");
 
             if (!confidentiality.IsSet)
-                throw new ArgumentException("Property is required for class Descendant2.", nameof(confidentiality));
+                throw new JsonException("Property is required for class Descendant2: confidentiality.");
 
             if (!objectType.IsSet)
-                throw new ArgumentException("Property is required for class Descendant2.", nameof(objectType));
+                throw new JsonException("Property is required for class Descendant2: objectType.");
 
             if (alternativeName.IsSet && alternativeName.Value == null)
-                throw new ArgumentNullException(nameof(alternativeName), "Property is not nullable for class Descendant2.");
+                throw new JsonException("Property is not nullable for class Descendant2: alternativeName.");
 
             if (confidentiality.IsSet && confidentiality.Value == null)
-                throw new ArgumentNullException(nameof(confidentiality), "Property is not nullable for class Descendant2.");
+                throw new JsonException("Property is not nullable for class Descendant2: confidentiality.");
 
             if (objectType.IsSet && objectType.Value == null)
-                throw new ArgumentNullException(nameof(objectType), "Property is not nullable for class Descendant2.");
+                throw new JsonException("Property is not nullable for class Descendant2: objectType.");
 
             return new Descendant2(alternativeName.Value!, confidentiality.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Dog.cs
@@ -140,16 +140,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Dog.", nameof(className));
+                throw new JsonException("Property is required for class Dog: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Dog.");
+                throw new JsonException("Property is not nullable for class Dog: className.");
 
             if (breed.IsSet && breed.Value == null)
-                throw new ArgumentNullException(nameof(breed), "Property is not nullable for class Dog.");
+                throw new JsonException("Property is not nullable for class Dog: breed.");
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Dog.");
+                throw new JsonException("Property is not nullable for class Dog: color.");
 
             return new Dog(breed, color);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Drawing.cs
@@ -207,10 +207,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (mainShape.IsSet && mainShape.Value == null)
-                throw new ArgumentNullException(nameof(mainShape), "Property is not nullable for class Drawing.");
+                throw new JsonException("Property is not nullable for class Drawing: mainShape.");
 
             if (shapes.IsSet && shapes.Value == null)
-                throw new ArgumentNullException(nameof(shapes), "Property is not nullable for class Drawing.");
+                throw new JsonException("Property is not nullable for class Drawing: shapes.");
 
             return new Drawing(mainShape, nullableShape, shapeOrNull, shapes);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/EntityBase.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/EntityBase.cs
@@ -154,10 +154,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!schema.IsSet)
-                throw new ArgumentException("Property is required for class EntityBase.", nameof(schema));
+                throw new JsonException("Property is required for class EntityBase: $schema.");
 
             if (schema.IsSet && schema.Value == null)
-                throw new ArgumentNullException(nameof(schema), "Property is not nullable for class EntityBase.");
+                throw new JsonException("Property is not nullable for class EntityBase: $schema.");
 
             return new EntityBase();
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -306,10 +306,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayEnum.IsSet && arrayEnum.Value == null)
-                throw new ArgumentNullException(nameof(arrayEnum), "Property is not nullable for class EnumArrays.");
+                throw new JsonException("Property is not nullable for class EnumArrays: array_enum.");
 
             if (justSymbol.IsSet && justSymbol.Value == null)
-                throw new ArgumentNullException(nameof(justSymbol), "Property is not nullable for class EnumArrays.");
+                throw new JsonException("Property is not nullable for class EnumArrays: just_symbol.");
 
             return new EnumArrays(arrayEnum, justSymbol);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -824,31 +824,31 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!enumStringRequired.IsSet)
-                throw new ArgumentException("Property is required for class EnumTest.", nameof(enumStringRequired));
+                throw new JsonException("Property is required for class EnumTest: enum_string_required.");
 
             if (enumStringRequired.IsSet && enumStringRequired.Value == null)
-                throw new ArgumentNullException(nameof(enumStringRequired), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_string_required.");
 
             if (enumInteger.IsSet && enumInteger.Value == null)
-                throw new ArgumentNullException(nameof(enumInteger), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_integer.");
 
             if (enumIntegerOnly.IsSet && enumIntegerOnly.Value == null)
-                throw new ArgumentNullException(nameof(enumIntegerOnly), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_integer_only.");
 
             if (enumNumber.IsSet && enumNumber.Value == null)
-                throw new ArgumentNullException(nameof(enumNumber), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_number.");
 
             if (enumString.IsSet && enumString.Value == null)
-                throw new ArgumentNullException(nameof(enumString), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_string.");
 
             if (outerEnumDefaultValue.IsSet && outerEnumDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(outerEnumDefaultValue), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: outerEnumDefaultValue.");
 
             if (outerEnumInteger.IsSet && outerEnumInteger.Value == null)
-                throw new ArgumentNullException(nameof(outerEnumInteger), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: outerEnumInteger.");
 
             if (outerEnumIntegerDefaultValue.IsSet && outerEnumIntegerDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(outerEnumIntegerDefaultValue), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: outerEnumIntegerDefaultValue.");
 
             return new EnumTest(enumStringRequired.Value!.Value!, enumInteger, enumIntegerOnly, enumNumber, enumString, outerEnum, outerEnumDefaultValue, outerEnumInteger, outerEnumIntegerDefaultValue);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
@@ -153,16 +153,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class EquilateralTriangle.", nameof(shapeType));
+                throw new JsonException("Property is required for class EquilateralTriangle: shapeType.");
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class EquilateralTriangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class EquilateralTriangle: triangleType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class EquilateralTriangle.");
+                throw new JsonException("Property is not nullable for class EquilateralTriangle: shapeType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class EquilateralTriangle.");
+                throw new JsonException("Property is not nullable for class EquilateralTriangle: triangleType.");
 
             return new EquilateralTriangle(shapeType.Value!, triangleType.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/File.cs
@@ -148,7 +148,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (sourceURI.IsSet && sourceURI.Value == null)
-                throw new ArgumentNullException(nameof(sourceURI), "Property is not nullable for class File.");
+                throw new JsonException("Property is not nullable for class File: sourceURI.");
 
             return new File(sourceURI);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -167,10 +167,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (file.IsSet && file.Value == null)
-                throw new ArgumentNullException(nameof(file), "Property is not nullable for class FileSchemaTestClass.");
+                throw new JsonException("Property is not nullable for class FileSchemaTestClass: file.");
 
             if (files.IsSet && files.Value == null)
-                throw new ArgumentNullException(nameof(files), "Property is not nullable for class FileSchemaTestClass.");
+                throw new JsonException("Property is not nullable for class FileSchemaTestClass: files.");
 
             return new FileSchemaTestClass(file, files);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Foo.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bar.IsSet && bar.Value == null)
-                throw new ArgumentNullException(nameof(bar), "Property is not nullable for class Foo.");
+                throw new JsonException("Property is not nullable for class Foo: bar.");
 
             return new Foo(bar);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varString.IsSet && varString.Value == null)
-                throw new ArgumentNullException(nameof(varString), "Property is not nullable for class FooGetDefaultResponse.");
+                throw new JsonException("Property is not nullable for class FooGetDefaultResponse: string.");
 
             return new FooGetDefaultResponse(varString);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -828,103 +828,103 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!varByte.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(varByte));
+                throw new JsonException("Property is required for class FormatTest: byte.");
 
             if (!date.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(date));
+                throw new JsonException("Property is required for class FormatTest: date.");
 
             if (!number.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(number));
+                throw new JsonException("Property is required for class FormatTest: number.");
 
             if (!password.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(password));
+                throw new JsonException("Property is required for class FormatTest: password.");
 
             if (!stringFormattedAsDecimalRequired.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(stringFormattedAsDecimalRequired));
+                throw new JsonException("Property is required for class FormatTest: string_formatted_as_decimal_required.");
 
             if (varByte.IsSet && varByte.Value == null)
-                throw new ArgumentNullException(nameof(varByte), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: byte.");
 
             if (date.IsSet && date.Value == null)
-                throw new ArgumentNullException(nameof(date), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: date.");
 
             if (number.IsSet && number.Value == null)
-                throw new ArgumentNullException(nameof(number), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: number.");
 
             if (password.IsSet && password.Value == null)
-                throw new ArgumentNullException(nameof(password), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: password.");
 
             if (stringFormattedAsDecimalRequired.IsSet && stringFormattedAsDecimalRequired.Value == null)
-                throw new ArgumentNullException(nameof(stringFormattedAsDecimalRequired), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: string_formatted_as_decimal_required.");
 
             if (binary.IsSet && binary.Value == null)
-                throw new ArgumentNullException(nameof(binary), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: binary.");
 
             if (dateTime.IsSet && dateTime.Value == null)
-                throw new ArgumentNullException(nameof(dateTime), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: dateTime.");
 
             if (varDecimal.IsSet && varDecimal.Value == null)
-                throw new ArgumentNullException(nameof(varDecimal), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: decimal.");
 
             if (varDouble.IsSet && varDouble.Value == null)
-                throw new ArgumentNullException(nameof(varDouble), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: double.");
 
             if (duplicatePropertyName2.IsSet && duplicatePropertyName2.Value == null)
-                throw new ArgumentNullException(nameof(duplicatePropertyName2), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: duplicate_property_name.");
 
             if (duplicatePropertyName.IsSet && duplicatePropertyName.Value == null)
-                throw new ArgumentNullException(nameof(duplicatePropertyName), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: @duplicate_property_name.");
 
             if (varFloat.IsSet && varFloat.Value == null)
-                throw new ArgumentNullException(nameof(varFloat), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: float.");
 
             if (int32.IsSet && int32.Value == null)
-                throw new ArgumentNullException(nameof(int32), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int32.");
 
             if (int32Range.IsSet && int32Range.Value == null)
-                throw new ArgumentNullException(nameof(int32Range), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int32Range.");
 
             if (int64.IsSet && int64.Value == null)
-                throw new ArgumentNullException(nameof(int64), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64.");
 
             if (int64Negative.IsSet && int64Negative.Value == null)
-                throw new ArgumentNullException(nameof(int64Negative), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64Negative.");
 
             if (int64NegativeExclusive.IsSet && int64NegativeExclusive.Value == null)
-                throw new ArgumentNullException(nameof(int64NegativeExclusive), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64NegativeExclusive.");
 
             if (int64Positive.IsSet && int64Positive.Value == null)
-                throw new ArgumentNullException(nameof(int64Positive), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64Positive.");
 
             if (int64PositiveExclusive.IsSet && int64PositiveExclusive.Value == null)
-                throw new ArgumentNullException(nameof(int64PositiveExclusive), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64PositiveExclusive.");
 
             if (integer.IsSet && integer.Value == null)
-                throw new ArgumentNullException(nameof(integer), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: integer.");
 
             if (patternWithBackslash.IsSet && patternWithBackslash.Value == null)
-                throw new ArgumentNullException(nameof(patternWithBackslash), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: pattern_with_backslash.");
 
             if (patternWithDigits.IsSet && patternWithDigits.Value == null)
-                throw new ArgumentNullException(nameof(patternWithDigits), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: pattern_with_digits.");
 
             if (patternWithDigitsAndDelimiter.IsSet && patternWithDigitsAndDelimiter.Value == null)
-                throw new ArgumentNullException(nameof(patternWithDigitsAndDelimiter), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: pattern_with_digits_and_delimiter.");
 
             if (varString.IsSet && varString.Value == null)
-                throw new ArgumentNullException(nameof(varString), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: string.");
 
             if (stringFormattedAsDecimal.IsSet && stringFormattedAsDecimal.Value == null)
-                throw new ArgumentNullException(nameof(stringFormattedAsDecimal), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: string_formatted_as_decimal.");
 
             if (unsignedInteger.IsSet && unsignedInteger.Value == null)
-                throw new ArgumentNullException(nameof(unsignedInteger), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: unsigned_integer.");
 
             if (unsignedLong.IsSet && unsignedLong.Value == null)
-                throw new ArgumentNullException(nameof(unsignedLong), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: unsigned_long.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: uuid.");
 
             return new FormatTest(varByte.Value!, date.Value!.Value!, number.Value!.Value!, password.Value!, stringFormattedAsDecimalRequired.Value!.Value!, binary, dateTime, varDecimal, varDouble, duplicatePropertyName2, duplicatePropertyName, varFloat, int32, int32Range, int64, int64Negative, int64NegativeExclusive, int64Positive, int64PositiveExclusive, integer, patternWithBackslash, patternWithDigits, patternWithDigitsAndDelimiter, varString, stringFormattedAsDecimal, unsignedInteger, unsignedLong, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Fruit.cs
@@ -185,7 +185,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Fruit.");
+                throw new JsonException("Property is not nullable for class Fruit: color.");
 
             if (apple != null)
                 return new Fruit(apple, color);

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -189,7 +189,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class GmFruit.");
+                throw new JsonException("Property is not nullable for class GmFruit: color.");
 
             Option<Apple?> appleParsedValue = apple == null
                 ? default

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
@@ -157,10 +157,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!petType.IsSet)
-                throw new ArgumentException("Property is required for class GrandparentAnimal.", nameof(petType));
+                throw new JsonException("Property is required for class GrandparentAnimal: pet_type.");
 
             if (petType.IsSet && petType.Value == null)
-                throw new ArgumentNullException(nameof(petType), "Property is not nullable for class GrandparentAnimal.");
+                throw new JsonException("Property is not nullable for class GrandparentAnimal: pet_type.");
 
             return new GrandparentAnimal();
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -208,10 +208,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bar.IsSet && bar.Value == null)
-                throw new ArgumentNullException(nameof(bar), "Property is not nullable for class HasOnlyReadOnly.");
+                throw new JsonException("Property is not nullable for class HasOnlyReadOnly: bar.");
 
             if (foo.IsSet && foo.Value == null)
-                throw new ArgumentNullException(nameof(foo), "Property is not nullable for class HasOnlyReadOnly.");
+                throw new JsonException("Property is not nullable for class HasOnlyReadOnly: foo.");
 
             return new HasOnlyReadOnly(bar, foo);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
@@ -294,22 +294,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (potentiallyOverriddenPropertyAccessor.IsSet && potentiallyOverriddenPropertyAccessor.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyAccessor), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyAccessor.");
 
             if (potentiallyOverriddenPropertyToInternal.IsSet && potentiallyOverriddenPropertyToInternal.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyToInternal), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyToInternal.");
 
             if (potentiallyOverriddenPropertyToPrivate.IsSet && potentiallyOverriddenPropertyToPrivate.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyToPrivate), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyToPrivate.");
 
             if (potentiallyOverriddenPropertyToPublic.IsSet && potentiallyOverriddenPropertyToPublic.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyToPublic), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyToPublic.");
 
             if (unalteredProperty.IsSet && unalteredProperty.Value == null)
-                throw new ArgumentNullException(nameof(unalteredProperty), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: unalteredProperty.");
 
             if (unalteredPropertyAccessor.IsSet && unalteredPropertyAccessor.Value == null)
-                throw new ArgumentNullException(nameof(unalteredPropertyAccessor), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: unalteredPropertyAccessor.");
 
             return new InjectedVendorExtensionsTest(potentiallyOverriddenPropertyAccessor, potentiallyOverriddenPropertyToInternal, potentiallyOverriddenPropertyToPrivate, potentiallyOverriddenPropertyToPublic, unalteredProperty, unalteredPropertyAccessor);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
@@ -146,16 +146,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class IsoscelesTriangle.", nameof(shapeType));
+                throw new JsonException("Property is required for class IsoscelesTriangle: shapeType.");
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class IsoscelesTriangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class IsoscelesTriangle: triangleType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class IsoscelesTriangle.");
+                throw new JsonException("Property is not nullable for class IsoscelesTriangle: shapeType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class IsoscelesTriangle.");
+                throw new JsonException("Property is not nullable for class IsoscelesTriangle: triangleType.");
 
             return new IsoscelesTriangle(shapeType.Value!, triangleType.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/List.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (var123List.IsSet && var123List.Value == null)
-                throw new ArgumentNullException(nameof(var123List), "Property is not nullable for class List.");
+                throw new JsonException("Property is not nullable for class List: 123-list.");
 
             return new List(var123List);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -167,10 +167,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (escapedLiteralString.IsSet && escapedLiteralString.Value == null)
-                throw new ArgumentNullException(nameof(escapedLiteralString), "Property is not nullable for class LiteralStringClass.");
+                throw new JsonException("Property is not nullable for class LiteralStringClass: escapedLiteralString.");
 
             if (unescapedLiteralString.IsSet && unescapedLiteralString.Value == null)
-                throw new ArgumentNullException(nameof(unescapedLiteralString), "Property is not nullable for class LiteralStringClass.");
+                throw new JsonException("Property is not nullable for class LiteralStringClass: unescapedLiteralString.");
 
             return new LiteralStringClass(escapedLiteralString, unescapedLiteralString);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Mammal.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Mammal.cs
@@ -216,10 +216,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Mammal.", nameof(className));
+                throw new JsonException("Property is required for class Mammal: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Mammal.");
+                throw new JsonException("Property is not nullable for class Mammal: className.");
 
             if (pig != null)
                 return new Mammal(pig);

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/MapTest.cs
@@ -273,16 +273,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (directMap.IsSet && directMap.Value == null)
-                throw new ArgumentNullException(nameof(directMap), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: direct_map.");
 
             if (indirectMap.IsSet && indirectMap.Value == null)
-                throw new ArgumentNullException(nameof(indirectMap), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: indirect_map.");
 
             if (mapMapOfString.IsSet && mapMapOfString.Value == null)
-                throw new ArgumentNullException(nameof(mapMapOfString), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: map_map_of_string.");
 
             if (mapOfEnumString.IsSet && mapOfEnumString.Value == null)
-                throw new ArgumentNullException(nameof(mapOfEnumString), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: map_of_enum_string.");
 
             return new MapTest(directMap, indirectMap, mapMapOfString, mapOfEnumString);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedAnyOf.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedAnyOf.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (content.IsSet && content.Value == null)
-                throw new ArgumentNullException(nameof(content), "Property is not nullable for class MixedAnyOf.");
+                throw new JsonException("Property is not nullable for class MixedAnyOf: content.");
 
             return new MixedAnyOf(content);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedOneOf.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedOneOf.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (content.IsSet && content.Value == null)
-                throw new ArgumentNullException(nameof(content), "Property is not nullable for class MixedOneOf.");
+                throw new JsonException("Property is not nullable for class MixedOneOf: content.");
 
             return new MixedOneOf(content);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -219,16 +219,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (dateTime.IsSet && dateTime.Value == null)
-                throw new ArgumentNullException(nameof(dateTime), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: dateTime.");
 
             if (map.IsSet && map.Value == null)
-                throw new ArgumentNullException(nameof(map), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: map.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: uuid.");
 
             if (uuidWithPattern.IsSet && uuidWithPattern.Value == null)
-                throw new ArgumentNullException(nameof(uuidWithPattern), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: uuid_with_pattern.");
 
             return new MixedPropertiesAndAdditionalPropertiesClass(dateTime, map, uuid, uuidWithPattern);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedSubId.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedSubId.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class MixedSubId.");
+                throw new JsonException("Property is not nullable for class MixedSubId: id.");
 
             return new MixedSubId(id);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -167,10 +167,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varClass.IsSet && varClass.Value == null)
-                throw new ArgumentNullException(nameof(varClass), "Property is not nullable for class Model200Response.");
+                throw new JsonException("Property is not nullable for class Model200Response: class.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Model200Response.");
+                throw new JsonException("Property is not nullable for class Model200Response: name.");
 
             return new Model200Response(varClass, name);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varClient.IsSet && varClient.Value == null)
-                throw new ArgumentNullException(nameof(varClient), "Property is not nullable for class ModelClient.");
+                throw new JsonException("Property is not nullable for class ModelClient: client.");
 
             return new ModelClient(varClient);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Name.cs
@@ -241,19 +241,19 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!varName.IsSet)
-                throw new ArgumentException("Property is required for class Name.", nameof(varName));
+                throw new JsonException("Property is required for class Name: name.");
 
             if (varName.IsSet && varName.Value == null)
-                throw new ArgumentNullException(nameof(varName), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: name.");
 
             if (property.IsSet && property.Value == null)
-                throw new ArgumentNullException(nameof(property), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: property.");
 
             if (snakeCase.IsSet && snakeCase.Value == null)
-                throw new ArgumentNullException(nameof(snakeCase), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: snake_case.");
 
             if (var123Number.IsSet && var123Number.Value == null)
-                throw new ArgumentNullException(nameof(var123Number), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: 123Number.");
 
             return new Name(varName.Value!.Value!, property, snakeCase, var123Number);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
@@ -153,16 +153,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!aObjVariableobject.IsSet)
-                throw new ArgumentException("Property is required for class NotificationtestGetElementsV1ResponseMPayload.", nameof(aObjVariableobject));
+                throw new JsonException("Property is required for class NotificationtestGetElementsV1ResponseMPayload: a_objVariableobject.");
 
             if (!pkiNotificationtestID.IsSet)
-                throw new ArgumentException("Property is required for class NotificationtestGetElementsV1ResponseMPayload.", nameof(pkiNotificationtestID));
+                throw new JsonException("Property is required for class NotificationtestGetElementsV1ResponseMPayload: pkiNotificationtestID.");
 
             if (aObjVariableobject.IsSet && aObjVariableobject.Value == null)
-                throw new ArgumentNullException(nameof(aObjVariableobject), "Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload.");
+                throw new JsonException("Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload: a_objVariableobject.");
 
             if (pkiNotificationtestID.IsSet && pkiNotificationtestID.Value == null)
-                throw new ArgumentNullException(nameof(pkiNotificationtestID), "Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload.");
+                throw new JsonException("Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload: pkiNotificationtestID.");
 
             return new NotificationtestGetElementsV1ResponseMPayload(aObjVariableobject.Value!, pkiNotificationtestID.Value!.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -377,10 +377,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayItemsNullable.IsSet && arrayItemsNullable.Value == null)
-                throw new ArgumentNullException(nameof(arrayItemsNullable), "Property is not nullable for class NullableClass.");
+                throw new JsonException("Property is not nullable for class NullableClass: array_items_nullable.");
 
             if (objectItemsNullable.IsSet && objectItemsNullable.Value == null)
-                throw new ArgumentNullException(nameof(objectItemsNullable), "Property is not nullable for class NullableClass.");
+                throw new JsonException("Property is not nullable for class NullableClass: object_items_nullable.");
 
             return new NullableClass(arrayAndItemsNullableProp, arrayItemsNullable, arrayNullableProp, booleanProp, dateProp, datetimeProp, integerProp, numberProp, objectAndItemsNullableProp, objectItemsNullable, objectNullableProp, stringProp);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/NullableShape.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/NullableShape.cs
@@ -195,10 +195,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class NullableShape.", nameof(shapeType));
+                throw new JsonException("Property is required for class NullableShape: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class NullableShape.");
+                throw new JsonException("Property is not nullable for class NullableShape: shapeType.");
 
             if (quadrilateral != null)
                 return new NullableShape(quadrilateral);

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (justNumber.IsSet && justNumber.Value == null)
-                throw new ArgumentNullException(nameof(justNumber), "Property is not nullable for class NumberOnly.");
+                throw new JsonException("Property is not nullable for class NumberOnly: JustNumber.");
 
             return new NumberOnly(justNumber);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -210,16 +210,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bars.IsSet && bars.Value == null)
-                throw new ArgumentNullException(nameof(bars), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: bars.");
 
             if (deprecatedRef.IsSet && deprecatedRef.Value == null)
-                throw new ArgumentNullException(nameof(deprecatedRef), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: deprecatedRef.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: id.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: uuid.");
 
             return new ObjectWithDeprecatedFields(bars, deprecatedRef, id, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Order.cs
@@ -342,22 +342,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (complete.IsSet && complete.Value == null)
-                throw new ArgumentNullException(nameof(complete), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: complete.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: id.");
 
             if (petId.IsSet && petId.Value == null)
-                throw new ArgumentNullException(nameof(petId), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: petId.");
 
             if (quantity.IsSet && quantity.Value == null)
-                throw new ArgumentNullException(nameof(quantity), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: quantity.");
 
             if (shipDate.IsSet && shipDate.Value == null)
-                throw new ArgumentNullException(nameof(shipDate), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: shipDate.");
 
             if (status.IsSet && status.Value == null)
-                throw new ArgumentNullException(nameof(status), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: status.");
 
             return new Order(complete, id, petId, quantity, shipDate, status);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -187,13 +187,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (myBoolean.IsSet && myBoolean.Value == null)
-                throw new ArgumentNullException(nameof(myBoolean), "Property is not nullable for class OuterComposite.");
+                throw new JsonException("Property is not nullable for class OuterComposite: my_boolean.");
 
             if (myNumber.IsSet && myNumber.Value == null)
-                throw new ArgumentNullException(nameof(myNumber), "Property is not nullable for class OuterComposite.");
+                throw new JsonException("Property is not nullable for class OuterComposite: my_number.");
 
             if (myString.IsSet && myString.Value == null)
-                throw new ArgumentNullException(nameof(myString), "Property is not nullable for class OuterComposite.");
+                throw new JsonException("Property is not nullable for class OuterComposite: my_string.");
 
             return new OuterComposite(myBoolean, myNumber, myString);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ParentPet.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ParentPet.cs
@@ -120,10 +120,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!petType.IsSet)
-                throw new ArgumentException("Property is required for class ParentPet.", nameof(petType));
+                throw new JsonException("Property is required for class ParentPet: pet_type.");
 
             if (petType.IsSet && petType.Value == null)
-                throw new ArgumentNullException(nameof(petType), "Property is not nullable for class ParentPet.");
+                throw new JsonException("Property is not nullable for class ParentPet: pet_type.");
 
             return new ParentPet();
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Pet.cs
@@ -323,28 +323,28 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!name.IsSet)
-                throw new ArgumentException("Property is required for class Pet.", nameof(name));
+                throw new JsonException("Property is required for class Pet: name.");
 
             if (!photoUrls.IsSet)
-                throw new ArgumentException("Property is required for class Pet.", nameof(photoUrls));
+                throw new JsonException("Property is required for class Pet: photoUrls.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: name.");
 
             if (photoUrls.IsSet && photoUrls.Value == null)
-                throw new ArgumentNullException(nameof(photoUrls), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: photoUrls.");
 
             if (category.IsSet && category.Value == null)
-                throw new ArgumentNullException(nameof(category), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: category.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: id.");
 
             if (status.IsSet && status.Value == null)
-                throw new ArgumentNullException(nameof(status), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: status.");
 
             if (tags.IsSet && tags.Value == null)
-                throw new ArgumentNullException(nameof(tags), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: tags.");
 
             return new Pet(name.Value!, photoUrls.Value!, category, id, status, tags);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Pig.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Pig.cs
@@ -195,10 +195,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Pig.", nameof(className));
+                throw new JsonException("Property is required for class Pig: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Pig.");
+                throw new JsonException("Property is not nullable for class Pig: className.");
 
             if (basquePig != null)
                 return new Pig(basquePig);

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Quadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Quadrilateral.cs
@@ -195,10 +195,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class Quadrilateral.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class Quadrilateral: quadrilateralType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class Quadrilateral.");
+                throw new JsonException("Property is not nullable for class Quadrilateral: quadrilateralType.");
 
             if (complexQuadrilateral != null)
                 return new Quadrilateral(complexQuadrilateral);

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
@@ -140,10 +140,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class QuadrilateralInterface.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class QuadrilateralInterface: quadrilateralType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class QuadrilateralInterface.");
+                throw new JsonException("Property is not nullable for class QuadrilateralInterface: quadrilateralType.");
 
             return new QuadrilateralInterface(quadrilateralType.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -205,10 +205,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bar.IsSet && bar.Value == null)
-                throw new ArgumentNullException(nameof(bar), "Property is not nullable for class ReadOnlyFirst.");
+                throw new JsonException("Property is not nullable for class ReadOnlyFirst: bar.");
 
             if (baz.IsSet && baz.Value == null)
-                throw new ArgumentNullException(nameof(baz), "Property is not nullable for class ReadOnlyFirst.");
+                throw new JsonException("Property is not nullable for class ReadOnlyFirst: baz.");
 
             return new ReadOnlyFirst(bar, baz);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -2079,136 +2079,136 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!requiredNotNullableDateProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotNullableDateProp));
+                throw new JsonException("Property is required for class RequiredClass: required_not_nullable_date_prop.");
 
             if (!requiredNotnullableArrayOfString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableArrayOfString));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_array_of_string.");
 
             if (!requiredNotnullableBooleanProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableBooleanProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_boolean_prop.");
 
             if (!requiredNotnullableDatetimeProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableDatetimeProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_datetime_prop.");
 
             if (!requiredNotnullableEnumInteger.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableEnumInteger));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_enum_integer.");
 
             if (!requiredNotnullableEnumIntegerOnly.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableEnumIntegerOnly));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_enum_integer_only.");
 
             if (!requiredNotnullableEnumString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableEnumString));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_enum_string.");
 
             if (!requiredNotnullableOuterEnumDefaultValue.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableOuterEnumDefaultValue));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_outerEnumDefaultValue.");
 
             if (!requiredNotnullableStringProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableStringProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_string_prop.");
 
             if (!requiredNotnullableUuid.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableUuid));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_uuid.");
 
             if (!requiredNotnullableintegerProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableintegerProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullableinteger_prop.");
 
             if (!requiredNullableArrayOfString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableArrayOfString));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_array_of_string.");
 
             if (!requiredNullableBooleanProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableBooleanProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_boolean_prop.");
 
             if (!requiredNullableDateProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableDateProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_date_prop.");
 
             if (!requiredNullableDatetimeProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableDatetimeProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_datetime_prop.");
 
             if (!requiredNullableEnumInteger.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableEnumInteger));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_enum_integer.");
 
             if (!requiredNullableEnumIntegerOnly.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableEnumIntegerOnly));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_enum_integer_only.");
 
             if (!requiredNullableEnumString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableEnumString));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_enum_string.");
 
             if (!requiredNullableIntegerProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableIntegerProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_integer_prop.");
 
             if (!requiredNullableOuterEnumDefaultValue.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableOuterEnumDefaultValue));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_outerEnumDefaultValue.");
 
             if (!requiredNullableStringProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableStringProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_string_prop.");
 
             if (!requiredNullableUuid.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableUuid));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_uuid.");
 
             if (requiredNotNullableDateProp.IsSet && requiredNotNullableDateProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotNullableDateProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_not_nullable_date_prop.");
 
             if (requiredNotnullableArrayOfString.IsSet && requiredNotnullableArrayOfString.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableArrayOfString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_array_of_string.");
 
             if (requiredNotnullableBooleanProp.IsSet && requiredNotnullableBooleanProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableBooleanProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_boolean_prop.");
 
             if (requiredNotnullableDatetimeProp.IsSet && requiredNotnullableDatetimeProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableDatetimeProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_datetime_prop.");
 
             if (requiredNotnullableEnumInteger.IsSet && requiredNotnullableEnumInteger.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableEnumInteger), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_enum_integer.");
 
             if (requiredNotnullableEnumIntegerOnly.IsSet && requiredNotnullableEnumIntegerOnly.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableEnumIntegerOnly), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_enum_integer_only.");
 
             if (requiredNotnullableEnumString.IsSet && requiredNotnullableEnumString.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableEnumString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_enum_string.");
 
             if (requiredNotnullableOuterEnumDefaultValue.IsSet && requiredNotnullableOuterEnumDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableOuterEnumDefaultValue), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_outerEnumDefaultValue.");
 
             if (requiredNotnullableStringProp.IsSet && requiredNotnullableStringProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableStringProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_string_prop.");
 
             if (requiredNotnullableUuid.IsSet && requiredNotnullableUuid.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableUuid), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_uuid.");
 
             if (requiredNotnullableintegerProp.IsSet && requiredNotnullableintegerProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableintegerProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullableinteger_prop.");
 
             if (notRequiredNotnullableDateProp.IsSet && notRequiredNotnullableDateProp.Value == null)
-                throw new ArgumentNullException(nameof(notRequiredNotnullableDateProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: not_required_notnullable_date_prop.");
 
             if (notRequiredNotnullableintegerProp.IsSet && notRequiredNotnullableintegerProp.Value == null)
-                throw new ArgumentNullException(nameof(notRequiredNotnullableintegerProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: not_required_notnullableinteger_prop.");
 
             if (notrequiredNotnullableArrayOfString.IsSet && notrequiredNotnullableArrayOfString.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableArrayOfString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_array_of_string.");
 
             if (notrequiredNotnullableBooleanProp.IsSet && notrequiredNotnullableBooleanProp.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableBooleanProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_boolean_prop.");
 
             if (notrequiredNotnullableDatetimeProp.IsSet && notrequiredNotnullableDatetimeProp.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableDatetimeProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_datetime_prop.");
 
             if (notrequiredNotnullableEnumInteger.IsSet && notrequiredNotnullableEnumInteger.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableEnumInteger), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_enum_integer.");
 
             if (notrequiredNotnullableEnumIntegerOnly.IsSet && notrequiredNotnullableEnumIntegerOnly.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableEnumIntegerOnly), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_enum_integer_only.");
 
             if (notrequiredNotnullableEnumString.IsSet && notrequiredNotnullableEnumString.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableEnumString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_enum_string.");
 
             if (notrequiredNotnullableOuterEnumDefaultValue.IsSet && notrequiredNotnullableOuterEnumDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableOuterEnumDefaultValue), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_outerEnumDefaultValue.");
 
             if (notrequiredNotnullableStringProp.IsSet && notrequiredNotnullableStringProp.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableStringProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_string_prop.");
 
             if (notrequiredNotnullableUuid.IsSet && notrequiredNotnullableUuid.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableUuid), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_uuid.");
 
             return new RequiredClass(requiredNotNullableDateProp.Value!.Value!, requiredNotnullableArrayOfString.Value!, requiredNotnullableBooleanProp.Value!.Value!, requiredNotnullableDatetimeProp.Value!.Value!, requiredNotnullableEnumInteger.Value!.Value!, requiredNotnullableEnumIntegerOnly.Value!.Value!, requiredNotnullableEnumString.Value!.Value!, requiredNotnullableOuterEnumDefaultValue.Value!.Value!, requiredNotnullableStringProp.Value!, requiredNotnullableUuid.Value!.Value!, requiredNotnullableintegerProp.Value!.Value!, notRequiredNotnullableDateProp, notRequiredNotnullableintegerProp, notRequiredNullableDateProp, notRequiredNullableIntegerProp, notrequiredNotnullableArrayOfString, notrequiredNotnullableBooleanProp, notrequiredNotnullableDatetimeProp, notrequiredNotnullableEnumInteger, notrequiredNotnullableEnumIntegerOnly, notrequiredNotnullableEnumString, notrequiredNotnullableOuterEnumDefaultValue, notrequiredNotnullableStringProp, notrequiredNotnullableUuid, notrequiredNullableArrayOfString, notrequiredNullableBooleanProp, notrequiredNullableDatetimeProp, notrequiredNullableEnumInteger, notrequiredNullableEnumIntegerOnly, notrequiredNullableEnumString, notrequiredNullableOuterEnumDefaultValue, notrequiredNullableStringProp, notrequiredNullableUuid, requiredNullableArrayOfString.Value!, requiredNullableBooleanProp.Value!, requiredNullableDateProp.Value!, requiredNullableDatetimeProp.Value!, requiredNullableEnumInteger.Value!, requiredNullableEnumIntegerOnly.Value!, requiredNullableEnumString.Value!, requiredNullableIntegerProp.Value!, requiredNullableOuterEnumDefaultValue.Value!, requiredNullableStringProp.Value!, requiredNullableUuid.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Result.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Result.cs
@@ -190,13 +190,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (code.IsSet && code.Value == null)
-                throw new ArgumentNullException(nameof(code), "Property is not nullable for class Result.");
+                throw new JsonException("Property is not nullable for class Result: code.");
 
             if (data.IsSet && data.Value == null)
-                throw new ArgumentNullException(nameof(data), "Property is not nullable for class Result.");
+                throw new JsonException("Property is not nullable for class Result: data.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class Result.");
+                throw new JsonException("Property is not nullable for class Result: uuid.");
 
             return new Result(code, data, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Return.cs
@@ -193,19 +193,19 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!varLock.IsSet)
-                throw new ArgumentException("Property is required for class Return.", nameof(varLock));
+                throw new JsonException("Property is required for class Return: lock.");
 
             if (!varAbstract.IsSet)
-                throw new ArgumentException("Property is required for class Return.", nameof(varAbstract));
+                throw new JsonException("Property is required for class Return: abstract.");
 
             if (varLock.IsSet && varLock.Value == null)
-                throw new ArgumentNullException(nameof(varLock), "Property is not nullable for class Return.");
+                throw new JsonException("Property is not nullable for class Return: lock.");
 
             if (varReturn.IsSet && varReturn.Value == null)
-                throw new ArgumentNullException(nameof(varReturn), "Property is not nullable for class Return.");
+                throw new JsonException("Property is not nullable for class Return: return.");
 
             if (varUnsafe.IsSet && varUnsafe.Value == null)
-                throw new ArgumentNullException(nameof(varUnsafe), "Property is not nullable for class Return.");
+                throw new JsonException("Property is not nullable for class Return: unsafe.");
 
             return new Return(varLock.Value!, varAbstract.Value!, varReturn, varUnsafe);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -167,10 +167,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (role.IsSet && role.Value == null)
-                throw new ArgumentNullException(nameof(role), "Property is not nullable for class RolesReportsHash.");
+                throw new JsonException("Property is not nullable for class RolesReportsHash: role.");
 
             if (roleUuid.IsSet && roleUuid.Value == null)
-                throw new ArgumentNullException(nameof(roleUuid), "Property is not nullable for class RolesReportsHash.");
+                throw new JsonException("Property is not nullable for class RolesReportsHash: role_uuid.");
 
             return new RolesReportsHash(role, roleUuid);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class RolesReportsHashRole.");
+                throw new JsonException("Property is not nullable for class RolesReportsHashRole: name.");
 
             return new RolesReportsHashRole(name);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
@@ -153,16 +153,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ScaleneTriangle.", nameof(shapeType));
+                throw new JsonException("Property is required for class ScaleneTriangle: shapeType.");
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class ScaleneTriangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class ScaleneTriangle: triangleType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ScaleneTriangle.");
+                throw new JsonException("Property is not nullable for class ScaleneTriangle: shapeType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class ScaleneTriangle.");
+                throw new JsonException("Property is not nullable for class ScaleneTriangle: triangleType.");
 
             return new ScaleneTriangle(shapeType.Value!, triangleType.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Shape.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Shape.cs
@@ -195,10 +195,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class Shape.", nameof(shapeType));
+                throw new JsonException("Property is required for class Shape: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class Shape.");
+                throw new JsonException("Property is not nullable for class Shape: shapeType.");
 
             if (quadrilateral != null)
                 return new Shape(quadrilateral);

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ShapeInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ShapeInterface.cs
@@ -140,10 +140,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ShapeInterface.", nameof(shapeType));
+                throw new JsonException("Property is required for class ShapeInterface: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ShapeInterface.");
+                throw new JsonException("Property is not nullable for class ShapeInterface: shapeType.");
 
             return new ShapeInterface(shapeType.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ShapeOrNull.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ShapeOrNull.cs
@@ -195,10 +195,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ShapeOrNull.", nameof(shapeType));
+                throw new JsonException("Property is required for class ShapeOrNull: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ShapeOrNull.");
+                throw new JsonException("Property is not nullable for class ShapeOrNull: shapeType.");
 
             if (quadrilateral != null)
                 return new ShapeOrNull(quadrilateral);

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
@@ -153,16 +153,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class SimpleQuadrilateral.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class SimpleQuadrilateral: quadrilateralType.");
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class SimpleQuadrilateral.", nameof(shapeType));
+                throw new JsonException("Property is required for class SimpleQuadrilateral: shapeType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class SimpleQuadrilateral.");
+                throw new JsonException("Property is not nullable for class SimpleQuadrilateral: quadrilateralType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class SimpleQuadrilateral.");
+                throw new JsonException("Property is not nullable for class SimpleQuadrilateral: shapeType.");
 
             return new SimpleQuadrilateral(quadrilateralType.Value!, shapeType.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -167,10 +167,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varSpecialModelName.IsSet && varSpecialModelName.Value == null)
-                throw new ArgumentNullException(nameof(varSpecialModelName), "Property is not nullable for class SpecialModelName.");
+                throw new JsonException("Property is not nullable for class SpecialModelName: _special_model.name_.");
 
             if (specialPropertyName.IsSet && specialPropertyName.Value == null)
-                throw new ArgumentNullException(nameof(specialPropertyName), "Property is not nullable for class SpecialModelName.");
+                throw new JsonException("Property is not nullable for class SpecialModelName: $special[property.name].");
 
             return new SpecialModelName(varSpecialModelName, specialPropertyName);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Tag.cs
@@ -167,10 +167,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Tag.");
+                throw new JsonException("Property is not nullable for class Tag: id.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Tag.");
+                throw new JsonException("Property is not nullable for class Tag: name.");
 
             return new Tag(id, name);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (value.IsSet && value.Value == null)
-                throw new ArgumentNullException(nameof(value), "Property is not nullable for class TestCollectionEndingWithWordList.");
+                throw new JsonException("Property is not nullable for class TestCollectionEndingWithWordList: value.");
 
             return new TestCollectionEndingWithWordList(value);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (testCollectionEndingWithWordList.IsSet && testCollectionEndingWithWordList.Value == null)
-                throw new ArgumentNullException(nameof(testCollectionEndingWithWordList), "Property is not nullable for class TestCollectionEndingWithWordListObject.");
+                throw new JsonException("Property is not nullable for class TestCollectionEndingWithWordListObject: TestCollectionEndingWithWordList.");
 
             return new TestCollectionEndingWithWordListObject(testCollectionEndingWithWordList);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/TestDescendants.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/TestDescendants.cs
@@ -243,16 +243,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!alternativeName.IsSet)
-                throw new ArgumentException("Property is required for class TestDescendants.", nameof(alternativeName));
+                throw new JsonException("Property is required for class TestDescendants: alternativeName.");
 
             if (!objectType.IsSet)
-                throw new ArgumentException("Property is required for class TestDescendants.", nameof(objectType));
+                throw new JsonException("Property is required for class TestDescendants: objectType.");
 
             if (alternativeName.IsSet && alternativeName.Value == null)
-                throw new ArgumentNullException(nameof(alternativeName), "Property is not nullable for class TestDescendants.");
+                throw new JsonException("Property is not nullable for class TestDescendants: alternativeName.");
 
             if (objectType.IsSet && objectType.Value == null)
-                throw new ArgumentNullException(nameof(objectType), "Property is not nullable for class TestDescendants.");
+                throw new JsonException("Property is not nullable for class TestDescendants: objectType.");
 
             return new TestDescendants(alternativeName.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (someProperty.IsSet && someProperty.Value == null)
-                throw new ArgumentNullException(nameof(someProperty), "Property is not nullable for class TestInlineFreeformAdditionalPropertiesRequest.");
+                throw new JsonException("Property is not nullable for class TestInlineFreeformAdditionalPropertiesRequest: someProperty.");
 
             return new TestInlineFreeformAdditionalPropertiesRequest(someProperty);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/TestResult.cs
@@ -189,13 +189,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (code.IsSet && code.Value == null)
-                throw new ArgumentNullException(nameof(code), "Property is not nullable for class TestResult.");
+                throw new JsonException("Property is not nullable for class TestResult: code.");
 
             if (data.IsSet && data.Value == null)
-                throw new ArgumentNullException(nameof(data), "Property is not nullable for class TestResult.");
+                throw new JsonException("Property is not nullable for class TestResult: data.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class TestResult.");
+                throw new JsonException("Property is not nullable for class TestResult: uuid.");
 
             return new TestResult(code, data, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Triangle.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Triangle.cs
@@ -216,10 +216,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class Triangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class Triangle: triangleType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class Triangle.");
+                throw new JsonException("Property is not nullable for class Triangle: triangleType.");
 
             if (equilateralTriangle != null)
                 return new Triangle(equilateralTriangle);

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/TriangleInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/TriangleInterface.cs
@@ -140,10 +140,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class TriangleInterface.", nameof(triangleType));
+                throw new JsonException("Property is required for class TriangleInterface: triangleType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class TriangleInterface.");
+                throw new JsonException("Property is not nullable for class TriangleInterface: triangleType.");
 
             return new TriangleInterface(triangleType.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/User.cs
@@ -372,31 +372,31 @@ namespace Org.OpenAPITools.Model
             }
 
             if (email.IsSet && email.Value == null)
-                throw new ArgumentNullException(nameof(email), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: email.");
 
             if (firstName.IsSet && firstName.Value == null)
-                throw new ArgumentNullException(nameof(firstName), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: firstName.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: id.");
 
             if (lastName.IsSet && lastName.Value == null)
-                throw new ArgumentNullException(nameof(lastName), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: lastName.");
 
             if (objectWithNoDeclaredProps.IsSet && objectWithNoDeclaredProps.Value == null)
-                throw new ArgumentNullException(nameof(objectWithNoDeclaredProps), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: objectWithNoDeclaredProps.");
 
             if (password.IsSet && password.Value == null)
-                throw new ArgumentNullException(nameof(password), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: password.");
 
             if (phone.IsSet && phone.Value == null)
-                throw new ArgumentNullException(nameof(phone), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: phone.");
 
             if (userStatus.IsSet && userStatus.Value == null)
-                throw new ArgumentNullException(nameof(userStatus), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: userStatus.");
 
             if (username.IsSet && username.Value == null)
-                throw new ArgumentNullException(nameof(username), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: username.");
 
             return new User(anyTypeProp, anyTypePropNullable, email, firstName, id, lastName, objectWithNoDeclaredProps, objectWithNoDeclaredPropsNullable, password, phone, userStatus, username);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Whale.cs
@@ -180,16 +180,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Whale.", nameof(className));
+                throw new JsonException("Property is required for class Whale: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Whale.");
+                throw new JsonException("Property is not nullable for class Whale: className.");
 
             if (hasBaleen.IsSet && hasBaleen.Value == null)
-                throw new ArgumentNullException(nameof(hasBaleen), "Property is not nullable for class Whale.");
+                throw new JsonException("Property is not nullable for class Whale: hasBaleen.");
 
             if (hasTeeth.IsSet && hasTeeth.Value == null)
-                throw new ArgumentNullException(nameof(hasTeeth), "Property is not nullable for class Whale.");
+                throw new JsonException("Property is not nullable for class Whale: hasTeeth.");
 
             return new Whale(className.Value!, hasBaleen, hasTeeth);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Zebra.cs
@@ -247,13 +247,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Zebra.", nameof(className));
+                throw new JsonException("Property is required for class Zebra: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Zebra.");
+                throw new JsonException("Property is not nullable for class Zebra: className.");
 
             if (type.IsSet && type.Value == null)
-                throw new ArgumentNullException(nameof(type), "Property is not nullable for class Zebra.");
+                throw new JsonException("Property is not nullable for class Zebra: type.");
 
             return new Zebra(className.Value!, type);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
@@ -220,7 +220,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (zeroBasedEnum.IsSet && zeroBasedEnum.Value == null)
-                throw new ArgumentNullException(nameof(zeroBasedEnum), "Property is not nullable for class ZeroBasedEnumClass.");
+                throw new JsonException("Property is not nullable for class ZeroBasedEnumClass: ZeroBasedEnum.");
 
             return new ZeroBasedEnumClass(zeroBasedEnum);
         }

--- a/samples/client/petstore/csharp/generichost/net8/OneOf/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net8/OneOf/src/Org.OpenAPITools/Model/Apple.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (kind.IsSet && kind.Value == null)
-                throw new ArgumentNullException(nameof(kind), "Property is not nullable for class Apple.");
+                throw new JsonException("Property is not nullable for class Apple: kind.");
 
             return new Apple(kind);
         }

--- a/samples/client/petstore/csharp/generichost/net8/OneOf/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net8/OneOf/src/Org.OpenAPITools/Model/Banana.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (count.IsSet && count.Value == null)
-                throw new ArgumentNullException(nameof(count), "Property is not nullable for class Banana.");
+                throw new JsonException("Property is not nullable for class Banana: count.");
 
             return new Banana(count);
         }

--- a/samples/client/petstore/csharp/generichost/net8/OneOf/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net8/OneOf/src/Org.OpenAPITools/Model/Fruit.cs
@@ -213,7 +213,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Fruit.");
+                throw new JsonException("Property is not nullable for class Fruit: color.");
 
             if (apple != null)
                 return new Fruit(apple, color);

--- a/samples/client/petstore/csharp/generichost/net8/OneOf/src/Org.OpenAPITools/Model/Orange.cs
+++ b/samples/client/petstore/csharp/generichost/net8/OneOf/src/Org.OpenAPITools/Model/Orange.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (sweet.IsSet && sweet.Value == null)
-                throw new ArgumentNullException(nameof(sweet), "Property is not nullable for class Orange.");
+                throw new JsonException("Property is not nullable for class Orange: sweet.");
 
             return new Orange(sweet);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Activity.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (activityOutputs.IsSet && activityOutputs.Value == null)
-                throw new ArgumentNullException(nameof(activityOutputs), "Property is not nullable for class Activity.");
+                throw new JsonException("Property is not nullable for class Activity: activity_outputs.");
 
             return new Activity(activityOutputs);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (prop1.IsSet && prop1.Value == null)
-                throw new ArgumentNullException(nameof(prop1), "Property is not nullable for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Property is not nullable for class ActivityOutputElementRepresentation: prop1.");
 
             if (prop2.IsSet && prop2.Value == null)
-                throw new ArgumentNullException(nameof(prop2), "Property is not nullable for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Property is not nullable for class ActivityOutputElementRepresentation: prop2.");
 
             return new ActivityOutputElementRepresentation(prop1, prop2);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -286,25 +286,25 @@ namespace Org.OpenAPITools.Model
             }
 
             if (emptyMap.IsSet && emptyMap.Value == null)
-                throw new ArgumentNullException(nameof(emptyMap), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: empty_map.");
 
             if (mapOfMapProperty.IsSet && mapOfMapProperty.Value == null)
-                throw new ArgumentNullException(nameof(mapOfMapProperty), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_of_map_property.");
 
             if (mapProperty.IsSet && mapProperty.Value == null)
-                throw new ArgumentNullException(nameof(mapProperty), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_property.");
 
             if (mapWithUndeclaredPropertiesAnytype1.IsSet && mapWithUndeclaredPropertiesAnytype1.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesAnytype1), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_anytype_1.");
 
             if (mapWithUndeclaredPropertiesAnytype2.IsSet && mapWithUndeclaredPropertiesAnytype2.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesAnytype2), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_anytype_2.");
 
             if (mapWithUndeclaredPropertiesAnytype3.IsSet && mapWithUndeclaredPropertiesAnytype3.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesAnytype3), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_anytype_3.");
 
             if (mapWithUndeclaredPropertiesString.IsSet && mapWithUndeclaredPropertiesString.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesString), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_string.");
 
             return new AdditionalPropertiesClass(anytype1, emptyMap, mapOfMapProperty, mapProperty, mapWithUndeclaredPropertiesAnytype1, mapWithUndeclaredPropertiesAnytype2, mapWithUndeclaredPropertiesAnytype3, mapWithUndeclaredPropertiesString);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Animal.cs
@@ -175,13 +175,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Animal.", nameof(className));
+                throw new JsonException("Property is required for class Animal: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Animal.");
+                throw new JsonException("Property is not nullable for class Animal: className.");
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Animal.");
+                throw new JsonException("Property is not nullable for class Animal: color.");
 
             return new Animal(color);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -185,13 +185,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (code.IsSet && code.Value == null)
-                throw new ArgumentNullException(nameof(code), "Property is not nullable for class ApiResponse.");
+                throw new JsonException("Property is not nullable for class ApiResponse: code.");
 
             if (message.IsSet && message.Value == null)
-                throw new ArgumentNullException(nameof(message), "Property is not nullable for class ApiResponse.");
+                throw new JsonException("Property is not nullable for class ApiResponse: message.");
 
             if (type.IsSet && type.Value == null)
-                throw new ArgumentNullException(nameof(type), "Property is not nullable for class ApiResponse.");
+                throw new JsonException("Property is not nullable for class ApiResponse: type.");
 
             return new ApiResponse(code, message, type);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Apple.cs
@@ -215,13 +215,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (colorCode.IsSet && colorCode.Value == null)
-                throw new ArgumentNullException(nameof(colorCode), "Property is not nullable for class Apple.");
+                throw new JsonException("Property is not nullable for class Apple: color_code.");
 
             if (cultivar.IsSet && cultivar.Value == null)
-                throw new ArgumentNullException(nameof(cultivar), "Property is not nullable for class Apple.");
+                throw new JsonException("Property is not nullable for class Apple: cultivar.");
 
             if (origin.IsSet && origin.Value == null)
-                throw new ArgumentNullException(nameof(origin), "Property is not nullable for class Apple.");
+                throw new JsonException("Property is not nullable for class Apple: origin.");
 
             return new Apple(colorCode, cultivar, origin);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -151,13 +151,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!cultivar.IsSet)
-                throw new ArgumentException("Property is required for class AppleReq.", nameof(cultivar));
+                throw new JsonException("Property is required for class AppleReq: cultivar.");
 
             if (cultivar.IsSet && cultivar.Value == null)
-                throw new ArgumentNullException(nameof(cultivar), "Property is not nullable for class AppleReq.");
+                throw new JsonException("Property is not nullable for class AppleReq: cultivar.");
 
             if (mealy.IsSet && mealy.Value == null)
-                throw new ArgumentNullException(nameof(mealy), "Property is not nullable for class AppleReq.");
+                throw new JsonException("Property is not nullable for class AppleReq: mealy.");
 
             return new AppleReq(cultivar.Value, mealy);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayArrayNumber.IsSet && arrayArrayNumber.Value == null)
-                throw new ArgumentNullException(nameof(arrayArrayNumber), "Property is not nullable for class ArrayOfArrayOfNumberOnly.");
+                throw new JsonException("Property is not nullable for class ArrayOfArrayOfNumberOnly: ArrayArrayNumber.");
 
             return new ArrayOfArrayOfNumberOnly(arrayArrayNumber);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayNumber.IsSet && arrayNumber.Value == null)
-                throw new ArgumentNullException(nameof(arrayNumber), "Property is not nullable for class ArrayOfNumberOnly.");
+                throw new JsonException("Property is not nullable for class ArrayOfNumberOnly: ArrayNumber.");
 
             return new ArrayOfNumberOnly(arrayNumber);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -185,13 +185,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayArrayOfInteger.IsSet && arrayArrayOfInteger.Value == null)
-                throw new ArgumentNullException(nameof(arrayArrayOfInteger), "Property is not nullable for class ArrayTest.");
+                throw new JsonException("Property is not nullable for class ArrayTest: array_array_of_integer.");
 
             if (arrayArrayOfModel.IsSet && arrayArrayOfModel.Value == null)
-                throw new ArgumentNullException(nameof(arrayArrayOfModel), "Property is not nullable for class ArrayTest.");
+                throw new JsonException("Property is not nullable for class ArrayTest: array_array_of_model.");
 
             if (arrayOfString.IsSet && arrayOfString.Value == null)
-                throw new ArgumentNullException(nameof(arrayOfString), "Property is not nullable for class ArrayTest.");
+                throw new JsonException("Property is not nullable for class ArrayTest: array_of_string.");
 
             return new ArrayTest(arrayArrayOfInteger, arrayArrayOfModel, arrayOfString);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Banana.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (lengthCm.IsSet && lengthCm.Value == null)
-                throw new ArgumentNullException(nameof(lengthCm), "Property is not nullable for class Banana.");
+                throw new JsonException("Property is not nullable for class Banana: lengthCm.");
 
             return new Banana(lengthCm);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -151,13 +151,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!lengthCm.IsSet)
-                throw new ArgumentException("Property is required for class BananaReq.", nameof(lengthCm));
+                throw new JsonException("Property is required for class BananaReq: lengthCm.");
 
             if (lengthCm.IsSet && lengthCm.Value == null)
-                throw new ArgumentNullException(nameof(lengthCm), "Property is not nullable for class BananaReq.");
+                throw new JsonException("Property is not nullable for class BananaReq: lengthCm.");
 
             if (sweet.IsSet && sweet.Value == null)
-                throw new ArgumentNullException(nameof(sweet), "Property is not nullable for class BananaReq.");
+                throw new JsonException("Property is not nullable for class BananaReq: sweet.");
 
             return new BananaReq(lengthCm.Value.Value, sweet);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/BasquePig.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/BasquePig.cs
@@ -138,10 +138,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class BasquePig.", nameof(className));
+                throw new JsonException("Property is required for class BasquePig: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class BasquePig.");
+                throw new JsonException("Property is not nullable for class BasquePig: className.");
 
             return new BasquePig(className.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -246,22 +246,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (aTTNAME.IsSet && aTTNAME.Value == null)
-                throw new ArgumentNullException(nameof(aTTNAME), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: ATT_NAME.");
 
             if (capitalCamel.IsSet && capitalCamel.Value == null)
-                throw new ArgumentNullException(nameof(capitalCamel), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: CapitalCamel.");
 
             if (capitalSnake.IsSet && capitalSnake.Value == null)
-                throw new ArgumentNullException(nameof(capitalSnake), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: Capital_Snake.");
 
             if (sCAETHFlowPoints.IsSet && sCAETHFlowPoints.Value == null)
-                throw new ArgumentNullException(nameof(sCAETHFlowPoints), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: SCA_ETH_Flow_Points.");
 
             if (smallCamel.IsSet && smallCamel.Value == null)
-                throw new ArgumentNullException(nameof(smallCamel), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: smallCamel.");
 
             if (smallSnake.IsSet && smallSnake.Value == null)
-                throw new ArgumentNullException(nameof(smallSnake), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: small_Snake.");
 
             return new Capitalization(aTTNAME, capitalCamel, capitalSnake, sCAETHFlowPoints, smallCamel, smallSnake);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Cat.cs
@@ -138,16 +138,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Cat.", nameof(className));
+                throw new JsonException("Property is required for class Cat: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Cat.");
+                throw new JsonException("Property is not nullable for class Cat: className.");
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Cat.");
+                throw new JsonException("Property is not nullable for class Cat: color.");
 
             if (declawed.IsSet && declawed.Value == null)
-                throw new ArgumentNullException(nameof(declawed), "Property is not nullable for class Cat.");
+                throw new JsonException("Property is not nullable for class Cat: declawed.");
 
             return new Cat(color, declawed);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Category.cs
@@ -158,13 +158,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!name.IsSet)
-                throw new ArgumentException("Property is required for class Category.", nameof(name));
+                throw new JsonException("Property is required for class Category: name.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Category.");
+                throw new JsonException("Property is not nullable for class Category: id.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Category.");
+                throw new JsonException("Property is not nullable for class Category: name.");
 
             return new Category(id, name.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -200,13 +200,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!petType.IsSet)
-                throw new ArgumentException("Property is required for class ChildCat.", nameof(petType));
+                throw new JsonException("Property is required for class ChildCat: pet_type.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class ChildCat.");
+                throw new JsonException("Property is not nullable for class ChildCat: name.");
 
             if (petType.IsSet && petType.Value == null)
-                throw new ArgumentNullException(nameof(petType), "Property is not nullable for class ChildCat.");
+                throw new JsonException("Property is not nullable for class ChildCat: pet_type.");
 
             return new ChildCat(name);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varClass.IsSet && varClass.Value == null)
-                throw new ArgumentNullException(nameof(varClass), "Property is not nullable for class ClassModel.");
+                throw new JsonException("Property is not nullable for class ClassModel: _class.");
 
             return new ClassModel(varClass);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
@@ -151,16 +151,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class ComplexQuadrilateral.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class ComplexQuadrilateral: quadrilateralType.");
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ComplexQuadrilateral.", nameof(shapeType));
+                throw new JsonException("Property is required for class ComplexQuadrilateral: shapeType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class ComplexQuadrilateral.");
+                throw new JsonException("Property is not nullable for class ComplexQuadrilateral: quadrilateralType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ComplexQuadrilateral.");
+                throw new JsonException("Property is not nullable for class ComplexQuadrilateral: shapeType.");
 
             return new ComplexQuadrilateral(quadrilateralType.Value, shapeType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/CopyActivity.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/CopyActivity.cs
@@ -193,16 +193,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!copyActivitytt.IsSet)
-                throw new ArgumentException("Property is required for class CopyActivity.", nameof(copyActivitytt));
+                throw new JsonException("Property is required for class CopyActivity: copyActivitytt.");
 
             if (!schema.IsSet)
-                throw new ArgumentException("Property is required for class CopyActivity.", nameof(schema));
+                throw new JsonException("Property is required for class CopyActivity: $schema.");
 
             if (copyActivitytt.IsSet && copyActivitytt.Value == null)
-                throw new ArgumentNullException(nameof(copyActivitytt), "Property is not nullable for class CopyActivity.");
+                throw new JsonException("Property is not nullable for class CopyActivity: copyActivitytt.");
 
             if (schema.IsSet && schema.Value == null)
-                throw new ArgumentNullException(nameof(schema), "Property is not nullable for class CopyActivity.");
+                throw new JsonException("Property is not nullable for class CopyActivity: $schema.");
 
             return new CopyActivity(copyActivitytt.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/DanishPig.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/DanishPig.cs
@@ -138,10 +138,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class DanishPig.", nameof(className));
+                throw new JsonException("Property is required for class DanishPig: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class DanishPig.");
+                throw new JsonException("Property is not nullable for class DanishPig: className.");
 
             return new DanishPig(className.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -151,7 +151,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (dateOnlyProperty.IsSet && dateOnlyProperty.Value == null)
-                throw new ArgumentNullException(nameof(dateOnlyProperty), "Property is not nullable for class DateOnlyClass.");
+                throw new JsonException("Property is not nullable for class DateOnlyClass: dateOnlyProperty.");
 
             return new DateOnlyClass(dateOnlyProperty);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class DeprecatedObject.");
+                throw new JsonException("Property is not nullable for class DeprecatedObject: name.");
 
             return new DeprecatedObject(name);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Descendant1.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Descendant1.cs
@@ -138,22 +138,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!alternativeName.IsSet)
-                throw new ArgumentException("Property is required for class Descendant1.", nameof(alternativeName));
+                throw new JsonException("Property is required for class Descendant1: alternativeName.");
 
             if (!descendantName.IsSet)
-                throw new ArgumentException("Property is required for class Descendant1.", nameof(descendantName));
+                throw new JsonException("Property is required for class Descendant1: descendantName.");
 
             if (!objectType.IsSet)
-                throw new ArgumentException("Property is required for class Descendant1.", nameof(objectType));
+                throw new JsonException("Property is required for class Descendant1: objectType.");
 
             if (alternativeName.IsSet && alternativeName.Value == null)
-                throw new ArgumentNullException(nameof(alternativeName), "Property is not nullable for class Descendant1.");
+                throw new JsonException("Property is not nullable for class Descendant1: alternativeName.");
 
             if (descendantName.IsSet && descendantName.Value == null)
-                throw new ArgumentNullException(nameof(descendantName), "Property is not nullable for class Descendant1.");
+                throw new JsonException("Property is not nullable for class Descendant1: descendantName.");
 
             if (objectType.IsSet && objectType.Value == null)
-                throw new ArgumentNullException(nameof(objectType), "Property is not nullable for class Descendant1.");
+                throw new JsonException("Property is not nullable for class Descendant1: objectType.");
 
             return new Descendant1(alternativeName.Value, descendantName.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Descendant2.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Descendant2.cs
@@ -138,22 +138,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!alternativeName.IsSet)
-                throw new ArgumentException("Property is required for class Descendant2.", nameof(alternativeName));
+                throw new JsonException("Property is required for class Descendant2: alternativeName.");
 
             if (!confidentiality.IsSet)
-                throw new ArgumentException("Property is required for class Descendant2.", nameof(confidentiality));
+                throw new JsonException("Property is required for class Descendant2: confidentiality.");
 
             if (!objectType.IsSet)
-                throw new ArgumentException("Property is required for class Descendant2.", nameof(objectType));
+                throw new JsonException("Property is required for class Descendant2: objectType.");
 
             if (alternativeName.IsSet && alternativeName.Value == null)
-                throw new ArgumentNullException(nameof(alternativeName), "Property is not nullable for class Descendant2.");
+                throw new JsonException("Property is not nullable for class Descendant2: alternativeName.");
 
             if (confidentiality.IsSet && confidentiality.Value == null)
-                throw new ArgumentNullException(nameof(confidentiality), "Property is not nullable for class Descendant2.");
+                throw new JsonException("Property is not nullable for class Descendant2: confidentiality.");
 
             if (objectType.IsSet && objectType.Value == null)
-                throw new ArgumentNullException(nameof(objectType), "Property is not nullable for class Descendant2.");
+                throw new JsonException("Property is not nullable for class Descendant2: objectType.");
 
             return new Descendant2(alternativeName.Value, confidentiality.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Dog.cs
@@ -138,16 +138,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Dog.", nameof(className));
+                throw new JsonException("Property is required for class Dog: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Dog.");
+                throw new JsonException("Property is not nullable for class Dog: className.");
 
             if (breed.IsSet && breed.Value == null)
-                throw new ArgumentNullException(nameof(breed), "Property is not nullable for class Dog.");
+                throw new JsonException("Property is not nullable for class Dog: breed.");
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Dog.");
+                throw new JsonException("Property is not nullable for class Dog: color.");
 
             return new Dog(breed, color);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Drawing.cs
@@ -205,10 +205,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (mainShape.IsSet && mainShape.Value == null)
-                throw new ArgumentNullException(nameof(mainShape), "Property is not nullable for class Drawing.");
+                throw new JsonException("Property is not nullable for class Drawing: mainShape.");
 
             if (shapes.IsSet && shapes.Value == null)
-                throw new ArgumentNullException(nameof(shapes), "Property is not nullable for class Drawing.");
+                throw new JsonException("Property is not nullable for class Drawing: shapes.");
 
             return new Drawing(mainShape, nullableShape, shapeOrNull, shapes);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/EntityBase.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/EntityBase.cs
@@ -152,10 +152,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!schema.IsSet)
-                throw new ArgumentException("Property is required for class EntityBase.", nameof(schema));
+                throw new JsonException("Property is required for class EntityBase: $schema.");
 
             if (schema.IsSet && schema.Value == null)
-                throw new ArgumentNullException(nameof(schema), "Property is not nullable for class EntityBase.");
+                throw new JsonException("Property is not nullable for class EntityBase: $schema.");
 
             return new EntityBase();
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -304,10 +304,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayEnum.IsSet && arrayEnum.Value == null)
-                throw new ArgumentNullException(nameof(arrayEnum), "Property is not nullable for class EnumArrays.");
+                throw new JsonException("Property is not nullable for class EnumArrays: array_enum.");
 
             if (justSymbol.IsSet && justSymbol.Value == null)
-                throw new ArgumentNullException(nameof(justSymbol), "Property is not nullable for class EnumArrays.");
+                throw new JsonException("Property is not nullable for class EnumArrays: just_symbol.");
 
             return new EnumArrays(arrayEnum, justSymbol);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -822,31 +822,31 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!enumStringRequired.IsSet)
-                throw new ArgumentException("Property is required for class EnumTest.", nameof(enumStringRequired));
+                throw new JsonException("Property is required for class EnumTest: enum_string_required.");
 
             if (enumStringRequired.IsSet && enumStringRequired.Value == null)
-                throw new ArgumentNullException(nameof(enumStringRequired), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_string_required.");
 
             if (enumInteger.IsSet && enumInteger.Value == null)
-                throw new ArgumentNullException(nameof(enumInteger), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_integer.");
 
             if (enumIntegerOnly.IsSet && enumIntegerOnly.Value == null)
-                throw new ArgumentNullException(nameof(enumIntegerOnly), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_integer_only.");
 
             if (enumNumber.IsSet && enumNumber.Value == null)
-                throw new ArgumentNullException(nameof(enumNumber), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_number.");
 
             if (enumString.IsSet && enumString.Value == null)
-                throw new ArgumentNullException(nameof(enumString), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_string.");
 
             if (outerEnumDefaultValue.IsSet && outerEnumDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(outerEnumDefaultValue), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: outerEnumDefaultValue.");
 
             if (outerEnumInteger.IsSet && outerEnumInteger.Value == null)
-                throw new ArgumentNullException(nameof(outerEnumInteger), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: outerEnumInteger.");
 
             if (outerEnumIntegerDefaultValue.IsSet && outerEnumIntegerDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(outerEnumIntegerDefaultValue), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: outerEnumIntegerDefaultValue.");
 
             return new EnumTest(enumStringRequired.Value.Value, enumInteger, enumIntegerOnly, enumNumber, enumString, outerEnum, outerEnumDefaultValue, outerEnumInteger, outerEnumIntegerDefaultValue);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
@@ -151,16 +151,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class EquilateralTriangle.", nameof(shapeType));
+                throw new JsonException("Property is required for class EquilateralTriangle: shapeType.");
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class EquilateralTriangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class EquilateralTriangle: triangleType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class EquilateralTriangle.");
+                throw new JsonException("Property is not nullable for class EquilateralTriangle: shapeType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class EquilateralTriangle.");
+                throw new JsonException("Property is not nullable for class EquilateralTriangle: triangleType.");
 
             return new EquilateralTriangle(shapeType.Value, triangleType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/File.cs
@@ -146,7 +146,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (sourceURI.IsSet && sourceURI.Value == null)
-                throw new ArgumentNullException(nameof(sourceURI), "Property is not nullable for class File.");
+                throw new JsonException("Property is not nullable for class File: sourceURI.");
 
             return new File(sourceURI);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (file.IsSet && file.Value == null)
-                throw new ArgumentNullException(nameof(file), "Property is not nullable for class FileSchemaTestClass.");
+                throw new JsonException("Property is not nullable for class FileSchemaTestClass: file.");
 
             if (files.IsSet && files.Value == null)
-                throw new ArgumentNullException(nameof(files), "Property is not nullable for class FileSchemaTestClass.");
+                throw new JsonException("Property is not nullable for class FileSchemaTestClass: files.");
 
             return new FileSchemaTestClass(file, files);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Foo.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bar.IsSet && bar.Value == null)
-                throw new ArgumentNullException(nameof(bar), "Property is not nullable for class Foo.");
+                throw new JsonException("Property is not nullable for class Foo: bar.");
 
             return new Foo(bar);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varString.IsSet && varString.Value == null)
-                throw new ArgumentNullException(nameof(varString), "Property is not nullable for class FooGetDefaultResponse.");
+                throw new JsonException("Property is not nullable for class FooGetDefaultResponse: string.");
 
             return new FooGetDefaultResponse(varString);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -826,103 +826,103 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!varByte.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(varByte));
+                throw new JsonException("Property is required for class FormatTest: byte.");
 
             if (!date.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(date));
+                throw new JsonException("Property is required for class FormatTest: date.");
 
             if (!number.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(number));
+                throw new JsonException("Property is required for class FormatTest: number.");
 
             if (!password.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(password));
+                throw new JsonException("Property is required for class FormatTest: password.");
 
             if (!stringFormattedAsDecimalRequired.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(stringFormattedAsDecimalRequired));
+                throw new JsonException("Property is required for class FormatTest: string_formatted_as_decimal_required.");
 
             if (varByte.IsSet && varByte.Value == null)
-                throw new ArgumentNullException(nameof(varByte), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: byte.");
 
             if (date.IsSet && date.Value == null)
-                throw new ArgumentNullException(nameof(date), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: date.");
 
             if (number.IsSet && number.Value == null)
-                throw new ArgumentNullException(nameof(number), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: number.");
 
             if (password.IsSet && password.Value == null)
-                throw new ArgumentNullException(nameof(password), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: password.");
 
             if (stringFormattedAsDecimalRequired.IsSet && stringFormattedAsDecimalRequired.Value == null)
-                throw new ArgumentNullException(nameof(stringFormattedAsDecimalRequired), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: string_formatted_as_decimal_required.");
 
             if (binary.IsSet && binary.Value == null)
-                throw new ArgumentNullException(nameof(binary), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: binary.");
 
             if (dateTime.IsSet && dateTime.Value == null)
-                throw new ArgumentNullException(nameof(dateTime), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: dateTime.");
 
             if (varDecimal.IsSet && varDecimal.Value == null)
-                throw new ArgumentNullException(nameof(varDecimal), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: decimal.");
 
             if (varDouble.IsSet && varDouble.Value == null)
-                throw new ArgumentNullException(nameof(varDouble), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: double.");
 
             if (duplicatePropertyName2.IsSet && duplicatePropertyName2.Value == null)
-                throw new ArgumentNullException(nameof(duplicatePropertyName2), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: duplicate_property_name.");
 
             if (duplicatePropertyName.IsSet && duplicatePropertyName.Value == null)
-                throw new ArgumentNullException(nameof(duplicatePropertyName), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: @duplicate_property_name.");
 
             if (varFloat.IsSet && varFloat.Value == null)
-                throw new ArgumentNullException(nameof(varFloat), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: float.");
 
             if (int32.IsSet && int32.Value == null)
-                throw new ArgumentNullException(nameof(int32), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int32.");
 
             if (int32Range.IsSet && int32Range.Value == null)
-                throw new ArgumentNullException(nameof(int32Range), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int32Range.");
 
             if (int64.IsSet && int64.Value == null)
-                throw new ArgumentNullException(nameof(int64), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64.");
 
             if (int64Negative.IsSet && int64Negative.Value == null)
-                throw new ArgumentNullException(nameof(int64Negative), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64Negative.");
 
             if (int64NegativeExclusive.IsSet && int64NegativeExclusive.Value == null)
-                throw new ArgumentNullException(nameof(int64NegativeExclusive), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64NegativeExclusive.");
 
             if (int64Positive.IsSet && int64Positive.Value == null)
-                throw new ArgumentNullException(nameof(int64Positive), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64Positive.");
 
             if (int64PositiveExclusive.IsSet && int64PositiveExclusive.Value == null)
-                throw new ArgumentNullException(nameof(int64PositiveExclusive), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64PositiveExclusive.");
 
             if (integer.IsSet && integer.Value == null)
-                throw new ArgumentNullException(nameof(integer), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: integer.");
 
             if (patternWithBackslash.IsSet && patternWithBackslash.Value == null)
-                throw new ArgumentNullException(nameof(patternWithBackslash), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: pattern_with_backslash.");
 
             if (patternWithDigits.IsSet && patternWithDigits.Value == null)
-                throw new ArgumentNullException(nameof(patternWithDigits), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: pattern_with_digits.");
 
             if (patternWithDigitsAndDelimiter.IsSet && patternWithDigitsAndDelimiter.Value == null)
-                throw new ArgumentNullException(nameof(patternWithDigitsAndDelimiter), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: pattern_with_digits_and_delimiter.");
 
             if (varString.IsSet && varString.Value == null)
-                throw new ArgumentNullException(nameof(varString), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: string.");
 
             if (stringFormattedAsDecimal.IsSet && stringFormattedAsDecimal.Value == null)
-                throw new ArgumentNullException(nameof(stringFormattedAsDecimal), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: string_formatted_as_decimal.");
 
             if (unsignedInteger.IsSet && unsignedInteger.Value == null)
-                throw new ArgumentNullException(nameof(unsignedInteger), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: unsigned_integer.");
 
             if (unsignedLong.IsSet && unsignedLong.Value == null)
-                throw new ArgumentNullException(nameof(unsignedLong), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: unsigned_long.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: uuid.");
 
             return new FormatTest(varByte.Value, date.Value.Value, number.Value.Value, password.Value, stringFormattedAsDecimalRequired.Value.Value, binary, dateTime, varDecimal, varDouble, duplicatePropertyName2, duplicatePropertyName, varFloat, int32, int32Range, int64, int64Negative, int64NegativeExclusive, int64Positive, int64PositiveExclusive, integer, patternWithBackslash, patternWithDigits, patternWithDigitsAndDelimiter, varString, stringFormattedAsDecimal, unsignedInteger, unsignedLong, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
@@ -183,7 +183,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Fruit.");
+                throw new JsonException("Property is not nullable for class Fruit: color.");
 
             if (apple != null)
                 return new Fruit(apple, color);

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -187,7 +187,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class GmFruit.");
+                throw new JsonException("Property is not nullable for class GmFruit: color.");
 
             Option<Apple> appleParsedValue = apple == null
                 ? default

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
@@ -155,10 +155,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!petType.IsSet)
-                throw new ArgumentException("Property is required for class GrandparentAnimal.", nameof(petType));
+                throw new JsonException("Property is required for class GrandparentAnimal: pet_type.");
 
             if (petType.IsSet && petType.Value == null)
-                throw new ArgumentNullException(nameof(petType), "Property is not nullable for class GrandparentAnimal.");
+                throw new JsonException("Property is not nullable for class GrandparentAnimal: pet_type.");
 
             return new GrandparentAnimal();
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -206,10 +206,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bar.IsSet && bar.Value == null)
-                throw new ArgumentNullException(nameof(bar), "Property is not nullable for class HasOnlyReadOnly.");
+                throw new JsonException("Property is not nullable for class HasOnlyReadOnly: bar.");
 
             if (foo.IsSet && foo.Value == null)
-                throw new ArgumentNullException(nameof(foo), "Property is not nullable for class HasOnlyReadOnly.");
+                throw new JsonException("Property is not nullable for class HasOnlyReadOnly: foo.");
 
             return new HasOnlyReadOnly(bar, foo);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
@@ -292,22 +292,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (potentiallyOverriddenPropertyAccessor.IsSet && potentiallyOverriddenPropertyAccessor.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyAccessor), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyAccessor.");
 
             if (potentiallyOverriddenPropertyToInternal.IsSet && potentiallyOverriddenPropertyToInternal.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyToInternal), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyToInternal.");
 
             if (potentiallyOverriddenPropertyToPrivate.IsSet && potentiallyOverriddenPropertyToPrivate.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyToPrivate), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyToPrivate.");
 
             if (potentiallyOverriddenPropertyToPublic.IsSet && potentiallyOverriddenPropertyToPublic.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyToPublic), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyToPublic.");
 
             if (unalteredProperty.IsSet && unalteredProperty.Value == null)
-                throw new ArgumentNullException(nameof(unalteredProperty), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: unalteredProperty.");
 
             if (unalteredPropertyAccessor.IsSet && unalteredPropertyAccessor.Value == null)
-                throw new ArgumentNullException(nameof(unalteredPropertyAccessor), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: unalteredPropertyAccessor.");
 
             return new InjectedVendorExtensionsTest(potentiallyOverriddenPropertyAccessor, potentiallyOverriddenPropertyToInternal, potentiallyOverriddenPropertyToPrivate, potentiallyOverriddenPropertyToPublic, unalteredProperty, unalteredPropertyAccessor);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
@@ -144,16 +144,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class IsoscelesTriangle.", nameof(shapeType));
+                throw new JsonException("Property is required for class IsoscelesTriangle: shapeType.");
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class IsoscelesTriangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class IsoscelesTriangle: triangleType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class IsoscelesTriangle.");
+                throw new JsonException("Property is not nullable for class IsoscelesTriangle: shapeType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class IsoscelesTriangle.");
+                throw new JsonException("Property is not nullable for class IsoscelesTriangle: triangleType.");
 
             return new IsoscelesTriangle(shapeType.Value, triangleType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/List.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (var123List.IsSet && var123List.Value == null)
-                throw new ArgumentNullException(nameof(var123List), "Property is not nullable for class List.");
+                throw new JsonException("Property is not nullable for class List: 123-list.");
 
             return new List(var123List);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (escapedLiteralString.IsSet && escapedLiteralString.Value == null)
-                throw new ArgumentNullException(nameof(escapedLiteralString), "Property is not nullable for class LiteralStringClass.");
+                throw new JsonException("Property is not nullable for class LiteralStringClass: escapedLiteralString.");
 
             if (unescapedLiteralString.IsSet && unescapedLiteralString.Value == null)
-                throw new ArgumentNullException(nameof(unescapedLiteralString), "Property is not nullable for class LiteralStringClass.");
+                throw new JsonException("Property is not nullable for class LiteralStringClass: unescapedLiteralString.");
 
             return new LiteralStringClass(escapedLiteralString, unescapedLiteralString);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Mammal.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Mammal.cs
@@ -214,10 +214,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Mammal.", nameof(className));
+                throw new JsonException("Property is required for class Mammal: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Mammal.");
+                throw new JsonException("Property is not nullable for class Mammal: className.");
 
             if (pig != null)
                 return new Mammal(pig);

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/MapTest.cs
@@ -271,16 +271,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (directMap.IsSet && directMap.Value == null)
-                throw new ArgumentNullException(nameof(directMap), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: direct_map.");
 
             if (indirectMap.IsSet && indirectMap.Value == null)
-                throw new ArgumentNullException(nameof(indirectMap), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: indirect_map.");
 
             if (mapMapOfString.IsSet && mapMapOfString.Value == null)
-                throw new ArgumentNullException(nameof(mapMapOfString), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: map_map_of_string.");
 
             if (mapOfEnumString.IsSet && mapOfEnumString.Value == null)
-                throw new ArgumentNullException(nameof(mapOfEnumString), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: map_of_enum_string.");
 
             return new MapTest(directMap, indirectMap, mapMapOfString, mapOfEnumString);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/MixedAnyOf.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/MixedAnyOf.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (content.IsSet && content.Value == null)
-                throw new ArgumentNullException(nameof(content), "Property is not nullable for class MixedAnyOf.");
+                throw new JsonException("Property is not nullable for class MixedAnyOf: content.");
 
             return new MixedAnyOf(content);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/MixedOneOf.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/MixedOneOf.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (content.IsSet && content.Value == null)
-                throw new ArgumentNullException(nameof(content), "Property is not nullable for class MixedOneOf.");
+                throw new JsonException("Property is not nullable for class MixedOneOf: content.");
 
             return new MixedOneOf(content);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -217,16 +217,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (dateTime.IsSet && dateTime.Value == null)
-                throw new ArgumentNullException(nameof(dateTime), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: dateTime.");
 
             if (map.IsSet && map.Value == null)
-                throw new ArgumentNullException(nameof(map), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: map.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: uuid.");
 
             if (uuidWithPattern.IsSet && uuidWithPattern.Value == null)
-                throw new ArgumentNullException(nameof(uuidWithPattern), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: uuid_with_pattern.");
 
             return new MixedPropertiesAndAdditionalPropertiesClass(dateTime, map, uuid, uuidWithPattern);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/MixedSubId.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/MixedSubId.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class MixedSubId.");
+                throw new JsonException("Property is not nullable for class MixedSubId: id.");
 
             return new MixedSubId(id);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varClass.IsSet && varClass.Value == null)
-                throw new ArgumentNullException(nameof(varClass), "Property is not nullable for class Model200Response.");
+                throw new JsonException("Property is not nullable for class Model200Response: class.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Model200Response.");
+                throw new JsonException("Property is not nullable for class Model200Response: name.");
 
             return new Model200Response(varClass, name);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varClient.IsSet && varClient.Value == null)
-                throw new ArgumentNullException(nameof(varClient), "Property is not nullable for class ModelClient.");
+                throw new JsonException("Property is not nullable for class ModelClient: client.");
 
             return new ModelClient(varClient);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Name.cs
@@ -239,19 +239,19 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!varName.IsSet)
-                throw new ArgumentException("Property is required for class Name.", nameof(varName));
+                throw new JsonException("Property is required for class Name: name.");
 
             if (varName.IsSet && varName.Value == null)
-                throw new ArgumentNullException(nameof(varName), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: name.");
 
             if (property.IsSet && property.Value == null)
-                throw new ArgumentNullException(nameof(property), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: property.");
 
             if (snakeCase.IsSet && snakeCase.Value == null)
-                throw new ArgumentNullException(nameof(snakeCase), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: snake_case.");
 
             if (var123Number.IsSet && var123Number.Value == null)
-                throw new ArgumentNullException(nameof(var123Number), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: 123Number.");
 
             return new Name(varName.Value.Value, property, snakeCase, var123Number);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
@@ -151,16 +151,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!aObjVariableobject.IsSet)
-                throw new ArgumentException("Property is required for class NotificationtestGetElementsV1ResponseMPayload.", nameof(aObjVariableobject));
+                throw new JsonException("Property is required for class NotificationtestGetElementsV1ResponseMPayload: a_objVariableobject.");
 
             if (!pkiNotificationtestID.IsSet)
-                throw new ArgumentException("Property is required for class NotificationtestGetElementsV1ResponseMPayload.", nameof(pkiNotificationtestID));
+                throw new JsonException("Property is required for class NotificationtestGetElementsV1ResponseMPayload: pkiNotificationtestID.");
 
             if (aObjVariableobject.IsSet && aObjVariableobject.Value == null)
-                throw new ArgumentNullException(nameof(aObjVariableobject), "Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload.");
+                throw new JsonException("Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload: a_objVariableobject.");
 
             if (pkiNotificationtestID.IsSet && pkiNotificationtestID.Value == null)
-                throw new ArgumentNullException(nameof(pkiNotificationtestID), "Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload.");
+                throw new JsonException("Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload: pkiNotificationtestID.");
 
             return new NotificationtestGetElementsV1ResponseMPayload(aObjVariableobject.Value, pkiNotificationtestID.Value.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -375,10 +375,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayItemsNullable.IsSet && arrayItemsNullable.Value == null)
-                throw new ArgumentNullException(nameof(arrayItemsNullable), "Property is not nullable for class NullableClass.");
+                throw new JsonException("Property is not nullable for class NullableClass: array_items_nullable.");
 
             if (objectItemsNullable.IsSet && objectItemsNullable.Value == null)
-                throw new ArgumentNullException(nameof(objectItemsNullable), "Property is not nullable for class NullableClass.");
+                throw new JsonException("Property is not nullable for class NullableClass: object_items_nullable.");
 
             return new NullableClass(arrayAndItemsNullableProp, arrayItemsNullable, arrayNullableProp, booleanProp, dateProp, datetimeProp, integerProp, numberProp, objectAndItemsNullableProp, objectItemsNullable, objectNullableProp, stringProp);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/NullableShape.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/NullableShape.cs
@@ -193,10 +193,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class NullableShape.", nameof(shapeType));
+                throw new JsonException("Property is required for class NullableShape: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class NullableShape.");
+                throw new JsonException("Property is not nullable for class NullableShape: shapeType.");
 
             if (quadrilateral != null)
                 return new NullableShape(quadrilateral);

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (justNumber.IsSet && justNumber.Value == null)
-                throw new ArgumentNullException(nameof(justNumber), "Property is not nullable for class NumberOnly.");
+                throw new JsonException("Property is not nullable for class NumberOnly: JustNumber.");
 
             return new NumberOnly(justNumber);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -208,16 +208,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bars.IsSet && bars.Value == null)
-                throw new ArgumentNullException(nameof(bars), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: bars.");
 
             if (deprecatedRef.IsSet && deprecatedRef.Value == null)
-                throw new ArgumentNullException(nameof(deprecatedRef), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: deprecatedRef.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: id.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: uuid.");
 
             return new ObjectWithDeprecatedFields(bars, deprecatedRef, id, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Order.cs
@@ -340,22 +340,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (complete.IsSet && complete.Value == null)
-                throw new ArgumentNullException(nameof(complete), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: complete.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: id.");
 
             if (petId.IsSet && petId.Value == null)
-                throw new ArgumentNullException(nameof(petId), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: petId.");
 
             if (quantity.IsSet && quantity.Value == null)
-                throw new ArgumentNullException(nameof(quantity), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: quantity.");
 
             if (shipDate.IsSet && shipDate.Value == null)
-                throw new ArgumentNullException(nameof(shipDate), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: shipDate.");
 
             if (status.IsSet && status.Value == null)
-                throw new ArgumentNullException(nameof(status), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: status.");
 
             return new Order(complete, id, petId, quantity, shipDate, status);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -185,13 +185,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (myBoolean.IsSet && myBoolean.Value == null)
-                throw new ArgumentNullException(nameof(myBoolean), "Property is not nullable for class OuterComposite.");
+                throw new JsonException("Property is not nullable for class OuterComposite: my_boolean.");
 
             if (myNumber.IsSet && myNumber.Value == null)
-                throw new ArgumentNullException(nameof(myNumber), "Property is not nullable for class OuterComposite.");
+                throw new JsonException("Property is not nullable for class OuterComposite: my_number.");
 
             if (myString.IsSet && myString.Value == null)
-                throw new ArgumentNullException(nameof(myString), "Property is not nullable for class OuterComposite.");
+                throw new JsonException("Property is not nullable for class OuterComposite: my_string.");
 
             return new OuterComposite(myBoolean, myNumber, myString);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ParentPet.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ParentPet.cs
@@ -118,10 +118,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!petType.IsSet)
-                throw new ArgumentException("Property is required for class ParentPet.", nameof(petType));
+                throw new JsonException("Property is required for class ParentPet: pet_type.");
 
             if (petType.IsSet && petType.Value == null)
-                throw new ArgumentNullException(nameof(petType), "Property is not nullable for class ParentPet.");
+                throw new JsonException("Property is not nullable for class ParentPet: pet_type.");
 
             return new ParentPet();
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Pet.cs
@@ -321,28 +321,28 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!name.IsSet)
-                throw new ArgumentException("Property is required for class Pet.", nameof(name));
+                throw new JsonException("Property is required for class Pet: name.");
 
             if (!photoUrls.IsSet)
-                throw new ArgumentException("Property is required for class Pet.", nameof(photoUrls));
+                throw new JsonException("Property is required for class Pet: photoUrls.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: name.");
 
             if (photoUrls.IsSet && photoUrls.Value == null)
-                throw new ArgumentNullException(nameof(photoUrls), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: photoUrls.");
 
             if (category.IsSet && category.Value == null)
-                throw new ArgumentNullException(nameof(category), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: category.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: id.");
 
             if (status.IsSet && status.Value == null)
-                throw new ArgumentNullException(nameof(status), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: status.");
 
             if (tags.IsSet && tags.Value == null)
-                throw new ArgumentNullException(nameof(tags), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: tags.");
 
             return new Pet(name.Value, photoUrls.Value, category, id, status, tags);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Pig.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Pig.cs
@@ -193,10 +193,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Pig.", nameof(className));
+                throw new JsonException("Property is required for class Pig: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Pig.");
+                throw new JsonException("Property is not nullable for class Pig: className.");
 
             if (basquePig != null)
                 return new Pig(basquePig);

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Quadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Quadrilateral.cs
@@ -193,10 +193,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class Quadrilateral.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class Quadrilateral: quadrilateralType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class Quadrilateral.");
+                throw new JsonException("Property is not nullable for class Quadrilateral: quadrilateralType.");
 
             if (complexQuadrilateral != null)
                 return new Quadrilateral(complexQuadrilateral);

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
@@ -138,10 +138,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class QuadrilateralInterface.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class QuadrilateralInterface: quadrilateralType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class QuadrilateralInterface.");
+                throw new JsonException("Property is not nullable for class QuadrilateralInterface: quadrilateralType.");
 
             return new QuadrilateralInterface(quadrilateralType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -203,10 +203,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bar.IsSet && bar.Value == null)
-                throw new ArgumentNullException(nameof(bar), "Property is not nullable for class ReadOnlyFirst.");
+                throw new JsonException("Property is not nullable for class ReadOnlyFirst: bar.");
 
             if (baz.IsSet && baz.Value == null)
-                throw new ArgumentNullException(nameof(baz), "Property is not nullable for class ReadOnlyFirst.");
+                throw new JsonException("Property is not nullable for class ReadOnlyFirst: baz.");
 
             return new ReadOnlyFirst(bar, baz);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -2077,136 +2077,136 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!requiredNotNullableDateProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotNullableDateProp));
+                throw new JsonException("Property is required for class RequiredClass: required_not_nullable_date_prop.");
 
             if (!requiredNotnullableArrayOfString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableArrayOfString));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_array_of_string.");
 
             if (!requiredNotnullableBooleanProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableBooleanProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_boolean_prop.");
 
             if (!requiredNotnullableDatetimeProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableDatetimeProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_datetime_prop.");
 
             if (!requiredNotnullableEnumInteger.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableEnumInteger));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_enum_integer.");
 
             if (!requiredNotnullableEnumIntegerOnly.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableEnumIntegerOnly));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_enum_integer_only.");
 
             if (!requiredNotnullableEnumString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableEnumString));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_enum_string.");
 
             if (!requiredNotnullableOuterEnumDefaultValue.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableOuterEnumDefaultValue));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_outerEnumDefaultValue.");
 
             if (!requiredNotnullableStringProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableStringProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_string_prop.");
 
             if (!requiredNotnullableUuid.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableUuid));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_uuid.");
 
             if (!requiredNotnullableintegerProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableintegerProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullableinteger_prop.");
 
             if (!requiredNullableArrayOfString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableArrayOfString));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_array_of_string.");
 
             if (!requiredNullableBooleanProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableBooleanProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_boolean_prop.");
 
             if (!requiredNullableDateProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableDateProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_date_prop.");
 
             if (!requiredNullableDatetimeProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableDatetimeProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_datetime_prop.");
 
             if (!requiredNullableEnumInteger.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableEnumInteger));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_enum_integer.");
 
             if (!requiredNullableEnumIntegerOnly.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableEnumIntegerOnly));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_enum_integer_only.");
 
             if (!requiredNullableEnumString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableEnumString));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_enum_string.");
 
             if (!requiredNullableIntegerProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableIntegerProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_integer_prop.");
 
             if (!requiredNullableOuterEnumDefaultValue.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableOuterEnumDefaultValue));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_outerEnumDefaultValue.");
 
             if (!requiredNullableStringProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableStringProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_string_prop.");
 
             if (!requiredNullableUuid.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableUuid));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_uuid.");
 
             if (requiredNotNullableDateProp.IsSet && requiredNotNullableDateProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotNullableDateProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_not_nullable_date_prop.");
 
             if (requiredNotnullableArrayOfString.IsSet && requiredNotnullableArrayOfString.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableArrayOfString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_array_of_string.");
 
             if (requiredNotnullableBooleanProp.IsSet && requiredNotnullableBooleanProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableBooleanProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_boolean_prop.");
 
             if (requiredNotnullableDatetimeProp.IsSet && requiredNotnullableDatetimeProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableDatetimeProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_datetime_prop.");
 
             if (requiredNotnullableEnumInteger.IsSet && requiredNotnullableEnumInteger.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableEnumInteger), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_enum_integer.");
 
             if (requiredNotnullableEnumIntegerOnly.IsSet && requiredNotnullableEnumIntegerOnly.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableEnumIntegerOnly), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_enum_integer_only.");
 
             if (requiredNotnullableEnumString.IsSet && requiredNotnullableEnumString.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableEnumString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_enum_string.");
 
             if (requiredNotnullableOuterEnumDefaultValue.IsSet && requiredNotnullableOuterEnumDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableOuterEnumDefaultValue), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_outerEnumDefaultValue.");
 
             if (requiredNotnullableStringProp.IsSet && requiredNotnullableStringProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableStringProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_string_prop.");
 
             if (requiredNotnullableUuid.IsSet && requiredNotnullableUuid.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableUuid), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_uuid.");
 
             if (requiredNotnullableintegerProp.IsSet && requiredNotnullableintegerProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableintegerProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullableinteger_prop.");
 
             if (notRequiredNotnullableDateProp.IsSet && notRequiredNotnullableDateProp.Value == null)
-                throw new ArgumentNullException(nameof(notRequiredNotnullableDateProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: not_required_notnullable_date_prop.");
 
             if (notRequiredNotnullableintegerProp.IsSet && notRequiredNotnullableintegerProp.Value == null)
-                throw new ArgumentNullException(nameof(notRequiredNotnullableintegerProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: not_required_notnullableinteger_prop.");
 
             if (notrequiredNotnullableArrayOfString.IsSet && notrequiredNotnullableArrayOfString.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableArrayOfString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_array_of_string.");
 
             if (notrequiredNotnullableBooleanProp.IsSet && notrequiredNotnullableBooleanProp.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableBooleanProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_boolean_prop.");
 
             if (notrequiredNotnullableDatetimeProp.IsSet && notrequiredNotnullableDatetimeProp.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableDatetimeProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_datetime_prop.");
 
             if (notrequiredNotnullableEnumInteger.IsSet && notrequiredNotnullableEnumInteger.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableEnumInteger), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_enum_integer.");
 
             if (notrequiredNotnullableEnumIntegerOnly.IsSet && notrequiredNotnullableEnumIntegerOnly.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableEnumIntegerOnly), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_enum_integer_only.");
 
             if (notrequiredNotnullableEnumString.IsSet && notrequiredNotnullableEnumString.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableEnumString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_enum_string.");
 
             if (notrequiredNotnullableOuterEnumDefaultValue.IsSet && notrequiredNotnullableOuterEnumDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableOuterEnumDefaultValue), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_outerEnumDefaultValue.");
 
             if (notrequiredNotnullableStringProp.IsSet && notrequiredNotnullableStringProp.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableStringProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_string_prop.");
 
             if (notrequiredNotnullableUuid.IsSet && notrequiredNotnullableUuid.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableUuid), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_uuid.");
 
             return new RequiredClass(requiredNotNullableDateProp.Value.Value, requiredNotnullableArrayOfString.Value, requiredNotnullableBooleanProp.Value.Value, requiredNotnullableDatetimeProp.Value.Value, requiredNotnullableEnumInteger.Value.Value, requiredNotnullableEnumIntegerOnly.Value.Value, requiredNotnullableEnumString.Value.Value, requiredNotnullableOuterEnumDefaultValue.Value.Value, requiredNotnullableStringProp.Value, requiredNotnullableUuid.Value.Value, requiredNotnullableintegerProp.Value.Value, notRequiredNotnullableDateProp, notRequiredNotnullableintegerProp, notRequiredNullableDateProp, notRequiredNullableIntegerProp, notrequiredNotnullableArrayOfString, notrequiredNotnullableBooleanProp, notrequiredNotnullableDatetimeProp, notrequiredNotnullableEnumInteger, notrequiredNotnullableEnumIntegerOnly, notrequiredNotnullableEnumString, notrequiredNotnullableOuterEnumDefaultValue, notrequiredNotnullableStringProp, notrequiredNotnullableUuid, notrequiredNullableArrayOfString, notrequiredNullableBooleanProp, notrequiredNullableDatetimeProp, notrequiredNullableEnumInteger, notrequiredNullableEnumIntegerOnly, notrequiredNullableEnumString, notrequiredNullableOuterEnumDefaultValue, notrequiredNullableStringProp, notrequiredNullableUuid, requiredNullableArrayOfString.Value, requiredNullableBooleanProp.Value, requiredNullableDateProp.Value, requiredNullableDatetimeProp.Value, requiredNullableEnumInteger.Value, requiredNullableEnumIntegerOnly.Value, requiredNullableEnumString.Value, requiredNullableIntegerProp.Value, requiredNullableOuterEnumDefaultValue.Value, requiredNullableStringProp.Value, requiredNullableUuid.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Result.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Result.cs
@@ -188,13 +188,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (code.IsSet && code.Value == null)
-                throw new ArgumentNullException(nameof(code), "Property is not nullable for class Result.");
+                throw new JsonException("Property is not nullable for class Result: code.");
 
             if (data.IsSet && data.Value == null)
-                throw new ArgumentNullException(nameof(data), "Property is not nullable for class Result.");
+                throw new JsonException("Property is not nullable for class Result: data.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class Result.");
+                throw new JsonException("Property is not nullable for class Result: uuid.");
 
             return new Result(code, data, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Return.cs
@@ -191,19 +191,19 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!varLock.IsSet)
-                throw new ArgumentException("Property is required for class Return.", nameof(varLock));
+                throw new JsonException("Property is required for class Return: lock.");
 
             if (!varAbstract.IsSet)
-                throw new ArgumentException("Property is required for class Return.", nameof(varAbstract));
+                throw new JsonException("Property is required for class Return: abstract.");
 
             if (varLock.IsSet && varLock.Value == null)
-                throw new ArgumentNullException(nameof(varLock), "Property is not nullable for class Return.");
+                throw new JsonException("Property is not nullable for class Return: lock.");
 
             if (varReturn.IsSet && varReturn.Value == null)
-                throw new ArgumentNullException(nameof(varReturn), "Property is not nullable for class Return.");
+                throw new JsonException("Property is not nullable for class Return: return.");
 
             if (varUnsafe.IsSet && varUnsafe.Value == null)
-                throw new ArgumentNullException(nameof(varUnsafe), "Property is not nullable for class Return.");
+                throw new JsonException("Property is not nullable for class Return: unsafe.");
 
             return new Return(varLock.Value, varAbstract.Value, varReturn, varUnsafe);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (role.IsSet && role.Value == null)
-                throw new ArgumentNullException(nameof(role), "Property is not nullable for class RolesReportsHash.");
+                throw new JsonException("Property is not nullable for class RolesReportsHash: role.");
 
             if (roleUuid.IsSet && roleUuid.Value == null)
-                throw new ArgumentNullException(nameof(roleUuid), "Property is not nullable for class RolesReportsHash.");
+                throw new JsonException("Property is not nullable for class RolesReportsHash: role_uuid.");
 
             return new RolesReportsHash(role, roleUuid);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class RolesReportsHashRole.");
+                throw new JsonException("Property is not nullable for class RolesReportsHashRole: name.");
 
             return new RolesReportsHashRole(name);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
@@ -151,16 +151,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ScaleneTriangle.", nameof(shapeType));
+                throw new JsonException("Property is required for class ScaleneTriangle: shapeType.");
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class ScaleneTriangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class ScaleneTriangle: triangleType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ScaleneTriangle.");
+                throw new JsonException("Property is not nullable for class ScaleneTriangle: shapeType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class ScaleneTriangle.");
+                throw new JsonException("Property is not nullable for class ScaleneTriangle: triangleType.");
 
             return new ScaleneTriangle(shapeType.Value, triangleType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Shape.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Shape.cs
@@ -193,10 +193,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class Shape.", nameof(shapeType));
+                throw new JsonException("Property is required for class Shape: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class Shape.");
+                throw new JsonException("Property is not nullable for class Shape: shapeType.");
 
             if (quadrilateral != null)
                 return new Shape(quadrilateral);

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ShapeInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ShapeInterface.cs
@@ -138,10 +138,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ShapeInterface.", nameof(shapeType));
+                throw new JsonException("Property is required for class ShapeInterface: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ShapeInterface.");
+                throw new JsonException("Property is not nullable for class ShapeInterface: shapeType.");
 
             return new ShapeInterface(shapeType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ShapeOrNull.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ShapeOrNull.cs
@@ -193,10 +193,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ShapeOrNull.", nameof(shapeType));
+                throw new JsonException("Property is required for class ShapeOrNull: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ShapeOrNull.");
+                throw new JsonException("Property is not nullable for class ShapeOrNull: shapeType.");
 
             if (quadrilateral != null)
                 return new ShapeOrNull(quadrilateral);

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
@@ -151,16 +151,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class SimpleQuadrilateral.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class SimpleQuadrilateral: quadrilateralType.");
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class SimpleQuadrilateral.", nameof(shapeType));
+                throw new JsonException("Property is required for class SimpleQuadrilateral: shapeType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class SimpleQuadrilateral.");
+                throw new JsonException("Property is not nullable for class SimpleQuadrilateral: quadrilateralType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class SimpleQuadrilateral.");
+                throw new JsonException("Property is not nullable for class SimpleQuadrilateral: shapeType.");
 
             return new SimpleQuadrilateral(quadrilateralType.Value, shapeType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varSpecialModelName.IsSet && varSpecialModelName.Value == null)
-                throw new ArgumentNullException(nameof(varSpecialModelName), "Property is not nullable for class SpecialModelName.");
+                throw new JsonException("Property is not nullable for class SpecialModelName: _special_model.name_.");
 
             if (specialPropertyName.IsSet && specialPropertyName.Value == null)
-                throw new ArgumentNullException(nameof(specialPropertyName), "Property is not nullable for class SpecialModelName.");
+                throw new JsonException("Property is not nullable for class SpecialModelName: $special[property.name].");
 
             return new SpecialModelName(varSpecialModelName, specialPropertyName);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Tag.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Tag.");
+                throw new JsonException("Property is not nullable for class Tag: id.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Tag.");
+                throw new JsonException("Property is not nullable for class Tag: name.");
 
             return new Tag(id, name);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (value.IsSet && value.Value == null)
-                throw new ArgumentNullException(nameof(value), "Property is not nullable for class TestCollectionEndingWithWordList.");
+                throw new JsonException("Property is not nullable for class TestCollectionEndingWithWordList: value.");
 
             return new TestCollectionEndingWithWordList(value);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (testCollectionEndingWithWordList.IsSet && testCollectionEndingWithWordList.Value == null)
-                throw new ArgumentNullException(nameof(testCollectionEndingWithWordList), "Property is not nullable for class TestCollectionEndingWithWordListObject.");
+                throw new JsonException("Property is not nullable for class TestCollectionEndingWithWordListObject: TestCollectionEndingWithWordList.");
 
             return new TestCollectionEndingWithWordListObject(testCollectionEndingWithWordList);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/TestDescendants.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/TestDescendants.cs
@@ -241,16 +241,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!alternativeName.IsSet)
-                throw new ArgumentException("Property is required for class TestDescendants.", nameof(alternativeName));
+                throw new JsonException("Property is required for class TestDescendants: alternativeName.");
 
             if (!objectType.IsSet)
-                throw new ArgumentException("Property is required for class TestDescendants.", nameof(objectType));
+                throw new JsonException("Property is required for class TestDescendants: objectType.");
 
             if (alternativeName.IsSet && alternativeName.Value == null)
-                throw new ArgumentNullException(nameof(alternativeName), "Property is not nullable for class TestDescendants.");
+                throw new JsonException("Property is not nullable for class TestDescendants: alternativeName.");
 
             if (objectType.IsSet && objectType.Value == null)
-                throw new ArgumentNullException(nameof(objectType), "Property is not nullable for class TestDescendants.");
+                throw new JsonException("Property is not nullable for class TestDescendants: objectType.");
 
             return new TestDescendants(alternativeName.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (someProperty.IsSet && someProperty.Value == null)
-                throw new ArgumentNullException(nameof(someProperty), "Property is not nullable for class TestInlineFreeformAdditionalPropertiesRequest.");
+                throw new JsonException("Property is not nullable for class TestInlineFreeformAdditionalPropertiesRequest: someProperty.");
 
             return new TestInlineFreeformAdditionalPropertiesRequest(someProperty);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/TestResult.cs
@@ -187,13 +187,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (code.IsSet && code.Value == null)
-                throw new ArgumentNullException(nameof(code), "Property is not nullable for class TestResult.");
+                throw new JsonException("Property is not nullable for class TestResult: code.");
 
             if (data.IsSet && data.Value == null)
-                throw new ArgumentNullException(nameof(data), "Property is not nullable for class TestResult.");
+                throw new JsonException("Property is not nullable for class TestResult: data.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class TestResult.");
+                throw new JsonException("Property is not nullable for class TestResult: uuid.");
 
             return new TestResult(code, data, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Triangle.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Triangle.cs
@@ -214,10 +214,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class Triangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class Triangle: triangleType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class Triangle.");
+                throw new JsonException("Property is not nullable for class Triangle: triangleType.");
 
             if (equilateralTriangle != null)
                 return new Triangle(equilateralTriangle);

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/TriangleInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/TriangleInterface.cs
@@ -138,10 +138,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class TriangleInterface.", nameof(triangleType));
+                throw new JsonException("Property is required for class TriangleInterface: triangleType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class TriangleInterface.");
+                throw new JsonException("Property is not nullable for class TriangleInterface: triangleType.");
 
             return new TriangleInterface(triangleType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/User.cs
@@ -370,31 +370,31 @@ namespace Org.OpenAPITools.Model
             }
 
             if (email.IsSet && email.Value == null)
-                throw new ArgumentNullException(nameof(email), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: email.");
 
             if (firstName.IsSet && firstName.Value == null)
-                throw new ArgumentNullException(nameof(firstName), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: firstName.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: id.");
 
             if (lastName.IsSet && lastName.Value == null)
-                throw new ArgumentNullException(nameof(lastName), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: lastName.");
 
             if (objectWithNoDeclaredProps.IsSet && objectWithNoDeclaredProps.Value == null)
-                throw new ArgumentNullException(nameof(objectWithNoDeclaredProps), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: objectWithNoDeclaredProps.");
 
             if (password.IsSet && password.Value == null)
-                throw new ArgumentNullException(nameof(password), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: password.");
 
             if (phone.IsSet && phone.Value == null)
-                throw new ArgumentNullException(nameof(phone), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: phone.");
 
             if (userStatus.IsSet && userStatus.Value == null)
-                throw new ArgumentNullException(nameof(userStatus), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: userStatus.");
 
             if (username.IsSet && username.Value == null)
-                throw new ArgumentNullException(nameof(username), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: username.");
 
             return new User(anyTypeProp, anyTypePropNullable, email, firstName, id, lastName, objectWithNoDeclaredProps, objectWithNoDeclaredPropsNullable, password, phone, userStatus, username);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Whale.cs
@@ -178,16 +178,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Whale.", nameof(className));
+                throw new JsonException("Property is required for class Whale: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Whale.");
+                throw new JsonException("Property is not nullable for class Whale: className.");
 
             if (hasBaleen.IsSet && hasBaleen.Value == null)
-                throw new ArgumentNullException(nameof(hasBaleen), "Property is not nullable for class Whale.");
+                throw new JsonException("Property is not nullable for class Whale: hasBaleen.");
 
             if (hasTeeth.IsSet && hasTeeth.Value == null)
-                throw new ArgumentNullException(nameof(hasTeeth), "Property is not nullable for class Whale.");
+                throw new JsonException("Property is not nullable for class Whale: hasTeeth.");
 
             return new Whale(className.Value, hasBaleen, hasTeeth);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Zebra.cs
@@ -245,13 +245,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Zebra.", nameof(className));
+                throw new JsonException("Property is required for class Zebra: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Zebra.");
+                throw new JsonException("Property is not nullable for class Zebra: className.");
 
             if (type.IsSet && type.Value == null)
-                throw new ArgumentNullException(nameof(type), "Property is not nullable for class Zebra.");
+                throw new JsonException("Property is not nullable for class Zebra: type.");
 
             return new Zebra(className.Value, type);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
@@ -218,7 +218,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (zeroBasedEnum.IsSet && zeroBasedEnum.Value == null)
-                throw new ArgumentNullException(nameof(zeroBasedEnum), "Property is not nullable for class ZeroBasedEnumClass.");
+                throw new JsonException("Property is not nullable for class ZeroBasedEnumClass: ZeroBasedEnum.");
 
             return new ZeroBasedEnumClass(zeroBasedEnum);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Activity.cs
@@ -148,7 +148,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (activityOutputs.IsSet && activityOutputs.Value == null)
-                throw new ArgumentNullException(nameof(activityOutputs), "Property is not nullable for class Activity.");
+                throw new JsonException("Property is not nullable for class Activity: activity_outputs.");
 
             return new Activity(activityOutputs);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -168,10 +168,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (prop1.IsSet && prop1.Value == null)
-                throw new ArgumentNullException(nameof(prop1), "Property is not nullable for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Property is not nullable for class ActivityOutputElementRepresentation: prop1.");
 
             if (prop2.IsSet && prop2.Value == null)
-                throw new ArgumentNullException(nameof(prop2), "Property is not nullable for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Property is not nullable for class ActivityOutputElementRepresentation: prop2.");
 
             return new ActivityOutputElementRepresentation(prop1, prop2);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -289,25 +289,25 @@ namespace Org.OpenAPITools.Model
             }
 
             if (emptyMap.IsSet && emptyMap.Value == null)
-                throw new ArgumentNullException(nameof(emptyMap), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: empty_map.");
 
             if (mapOfMapProperty.IsSet && mapOfMapProperty.Value == null)
-                throw new ArgumentNullException(nameof(mapOfMapProperty), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_of_map_property.");
 
             if (mapProperty.IsSet && mapProperty.Value == null)
-                throw new ArgumentNullException(nameof(mapProperty), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_property.");
 
             if (mapWithUndeclaredPropertiesAnytype1.IsSet && mapWithUndeclaredPropertiesAnytype1.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesAnytype1), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_anytype_1.");
 
             if (mapWithUndeclaredPropertiesAnytype2.IsSet && mapWithUndeclaredPropertiesAnytype2.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesAnytype2), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_anytype_2.");
 
             if (mapWithUndeclaredPropertiesAnytype3.IsSet && mapWithUndeclaredPropertiesAnytype3.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesAnytype3), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_anytype_3.");
 
             if (mapWithUndeclaredPropertiesString.IsSet && mapWithUndeclaredPropertiesString.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesString), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_string.");
 
             return new AdditionalPropertiesClass(anytype1, emptyMap, mapOfMapProperty, mapProperty, mapWithUndeclaredPropertiesAnytype1, mapWithUndeclaredPropertiesAnytype2, mapWithUndeclaredPropertiesAnytype3, mapWithUndeclaredPropertiesString);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Animal.cs
@@ -178,13 +178,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Animal.", nameof(className));
+                throw new JsonException("Property is required for class Animal: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Animal.");
+                throw new JsonException("Property is not nullable for class Animal: className.");
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Animal.");
+                throw new JsonException("Property is not nullable for class Animal: color.");
 
             return new Animal(color);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -188,13 +188,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (code.IsSet && code.Value == null)
-                throw new ArgumentNullException(nameof(code), "Property is not nullable for class ApiResponse.");
+                throw new JsonException("Property is not nullable for class ApiResponse: code.");
 
             if (message.IsSet && message.Value == null)
-                throw new ArgumentNullException(nameof(message), "Property is not nullable for class ApiResponse.");
+                throw new JsonException("Property is not nullable for class ApiResponse: message.");
 
             if (type.IsSet && type.Value == null)
-                throw new ArgumentNullException(nameof(type), "Property is not nullable for class ApiResponse.");
+                throw new JsonException("Property is not nullable for class ApiResponse: type.");
 
             return new ApiResponse(code, message, type);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Apple.cs
@@ -218,13 +218,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (colorCode.IsSet && colorCode.Value == null)
-                throw new ArgumentNullException(nameof(colorCode), "Property is not nullable for class Apple.");
+                throw new JsonException("Property is not nullable for class Apple: color_code.");
 
             if (cultivar.IsSet && cultivar.Value == null)
-                throw new ArgumentNullException(nameof(cultivar), "Property is not nullable for class Apple.");
+                throw new JsonException("Property is not nullable for class Apple: cultivar.");
 
             if (origin.IsSet && origin.Value == null)
-                throw new ArgumentNullException(nameof(origin), "Property is not nullable for class Apple.");
+                throw new JsonException("Property is not nullable for class Apple: origin.");
 
             return new Apple(colorCode, cultivar, origin);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -154,13 +154,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!cultivar.IsSet)
-                throw new ArgumentException("Property is required for class AppleReq.", nameof(cultivar));
+                throw new JsonException("Property is required for class AppleReq: cultivar.");
 
             if (cultivar.IsSet && cultivar.Value == null)
-                throw new ArgumentNullException(nameof(cultivar), "Property is not nullable for class AppleReq.");
+                throw new JsonException("Property is not nullable for class AppleReq: cultivar.");
 
             if (mealy.IsSet && mealy.Value == null)
-                throw new ArgumentNullException(nameof(mealy), "Property is not nullable for class AppleReq.");
+                throw new JsonException("Property is not nullable for class AppleReq: mealy.");
 
             return new AppleReq(cultivar.Value!, mealy);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -148,7 +148,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayArrayNumber.IsSet && arrayArrayNumber.Value == null)
-                throw new ArgumentNullException(nameof(arrayArrayNumber), "Property is not nullable for class ArrayOfArrayOfNumberOnly.");
+                throw new JsonException("Property is not nullable for class ArrayOfArrayOfNumberOnly: ArrayArrayNumber.");
 
             return new ArrayOfArrayOfNumberOnly(arrayArrayNumber);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -148,7 +148,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayNumber.IsSet && arrayNumber.Value == null)
-                throw new ArgumentNullException(nameof(arrayNumber), "Property is not nullable for class ArrayOfNumberOnly.");
+                throw new JsonException("Property is not nullable for class ArrayOfNumberOnly: ArrayNumber.");
 
             return new ArrayOfNumberOnly(arrayNumber);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -188,13 +188,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayArrayOfInteger.IsSet && arrayArrayOfInteger.Value == null)
-                throw new ArgumentNullException(nameof(arrayArrayOfInteger), "Property is not nullable for class ArrayTest.");
+                throw new JsonException("Property is not nullable for class ArrayTest: array_array_of_integer.");
 
             if (arrayArrayOfModel.IsSet && arrayArrayOfModel.Value == null)
-                throw new ArgumentNullException(nameof(arrayArrayOfModel), "Property is not nullable for class ArrayTest.");
+                throw new JsonException("Property is not nullable for class ArrayTest: array_array_of_model.");
 
             if (arrayOfString.IsSet && arrayOfString.Value == null)
-                throw new ArgumentNullException(nameof(arrayOfString), "Property is not nullable for class ArrayTest.");
+                throw new JsonException("Property is not nullable for class ArrayTest: array_of_string.");
 
             return new ArrayTest(arrayArrayOfInteger, arrayArrayOfModel, arrayOfString);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Banana.cs
@@ -148,7 +148,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (lengthCm.IsSet && lengthCm.Value == null)
-                throw new ArgumentNullException(nameof(lengthCm), "Property is not nullable for class Banana.");
+                throw new JsonException("Property is not nullable for class Banana: lengthCm.");
 
             return new Banana(lengthCm);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -154,13 +154,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!lengthCm.IsSet)
-                throw new ArgumentException("Property is required for class BananaReq.", nameof(lengthCm));
+                throw new JsonException("Property is required for class BananaReq: lengthCm.");
 
             if (lengthCm.IsSet && lengthCm.Value == null)
-                throw new ArgumentNullException(nameof(lengthCm), "Property is not nullable for class BananaReq.");
+                throw new JsonException("Property is not nullable for class BananaReq: lengthCm.");
 
             if (sweet.IsSet && sweet.Value == null)
-                throw new ArgumentNullException(nameof(sweet), "Property is not nullable for class BananaReq.");
+                throw new JsonException("Property is not nullable for class BananaReq: sweet.");
 
             return new BananaReq(lengthCm.Value!.Value!, sweet);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/BasquePig.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/BasquePig.cs
@@ -141,10 +141,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class BasquePig.", nameof(className));
+                throw new JsonException("Property is required for class BasquePig: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class BasquePig.");
+                throw new JsonException("Property is not nullable for class BasquePig: className.");
 
             return new BasquePig(className.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -249,22 +249,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (aTTNAME.IsSet && aTTNAME.Value == null)
-                throw new ArgumentNullException(nameof(aTTNAME), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: ATT_NAME.");
 
             if (capitalCamel.IsSet && capitalCamel.Value == null)
-                throw new ArgumentNullException(nameof(capitalCamel), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: CapitalCamel.");
 
             if (capitalSnake.IsSet && capitalSnake.Value == null)
-                throw new ArgumentNullException(nameof(capitalSnake), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: Capital_Snake.");
 
             if (sCAETHFlowPoints.IsSet && sCAETHFlowPoints.Value == null)
-                throw new ArgumentNullException(nameof(sCAETHFlowPoints), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: SCA_ETH_Flow_Points.");
 
             if (smallCamel.IsSet && smallCamel.Value == null)
-                throw new ArgumentNullException(nameof(smallCamel), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: smallCamel.");
 
             if (smallSnake.IsSet && smallSnake.Value == null)
-                throw new ArgumentNullException(nameof(smallSnake), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: small_Snake.");
 
             return new Capitalization(aTTNAME, capitalCamel, capitalSnake, sCAETHFlowPoints, smallCamel, smallSnake);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Cat.cs
@@ -141,16 +141,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Cat.", nameof(className));
+                throw new JsonException("Property is required for class Cat: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Cat.");
+                throw new JsonException("Property is not nullable for class Cat: className.");
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Cat.");
+                throw new JsonException("Property is not nullable for class Cat: color.");
 
             if (declawed.IsSet && declawed.Value == null)
-                throw new ArgumentNullException(nameof(declawed), "Property is not nullable for class Cat.");
+                throw new JsonException("Property is not nullable for class Cat: declawed.");
 
             return new Cat(color, declawed);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Category.cs
@@ -161,13 +161,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!name.IsSet)
-                throw new ArgumentException("Property is required for class Category.", nameof(name));
+                throw new JsonException("Property is required for class Category: name.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Category.");
+                throw new JsonException("Property is not nullable for class Category: id.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Category.");
+                throw new JsonException("Property is not nullable for class Category: name.");
 
             return new Category(id, name.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -203,13 +203,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!petType.IsSet)
-                throw new ArgumentException("Property is required for class ChildCat.", nameof(petType));
+                throw new JsonException("Property is required for class ChildCat: pet_type.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class ChildCat.");
+                throw new JsonException("Property is not nullable for class ChildCat: name.");
 
             if (petType.IsSet && petType.Value == null)
-                throw new ArgumentNullException(nameof(petType), "Property is not nullable for class ChildCat.");
+                throw new JsonException("Property is not nullable for class ChildCat: pet_type.");
 
             return new ChildCat(name);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -148,7 +148,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varClass.IsSet && varClass.Value == null)
-                throw new ArgumentNullException(nameof(varClass), "Property is not nullable for class ClassModel.");
+                throw new JsonException("Property is not nullable for class ClassModel: _class.");
 
             return new ClassModel(varClass);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
@@ -154,16 +154,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class ComplexQuadrilateral.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class ComplexQuadrilateral: quadrilateralType.");
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ComplexQuadrilateral.", nameof(shapeType));
+                throw new JsonException("Property is required for class ComplexQuadrilateral: shapeType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class ComplexQuadrilateral.");
+                throw new JsonException("Property is not nullable for class ComplexQuadrilateral: quadrilateralType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ComplexQuadrilateral.");
+                throw new JsonException("Property is not nullable for class ComplexQuadrilateral: shapeType.");
 
             return new ComplexQuadrilateral(quadrilateralType.Value!, shapeType.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/CopyActivity.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/CopyActivity.cs
@@ -196,16 +196,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!copyActivitytt.IsSet)
-                throw new ArgumentException("Property is required for class CopyActivity.", nameof(copyActivitytt));
+                throw new JsonException("Property is required for class CopyActivity: copyActivitytt.");
 
             if (!schema.IsSet)
-                throw new ArgumentException("Property is required for class CopyActivity.", nameof(schema));
+                throw new JsonException("Property is required for class CopyActivity: $schema.");
 
             if (copyActivitytt.IsSet && copyActivitytt.Value == null)
-                throw new ArgumentNullException(nameof(copyActivitytt), "Property is not nullable for class CopyActivity.");
+                throw new JsonException("Property is not nullable for class CopyActivity: copyActivitytt.");
 
             if (schema.IsSet && schema.Value == null)
-                throw new ArgumentNullException(nameof(schema), "Property is not nullable for class CopyActivity.");
+                throw new JsonException("Property is not nullable for class CopyActivity: $schema.");
 
             return new CopyActivity(copyActivitytt.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/DanishPig.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/DanishPig.cs
@@ -141,10 +141,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class DanishPig.", nameof(className));
+                throw new JsonException("Property is required for class DanishPig: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class DanishPig.");
+                throw new JsonException("Property is not nullable for class DanishPig: className.");
 
             return new DanishPig(className.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -154,7 +154,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (dateOnlyProperty.IsSet && dateOnlyProperty.Value == null)
-                throw new ArgumentNullException(nameof(dateOnlyProperty), "Property is not nullable for class DateOnlyClass.");
+                throw new JsonException("Property is not nullable for class DateOnlyClass: dateOnlyProperty.");
 
             return new DateOnlyClass(dateOnlyProperty);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -148,7 +148,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class DeprecatedObject.");
+                throw new JsonException("Property is not nullable for class DeprecatedObject: name.");
 
             return new DeprecatedObject(name);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Descendant1.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Descendant1.cs
@@ -141,22 +141,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!alternativeName.IsSet)
-                throw new ArgumentException("Property is required for class Descendant1.", nameof(alternativeName));
+                throw new JsonException("Property is required for class Descendant1: alternativeName.");
 
             if (!descendantName.IsSet)
-                throw new ArgumentException("Property is required for class Descendant1.", nameof(descendantName));
+                throw new JsonException("Property is required for class Descendant1: descendantName.");
 
             if (!objectType.IsSet)
-                throw new ArgumentException("Property is required for class Descendant1.", nameof(objectType));
+                throw new JsonException("Property is required for class Descendant1: objectType.");
 
             if (alternativeName.IsSet && alternativeName.Value == null)
-                throw new ArgumentNullException(nameof(alternativeName), "Property is not nullable for class Descendant1.");
+                throw new JsonException("Property is not nullable for class Descendant1: alternativeName.");
 
             if (descendantName.IsSet && descendantName.Value == null)
-                throw new ArgumentNullException(nameof(descendantName), "Property is not nullable for class Descendant1.");
+                throw new JsonException("Property is not nullable for class Descendant1: descendantName.");
 
             if (objectType.IsSet && objectType.Value == null)
-                throw new ArgumentNullException(nameof(objectType), "Property is not nullable for class Descendant1.");
+                throw new JsonException("Property is not nullable for class Descendant1: objectType.");
 
             return new Descendant1(alternativeName.Value!, descendantName.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Descendant2.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Descendant2.cs
@@ -141,22 +141,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!alternativeName.IsSet)
-                throw new ArgumentException("Property is required for class Descendant2.", nameof(alternativeName));
+                throw new JsonException("Property is required for class Descendant2: alternativeName.");
 
             if (!confidentiality.IsSet)
-                throw new ArgumentException("Property is required for class Descendant2.", nameof(confidentiality));
+                throw new JsonException("Property is required for class Descendant2: confidentiality.");
 
             if (!objectType.IsSet)
-                throw new ArgumentException("Property is required for class Descendant2.", nameof(objectType));
+                throw new JsonException("Property is required for class Descendant2: objectType.");
 
             if (alternativeName.IsSet && alternativeName.Value == null)
-                throw new ArgumentNullException(nameof(alternativeName), "Property is not nullable for class Descendant2.");
+                throw new JsonException("Property is not nullable for class Descendant2: alternativeName.");
 
             if (confidentiality.IsSet && confidentiality.Value == null)
-                throw new ArgumentNullException(nameof(confidentiality), "Property is not nullable for class Descendant2.");
+                throw new JsonException("Property is not nullable for class Descendant2: confidentiality.");
 
             if (objectType.IsSet && objectType.Value == null)
-                throw new ArgumentNullException(nameof(objectType), "Property is not nullable for class Descendant2.");
+                throw new JsonException("Property is not nullable for class Descendant2: objectType.");
 
             return new Descendant2(alternativeName.Value!, confidentiality.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Dog.cs
@@ -141,16 +141,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Dog.", nameof(className));
+                throw new JsonException("Property is required for class Dog: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Dog.");
+                throw new JsonException("Property is not nullable for class Dog: className.");
 
             if (breed.IsSet && breed.Value == null)
-                throw new ArgumentNullException(nameof(breed), "Property is not nullable for class Dog.");
+                throw new JsonException("Property is not nullable for class Dog: breed.");
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Dog.");
+                throw new JsonException("Property is not nullable for class Dog: color.");
 
             return new Dog(breed, color);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Drawing.cs
@@ -208,10 +208,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (mainShape.IsSet && mainShape.Value == null)
-                throw new ArgumentNullException(nameof(mainShape), "Property is not nullable for class Drawing.");
+                throw new JsonException("Property is not nullable for class Drawing: mainShape.");
 
             if (shapes.IsSet && shapes.Value == null)
-                throw new ArgumentNullException(nameof(shapes), "Property is not nullable for class Drawing.");
+                throw new JsonException("Property is not nullable for class Drawing: shapes.");
 
             return new Drawing(mainShape, nullableShape, shapeOrNull, shapes);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/EntityBase.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/EntityBase.cs
@@ -155,10 +155,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!schema.IsSet)
-                throw new ArgumentException("Property is required for class EntityBase.", nameof(schema));
+                throw new JsonException("Property is required for class EntityBase: $schema.");
 
             if (schema.IsSet && schema.Value == null)
-                throw new ArgumentNullException(nameof(schema), "Property is not nullable for class EntityBase.");
+                throw new JsonException("Property is not nullable for class EntityBase: $schema.");
 
             return new EntityBase();
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -307,10 +307,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayEnum.IsSet && arrayEnum.Value == null)
-                throw new ArgumentNullException(nameof(arrayEnum), "Property is not nullable for class EnumArrays.");
+                throw new JsonException("Property is not nullable for class EnumArrays: array_enum.");
 
             if (justSymbol.IsSet && justSymbol.Value == null)
-                throw new ArgumentNullException(nameof(justSymbol), "Property is not nullable for class EnumArrays.");
+                throw new JsonException("Property is not nullable for class EnumArrays: just_symbol.");
 
             return new EnumArrays(arrayEnum, justSymbol);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -825,31 +825,31 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!enumStringRequired.IsSet)
-                throw new ArgumentException("Property is required for class EnumTest.", nameof(enumStringRequired));
+                throw new JsonException("Property is required for class EnumTest: enum_string_required.");
 
             if (enumStringRequired.IsSet && enumStringRequired.Value == null)
-                throw new ArgumentNullException(nameof(enumStringRequired), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_string_required.");
 
             if (enumInteger.IsSet && enumInteger.Value == null)
-                throw new ArgumentNullException(nameof(enumInteger), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_integer.");
 
             if (enumIntegerOnly.IsSet && enumIntegerOnly.Value == null)
-                throw new ArgumentNullException(nameof(enumIntegerOnly), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_integer_only.");
 
             if (enumNumber.IsSet && enumNumber.Value == null)
-                throw new ArgumentNullException(nameof(enumNumber), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_number.");
 
             if (enumString.IsSet && enumString.Value == null)
-                throw new ArgumentNullException(nameof(enumString), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_string.");
 
             if (outerEnumDefaultValue.IsSet && outerEnumDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(outerEnumDefaultValue), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: outerEnumDefaultValue.");
 
             if (outerEnumInteger.IsSet && outerEnumInteger.Value == null)
-                throw new ArgumentNullException(nameof(outerEnumInteger), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: outerEnumInteger.");
 
             if (outerEnumIntegerDefaultValue.IsSet && outerEnumIntegerDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(outerEnumIntegerDefaultValue), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: outerEnumIntegerDefaultValue.");
 
             return new EnumTest(enumStringRequired.Value!.Value!, enumInteger, enumIntegerOnly, enumNumber, enumString, outerEnum, outerEnumDefaultValue, outerEnumInteger, outerEnumIntegerDefaultValue);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
@@ -154,16 +154,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class EquilateralTriangle.", nameof(shapeType));
+                throw new JsonException("Property is required for class EquilateralTriangle: shapeType.");
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class EquilateralTriangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class EquilateralTriangle: triangleType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class EquilateralTriangle.");
+                throw new JsonException("Property is not nullable for class EquilateralTriangle: shapeType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class EquilateralTriangle.");
+                throw new JsonException("Property is not nullable for class EquilateralTriangle: triangleType.");
 
             return new EquilateralTriangle(shapeType.Value!, triangleType.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/File.cs
@@ -149,7 +149,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (sourceURI.IsSet && sourceURI.Value == null)
-                throw new ArgumentNullException(nameof(sourceURI), "Property is not nullable for class File.");
+                throw new JsonException("Property is not nullable for class File: sourceURI.");
 
             return new File(sourceURI);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -168,10 +168,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (file.IsSet && file.Value == null)
-                throw new ArgumentNullException(nameof(file), "Property is not nullable for class FileSchemaTestClass.");
+                throw new JsonException("Property is not nullable for class FileSchemaTestClass: file.");
 
             if (files.IsSet && files.Value == null)
-                throw new ArgumentNullException(nameof(files), "Property is not nullable for class FileSchemaTestClass.");
+                throw new JsonException("Property is not nullable for class FileSchemaTestClass: files.");
 
             return new FileSchemaTestClass(file, files);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Foo.cs
@@ -148,7 +148,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bar.IsSet && bar.Value == null)
-                throw new ArgumentNullException(nameof(bar), "Property is not nullable for class Foo.");
+                throw new JsonException("Property is not nullable for class Foo: bar.");
 
             return new Foo(bar);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -148,7 +148,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varString.IsSet && varString.Value == null)
-                throw new ArgumentNullException(nameof(varString), "Property is not nullable for class FooGetDefaultResponse.");
+                throw new JsonException("Property is not nullable for class FooGetDefaultResponse: string.");
 
             return new FooGetDefaultResponse(varString);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -829,103 +829,103 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!varByte.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(varByte));
+                throw new JsonException("Property is required for class FormatTest: byte.");
 
             if (!date.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(date));
+                throw new JsonException("Property is required for class FormatTest: date.");
 
             if (!number.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(number));
+                throw new JsonException("Property is required for class FormatTest: number.");
 
             if (!password.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(password));
+                throw new JsonException("Property is required for class FormatTest: password.");
 
             if (!stringFormattedAsDecimalRequired.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(stringFormattedAsDecimalRequired));
+                throw new JsonException("Property is required for class FormatTest: string_formatted_as_decimal_required.");
 
             if (varByte.IsSet && varByte.Value == null)
-                throw new ArgumentNullException(nameof(varByte), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: byte.");
 
             if (date.IsSet && date.Value == null)
-                throw new ArgumentNullException(nameof(date), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: date.");
 
             if (number.IsSet && number.Value == null)
-                throw new ArgumentNullException(nameof(number), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: number.");
 
             if (password.IsSet && password.Value == null)
-                throw new ArgumentNullException(nameof(password), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: password.");
 
             if (stringFormattedAsDecimalRequired.IsSet && stringFormattedAsDecimalRequired.Value == null)
-                throw new ArgumentNullException(nameof(stringFormattedAsDecimalRequired), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: string_formatted_as_decimal_required.");
 
             if (binary.IsSet && binary.Value == null)
-                throw new ArgumentNullException(nameof(binary), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: binary.");
 
             if (dateTime.IsSet && dateTime.Value == null)
-                throw new ArgumentNullException(nameof(dateTime), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: dateTime.");
 
             if (varDecimal.IsSet && varDecimal.Value == null)
-                throw new ArgumentNullException(nameof(varDecimal), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: decimal.");
 
             if (varDouble.IsSet && varDouble.Value == null)
-                throw new ArgumentNullException(nameof(varDouble), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: double.");
 
             if (duplicatePropertyName2.IsSet && duplicatePropertyName2.Value == null)
-                throw new ArgumentNullException(nameof(duplicatePropertyName2), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: duplicate_property_name.");
 
             if (duplicatePropertyName.IsSet && duplicatePropertyName.Value == null)
-                throw new ArgumentNullException(nameof(duplicatePropertyName), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: @duplicate_property_name.");
 
             if (varFloat.IsSet && varFloat.Value == null)
-                throw new ArgumentNullException(nameof(varFloat), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: float.");
 
             if (int32.IsSet && int32.Value == null)
-                throw new ArgumentNullException(nameof(int32), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int32.");
 
             if (int32Range.IsSet && int32Range.Value == null)
-                throw new ArgumentNullException(nameof(int32Range), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int32Range.");
 
             if (int64.IsSet && int64.Value == null)
-                throw new ArgumentNullException(nameof(int64), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64.");
 
             if (int64Negative.IsSet && int64Negative.Value == null)
-                throw new ArgumentNullException(nameof(int64Negative), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64Negative.");
 
             if (int64NegativeExclusive.IsSet && int64NegativeExclusive.Value == null)
-                throw new ArgumentNullException(nameof(int64NegativeExclusive), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64NegativeExclusive.");
 
             if (int64Positive.IsSet && int64Positive.Value == null)
-                throw new ArgumentNullException(nameof(int64Positive), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64Positive.");
 
             if (int64PositiveExclusive.IsSet && int64PositiveExclusive.Value == null)
-                throw new ArgumentNullException(nameof(int64PositiveExclusive), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64PositiveExclusive.");
 
             if (integer.IsSet && integer.Value == null)
-                throw new ArgumentNullException(nameof(integer), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: integer.");
 
             if (patternWithBackslash.IsSet && patternWithBackslash.Value == null)
-                throw new ArgumentNullException(nameof(patternWithBackslash), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: pattern_with_backslash.");
 
             if (patternWithDigits.IsSet && patternWithDigits.Value == null)
-                throw new ArgumentNullException(nameof(patternWithDigits), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: pattern_with_digits.");
 
             if (patternWithDigitsAndDelimiter.IsSet && patternWithDigitsAndDelimiter.Value == null)
-                throw new ArgumentNullException(nameof(patternWithDigitsAndDelimiter), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: pattern_with_digits_and_delimiter.");
 
             if (varString.IsSet && varString.Value == null)
-                throw new ArgumentNullException(nameof(varString), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: string.");
 
             if (stringFormattedAsDecimal.IsSet && stringFormattedAsDecimal.Value == null)
-                throw new ArgumentNullException(nameof(stringFormattedAsDecimal), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: string_formatted_as_decimal.");
 
             if (unsignedInteger.IsSet && unsignedInteger.Value == null)
-                throw new ArgumentNullException(nameof(unsignedInteger), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: unsigned_integer.");
 
             if (unsignedLong.IsSet && unsignedLong.Value == null)
-                throw new ArgumentNullException(nameof(unsignedLong), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: unsigned_long.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: uuid.");
 
             return new FormatTest(varByte.Value!, date.Value!.Value!, number.Value!.Value!, password.Value!, stringFormattedAsDecimalRequired.Value!.Value!, binary, dateTime, varDecimal, varDouble, duplicatePropertyName2, duplicatePropertyName, varFloat, int32, int32Range, int64, int64Negative, int64NegativeExclusive, int64Positive, int64PositiveExclusive, integer, patternWithBackslash, patternWithDigits, patternWithDigitsAndDelimiter, varString, stringFormattedAsDecimal, unsignedInteger, unsignedLong, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Fruit.cs
@@ -186,7 +186,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Fruit.");
+                throw new JsonException("Property is not nullable for class Fruit: color.");
 
             if (apple != null)
                 return new Fruit(apple, color);

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -190,7 +190,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class GmFruit.");
+                throw new JsonException("Property is not nullable for class GmFruit: color.");
 
             Option<Apple?> appleParsedValue = apple == null
                 ? default

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
@@ -158,10 +158,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!petType.IsSet)
-                throw new ArgumentException("Property is required for class GrandparentAnimal.", nameof(petType));
+                throw new JsonException("Property is required for class GrandparentAnimal: pet_type.");
 
             if (petType.IsSet && petType.Value == null)
-                throw new ArgumentNullException(nameof(petType), "Property is not nullable for class GrandparentAnimal.");
+                throw new JsonException("Property is not nullable for class GrandparentAnimal: pet_type.");
 
             return new GrandparentAnimal();
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -209,10 +209,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bar.IsSet && bar.Value == null)
-                throw new ArgumentNullException(nameof(bar), "Property is not nullable for class HasOnlyReadOnly.");
+                throw new JsonException("Property is not nullable for class HasOnlyReadOnly: bar.");
 
             if (foo.IsSet && foo.Value == null)
-                throw new ArgumentNullException(nameof(foo), "Property is not nullable for class HasOnlyReadOnly.");
+                throw new JsonException("Property is not nullable for class HasOnlyReadOnly: foo.");
 
             return new HasOnlyReadOnly(bar, foo);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
@@ -295,22 +295,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (potentiallyOverriddenPropertyAccessor.IsSet && potentiallyOverriddenPropertyAccessor.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyAccessor), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyAccessor.");
 
             if (potentiallyOverriddenPropertyToInternal.IsSet && potentiallyOverriddenPropertyToInternal.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyToInternal), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyToInternal.");
 
             if (potentiallyOverriddenPropertyToPrivate.IsSet && potentiallyOverriddenPropertyToPrivate.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyToPrivate), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyToPrivate.");
 
             if (potentiallyOverriddenPropertyToPublic.IsSet && potentiallyOverriddenPropertyToPublic.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyToPublic), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyToPublic.");
 
             if (unalteredProperty.IsSet && unalteredProperty.Value == null)
-                throw new ArgumentNullException(nameof(unalteredProperty), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: unalteredProperty.");
 
             if (unalteredPropertyAccessor.IsSet && unalteredPropertyAccessor.Value == null)
-                throw new ArgumentNullException(nameof(unalteredPropertyAccessor), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: unalteredPropertyAccessor.");
 
             return new InjectedVendorExtensionsTest(potentiallyOverriddenPropertyAccessor, potentiallyOverriddenPropertyToInternal, potentiallyOverriddenPropertyToPrivate, potentiallyOverriddenPropertyToPublic, unalteredProperty, unalteredPropertyAccessor);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
@@ -147,16 +147,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class IsoscelesTriangle.", nameof(shapeType));
+                throw new JsonException("Property is required for class IsoscelesTriangle: shapeType.");
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class IsoscelesTriangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class IsoscelesTriangle: triangleType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class IsoscelesTriangle.");
+                throw new JsonException("Property is not nullable for class IsoscelesTriangle: shapeType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class IsoscelesTriangle.");
+                throw new JsonException("Property is not nullable for class IsoscelesTriangle: triangleType.");
 
             return new IsoscelesTriangle(shapeType.Value!, triangleType.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/List.cs
@@ -148,7 +148,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (var123List.IsSet && var123List.Value == null)
-                throw new ArgumentNullException(nameof(var123List), "Property is not nullable for class List.");
+                throw new JsonException("Property is not nullable for class List: 123-list.");
 
             return new List(var123List);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -168,10 +168,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (escapedLiteralString.IsSet && escapedLiteralString.Value == null)
-                throw new ArgumentNullException(nameof(escapedLiteralString), "Property is not nullable for class LiteralStringClass.");
+                throw new JsonException("Property is not nullable for class LiteralStringClass: escapedLiteralString.");
 
             if (unescapedLiteralString.IsSet && unescapedLiteralString.Value == null)
-                throw new ArgumentNullException(nameof(unescapedLiteralString), "Property is not nullable for class LiteralStringClass.");
+                throw new JsonException("Property is not nullable for class LiteralStringClass: unescapedLiteralString.");
 
             return new LiteralStringClass(escapedLiteralString, unescapedLiteralString);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Mammal.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Mammal.cs
@@ -217,10 +217,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Mammal.", nameof(className));
+                throw new JsonException("Property is required for class Mammal: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Mammal.");
+                throw new JsonException("Property is not nullable for class Mammal: className.");
 
             if (pig != null)
                 return new Mammal(pig);

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/MapTest.cs
@@ -274,16 +274,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (directMap.IsSet && directMap.Value == null)
-                throw new ArgumentNullException(nameof(directMap), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: direct_map.");
 
             if (indirectMap.IsSet && indirectMap.Value == null)
-                throw new ArgumentNullException(nameof(indirectMap), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: indirect_map.");
 
             if (mapMapOfString.IsSet && mapMapOfString.Value == null)
-                throw new ArgumentNullException(nameof(mapMapOfString), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: map_map_of_string.");
 
             if (mapOfEnumString.IsSet && mapOfEnumString.Value == null)
-                throw new ArgumentNullException(nameof(mapOfEnumString), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: map_of_enum_string.");
 
             return new MapTest(directMap, indirectMap, mapMapOfString, mapOfEnumString);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/MixedAnyOf.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/MixedAnyOf.cs
@@ -148,7 +148,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (content.IsSet && content.Value == null)
-                throw new ArgumentNullException(nameof(content), "Property is not nullable for class MixedAnyOf.");
+                throw new JsonException("Property is not nullable for class MixedAnyOf: content.");
 
             return new MixedAnyOf(content);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/MixedOneOf.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/MixedOneOf.cs
@@ -148,7 +148,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (content.IsSet && content.Value == null)
-                throw new ArgumentNullException(nameof(content), "Property is not nullable for class MixedOneOf.");
+                throw new JsonException("Property is not nullable for class MixedOneOf: content.");
 
             return new MixedOneOf(content);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -220,16 +220,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (dateTime.IsSet && dateTime.Value == null)
-                throw new ArgumentNullException(nameof(dateTime), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: dateTime.");
 
             if (map.IsSet && map.Value == null)
-                throw new ArgumentNullException(nameof(map), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: map.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: uuid.");
 
             if (uuidWithPattern.IsSet && uuidWithPattern.Value == null)
-                throw new ArgumentNullException(nameof(uuidWithPattern), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: uuid_with_pattern.");
 
             return new MixedPropertiesAndAdditionalPropertiesClass(dateTime, map, uuid, uuidWithPattern);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/MixedSubId.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/MixedSubId.cs
@@ -148,7 +148,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class MixedSubId.");
+                throw new JsonException("Property is not nullable for class MixedSubId: id.");
 
             return new MixedSubId(id);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -168,10 +168,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varClass.IsSet && varClass.Value == null)
-                throw new ArgumentNullException(nameof(varClass), "Property is not nullable for class Model200Response.");
+                throw new JsonException("Property is not nullable for class Model200Response: class.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Model200Response.");
+                throw new JsonException("Property is not nullable for class Model200Response: name.");
 
             return new Model200Response(varClass, name);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -148,7 +148,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varClient.IsSet && varClient.Value == null)
-                throw new ArgumentNullException(nameof(varClient), "Property is not nullable for class ModelClient.");
+                throw new JsonException("Property is not nullable for class ModelClient: client.");
 
             return new ModelClient(varClient);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Name.cs
@@ -242,19 +242,19 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!varName.IsSet)
-                throw new ArgumentException("Property is required for class Name.", nameof(varName));
+                throw new JsonException("Property is required for class Name: name.");
 
             if (varName.IsSet && varName.Value == null)
-                throw new ArgumentNullException(nameof(varName), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: name.");
 
             if (property.IsSet && property.Value == null)
-                throw new ArgumentNullException(nameof(property), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: property.");
 
             if (snakeCase.IsSet && snakeCase.Value == null)
-                throw new ArgumentNullException(nameof(snakeCase), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: snake_case.");
 
             if (var123Number.IsSet && var123Number.Value == null)
-                throw new ArgumentNullException(nameof(var123Number), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: 123Number.");
 
             return new Name(varName.Value!.Value!, property, snakeCase, var123Number);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
@@ -154,16 +154,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!aObjVariableobject.IsSet)
-                throw new ArgumentException("Property is required for class NotificationtestGetElementsV1ResponseMPayload.", nameof(aObjVariableobject));
+                throw new JsonException("Property is required for class NotificationtestGetElementsV1ResponseMPayload: a_objVariableobject.");
 
             if (!pkiNotificationtestID.IsSet)
-                throw new ArgumentException("Property is required for class NotificationtestGetElementsV1ResponseMPayload.", nameof(pkiNotificationtestID));
+                throw new JsonException("Property is required for class NotificationtestGetElementsV1ResponseMPayload: pkiNotificationtestID.");
 
             if (aObjVariableobject.IsSet && aObjVariableobject.Value == null)
-                throw new ArgumentNullException(nameof(aObjVariableobject), "Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload.");
+                throw new JsonException("Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload: a_objVariableobject.");
 
             if (pkiNotificationtestID.IsSet && pkiNotificationtestID.Value == null)
-                throw new ArgumentNullException(nameof(pkiNotificationtestID), "Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload.");
+                throw new JsonException("Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload: pkiNotificationtestID.");
 
             return new NotificationtestGetElementsV1ResponseMPayload(aObjVariableobject.Value!, pkiNotificationtestID.Value!.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -378,10 +378,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayItemsNullable.IsSet && arrayItemsNullable.Value == null)
-                throw new ArgumentNullException(nameof(arrayItemsNullable), "Property is not nullable for class NullableClass.");
+                throw new JsonException("Property is not nullable for class NullableClass: array_items_nullable.");
 
             if (objectItemsNullable.IsSet && objectItemsNullable.Value == null)
-                throw new ArgumentNullException(nameof(objectItemsNullable), "Property is not nullable for class NullableClass.");
+                throw new JsonException("Property is not nullable for class NullableClass: object_items_nullable.");
 
             return new NullableClass(arrayAndItemsNullableProp, arrayItemsNullable, arrayNullableProp, booleanProp, dateProp, datetimeProp, integerProp, numberProp, objectAndItemsNullableProp, objectItemsNullable, objectNullableProp, stringProp);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/NullableShape.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/NullableShape.cs
@@ -196,10 +196,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class NullableShape.", nameof(shapeType));
+                throw new JsonException("Property is required for class NullableShape: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class NullableShape.");
+                throw new JsonException("Property is not nullable for class NullableShape: shapeType.");
 
             if (quadrilateral != null)
                 return new NullableShape(quadrilateral);

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -148,7 +148,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (justNumber.IsSet && justNumber.Value == null)
-                throw new ArgumentNullException(nameof(justNumber), "Property is not nullable for class NumberOnly.");
+                throw new JsonException("Property is not nullable for class NumberOnly: JustNumber.");
 
             return new NumberOnly(justNumber);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -211,16 +211,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bars.IsSet && bars.Value == null)
-                throw new ArgumentNullException(nameof(bars), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: bars.");
 
             if (deprecatedRef.IsSet && deprecatedRef.Value == null)
-                throw new ArgumentNullException(nameof(deprecatedRef), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: deprecatedRef.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: id.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: uuid.");
 
             return new ObjectWithDeprecatedFields(bars, deprecatedRef, id, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Order.cs
@@ -343,22 +343,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (complete.IsSet && complete.Value == null)
-                throw new ArgumentNullException(nameof(complete), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: complete.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: id.");
 
             if (petId.IsSet && petId.Value == null)
-                throw new ArgumentNullException(nameof(petId), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: petId.");
 
             if (quantity.IsSet && quantity.Value == null)
-                throw new ArgumentNullException(nameof(quantity), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: quantity.");
 
             if (shipDate.IsSet && shipDate.Value == null)
-                throw new ArgumentNullException(nameof(shipDate), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: shipDate.");
 
             if (status.IsSet && status.Value == null)
-                throw new ArgumentNullException(nameof(status), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: status.");
 
             return new Order(complete, id, petId, quantity, shipDate, status);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -188,13 +188,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (myBoolean.IsSet && myBoolean.Value == null)
-                throw new ArgumentNullException(nameof(myBoolean), "Property is not nullable for class OuterComposite.");
+                throw new JsonException("Property is not nullable for class OuterComposite: my_boolean.");
 
             if (myNumber.IsSet && myNumber.Value == null)
-                throw new ArgumentNullException(nameof(myNumber), "Property is not nullable for class OuterComposite.");
+                throw new JsonException("Property is not nullable for class OuterComposite: my_number.");
 
             if (myString.IsSet && myString.Value == null)
-                throw new ArgumentNullException(nameof(myString), "Property is not nullable for class OuterComposite.");
+                throw new JsonException("Property is not nullable for class OuterComposite: my_string.");
 
             return new OuterComposite(myBoolean, myNumber, myString);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ParentPet.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ParentPet.cs
@@ -121,10 +121,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!petType.IsSet)
-                throw new ArgumentException("Property is required for class ParentPet.", nameof(petType));
+                throw new JsonException("Property is required for class ParentPet: pet_type.");
 
             if (petType.IsSet && petType.Value == null)
-                throw new ArgumentNullException(nameof(petType), "Property is not nullable for class ParentPet.");
+                throw new JsonException("Property is not nullable for class ParentPet: pet_type.");
 
             return new ParentPet();
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Pet.cs
@@ -324,28 +324,28 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!name.IsSet)
-                throw new ArgumentException("Property is required for class Pet.", nameof(name));
+                throw new JsonException("Property is required for class Pet: name.");
 
             if (!photoUrls.IsSet)
-                throw new ArgumentException("Property is required for class Pet.", nameof(photoUrls));
+                throw new JsonException("Property is required for class Pet: photoUrls.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: name.");
 
             if (photoUrls.IsSet && photoUrls.Value == null)
-                throw new ArgumentNullException(nameof(photoUrls), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: photoUrls.");
 
             if (category.IsSet && category.Value == null)
-                throw new ArgumentNullException(nameof(category), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: category.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: id.");
 
             if (status.IsSet && status.Value == null)
-                throw new ArgumentNullException(nameof(status), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: status.");
 
             if (tags.IsSet && tags.Value == null)
-                throw new ArgumentNullException(nameof(tags), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: tags.");
 
             return new Pet(name.Value!, photoUrls.Value!, category, id, status, tags);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Pig.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Pig.cs
@@ -196,10 +196,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Pig.", nameof(className));
+                throw new JsonException("Property is required for class Pig: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Pig.");
+                throw new JsonException("Property is not nullable for class Pig: className.");
 
             if (basquePig != null)
                 return new Pig(basquePig);

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Quadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Quadrilateral.cs
@@ -196,10 +196,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class Quadrilateral.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class Quadrilateral: quadrilateralType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class Quadrilateral.");
+                throw new JsonException("Property is not nullable for class Quadrilateral: quadrilateralType.");
 
             if (complexQuadrilateral != null)
                 return new Quadrilateral(complexQuadrilateral);

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
@@ -141,10 +141,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class QuadrilateralInterface.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class QuadrilateralInterface: quadrilateralType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class QuadrilateralInterface.");
+                throw new JsonException("Property is not nullable for class QuadrilateralInterface: quadrilateralType.");
 
             return new QuadrilateralInterface(quadrilateralType.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -206,10 +206,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bar.IsSet && bar.Value == null)
-                throw new ArgumentNullException(nameof(bar), "Property is not nullable for class ReadOnlyFirst.");
+                throw new JsonException("Property is not nullable for class ReadOnlyFirst: bar.");
 
             if (baz.IsSet && baz.Value == null)
-                throw new ArgumentNullException(nameof(baz), "Property is not nullable for class ReadOnlyFirst.");
+                throw new JsonException("Property is not nullable for class ReadOnlyFirst: baz.");
 
             return new ReadOnlyFirst(bar, baz);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -2080,136 +2080,136 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!requiredNotNullableDateProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotNullableDateProp));
+                throw new JsonException("Property is required for class RequiredClass: required_not_nullable_date_prop.");
 
             if (!requiredNotnullableArrayOfString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableArrayOfString));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_array_of_string.");
 
             if (!requiredNotnullableBooleanProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableBooleanProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_boolean_prop.");
 
             if (!requiredNotnullableDatetimeProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableDatetimeProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_datetime_prop.");
 
             if (!requiredNotnullableEnumInteger.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableEnumInteger));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_enum_integer.");
 
             if (!requiredNotnullableEnumIntegerOnly.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableEnumIntegerOnly));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_enum_integer_only.");
 
             if (!requiredNotnullableEnumString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableEnumString));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_enum_string.");
 
             if (!requiredNotnullableOuterEnumDefaultValue.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableOuterEnumDefaultValue));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_outerEnumDefaultValue.");
 
             if (!requiredNotnullableStringProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableStringProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_string_prop.");
 
             if (!requiredNotnullableUuid.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableUuid));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_uuid.");
 
             if (!requiredNotnullableintegerProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableintegerProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullableinteger_prop.");
 
             if (!requiredNullableArrayOfString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableArrayOfString));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_array_of_string.");
 
             if (!requiredNullableBooleanProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableBooleanProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_boolean_prop.");
 
             if (!requiredNullableDateProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableDateProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_date_prop.");
 
             if (!requiredNullableDatetimeProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableDatetimeProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_datetime_prop.");
 
             if (!requiredNullableEnumInteger.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableEnumInteger));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_enum_integer.");
 
             if (!requiredNullableEnumIntegerOnly.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableEnumIntegerOnly));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_enum_integer_only.");
 
             if (!requiredNullableEnumString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableEnumString));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_enum_string.");
 
             if (!requiredNullableIntegerProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableIntegerProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_integer_prop.");
 
             if (!requiredNullableOuterEnumDefaultValue.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableOuterEnumDefaultValue));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_outerEnumDefaultValue.");
 
             if (!requiredNullableStringProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableStringProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_string_prop.");
 
             if (!requiredNullableUuid.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableUuid));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_uuid.");
 
             if (requiredNotNullableDateProp.IsSet && requiredNotNullableDateProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotNullableDateProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_not_nullable_date_prop.");
 
             if (requiredNotnullableArrayOfString.IsSet && requiredNotnullableArrayOfString.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableArrayOfString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_array_of_string.");
 
             if (requiredNotnullableBooleanProp.IsSet && requiredNotnullableBooleanProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableBooleanProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_boolean_prop.");
 
             if (requiredNotnullableDatetimeProp.IsSet && requiredNotnullableDatetimeProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableDatetimeProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_datetime_prop.");
 
             if (requiredNotnullableEnumInteger.IsSet && requiredNotnullableEnumInteger.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableEnumInteger), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_enum_integer.");
 
             if (requiredNotnullableEnumIntegerOnly.IsSet && requiredNotnullableEnumIntegerOnly.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableEnumIntegerOnly), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_enum_integer_only.");
 
             if (requiredNotnullableEnumString.IsSet && requiredNotnullableEnumString.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableEnumString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_enum_string.");
 
             if (requiredNotnullableOuterEnumDefaultValue.IsSet && requiredNotnullableOuterEnumDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableOuterEnumDefaultValue), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_outerEnumDefaultValue.");
 
             if (requiredNotnullableStringProp.IsSet && requiredNotnullableStringProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableStringProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_string_prop.");
 
             if (requiredNotnullableUuid.IsSet && requiredNotnullableUuid.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableUuid), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_uuid.");
 
             if (requiredNotnullableintegerProp.IsSet && requiredNotnullableintegerProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableintegerProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullableinteger_prop.");
 
             if (notRequiredNotnullableDateProp.IsSet && notRequiredNotnullableDateProp.Value == null)
-                throw new ArgumentNullException(nameof(notRequiredNotnullableDateProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: not_required_notnullable_date_prop.");
 
             if (notRequiredNotnullableintegerProp.IsSet && notRequiredNotnullableintegerProp.Value == null)
-                throw new ArgumentNullException(nameof(notRequiredNotnullableintegerProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: not_required_notnullableinteger_prop.");
 
             if (notrequiredNotnullableArrayOfString.IsSet && notrequiredNotnullableArrayOfString.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableArrayOfString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_array_of_string.");
 
             if (notrequiredNotnullableBooleanProp.IsSet && notrequiredNotnullableBooleanProp.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableBooleanProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_boolean_prop.");
 
             if (notrequiredNotnullableDatetimeProp.IsSet && notrequiredNotnullableDatetimeProp.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableDatetimeProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_datetime_prop.");
 
             if (notrequiredNotnullableEnumInteger.IsSet && notrequiredNotnullableEnumInteger.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableEnumInteger), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_enum_integer.");
 
             if (notrequiredNotnullableEnumIntegerOnly.IsSet && notrequiredNotnullableEnumIntegerOnly.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableEnumIntegerOnly), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_enum_integer_only.");
 
             if (notrequiredNotnullableEnumString.IsSet && notrequiredNotnullableEnumString.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableEnumString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_enum_string.");
 
             if (notrequiredNotnullableOuterEnumDefaultValue.IsSet && notrequiredNotnullableOuterEnumDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableOuterEnumDefaultValue), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_outerEnumDefaultValue.");
 
             if (notrequiredNotnullableStringProp.IsSet && notrequiredNotnullableStringProp.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableStringProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_string_prop.");
 
             if (notrequiredNotnullableUuid.IsSet && notrequiredNotnullableUuid.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableUuid), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_uuid.");
 
             return new RequiredClass(requiredNotNullableDateProp.Value!.Value!, requiredNotnullableArrayOfString.Value!, requiredNotnullableBooleanProp.Value!.Value!, requiredNotnullableDatetimeProp.Value!.Value!, requiredNotnullableEnumInteger.Value!.Value!, requiredNotnullableEnumIntegerOnly.Value!.Value!, requiredNotnullableEnumString.Value!.Value!, requiredNotnullableOuterEnumDefaultValue.Value!.Value!, requiredNotnullableStringProp.Value!, requiredNotnullableUuid.Value!.Value!, requiredNotnullableintegerProp.Value!.Value!, notRequiredNotnullableDateProp, notRequiredNotnullableintegerProp, notRequiredNullableDateProp, notRequiredNullableIntegerProp, notrequiredNotnullableArrayOfString, notrequiredNotnullableBooleanProp, notrequiredNotnullableDatetimeProp, notrequiredNotnullableEnumInteger, notrequiredNotnullableEnumIntegerOnly, notrequiredNotnullableEnumString, notrequiredNotnullableOuterEnumDefaultValue, notrequiredNotnullableStringProp, notrequiredNotnullableUuid, notrequiredNullableArrayOfString, notrequiredNullableBooleanProp, notrequiredNullableDatetimeProp, notrequiredNullableEnumInteger, notrequiredNullableEnumIntegerOnly, notrequiredNullableEnumString, notrequiredNullableOuterEnumDefaultValue, notrequiredNullableStringProp, notrequiredNullableUuid, requiredNullableArrayOfString.Value!, requiredNullableBooleanProp.Value!, requiredNullableDateProp.Value!, requiredNullableDatetimeProp.Value!, requiredNullableEnumInteger.Value!, requiredNullableEnumIntegerOnly.Value!, requiredNullableEnumString.Value!, requiredNullableIntegerProp.Value!, requiredNullableOuterEnumDefaultValue.Value!, requiredNullableStringProp.Value!, requiredNullableUuid.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Result.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Result.cs
@@ -191,13 +191,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (code.IsSet && code.Value == null)
-                throw new ArgumentNullException(nameof(code), "Property is not nullable for class Result.");
+                throw new JsonException("Property is not nullable for class Result: code.");
 
             if (data.IsSet && data.Value == null)
-                throw new ArgumentNullException(nameof(data), "Property is not nullable for class Result.");
+                throw new JsonException("Property is not nullable for class Result: data.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class Result.");
+                throw new JsonException("Property is not nullable for class Result: uuid.");
 
             return new Result(code, data, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Return.cs
@@ -194,19 +194,19 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!varLock.IsSet)
-                throw new ArgumentException("Property is required for class Return.", nameof(varLock));
+                throw new JsonException("Property is required for class Return: lock.");
 
             if (!varAbstract.IsSet)
-                throw new ArgumentException("Property is required for class Return.", nameof(varAbstract));
+                throw new JsonException("Property is required for class Return: abstract.");
 
             if (varLock.IsSet && varLock.Value == null)
-                throw new ArgumentNullException(nameof(varLock), "Property is not nullable for class Return.");
+                throw new JsonException("Property is not nullable for class Return: lock.");
 
             if (varReturn.IsSet && varReturn.Value == null)
-                throw new ArgumentNullException(nameof(varReturn), "Property is not nullable for class Return.");
+                throw new JsonException("Property is not nullable for class Return: return.");
 
             if (varUnsafe.IsSet && varUnsafe.Value == null)
-                throw new ArgumentNullException(nameof(varUnsafe), "Property is not nullable for class Return.");
+                throw new JsonException("Property is not nullable for class Return: unsafe.");
 
             return new Return(varLock.Value!, varAbstract.Value!, varReturn, varUnsafe);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -168,10 +168,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (role.IsSet && role.Value == null)
-                throw new ArgumentNullException(nameof(role), "Property is not nullable for class RolesReportsHash.");
+                throw new JsonException("Property is not nullable for class RolesReportsHash: role.");
 
             if (roleUuid.IsSet && roleUuid.Value == null)
-                throw new ArgumentNullException(nameof(roleUuid), "Property is not nullable for class RolesReportsHash.");
+                throw new JsonException("Property is not nullable for class RolesReportsHash: role_uuid.");
 
             return new RolesReportsHash(role, roleUuid);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
@@ -148,7 +148,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class RolesReportsHashRole.");
+                throw new JsonException("Property is not nullable for class RolesReportsHashRole: name.");
 
             return new RolesReportsHashRole(name);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
@@ -154,16 +154,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ScaleneTriangle.", nameof(shapeType));
+                throw new JsonException("Property is required for class ScaleneTriangle: shapeType.");
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class ScaleneTriangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class ScaleneTriangle: triangleType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ScaleneTriangle.");
+                throw new JsonException("Property is not nullable for class ScaleneTriangle: shapeType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class ScaleneTriangle.");
+                throw new JsonException("Property is not nullable for class ScaleneTriangle: triangleType.");
 
             return new ScaleneTriangle(shapeType.Value!, triangleType.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Shape.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Shape.cs
@@ -196,10 +196,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class Shape.", nameof(shapeType));
+                throw new JsonException("Property is required for class Shape: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class Shape.");
+                throw new JsonException("Property is not nullable for class Shape: shapeType.");
 
             if (quadrilateral != null)
                 return new Shape(quadrilateral);

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ShapeInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ShapeInterface.cs
@@ -141,10 +141,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ShapeInterface.", nameof(shapeType));
+                throw new JsonException("Property is required for class ShapeInterface: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ShapeInterface.");
+                throw new JsonException("Property is not nullable for class ShapeInterface: shapeType.");
 
             return new ShapeInterface(shapeType.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ShapeOrNull.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ShapeOrNull.cs
@@ -196,10 +196,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ShapeOrNull.", nameof(shapeType));
+                throw new JsonException("Property is required for class ShapeOrNull: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ShapeOrNull.");
+                throw new JsonException("Property is not nullable for class ShapeOrNull: shapeType.");
 
             if (quadrilateral != null)
                 return new ShapeOrNull(quadrilateral);

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
@@ -154,16 +154,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class SimpleQuadrilateral.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class SimpleQuadrilateral: quadrilateralType.");
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class SimpleQuadrilateral.", nameof(shapeType));
+                throw new JsonException("Property is required for class SimpleQuadrilateral: shapeType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class SimpleQuadrilateral.");
+                throw new JsonException("Property is not nullable for class SimpleQuadrilateral: quadrilateralType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class SimpleQuadrilateral.");
+                throw new JsonException("Property is not nullable for class SimpleQuadrilateral: shapeType.");
 
             return new SimpleQuadrilateral(quadrilateralType.Value!, shapeType.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -168,10 +168,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varSpecialModelName.IsSet && varSpecialModelName.Value == null)
-                throw new ArgumentNullException(nameof(varSpecialModelName), "Property is not nullable for class SpecialModelName.");
+                throw new JsonException("Property is not nullable for class SpecialModelName: _special_model.name_.");
 
             if (specialPropertyName.IsSet && specialPropertyName.Value == null)
-                throw new ArgumentNullException(nameof(specialPropertyName), "Property is not nullable for class SpecialModelName.");
+                throw new JsonException("Property is not nullable for class SpecialModelName: $special[property.name].");
 
             return new SpecialModelName(varSpecialModelName, specialPropertyName);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Tag.cs
@@ -168,10 +168,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Tag.");
+                throw new JsonException("Property is not nullable for class Tag: id.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Tag.");
+                throw new JsonException("Property is not nullable for class Tag: name.");
 
             return new Tag(id, name);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -148,7 +148,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (value.IsSet && value.Value == null)
-                throw new ArgumentNullException(nameof(value), "Property is not nullable for class TestCollectionEndingWithWordList.");
+                throw new JsonException("Property is not nullable for class TestCollectionEndingWithWordList: value.");
 
             return new TestCollectionEndingWithWordList(value);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -148,7 +148,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (testCollectionEndingWithWordList.IsSet && testCollectionEndingWithWordList.Value == null)
-                throw new ArgumentNullException(nameof(testCollectionEndingWithWordList), "Property is not nullable for class TestCollectionEndingWithWordListObject.");
+                throw new JsonException("Property is not nullable for class TestCollectionEndingWithWordListObject: TestCollectionEndingWithWordList.");
 
             return new TestCollectionEndingWithWordListObject(testCollectionEndingWithWordList);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/TestDescendants.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/TestDescendants.cs
@@ -244,16 +244,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!alternativeName.IsSet)
-                throw new ArgumentException("Property is required for class TestDescendants.", nameof(alternativeName));
+                throw new JsonException("Property is required for class TestDescendants: alternativeName.");
 
             if (!objectType.IsSet)
-                throw new ArgumentException("Property is required for class TestDescendants.", nameof(objectType));
+                throw new JsonException("Property is required for class TestDescendants: objectType.");
 
             if (alternativeName.IsSet && alternativeName.Value == null)
-                throw new ArgumentNullException(nameof(alternativeName), "Property is not nullable for class TestDescendants.");
+                throw new JsonException("Property is not nullable for class TestDescendants: alternativeName.");
 
             if (objectType.IsSet && objectType.Value == null)
-                throw new ArgumentNullException(nameof(objectType), "Property is not nullable for class TestDescendants.");
+                throw new JsonException("Property is not nullable for class TestDescendants: objectType.");
 
             return new TestDescendants(alternativeName.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
@@ -148,7 +148,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (someProperty.IsSet && someProperty.Value == null)
-                throw new ArgumentNullException(nameof(someProperty), "Property is not nullable for class TestInlineFreeformAdditionalPropertiesRequest.");
+                throw new JsonException("Property is not nullable for class TestInlineFreeformAdditionalPropertiesRequest: someProperty.");
 
             return new TestInlineFreeformAdditionalPropertiesRequest(someProperty);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/TestResult.cs
@@ -190,13 +190,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (code.IsSet && code.Value == null)
-                throw new ArgumentNullException(nameof(code), "Property is not nullable for class TestResult.");
+                throw new JsonException("Property is not nullable for class TestResult: code.");
 
             if (data.IsSet && data.Value == null)
-                throw new ArgumentNullException(nameof(data), "Property is not nullable for class TestResult.");
+                throw new JsonException("Property is not nullable for class TestResult: data.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class TestResult.");
+                throw new JsonException("Property is not nullable for class TestResult: uuid.");
 
             return new TestResult(code, data, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Triangle.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Triangle.cs
@@ -217,10 +217,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class Triangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class Triangle: triangleType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class Triangle.");
+                throw new JsonException("Property is not nullable for class Triangle: triangleType.");
 
             if (equilateralTriangle != null)
                 return new Triangle(equilateralTriangle);

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/TriangleInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/TriangleInterface.cs
@@ -141,10 +141,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class TriangleInterface.", nameof(triangleType));
+                throw new JsonException("Property is required for class TriangleInterface: triangleType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class TriangleInterface.");
+                throw new JsonException("Property is not nullable for class TriangleInterface: triangleType.");
 
             return new TriangleInterface(triangleType.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/User.cs
@@ -373,31 +373,31 @@ namespace Org.OpenAPITools.Model
             }
 
             if (email.IsSet && email.Value == null)
-                throw new ArgumentNullException(nameof(email), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: email.");
 
             if (firstName.IsSet && firstName.Value == null)
-                throw new ArgumentNullException(nameof(firstName), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: firstName.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: id.");
 
             if (lastName.IsSet && lastName.Value == null)
-                throw new ArgumentNullException(nameof(lastName), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: lastName.");
 
             if (objectWithNoDeclaredProps.IsSet && objectWithNoDeclaredProps.Value == null)
-                throw new ArgumentNullException(nameof(objectWithNoDeclaredProps), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: objectWithNoDeclaredProps.");
 
             if (password.IsSet && password.Value == null)
-                throw new ArgumentNullException(nameof(password), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: password.");
 
             if (phone.IsSet && phone.Value == null)
-                throw new ArgumentNullException(nameof(phone), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: phone.");
 
             if (userStatus.IsSet && userStatus.Value == null)
-                throw new ArgumentNullException(nameof(userStatus), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: userStatus.");
 
             if (username.IsSet && username.Value == null)
-                throw new ArgumentNullException(nameof(username), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: username.");
 
             return new User(anyTypeProp, anyTypePropNullable, email, firstName, id, lastName, objectWithNoDeclaredProps, objectWithNoDeclaredPropsNullable, password, phone, userStatus, username);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Whale.cs
@@ -181,16 +181,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Whale.", nameof(className));
+                throw new JsonException("Property is required for class Whale: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Whale.");
+                throw new JsonException("Property is not nullable for class Whale: className.");
 
             if (hasBaleen.IsSet && hasBaleen.Value == null)
-                throw new ArgumentNullException(nameof(hasBaleen), "Property is not nullable for class Whale.");
+                throw new JsonException("Property is not nullable for class Whale: hasBaleen.");
 
             if (hasTeeth.IsSet && hasTeeth.Value == null)
-                throw new ArgumentNullException(nameof(hasTeeth), "Property is not nullable for class Whale.");
+                throw new JsonException("Property is not nullable for class Whale: hasTeeth.");
 
             return new Whale(className.Value!, hasBaleen, hasTeeth);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Zebra.cs
@@ -248,13 +248,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Zebra.", nameof(className));
+                throw new JsonException("Property is required for class Zebra: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Zebra.");
+                throw new JsonException("Property is not nullable for class Zebra: className.");
 
             if (type.IsSet && type.Value == null)
-                throw new ArgumentNullException(nameof(type), "Property is not nullable for class Zebra.");
+                throw new JsonException("Property is not nullable for class Zebra: type.");
 
             return new Zebra(className.Value!, type);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
@@ -221,7 +221,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (zeroBasedEnum.IsSet && zeroBasedEnum.Value == null)
-                throw new ArgumentNullException(nameof(zeroBasedEnum), "Property is not nullable for class ZeroBasedEnumClass.");
+                throw new JsonException("Property is not nullable for class ZeroBasedEnumClass: ZeroBasedEnum.");
 
             return new ZeroBasedEnumClass(zeroBasedEnum);
         }

--- a/samples/client/petstore/csharp/generichost/net8/UseDateTimeForDate/src/Org.OpenAPITools/Model/NowGet200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net8/UseDateTimeForDate/src/Org.OpenAPITools/Model/NowGet200Response.cs
@@ -169,10 +169,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (now.IsSet && now.Value == null)
-                throw new ArgumentNullException(nameof(now), "Property is not nullable for class NowGet200Response.");
+                throw new JsonException("Property is not nullable for class NowGet200Response: now.");
 
             if (today.IsSet && today.Value == null)
-                throw new ArgumentNullException(nameof(today), "Property is not nullable for class NowGet200Response.");
+                throw new JsonException("Property is not nullable for class NowGet200Response: today.");
 
             return new NowGet200Response(now, today);
         }

--- a/samples/client/petstore/csharp/generichost/net9/AllOf/src/Org.OpenAPITools/Model/Adult.cs
+++ b/samples/client/petstore/csharp/generichost/net9/AllOf/src/Org.OpenAPITools/Model/Adult.cs
@@ -145,16 +145,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (children.IsSet && children.Value == null)
-                throw new ArgumentNullException(nameof(children), "Property is not nullable for class Adult.");
+                throw new JsonException("Property is not nullable for class Adult: children.");
 
             if (firstName.IsSet && firstName.Value == null)
-                throw new ArgumentNullException(nameof(firstName), "Property is not nullable for class Adult.");
+                throw new JsonException("Property is not nullable for class Adult: firstName.");
 
             if (lastName.IsSet && lastName.Value == null)
-                throw new ArgumentNullException(nameof(lastName), "Property is not nullable for class Adult.");
+                throw new JsonException("Property is not nullable for class Adult: lastName.");
 
             if (type.IsSet && type.Value == null)
-                throw new ArgumentNullException(nameof(type), "Property is not nullable for class Adult.");
+                throw new JsonException("Property is not nullable for class Adult: $_type.");
 
             return new Adult(children, firstName, lastName);
         }

--- a/samples/client/petstore/csharp/generichost/net9/AllOf/src/Org.OpenAPITools/Model/Child.cs
+++ b/samples/client/petstore/csharp/generichost/net9/AllOf/src/Org.OpenAPITools/Model/Child.cs
@@ -165,19 +165,19 @@ namespace Org.OpenAPITools.Model
             }
 
             if (age.IsSet && age.Value == null)
-                throw new ArgumentNullException(nameof(age), "Property is not nullable for class Child.");
+                throw new JsonException("Property is not nullable for class Child: age.");
 
             if (boosterSeat.IsSet && boosterSeat.Value == null)
-                throw new ArgumentNullException(nameof(boosterSeat), "Property is not nullable for class Child.");
+                throw new JsonException("Property is not nullable for class Child: boosterSeat.");
 
             if (firstName.IsSet && firstName.Value == null)
-                throw new ArgumentNullException(nameof(firstName), "Property is not nullable for class Child.");
+                throw new JsonException("Property is not nullable for class Child: firstName.");
 
             if (lastName.IsSet && lastName.Value == null)
-                throw new ArgumentNullException(nameof(lastName), "Property is not nullable for class Child.");
+                throw new JsonException("Property is not nullable for class Child: lastName.");
 
             if (type.IsSet && type.Value == null)
-                throw new ArgumentNullException(nameof(type), "Property is not nullable for class Child.");
+                throw new JsonException("Property is not nullable for class Child: $_type.");
 
             return new Child(age, boosterSeat, firstName, lastName);
         }

--- a/samples/client/petstore/csharp/generichost/net9/AllOf/src/Org.OpenAPITools/Model/Person.cs
+++ b/samples/client/petstore/csharp/generichost/net9/AllOf/src/Org.OpenAPITools/Model/Person.cs
@@ -197,13 +197,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (firstName.IsSet && firstName.Value == null)
-                throw new ArgumentNullException(nameof(firstName), "Property is not nullable for class Person.");
+                throw new JsonException("Property is not nullable for class Person: firstName.");
 
             if (lastName.IsSet && lastName.Value == null)
-                throw new ArgumentNullException(nameof(lastName), "Property is not nullable for class Person.");
+                throw new JsonException("Property is not nullable for class Person: lastName.");
 
             if (type.IsSet && type.Value == null)
-                throw new ArgumentNullException(nameof(type), "Property is not nullable for class Person.");
+                throw new JsonException("Property is not nullable for class Person: $_type.");
 
             return new Person(firstName, lastName);
         }

--- a/samples/client/petstore/csharp/generichost/net9/AnyOf/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net9/AnyOf/src/Org.OpenAPITools/Model/Apple.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (kind.IsSet && kind.Value == null)
-                throw new ArgumentNullException(nameof(kind), "Property is not nullable for class Apple.");
+                throw new JsonException("Property is not nullable for class Apple: kind.");
 
             return new Apple(kind);
         }

--- a/samples/client/petstore/csharp/generichost/net9/AnyOf/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net9/AnyOf/src/Org.OpenAPITools/Model/Banana.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (count.IsSet && count.Value == null)
-                throw new ArgumentNullException(nameof(count), "Property is not nullable for class Banana.");
+                throw new JsonException("Property is not nullable for class Banana: count.");
 
             return new Banana(count);
         }

--- a/samples/client/petstore/csharp/generichost/net9/AnyOf/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net9/AnyOf/src/Org.OpenAPITools/Model/Fruit.cs
@@ -196,7 +196,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Fruit.");
+                throw new JsonException("Property is not nullable for class Fruit: color.");
 
             Option<Apple?> appleParsedValue = apple == null
                 ? default

--- a/samples/client/petstore/csharp/generichost/net9/AnyOfNoCompare/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net9/AnyOfNoCompare/src/Org.OpenAPITools/Model/Apple.cs
@@ -146,7 +146,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (kind.IsSet && kind.Value == null)
-                throw new ArgumentNullException(nameof(kind), "Property is not nullable for class Apple.");
+                throw new JsonException("Property is not nullable for class Apple: kind.");
 
             return new Apple(kind);
         }

--- a/samples/client/petstore/csharp/generichost/net9/AnyOfNoCompare/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net9/AnyOfNoCompare/src/Org.OpenAPITools/Model/Banana.cs
@@ -146,7 +146,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (count.IsSet && count.Value == null)
-                throw new ArgumentNullException(nameof(count), "Property is not nullable for class Banana.");
+                throw new JsonException("Property is not nullable for class Banana: count.");
 
             return new Banana(count);
         }

--- a/samples/client/petstore/csharp/generichost/net9/AnyOfNoCompare/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net9/AnyOfNoCompare/src/Org.OpenAPITools/Model/Fruit.cs
@@ -195,7 +195,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Fruit.");
+                throw new JsonException("Property is not nullable for class Fruit: color.");
 
             Option<Apple?> appleParsedValue = apple == null
                 ? default

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Activity.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (activityOutputs.IsSet && activityOutputs.Value == null)
-                throw new ArgumentNullException(nameof(activityOutputs), "Property is not nullable for class Activity.");
+                throw new JsonException("Property is not nullable for class Activity: activity_outputs.");
 
             return new Activity(activityOutputs);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (prop1.IsSet && prop1.Value == null)
-                throw new ArgumentNullException(nameof(prop1), "Property is not nullable for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Property is not nullable for class ActivityOutputElementRepresentation: prop1.");
 
             if (prop2.IsSet && prop2.Value == null)
-                throw new ArgumentNullException(nameof(prop2), "Property is not nullable for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Property is not nullable for class ActivityOutputElementRepresentation: prop2.");
 
             return new ActivityOutputElementRepresentation(prop1, prop2);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -286,25 +286,25 @@ namespace Org.OpenAPITools.Model
             }
 
             if (emptyMap.IsSet && emptyMap.Value == null)
-                throw new ArgumentNullException(nameof(emptyMap), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: empty_map.");
 
             if (mapOfMapProperty.IsSet && mapOfMapProperty.Value == null)
-                throw new ArgumentNullException(nameof(mapOfMapProperty), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_of_map_property.");
 
             if (mapProperty.IsSet && mapProperty.Value == null)
-                throw new ArgumentNullException(nameof(mapProperty), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_property.");
 
             if (mapWithUndeclaredPropertiesAnytype1.IsSet && mapWithUndeclaredPropertiesAnytype1.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesAnytype1), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_anytype_1.");
 
             if (mapWithUndeclaredPropertiesAnytype2.IsSet && mapWithUndeclaredPropertiesAnytype2.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesAnytype2), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_anytype_2.");
 
             if (mapWithUndeclaredPropertiesAnytype3.IsSet && mapWithUndeclaredPropertiesAnytype3.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesAnytype3), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_anytype_3.");
 
             if (mapWithUndeclaredPropertiesString.IsSet && mapWithUndeclaredPropertiesString.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesString), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_string.");
 
             return new AdditionalPropertiesClass(anytype1, emptyMap, mapOfMapProperty, mapProperty, mapWithUndeclaredPropertiesAnytype1, mapWithUndeclaredPropertiesAnytype2, mapWithUndeclaredPropertiesAnytype3, mapWithUndeclaredPropertiesString);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Animal.cs
@@ -175,13 +175,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Animal.", nameof(className));
+                throw new JsonException("Property is required for class Animal: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Animal.");
+                throw new JsonException("Property is not nullable for class Animal: className.");
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Animal.");
+                throw new JsonException("Property is not nullable for class Animal: color.");
 
             return new Animal(color);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -185,13 +185,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (code.IsSet && code.Value == null)
-                throw new ArgumentNullException(nameof(code), "Property is not nullable for class ApiResponse.");
+                throw new JsonException("Property is not nullable for class ApiResponse: code.");
 
             if (message.IsSet && message.Value == null)
-                throw new ArgumentNullException(nameof(message), "Property is not nullable for class ApiResponse.");
+                throw new JsonException("Property is not nullable for class ApiResponse: message.");
 
             if (type.IsSet && type.Value == null)
-                throw new ArgumentNullException(nameof(type), "Property is not nullable for class ApiResponse.");
+                throw new JsonException("Property is not nullable for class ApiResponse: type.");
 
             return new ApiResponse(code, message, type);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Apple.cs
@@ -215,13 +215,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (colorCode.IsSet && colorCode.Value == null)
-                throw new ArgumentNullException(nameof(colorCode), "Property is not nullable for class Apple.");
+                throw new JsonException("Property is not nullable for class Apple: color_code.");
 
             if (cultivar.IsSet && cultivar.Value == null)
-                throw new ArgumentNullException(nameof(cultivar), "Property is not nullable for class Apple.");
+                throw new JsonException("Property is not nullable for class Apple: cultivar.");
 
             if (origin.IsSet && origin.Value == null)
-                throw new ArgumentNullException(nameof(origin), "Property is not nullable for class Apple.");
+                throw new JsonException("Property is not nullable for class Apple: origin.");
 
             return new Apple(colorCode, cultivar, origin);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -151,13 +151,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!cultivar.IsSet)
-                throw new ArgumentException("Property is required for class AppleReq.", nameof(cultivar));
+                throw new JsonException("Property is required for class AppleReq: cultivar.");
 
             if (cultivar.IsSet && cultivar.Value == null)
-                throw new ArgumentNullException(nameof(cultivar), "Property is not nullable for class AppleReq.");
+                throw new JsonException("Property is not nullable for class AppleReq: cultivar.");
 
             if (mealy.IsSet && mealy.Value == null)
-                throw new ArgumentNullException(nameof(mealy), "Property is not nullable for class AppleReq.");
+                throw new JsonException("Property is not nullable for class AppleReq: mealy.");
 
             return new AppleReq(cultivar.Value, mealy);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayArrayNumber.IsSet && arrayArrayNumber.Value == null)
-                throw new ArgumentNullException(nameof(arrayArrayNumber), "Property is not nullable for class ArrayOfArrayOfNumberOnly.");
+                throw new JsonException("Property is not nullable for class ArrayOfArrayOfNumberOnly: ArrayArrayNumber.");
 
             return new ArrayOfArrayOfNumberOnly(arrayArrayNumber);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayNumber.IsSet && arrayNumber.Value == null)
-                throw new ArgumentNullException(nameof(arrayNumber), "Property is not nullable for class ArrayOfNumberOnly.");
+                throw new JsonException("Property is not nullable for class ArrayOfNumberOnly: ArrayNumber.");
 
             return new ArrayOfNumberOnly(arrayNumber);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -185,13 +185,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayArrayOfInteger.IsSet && arrayArrayOfInteger.Value == null)
-                throw new ArgumentNullException(nameof(arrayArrayOfInteger), "Property is not nullable for class ArrayTest.");
+                throw new JsonException("Property is not nullable for class ArrayTest: array_array_of_integer.");
 
             if (arrayArrayOfModel.IsSet && arrayArrayOfModel.Value == null)
-                throw new ArgumentNullException(nameof(arrayArrayOfModel), "Property is not nullable for class ArrayTest.");
+                throw new JsonException("Property is not nullable for class ArrayTest: array_array_of_model.");
 
             if (arrayOfString.IsSet && arrayOfString.Value == null)
-                throw new ArgumentNullException(nameof(arrayOfString), "Property is not nullable for class ArrayTest.");
+                throw new JsonException("Property is not nullable for class ArrayTest: array_of_string.");
 
             return new ArrayTest(arrayArrayOfInteger, arrayArrayOfModel, arrayOfString);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Banana.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (lengthCm.IsSet && lengthCm.Value == null)
-                throw new ArgumentNullException(nameof(lengthCm), "Property is not nullable for class Banana.");
+                throw new JsonException("Property is not nullable for class Banana: lengthCm.");
 
             return new Banana(lengthCm);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -151,13 +151,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!lengthCm.IsSet)
-                throw new ArgumentException("Property is required for class BananaReq.", nameof(lengthCm));
+                throw new JsonException("Property is required for class BananaReq: lengthCm.");
 
             if (lengthCm.IsSet && lengthCm.Value == null)
-                throw new ArgumentNullException(nameof(lengthCm), "Property is not nullable for class BananaReq.");
+                throw new JsonException("Property is not nullable for class BananaReq: lengthCm.");
 
             if (sweet.IsSet && sweet.Value == null)
-                throw new ArgumentNullException(nameof(sweet), "Property is not nullable for class BananaReq.");
+                throw new JsonException("Property is not nullable for class BananaReq: sweet.");
 
             return new BananaReq(lengthCm.Value.Value, sweet);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/BasquePig.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/BasquePig.cs
@@ -138,10 +138,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class BasquePig.", nameof(className));
+                throw new JsonException("Property is required for class BasquePig: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class BasquePig.");
+                throw new JsonException("Property is not nullable for class BasquePig: className.");
 
             return new BasquePig(className.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -246,22 +246,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (aTTNAME.IsSet && aTTNAME.Value == null)
-                throw new ArgumentNullException(nameof(aTTNAME), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: ATT_NAME.");
 
             if (capitalCamel.IsSet && capitalCamel.Value == null)
-                throw new ArgumentNullException(nameof(capitalCamel), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: CapitalCamel.");
 
             if (capitalSnake.IsSet && capitalSnake.Value == null)
-                throw new ArgumentNullException(nameof(capitalSnake), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: Capital_Snake.");
 
             if (sCAETHFlowPoints.IsSet && sCAETHFlowPoints.Value == null)
-                throw new ArgumentNullException(nameof(sCAETHFlowPoints), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: SCA_ETH_Flow_Points.");
 
             if (smallCamel.IsSet && smallCamel.Value == null)
-                throw new ArgumentNullException(nameof(smallCamel), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: smallCamel.");
 
             if (smallSnake.IsSet && smallSnake.Value == null)
-                throw new ArgumentNullException(nameof(smallSnake), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: small_Snake.");
 
             return new Capitalization(aTTNAME, capitalCamel, capitalSnake, sCAETHFlowPoints, smallCamel, smallSnake);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Cat.cs
@@ -138,16 +138,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Cat.", nameof(className));
+                throw new JsonException("Property is required for class Cat: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Cat.");
+                throw new JsonException("Property is not nullable for class Cat: className.");
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Cat.");
+                throw new JsonException("Property is not nullable for class Cat: color.");
 
             if (declawed.IsSet && declawed.Value == null)
-                throw new ArgumentNullException(nameof(declawed), "Property is not nullable for class Cat.");
+                throw new JsonException("Property is not nullable for class Cat: declawed.");
 
             return new Cat(color, declawed);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Category.cs
@@ -158,13 +158,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!name.IsSet)
-                throw new ArgumentException("Property is required for class Category.", nameof(name));
+                throw new JsonException("Property is required for class Category: name.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Category.");
+                throw new JsonException("Property is not nullable for class Category: id.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Category.");
+                throw new JsonException("Property is not nullable for class Category: name.");
 
             return new Category(id, name.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -141,13 +141,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!petType.IsSet)
-                throw new ArgumentException("Property is required for class ChildCat.", nameof(petType));
+                throw new JsonException("Property is required for class ChildCat: pet_type.");
 
             if (petType.IsSet && petType.Value == null)
-                throw new ArgumentNullException(nameof(petType), "Property is not nullable for class ChildCat.");
+                throw new JsonException("Property is not nullable for class ChildCat: pet_type.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class ChildCat.");
+                throw new JsonException("Property is not nullable for class ChildCat: name.");
 
             return new ChildCat(name);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varClass.IsSet && varClass.Value == null)
-                throw new ArgumentNullException(nameof(varClass), "Property is not nullable for class ClassModel.");
+                throw new JsonException("Property is not nullable for class ClassModel: _class.");
 
             return new ClassModel(varClass);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
@@ -151,16 +151,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class ComplexQuadrilateral.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class ComplexQuadrilateral: quadrilateralType.");
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ComplexQuadrilateral.", nameof(shapeType));
+                throw new JsonException("Property is required for class ComplexQuadrilateral: shapeType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class ComplexQuadrilateral.");
+                throw new JsonException("Property is not nullable for class ComplexQuadrilateral: quadrilateralType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ComplexQuadrilateral.");
+                throw new JsonException("Property is not nullable for class ComplexQuadrilateral: shapeType.");
 
             return new ComplexQuadrilateral(quadrilateralType.Value, shapeType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/CopyActivity.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/CopyActivity.cs
@@ -134,16 +134,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!copyActivitytt.IsSet)
-                throw new ArgumentException("Property is required for class CopyActivity.", nameof(copyActivitytt));
+                throw new JsonException("Property is required for class CopyActivity: copyActivitytt.");
 
             if (!schema.IsSet)
-                throw new ArgumentException("Property is required for class CopyActivity.", nameof(schema));
+                throw new JsonException("Property is required for class CopyActivity: $schema.");
 
             if (copyActivitytt.IsSet && copyActivitytt.Value == null)
-                throw new ArgumentNullException(nameof(copyActivitytt), "Property is not nullable for class CopyActivity.");
+                throw new JsonException("Property is not nullable for class CopyActivity: copyActivitytt.");
 
             if (schema.IsSet && schema.Value == null)
-                throw new ArgumentNullException(nameof(schema), "Property is not nullable for class CopyActivity.");
+                throw new JsonException("Property is not nullable for class CopyActivity: $schema.");
 
             return new CopyActivity(copyActivitytt.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/DanishPig.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/DanishPig.cs
@@ -138,10 +138,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class DanishPig.", nameof(className));
+                throw new JsonException("Property is required for class DanishPig: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class DanishPig.");
+                throw new JsonException("Property is not nullable for class DanishPig: className.");
 
             return new DanishPig(className.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -151,7 +151,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (dateOnlyProperty.IsSet && dateOnlyProperty.Value == null)
-                throw new ArgumentNullException(nameof(dateOnlyProperty), "Property is not nullable for class DateOnlyClass.");
+                throw new JsonException("Property is not nullable for class DateOnlyClass: dateOnlyProperty.");
 
             return new DateOnlyClass(dateOnlyProperty);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class DeprecatedObject.");
+                throw new JsonException("Property is not nullable for class DeprecatedObject: name.");
 
             return new DeprecatedObject(name);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Descendant1.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Descendant1.cs
@@ -131,22 +131,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!alternativeName.IsSet)
-                throw new ArgumentException("Property is required for class Descendant1.", nameof(alternativeName));
+                throw new JsonException("Property is required for class Descendant1: alternativeName.");
 
             if (!descendantName.IsSet)
-                throw new ArgumentException("Property is required for class Descendant1.", nameof(descendantName));
+                throw new JsonException("Property is required for class Descendant1: descendantName.");
 
             if (!objectType.IsSet)
-                throw new ArgumentException("Property is required for class Descendant1.", nameof(objectType));
+                throw new JsonException("Property is required for class Descendant1: objectType.");
 
             if (alternativeName.IsSet && alternativeName.Value == null)
-                throw new ArgumentNullException(nameof(alternativeName), "Property is not nullable for class Descendant1.");
+                throw new JsonException("Property is not nullable for class Descendant1: alternativeName.");
 
             if (descendantName.IsSet && descendantName.Value == null)
-                throw new ArgumentNullException(nameof(descendantName), "Property is not nullable for class Descendant1.");
+                throw new JsonException("Property is not nullable for class Descendant1: descendantName.");
 
             if (objectType.IsSet && objectType.Value == null)
-                throw new ArgumentNullException(nameof(objectType), "Property is not nullable for class Descendant1.");
+                throw new JsonException("Property is not nullable for class Descendant1: objectType.");
 
             return new Descendant1(alternativeName.Value, descendantName.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Descendant2.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Descendant2.cs
@@ -131,22 +131,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!alternativeName.IsSet)
-                throw new ArgumentException("Property is required for class Descendant2.", nameof(alternativeName));
+                throw new JsonException("Property is required for class Descendant2: alternativeName.");
 
             if (!confidentiality.IsSet)
-                throw new ArgumentException("Property is required for class Descendant2.", nameof(confidentiality));
+                throw new JsonException("Property is required for class Descendant2: confidentiality.");
 
             if (!objectType.IsSet)
-                throw new ArgumentException("Property is required for class Descendant2.", nameof(objectType));
+                throw new JsonException("Property is required for class Descendant2: objectType.");
 
             if (alternativeName.IsSet && alternativeName.Value == null)
-                throw new ArgumentNullException(nameof(alternativeName), "Property is not nullable for class Descendant2.");
+                throw new JsonException("Property is not nullable for class Descendant2: alternativeName.");
 
             if (confidentiality.IsSet && confidentiality.Value == null)
-                throw new ArgumentNullException(nameof(confidentiality), "Property is not nullable for class Descendant2.");
+                throw new JsonException("Property is not nullable for class Descendant2: confidentiality.");
 
             if (objectType.IsSet && objectType.Value == null)
-                throw new ArgumentNullException(nameof(objectType), "Property is not nullable for class Descendant2.");
+                throw new JsonException("Property is not nullable for class Descendant2: objectType.");
 
             return new Descendant2(alternativeName.Value, confidentiality.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Dog.cs
@@ -138,16 +138,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Dog.", nameof(className));
+                throw new JsonException("Property is required for class Dog: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Dog.");
+                throw new JsonException("Property is not nullable for class Dog: className.");
 
             if (breed.IsSet && breed.Value == null)
-                throw new ArgumentNullException(nameof(breed), "Property is not nullable for class Dog.");
+                throw new JsonException("Property is not nullable for class Dog: breed.");
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Dog.");
+                throw new JsonException("Property is not nullable for class Dog: color.");
 
             return new Dog(breed, color);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Drawing.cs
@@ -205,10 +205,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (mainShape.IsSet && mainShape.Value == null)
-                throw new ArgumentNullException(nameof(mainShape), "Property is not nullable for class Drawing.");
+                throw new JsonException("Property is not nullable for class Drawing: mainShape.");
 
             if (shapes.IsSet && shapes.Value == null)
-                throw new ArgumentNullException(nameof(shapes), "Property is not nullable for class Drawing.");
+                throw new JsonException("Property is not nullable for class Drawing: shapes.");
 
             return new Drawing(mainShape, nullableShape, shapeOrNull, shapes);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/EntityBase.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/EntityBase.cs
@@ -152,10 +152,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!schema.IsSet)
-                throw new ArgumentException("Property is required for class EntityBase.", nameof(schema));
+                throw new JsonException("Property is required for class EntityBase: $schema.");
 
             if (schema.IsSet && schema.Value == null)
-                throw new ArgumentNullException(nameof(schema), "Property is not nullable for class EntityBase.");
+                throw new JsonException("Property is not nullable for class EntityBase: $schema.");
 
             return new EntityBase();
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayEnum.IsSet && arrayEnum.Value == null)
-                throw new ArgumentNullException(nameof(arrayEnum), "Property is not nullable for class EnumArrays.");
+                throw new JsonException("Property is not nullable for class EnumArrays: array_enum.");
 
             if (justSymbol.IsSet && justSymbol.Value == null)
-                throw new ArgumentNullException(nameof(justSymbol), "Property is not nullable for class EnumArrays.");
+                throw new JsonException("Property is not nullable for class EnumArrays: just_symbol.");
 
             return new EnumArrays(arrayEnum, justSymbol);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -298,31 +298,31 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!enumStringRequired.IsSet)
-                throw new ArgumentException("Property is required for class EnumTest.", nameof(enumStringRequired));
+                throw new JsonException("Property is required for class EnumTest: enum_string_required.");
 
             if (enumStringRequired.IsSet && enumStringRequired.Value == null)
-                throw new ArgumentNullException(nameof(enumStringRequired), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_string_required.");
 
             if (enumInteger.IsSet && enumInteger.Value == null)
-                throw new ArgumentNullException(nameof(enumInteger), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_integer.");
 
             if (enumIntegerOnly.IsSet && enumIntegerOnly.Value == null)
-                throw new ArgumentNullException(nameof(enumIntegerOnly), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_integer_only.");
 
             if (enumNumber.IsSet && enumNumber.Value == null)
-                throw new ArgumentNullException(nameof(enumNumber), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_number.");
 
             if (enumString.IsSet && enumString.Value == null)
-                throw new ArgumentNullException(nameof(enumString), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_string.");
 
             if (outerEnumDefaultValue.IsSet && outerEnumDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(outerEnumDefaultValue), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: outerEnumDefaultValue.");
 
             if (outerEnumInteger.IsSet && outerEnumInteger.Value == null)
-                throw new ArgumentNullException(nameof(outerEnumInteger), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: outerEnumInteger.");
 
             if (outerEnumIntegerDefaultValue.IsSet && outerEnumIntegerDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(outerEnumIntegerDefaultValue), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: outerEnumIntegerDefaultValue.");
 
             return new EnumTest(enumStringRequired.Value.Value, enumInteger, enumIntegerOnly, enumNumber, enumString, outerEnum, outerEnumDefaultValue, outerEnumInteger, outerEnumIntegerDefaultValue);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
@@ -151,16 +151,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class EquilateralTriangle.", nameof(shapeType));
+                throw new JsonException("Property is required for class EquilateralTriangle: shapeType.");
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class EquilateralTriangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class EquilateralTriangle: triangleType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class EquilateralTriangle.");
+                throw new JsonException("Property is not nullable for class EquilateralTriangle: shapeType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class EquilateralTriangle.");
+                throw new JsonException("Property is not nullable for class EquilateralTriangle: triangleType.");
 
             return new EquilateralTriangle(shapeType.Value, triangleType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/File.cs
@@ -146,7 +146,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (sourceURI.IsSet && sourceURI.Value == null)
-                throw new ArgumentNullException(nameof(sourceURI), "Property is not nullable for class File.");
+                throw new JsonException("Property is not nullable for class File: sourceURI.");
 
             return new File(sourceURI);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (file.IsSet && file.Value == null)
-                throw new ArgumentNullException(nameof(file), "Property is not nullable for class FileSchemaTestClass.");
+                throw new JsonException("Property is not nullable for class FileSchemaTestClass: file.");
 
             if (files.IsSet && files.Value == null)
-                throw new ArgumentNullException(nameof(files), "Property is not nullable for class FileSchemaTestClass.");
+                throw new JsonException("Property is not nullable for class FileSchemaTestClass: files.");
 
             return new FileSchemaTestClass(file, files);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Foo.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bar.IsSet && bar.Value == null)
-                throw new ArgumentNullException(nameof(bar), "Property is not nullable for class Foo.");
+                throw new JsonException("Property is not nullable for class Foo: bar.");
 
             return new Foo(bar);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varString.IsSet && varString.Value == null)
-                throw new ArgumentNullException(nameof(varString), "Property is not nullable for class FooGetDefaultResponse.");
+                throw new JsonException("Property is not nullable for class FooGetDefaultResponse: string.");
 
             return new FooGetDefaultResponse(varString);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -826,103 +826,103 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!varByte.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(varByte));
+                throw new JsonException("Property is required for class FormatTest: byte.");
 
             if (!date.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(date));
+                throw new JsonException("Property is required for class FormatTest: date.");
 
             if (!number.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(number));
+                throw new JsonException("Property is required for class FormatTest: number.");
 
             if (!password.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(password));
+                throw new JsonException("Property is required for class FormatTest: password.");
 
             if (!stringFormattedAsDecimalRequired.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(stringFormattedAsDecimalRequired));
+                throw new JsonException("Property is required for class FormatTest: string_formatted_as_decimal_required.");
 
             if (varByte.IsSet && varByte.Value == null)
-                throw new ArgumentNullException(nameof(varByte), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: byte.");
 
             if (date.IsSet && date.Value == null)
-                throw new ArgumentNullException(nameof(date), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: date.");
 
             if (number.IsSet && number.Value == null)
-                throw new ArgumentNullException(nameof(number), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: number.");
 
             if (password.IsSet && password.Value == null)
-                throw new ArgumentNullException(nameof(password), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: password.");
 
             if (stringFormattedAsDecimalRequired.IsSet && stringFormattedAsDecimalRequired.Value == null)
-                throw new ArgumentNullException(nameof(stringFormattedAsDecimalRequired), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: string_formatted_as_decimal_required.");
 
             if (binary.IsSet && binary.Value == null)
-                throw new ArgumentNullException(nameof(binary), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: binary.");
 
             if (dateTime.IsSet && dateTime.Value == null)
-                throw new ArgumentNullException(nameof(dateTime), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: dateTime.");
 
             if (varDecimal.IsSet && varDecimal.Value == null)
-                throw new ArgumentNullException(nameof(varDecimal), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: decimal.");
 
             if (varDouble.IsSet && varDouble.Value == null)
-                throw new ArgumentNullException(nameof(varDouble), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: double.");
 
             if (duplicatePropertyName2.IsSet && duplicatePropertyName2.Value == null)
-                throw new ArgumentNullException(nameof(duplicatePropertyName2), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: duplicate_property_name.");
 
             if (duplicatePropertyName.IsSet && duplicatePropertyName.Value == null)
-                throw new ArgumentNullException(nameof(duplicatePropertyName), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: @duplicate_property_name.");
 
             if (varFloat.IsSet && varFloat.Value == null)
-                throw new ArgumentNullException(nameof(varFloat), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: float.");
 
             if (int32.IsSet && int32.Value == null)
-                throw new ArgumentNullException(nameof(int32), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int32.");
 
             if (int32Range.IsSet && int32Range.Value == null)
-                throw new ArgumentNullException(nameof(int32Range), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int32Range.");
 
             if (int64.IsSet && int64.Value == null)
-                throw new ArgumentNullException(nameof(int64), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64.");
 
             if (int64Negative.IsSet && int64Negative.Value == null)
-                throw new ArgumentNullException(nameof(int64Negative), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64Negative.");
 
             if (int64NegativeExclusive.IsSet && int64NegativeExclusive.Value == null)
-                throw new ArgumentNullException(nameof(int64NegativeExclusive), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64NegativeExclusive.");
 
             if (int64Positive.IsSet && int64Positive.Value == null)
-                throw new ArgumentNullException(nameof(int64Positive), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64Positive.");
 
             if (int64PositiveExclusive.IsSet && int64PositiveExclusive.Value == null)
-                throw new ArgumentNullException(nameof(int64PositiveExclusive), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64PositiveExclusive.");
 
             if (integer.IsSet && integer.Value == null)
-                throw new ArgumentNullException(nameof(integer), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: integer.");
 
             if (patternWithBackslash.IsSet && patternWithBackslash.Value == null)
-                throw new ArgumentNullException(nameof(patternWithBackslash), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: pattern_with_backslash.");
 
             if (patternWithDigits.IsSet && patternWithDigits.Value == null)
-                throw new ArgumentNullException(nameof(patternWithDigits), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: pattern_with_digits.");
 
             if (patternWithDigitsAndDelimiter.IsSet && patternWithDigitsAndDelimiter.Value == null)
-                throw new ArgumentNullException(nameof(patternWithDigitsAndDelimiter), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: pattern_with_digits_and_delimiter.");
 
             if (varString.IsSet && varString.Value == null)
-                throw new ArgumentNullException(nameof(varString), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: string.");
 
             if (stringFormattedAsDecimal.IsSet && stringFormattedAsDecimal.Value == null)
-                throw new ArgumentNullException(nameof(stringFormattedAsDecimal), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: string_formatted_as_decimal.");
 
             if (unsignedInteger.IsSet && unsignedInteger.Value == null)
-                throw new ArgumentNullException(nameof(unsignedInteger), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: unsigned_integer.");
 
             if (unsignedLong.IsSet && unsignedLong.Value == null)
-                throw new ArgumentNullException(nameof(unsignedLong), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: unsigned_long.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: uuid.");
 
             return new FormatTest(varByte.Value, date.Value.Value, number.Value.Value, password.Value, stringFormattedAsDecimalRequired.Value.Value, binary, dateTime, varDecimal, varDouble, duplicatePropertyName2, duplicatePropertyName, varFloat, int32, int32Range, int64, int64Negative, int64NegativeExclusive, int64Positive, int64PositiveExclusive, integer, patternWithBackslash, patternWithDigits, patternWithDigitsAndDelimiter, varString, stringFormattedAsDecimal, unsignedInteger, unsignedLong, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Fruit.cs
@@ -183,7 +183,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Fruit.");
+                throw new JsonException("Property is not nullable for class Fruit: color.");
 
             if (apple != null)
                 return new Fruit(apple, color);

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -187,7 +187,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class GmFruit.");
+                throw new JsonException("Property is not nullable for class GmFruit: color.");
 
             Option<Apple> appleParsedValue = apple == null
                 ? default

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
@@ -155,10 +155,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!petType.IsSet)
-                throw new ArgumentException("Property is required for class GrandparentAnimal.", nameof(petType));
+                throw new JsonException("Property is required for class GrandparentAnimal: pet_type.");
 
             if (petType.IsSet && petType.Value == null)
-                throw new ArgumentNullException(nameof(petType), "Property is not nullable for class GrandparentAnimal.");
+                throw new JsonException("Property is not nullable for class GrandparentAnimal: pet_type.");
 
             return new GrandparentAnimal();
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -206,10 +206,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bar.IsSet && bar.Value == null)
-                throw new ArgumentNullException(nameof(bar), "Property is not nullable for class HasOnlyReadOnly.");
+                throw new JsonException("Property is not nullable for class HasOnlyReadOnly: bar.");
 
             if (foo.IsSet && foo.Value == null)
-                throw new ArgumentNullException(nameof(foo), "Property is not nullable for class HasOnlyReadOnly.");
+                throw new JsonException("Property is not nullable for class HasOnlyReadOnly: foo.");
 
             return new HasOnlyReadOnly(bar, foo);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
@@ -292,22 +292,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (potentiallyOverriddenPropertyAccessor.IsSet && potentiallyOverriddenPropertyAccessor.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyAccessor), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyAccessor.");
 
             if (potentiallyOverriddenPropertyToInternal.IsSet && potentiallyOverriddenPropertyToInternal.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyToInternal), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyToInternal.");
 
             if (potentiallyOverriddenPropertyToPrivate.IsSet && potentiallyOverriddenPropertyToPrivate.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyToPrivate), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyToPrivate.");
 
             if (potentiallyOverriddenPropertyToPublic.IsSet && potentiallyOverriddenPropertyToPublic.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyToPublic), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyToPublic.");
 
             if (unalteredProperty.IsSet && unalteredProperty.Value == null)
-                throw new ArgumentNullException(nameof(unalteredProperty), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: unalteredProperty.");
 
             if (unalteredPropertyAccessor.IsSet && unalteredPropertyAccessor.Value == null)
-                throw new ArgumentNullException(nameof(unalteredPropertyAccessor), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: unalteredPropertyAccessor.");
 
             return new InjectedVendorExtensionsTest(potentiallyOverriddenPropertyAccessor, potentiallyOverriddenPropertyToInternal, potentiallyOverriddenPropertyToPrivate, potentiallyOverriddenPropertyToPublic, unalteredProperty, unalteredPropertyAccessor);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
@@ -144,16 +144,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class IsoscelesTriangle.", nameof(shapeType));
+                throw new JsonException("Property is required for class IsoscelesTriangle: shapeType.");
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class IsoscelesTriangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class IsoscelesTriangle: triangleType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class IsoscelesTriangle.");
+                throw new JsonException("Property is not nullable for class IsoscelesTriangle: shapeType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class IsoscelesTriangle.");
+                throw new JsonException("Property is not nullable for class IsoscelesTriangle: triangleType.");
 
             return new IsoscelesTriangle(shapeType.Value, triangleType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/List.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (var123List.IsSet && var123List.Value == null)
-                throw new ArgumentNullException(nameof(var123List), "Property is not nullable for class List.");
+                throw new JsonException("Property is not nullable for class List: 123-list.");
 
             return new List(var123List);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (escapedLiteralString.IsSet && escapedLiteralString.Value == null)
-                throw new ArgumentNullException(nameof(escapedLiteralString), "Property is not nullable for class LiteralStringClass.");
+                throw new JsonException("Property is not nullable for class LiteralStringClass: escapedLiteralString.");
 
             if (unescapedLiteralString.IsSet && unescapedLiteralString.Value == null)
-                throw new ArgumentNullException(nameof(unescapedLiteralString), "Property is not nullable for class LiteralStringClass.");
+                throw new JsonException("Property is not nullable for class LiteralStringClass: unescapedLiteralString.");
 
             return new LiteralStringClass(escapedLiteralString, unescapedLiteralString);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Mammal.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Mammal.cs
@@ -214,10 +214,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Mammal.", nameof(className));
+                throw new JsonException("Property is required for class Mammal: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Mammal.");
+                throw new JsonException("Property is not nullable for class Mammal: className.");
 
             if (pig != null)
                 return new Mammal(pig);

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/MapTest.cs
@@ -205,16 +205,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (directMap.IsSet && directMap.Value == null)
-                throw new ArgumentNullException(nameof(directMap), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: direct_map.");
 
             if (indirectMap.IsSet && indirectMap.Value == null)
-                throw new ArgumentNullException(nameof(indirectMap), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: indirect_map.");
 
             if (mapMapOfString.IsSet && mapMapOfString.Value == null)
-                throw new ArgumentNullException(nameof(mapMapOfString), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: map_map_of_string.");
 
             if (mapOfEnumString.IsSet && mapOfEnumString.Value == null)
-                throw new ArgumentNullException(nameof(mapOfEnumString), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: map_of_enum_string.");
 
             return new MapTest(directMap, indirectMap, mapMapOfString, mapOfEnumString);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/MixedAnyOf.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/MixedAnyOf.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (content.IsSet && content.Value == null)
-                throw new ArgumentNullException(nameof(content), "Property is not nullable for class MixedAnyOf.");
+                throw new JsonException("Property is not nullable for class MixedAnyOf: content.");
 
             return new MixedAnyOf(content);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/MixedOneOf.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/MixedOneOf.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (content.IsSet && content.Value == null)
-                throw new ArgumentNullException(nameof(content), "Property is not nullable for class MixedOneOf.");
+                throw new JsonException("Property is not nullable for class MixedOneOf: content.");
 
             return new MixedOneOf(content);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -217,16 +217,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (dateTime.IsSet && dateTime.Value == null)
-                throw new ArgumentNullException(nameof(dateTime), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: dateTime.");
 
             if (map.IsSet && map.Value == null)
-                throw new ArgumentNullException(nameof(map), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: map.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: uuid.");
 
             if (uuidWithPattern.IsSet && uuidWithPattern.Value == null)
-                throw new ArgumentNullException(nameof(uuidWithPattern), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: uuid_with_pattern.");
 
             return new MixedPropertiesAndAdditionalPropertiesClass(dateTime, map, uuid, uuidWithPattern);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/MixedSubId.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/MixedSubId.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class MixedSubId.");
+                throw new JsonException("Property is not nullable for class MixedSubId: id.");
 
             return new MixedSubId(id);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varClass.IsSet && varClass.Value == null)
-                throw new ArgumentNullException(nameof(varClass), "Property is not nullable for class Model200Response.");
+                throw new JsonException("Property is not nullable for class Model200Response: class.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Model200Response.");
+                throw new JsonException("Property is not nullable for class Model200Response: name.");
 
             return new Model200Response(varClass, name);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varClient.IsSet && varClient.Value == null)
-                throw new ArgumentNullException(nameof(varClient), "Property is not nullable for class ModelClient.");
+                throw new JsonException("Property is not nullable for class ModelClient: client.");
 
             return new ModelClient(varClient);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Name.cs
@@ -239,19 +239,19 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!varName.IsSet)
-                throw new ArgumentException("Property is required for class Name.", nameof(varName));
+                throw new JsonException("Property is required for class Name: name.");
 
             if (varName.IsSet && varName.Value == null)
-                throw new ArgumentNullException(nameof(varName), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: name.");
 
             if (property.IsSet && property.Value == null)
-                throw new ArgumentNullException(nameof(property), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: property.");
 
             if (snakeCase.IsSet && snakeCase.Value == null)
-                throw new ArgumentNullException(nameof(snakeCase), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: snake_case.");
 
             if (var123Number.IsSet && var123Number.Value == null)
-                throw new ArgumentNullException(nameof(var123Number), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: 123Number.");
 
             return new Name(varName.Value.Value, property, snakeCase, var123Number);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
@@ -151,16 +151,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!aObjVariableobject.IsSet)
-                throw new ArgumentException("Property is required for class NotificationtestGetElementsV1ResponseMPayload.", nameof(aObjVariableobject));
+                throw new JsonException("Property is required for class NotificationtestGetElementsV1ResponseMPayload: a_objVariableobject.");
 
             if (!pkiNotificationtestID.IsSet)
-                throw new ArgumentException("Property is required for class NotificationtestGetElementsV1ResponseMPayload.", nameof(pkiNotificationtestID));
+                throw new JsonException("Property is required for class NotificationtestGetElementsV1ResponseMPayload: pkiNotificationtestID.");
 
             if (aObjVariableobject.IsSet && aObjVariableobject.Value == null)
-                throw new ArgumentNullException(nameof(aObjVariableobject), "Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload.");
+                throw new JsonException("Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload: a_objVariableobject.");
 
             if (pkiNotificationtestID.IsSet && pkiNotificationtestID.Value == null)
-                throw new ArgumentNullException(nameof(pkiNotificationtestID), "Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload.");
+                throw new JsonException("Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload: pkiNotificationtestID.");
 
             return new NotificationtestGetElementsV1ResponseMPayload(aObjVariableobject.Value, pkiNotificationtestID.Value.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -375,10 +375,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayItemsNullable.IsSet && arrayItemsNullable.Value == null)
-                throw new ArgumentNullException(nameof(arrayItemsNullable), "Property is not nullable for class NullableClass.");
+                throw new JsonException("Property is not nullable for class NullableClass: array_items_nullable.");
 
             if (objectItemsNullable.IsSet && objectItemsNullable.Value == null)
-                throw new ArgumentNullException(nameof(objectItemsNullable), "Property is not nullable for class NullableClass.");
+                throw new JsonException("Property is not nullable for class NullableClass: object_items_nullable.");
 
             return new NullableClass(arrayAndItemsNullableProp, arrayItemsNullable, arrayNullableProp, booleanProp, dateProp, datetimeProp, integerProp, numberProp, objectAndItemsNullableProp, objectItemsNullable, objectNullableProp, stringProp);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/NullableShape.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/NullableShape.cs
@@ -193,10 +193,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class NullableShape.", nameof(shapeType));
+                throw new JsonException("Property is required for class NullableShape: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class NullableShape.");
+                throw new JsonException("Property is not nullable for class NullableShape: shapeType.");
 
             if (quadrilateral != null)
                 return new NullableShape(quadrilateral);

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (justNumber.IsSet && justNumber.Value == null)
-                throw new ArgumentNullException(nameof(justNumber), "Property is not nullable for class NumberOnly.");
+                throw new JsonException("Property is not nullable for class NumberOnly: JustNumber.");
 
             return new NumberOnly(justNumber);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -208,16 +208,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bars.IsSet && bars.Value == null)
-                throw new ArgumentNullException(nameof(bars), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: bars.");
 
             if (deprecatedRef.IsSet && deprecatedRef.Value == null)
-                throw new ArgumentNullException(nameof(deprecatedRef), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: deprecatedRef.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: id.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: uuid.");
 
             return new ObjectWithDeprecatedFields(bars, deprecatedRef, id, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Order.cs
@@ -251,22 +251,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (complete.IsSet && complete.Value == null)
-                throw new ArgumentNullException(nameof(complete), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: complete.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: id.");
 
             if (petId.IsSet && petId.Value == null)
-                throw new ArgumentNullException(nameof(petId), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: petId.");
 
             if (quantity.IsSet && quantity.Value == null)
-                throw new ArgumentNullException(nameof(quantity), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: quantity.");
 
             if (shipDate.IsSet && shipDate.Value == null)
-                throw new ArgumentNullException(nameof(shipDate), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: shipDate.");
 
             if (status.IsSet && status.Value == null)
-                throw new ArgumentNullException(nameof(status), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: status.");
 
             return new Order(complete, id, petId, quantity, shipDate, status);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -185,13 +185,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (myBoolean.IsSet && myBoolean.Value == null)
-                throw new ArgumentNullException(nameof(myBoolean), "Property is not nullable for class OuterComposite.");
+                throw new JsonException("Property is not nullable for class OuterComposite: my_boolean.");
 
             if (myNumber.IsSet && myNumber.Value == null)
-                throw new ArgumentNullException(nameof(myNumber), "Property is not nullable for class OuterComposite.");
+                throw new JsonException("Property is not nullable for class OuterComposite: my_number.");
 
             if (myString.IsSet && myString.Value == null)
-                throw new ArgumentNullException(nameof(myString), "Property is not nullable for class OuterComposite.");
+                throw new JsonException("Property is not nullable for class OuterComposite: my_string.");
 
             return new OuterComposite(myBoolean, myNumber, myString);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ParentPet.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ParentPet.cs
@@ -118,10 +118,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!petType.IsSet)
-                throw new ArgumentException("Property is required for class ParentPet.", nameof(petType));
+                throw new JsonException("Property is required for class ParentPet: pet_type.");
 
             if (petType.IsSet && petType.Value == null)
-                throw new ArgumentNullException(nameof(petType), "Property is not nullable for class ParentPet.");
+                throw new JsonException("Property is not nullable for class ParentPet: pet_type.");
 
             return new ParentPet();
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Pet.cs
@@ -232,28 +232,28 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!name.IsSet)
-                throw new ArgumentException("Property is required for class Pet.", nameof(name));
+                throw new JsonException("Property is required for class Pet: name.");
 
             if (!photoUrls.IsSet)
-                throw new ArgumentException("Property is required for class Pet.", nameof(photoUrls));
+                throw new JsonException("Property is required for class Pet: photoUrls.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: name.");
 
             if (photoUrls.IsSet && photoUrls.Value == null)
-                throw new ArgumentNullException(nameof(photoUrls), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: photoUrls.");
 
             if (category.IsSet && category.Value == null)
-                throw new ArgumentNullException(nameof(category), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: category.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: id.");
 
             if (status.IsSet && status.Value == null)
-                throw new ArgumentNullException(nameof(status), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: status.");
 
             if (tags.IsSet && tags.Value == null)
-                throw new ArgumentNullException(nameof(tags), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: tags.");
 
             return new Pet(name.Value, photoUrls.Value, category, id, status, tags);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Pig.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Pig.cs
@@ -193,10 +193,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Pig.", nameof(className));
+                throw new JsonException("Property is required for class Pig: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Pig.");
+                throw new JsonException("Property is not nullable for class Pig: className.");
 
             if (basquePig != null)
                 return new Pig(basquePig);

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Quadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Quadrilateral.cs
@@ -193,10 +193,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class Quadrilateral.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class Quadrilateral: quadrilateralType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class Quadrilateral.");
+                throw new JsonException("Property is not nullable for class Quadrilateral: quadrilateralType.");
 
             if (complexQuadrilateral != null)
                 return new Quadrilateral(complexQuadrilateral);

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
@@ -138,10 +138,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class QuadrilateralInterface.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class QuadrilateralInterface: quadrilateralType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class QuadrilateralInterface.");
+                throw new JsonException("Property is not nullable for class QuadrilateralInterface: quadrilateralType.");
 
             return new QuadrilateralInterface(quadrilateralType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -203,10 +203,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bar.IsSet && bar.Value == null)
-                throw new ArgumentNullException(nameof(bar), "Property is not nullable for class ReadOnlyFirst.");
+                throw new JsonException("Property is not nullable for class ReadOnlyFirst: bar.");
 
             if (baz.IsSet && baz.Value == null)
-                throw new ArgumentNullException(nameof(baz), "Property is not nullable for class ReadOnlyFirst.");
+                throw new JsonException("Property is not nullable for class ReadOnlyFirst: baz.");
 
             return new ReadOnlyFirst(bar, baz);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -895,136 +895,136 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!requiredNotNullableDateProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotNullableDateProp));
+                throw new JsonException("Property is required for class RequiredClass: required_not_nullable_date_prop.");
 
             if (!requiredNotnullableArrayOfString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableArrayOfString));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_array_of_string.");
 
             if (!requiredNotnullableBooleanProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableBooleanProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_boolean_prop.");
 
             if (!requiredNotnullableDatetimeProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableDatetimeProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_datetime_prop.");
 
             if (!requiredNotnullableEnumInteger.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableEnumInteger));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_enum_integer.");
 
             if (!requiredNotnullableEnumIntegerOnly.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableEnumIntegerOnly));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_enum_integer_only.");
 
             if (!requiredNotnullableEnumString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableEnumString));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_enum_string.");
 
             if (!requiredNotnullableOuterEnumDefaultValue.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableOuterEnumDefaultValue));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_outerEnumDefaultValue.");
 
             if (!requiredNotnullableStringProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableStringProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_string_prop.");
 
             if (!requiredNotnullableUuid.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableUuid));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_uuid.");
 
             if (!requiredNotnullableintegerProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableintegerProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullableinteger_prop.");
 
             if (!requiredNullableArrayOfString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableArrayOfString));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_array_of_string.");
 
             if (!requiredNullableBooleanProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableBooleanProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_boolean_prop.");
 
             if (!requiredNullableDateProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableDateProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_date_prop.");
 
             if (!requiredNullableDatetimeProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableDatetimeProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_datetime_prop.");
 
             if (!requiredNullableEnumInteger.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableEnumInteger));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_enum_integer.");
 
             if (!requiredNullableEnumIntegerOnly.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableEnumIntegerOnly));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_enum_integer_only.");
 
             if (!requiredNullableEnumString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableEnumString));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_enum_string.");
 
             if (!requiredNullableIntegerProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableIntegerProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_integer_prop.");
 
             if (!requiredNullableOuterEnumDefaultValue.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableOuterEnumDefaultValue));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_outerEnumDefaultValue.");
 
             if (!requiredNullableStringProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableStringProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_string_prop.");
 
             if (!requiredNullableUuid.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableUuid));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_uuid.");
 
             if (requiredNotNullableDateProp.IsSet && requiredNotNullableDateProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotNullableDateProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_not_nullable_date_prop.");
 
             if (requiredNotnullableArrayOfString.IsSet && requiredNotnullableArrayOfString.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableArrayOfString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_array_of_string.");
 
             if (requiredNotnullableBooleanProp.IsSet && requiredNotnullableBooleanProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableBooleanProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_boolean_prop.");
 
             if (requiredNotnullableDatetimeProp.IsSet && requiredNotnullableDatetimeProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableDatetimeProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_datetime_prop.");
 
             if (requiredNotnullableEnumInteger.IsSet && requiredNotnullableEnumInteger.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableEnumInteger), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_enum_integer.");
 
             if (requiredNotnullableEnumIntegerOnly.IsSet && requiredNotnullableEnumIntegerOnly.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableEnumIntegerOnly), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_enum_integer_only.");
 
             if (requiredNotnullableEnumString.IsSet && requiredNotnullableEnumString.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableEnumString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_enum_string.");
 
             if (requiredNotnullableOuterEnumDefaultValue.IsSet && requiredNotnullableOuterEnumDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableOuterEnumDefaultValue), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_outerEnumDefaultValue.");
 
             if (requiredNotnullableStringProp.IsSet && requiredNotnullableStringProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableStringProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_string_prop.");
 
             if (requiredNotnullableUuid.IsSet && requiredNotnullableUuid.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableUuid), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_uuid.");
 
             if (requiredNotnullableintegerProp.IsSet && requiredNotnullableintegerProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableintegerProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullableinteger_prop.");
 
             if (notRequiredNotnullableDateProp.IsSet && notRequiredNotnullableDateProp.Value == null)
-                throw new ArgumentNullException(nameof(notRequiredNotnullableDateProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: not_required_notnullable_date_prop.");
 
             if (notRequiredNotnullableintegerProp.IsSet && notRequiredNotnullableintegerProp.Value == null)
-                throw new ArgumentNullException(nameof(notRequiredNotnullableintegerProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: not_required_notnullableinteger_prop.");
 
             if (notrequiredNotnullableArrayOfString.IsSet && notrequiredNotnullableArrayOfString.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableArrayOfString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_array_of_string.");
 
             if (notrequiredNotnullableBooleanProp.IsSet && notrequiredNotnullableBooleanProp.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableBooleanProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_boolean_prop.");
 
             if (notrequiredNotnullableDatetimeProp.IsSet && notrequiredNotnullableDatetimeProp.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableDatetimeProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_datetime_prop.");
 
             if (notrequiredNotnullableEnumInteger.IsSet && notrequiredNotnullableEnumInteger.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableEnumInteger), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_enum_integer.");
 
             if (notrequiredNotnullableEnumIntegerOnly.IsSet && notrequiredNotnullableEnumIntegerOnly.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableEnumIntegerOnly), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_enum_integer_only.");
 
             if (notrequiredNotnullableEnumString.IsSet && notrequiredNotnullableEnumString.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableEnumString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_enum_string.");
 
             if (notrequiredNotnullableOuterEnumDefaultValue.IsSet && notrequiredNotnullableOuterEnumDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableOuterEnumDefaultValue), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_outerEnumDefaultValue.");
 
             if (notrequiredNotnullableStringProp.IsSet && notrequiredNotnullableStringProp.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableStringProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_string_prop.");
 
             if (notrequiredNotnullableUuid.IsSet && notrequiredNotnullableUuid.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableUuid), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_uuid.");
 
             return new RequiredClass(requiredNotNullableDateProp.Value.Value, requiredNotnullableArrayOfString.Value, requiredNotnullableBooleanProp.Value.Value, requiredNotnullableDatetimeProp.Value.Value, requiredNotnullableEnumInteger.Value.Value, requiredNotnullableEnumIntegerOnly.Value.Value, requiredNotnullableEnumString.Value.Value, requiredNotnullableOuterEnumDefaultValue.Value.Value, requiredNotnullableStringProp.Value, requiredNotnullableUuid.Value.Value, requiredNotnullableintegerProp.Value.Value, notRequiredNotnullableDateProp, notRequiredNotnullableintegerProp, notRequiredNullableDateProp, notRequiredNullableIntegerProp, notrequiredNotnullableArrayOfString, notrequiredNotnullableBooleanProp, notrequiredNotnullableDatetimeProp, notrequiredNotnullableEnumInteger, notrequiredNotnullableEnumIntegerOnly, notrequiredNotnullableEnumString, notrequiredNotnullableOuterEnumDefaultValue, notrequiredNotnullableStringProp, notrequiredNotnullableUuid, notrequiredNullableArrayOfString, notrequiredNullableBooleanProp, notrequiredNullableDatetimeProp, notrequiredNullableEnumInteger, notrequiredNullableEnumIntegerOnly, notrequiredNullableEnumString, notrequiredNullableOuterEnumDefaultValue, notrequiredNullableStringProp, notrequiredNullableUuid, requiredNullableArrayOfString.Value, requiredNullableBooleanProp.Value, requiredNullableDateProp.Value, requiredNullableDatetimeProp.Value, requiredNullableEnumInteger.Value, requiredNullableEnumIntegerOnly.Value, requiredNullableEnumString.Value, requiredNullableIntegerProp.Value, requiredNullableOuterEnumDefaultValue.Value, requiredNullableStringProp.Value, requiredNullableUuid.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Result.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Result.cs
@@ -188,13 +188,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (code.IsSet && code.Value == null)
-                throw new ArgumentNullException(nameof(code), "Property is not nullable for class Result.");
+                throw new JsonException("Property is not nullable for class Result: code.");
 
             if (data.IsSet && data.Value == null)
-                throw new ArgumentNullException(nameof(data), "Property is not nullable for class Result.");
+                throw new JsonException("Property is not nullable for class Result: data.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class Result.");
+                throw new JsonException("Property is not nullable for class Result: uuid.");
 
             return new Result(code, data, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Return.cs
@@ -191,19 +191,19 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!varLock.IsSet)
-                throw new ArgumentException("Property is required for class Return.", nameof(varLock));
+                throw new JsonException("Property is required for class Return: lock.");
 
             if (!varAbstract.IsSet)
-                throw new ArgumentException("Property is required for class Return.", nameof(varAbstract));
+                throw new JsonException("Property is required for class Return: abstract.");
 
             if (varLock.IsSet && varLock.Value == null)
-                throw new ArgumentNullException(nameof(varLock), "Property is not nullable for class Return.");
+                throw new JsonException("Property is not nullable for class Return: lock.");
 
             if (varReturn.IsSet && varReturn.Value == null)
-                throw new ArgumentNullException(nameof(varReturn), "Property is not nullable for class Return.");
+                throw new JsonException("Property is not nullable for class Return: return.");
 
             if (varUnsafe.IsSet && varUnsafe.Value == null)
-                throw new ArgumentNullException(nameof(varUnsafe), "Property is not nullable for class Return.");
+                throw new JsonException("Property is not nullable for class Return: unsafe.");
 
             return new Return(varLock.Value, varAbstract.Value, varReturn, varUnsafe);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (role.IsSet && role.Value == null)
-                throw new ArgumentNullException(nameof(role), "Property is not nullable for class RolesReportsHash.");
+                throw new JsonException("Property is not nullable for class RolesReportsHash: role.");
 
             if (roleUuid.IsSet && roleUuid.Value == null)
-                throw new ArgumentNullException(nameof(roleUuid), "Property is not nullable for class RolesReportsHash.");
+                throw new JsonException("Property is not nullable for class RolesReportsHash: role_uuid.");
 
             return new RolesReportsHash(role, roleUuid);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class RolesReportsHashRole.");
+                throw new JsonException("Property is not nullable for class RolesReportsHashRole: name.");
 
             return new RolesReportsHashRole(name);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
@@ -151,16 +151,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ScaleneTriangle.", nameof(shapeType));
+                throw new JsonException("Property is required for class ScaleneTriangle: shapeType.");
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class ScaleneTriangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class ScaleneTriangle: triangleType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ScaleneTriangle.");
+                throw new JsonException("Property is not nullable for class ScaleneTriangle: shapeType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class ScaleneTriangle.");
+                throw new JsonException("Property is not nullable for class ScaleneTriangle: triangleType.");
 
             return new ScaleneTriangle(shapeType.Value, triangleType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Shape.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Shape.cs
@@ -193,10 +193,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class Shape.", nameof(shapeType));
+                throw new JsonException("Property is required for class Shape: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class Shape.");
+                throw new JsonException("Property is not nullable for class Shape: shapeType.");
 
             if (quadrilateral != null)
                 return new Shape(quadrilateral);

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ShapeInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ShapeInterface.cs
@@ -138,10 +138,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ShapeInterface.", nameof(shapeType));
+                throw new JsonException("Property is required for class ShapeInterface: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ShapeInterface.");
+                throw new JsonException("Property is not nullable for class ShapeInterface: shapeType.");
 
             return new ShapeInterface(shapeType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ShapeOrNull.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ShapeOrNull.cs
@@ -193,10 +193,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ShapeOrNull.", nameof(shapeType));
+                throw new JsonException("Property is required for class ShapeOrNull: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ShapeOrNull.");
+                throw new JsonException("Property is not nullable for class ShapeOrNull: shapeType.");
 
             if (quadrilateral != null)
                 return new ShapeOrNull(quadrilateral);

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
@@ -151,16 +151,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class SimpleQuadrilateral.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class SimpleQuadrilateral: quadrilateralType.");
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class SimpleQuadrilateral.", nameof(shapeType));
+                throw new JsonException("Property is required for class SimpleQuadrilateral: shapeType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class SimpleQuadrilateral.");
+                throw new JsonException("Property is not nullable for class SimpleQuadrilateral: quadrilateralType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class SimpleQuadrilateral.");
+                throw new JsonException("Property is not nullable for class SimpleQuadrilateral: shapeType.");
 
             return new SimpleQuadrilateral(quadrilateralType.Value, shapeType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varSpecialModelName.IsSet && varSpecialModelName.Value == null)
-                throw new ArgumentNullException(nameof(varSpecialModelName), "Property is not nullable for class SpecialModelName.");
+                throw new JsonException("Property is not nullable for class SpecialModelName: _special_model.name_.");
 
             if (specialPropertyName.IsSet && specialPropertyName.Value == null)
-                throw new ArgumentNullException(nameof(specialPropertyName), "Property is not nullable for class SpecialModelName.");
+                throw new JsonException("Property is not nullable for class SpecialModelName: $special[property.name].");
 
             return new SpecialModelName(varSpecialModelName, specialPropertyName);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Tag.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Tag.");
+                throw new JsonException("Property is not nullable for class Tag: id.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Tag.");
+                throw new JsonException("Property is not nullable for class Tag: name.");
 
             return new Tag(id, name);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (value.IsSet && value.Value == null)
-                throw new ArgumentNullException(nameof(value), "Property is not nullable for class TestCollectionEndingWithWordList.");
+                throw new JsonException("Property is not nullable for class TestCollectionEndingWithWordList: value.");
 
             return new TestCollectionEndingWithWordList(value);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (testCollectionEndingWithWordList.IsSet && testCollectionEndingWithWordList.Value == null)
-                throw new ArgumentNullException(nameof(testCollectionEndingWithWordList), "Property is not nullable for class TestCollectionEndingWithWordListObject.");
+                throw new JsonException("Property is not nullable for class TestCollectionEndingWithWordListObject: TestCollectionEndingWithWordList.");
 
             return new TestCollectionEndingWithWordListObject(testCollectionEndingWithWordList);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/TestDescendants.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/TestDescendants.cs
@@ -168,16 +168,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!alternativeName.IsSet)
-                throw new ArgumentException("Property is required for class TestDescendants.", nameof(alternativeName));
+                throw new JsonException("Property is required for class TestDescendants: alternativeName.");
 
             if (!objectType.IsSet)
-                throw new ArgumentException("Property is required for class TestDescendants.", nameof(objectType));
+                throw new JsonException("Property is required for class TestDescendants: objectType.");
 
             if (alternativeName.IsSet && alternativeName.Value == null)
-                throw new ArgumentNullException(nameof(alternativeName), "Property is not nullable for class TestDescendants.");
+                throw new JsonException("Property is not nullable for class TestDescendants: alternativeName.");
 
             if (objectType.IsSet && objectType.Value == null)
-                throw new ArgumentNullException(nameof(objectType), "Property is not nullable for class TestDescendants.");
+                throw new JsonException("Property is not nullable for class TestDescendants: objectType.");
 
             return new TestDescendants(alternativeName.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (someProperty.IsSet && someProperty.Value == null)
-                throw new ArgumentNullException(nameof(someProperty), "Property is not nullable for class TestInlineFreeformAdditionalPropertiesRequest.");
+                throw new JsonException("Property is not nullable for class TestInlineFreeformAdditionalPropertiesRequest: someProperty.");
 
             return new TestInlineFreeformAdditionalPropertiesRequest(someProperty);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/TestResult.cs
@@ -187,13 +187,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (code.IsSet && code.Value == null)
-                throw new ArgumentNullException(nameof(code), "Property is not nullable for class TestResult.");
+                throw new JsonException("Property is not nullable for class TestResult: code.");
 
             if (data.IsSet && data.Value == null)
-                throw new ArgumentNullException(nameof(data), "Property is not nullable for class TestResult.");
+                throw new JsonException("Property is not nullable for class TestResult: data.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class TestResult.");
+                throw new JsonException("Property is not nullable for class TestResult: uuid.");
 
             return new TestResult(code, data, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Triangle.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Triangle.cs
@@ -214,10 +214,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class Triangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class Triangle: triangleType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class Triangle.");
+                throw new JsonException("Property is not nullable for class Triangle: triangleType.");
 
             if (equilateralTriangle != null)
                 return new Triangle(equilateralTriangle);

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/TriangleInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/TriangleInterface.cs
@@ -138,10 +138,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class TriangleInterface.", nameof(triangleType));
+                throw new JsonException("Property is required for class TriangleInterface: triangleType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class TriangleInterface.");
+                throw new JsonException("Property is not nullable for class TriangleInterface: triangleType.");
 
             return new TriangleInterface(triangleType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/User.cs
@@ -370,31 +370,31 @@ namespace Org.OpenAPITools.Model
             }
 
             if (email.IsSet && email.Value == null)
-                throw new ArgumentNullException(nameof(email), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: email.");
 
             if (firstName.IsSet && firstName.Value == null)
-                throw new ArgumentNullException(nameof(firstName), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: firstName.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: id.");
 
             if (lastName.IsSet && lastName.Value == null)
-                throw new ArgumentNullException(nameof(lastName), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: lastName.");
 
             if (objectWithNoDeclaredProps.IsSet && objectWithNoDeclaredProps.Value == null)
-                throw new ArgumentNullException(nameof(objectWithNoDeclaredProps), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: objectWithNoDeclaredProps.");
 
             if (password.IsSet && password.Value == null)
-                throw new ArgumentNullException(nameof(password), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: password.");
 
             if (phone.IsSet && phone.Value == null)
-                throw new ArgumentNullException(nameof(phone), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: phone.");
 
             if (userStatus.IsSet && userStatus.Value == null)
-                throw new ArgumentNullException(nameof(userStatus), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: userStatus.");
 
             if (username.IsSet && username.Value == null)
-                throw new ArgumentNullException(nameof(username), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: username.");
 
             return new User(anyTypeProp, anyTypePropNullable, email, firstName, id, lastName, objectWithNoDeclaredProps, objectWithNoDeclaredPropsNullable, password, phone, userStatus, username);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Whale.cs
@@ -178,16 +178,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Whale.", nameof(className));
+                throw new JsonException("Property is required for class Whale: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Whale.");
+                throw new JsonException("Property is not nullable for class Whale: className.");
 
             if (hasBaleen.IsSet && hasBaleen.Value == null)
-                throw new ArgumentNullException(nameof(hasBaleen), "Property is not nullable for class Whale.");
+                throw new JsonException("Property is not nullable for class Whale: hasBaleen.");
 
             if (hasTeeth.IsSet && hasTeeth.Value == null)
-                throw new ArgumentNullException(nameof(hasTeeth), "Property is not nullable for class Whale.");
+                throw new JsonException("Property is not nullable for class Whale: hasTeeth.");
 
             return new Whale(className.Value, hasBaleen, hasTeeth);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Zebra.cs
@@ -158,13 +158,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Zebra.", nameof(className));
+                throw new JsonException("Property is required for class Zebra: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Zebra.");
+                throw new JsonException("Property is not nullable for class Zebra: className.");
 
             if (type.IsSet && type.Value == null)
-                throw new ArgumentNullException(nameof(type), "Property is not nullable for class Zebra.");
+                throw new JsonException("Property is not nullable for class Zebra: type.");
 
             return new Zebra(className.Value, type);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (zeroBasedEnum.IsSet && zeroBasedEnum.Value == null)
-                throw new ArgumentNullException(nameof(zeroBasedEnum), "Property is not nullable for class ZeroBasedEnumClass.");
+                throw new JsonException("Property is not nullable for class ZeroBasedEnumClass: ZeroBasedEnum.");
 
             return new ZeroBasedEnumClass(zeroBasedEnum);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Activity.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (activityOutputs.IsSet && activityOutputs.Value == null)
-                throw new ArgumentNullException(nameof(activityOutputs), "Property is not nullable for class Activity.");
+                throw new JsonException("Property is not nullable for class Activity: activity_outputs.");
 
             return new Activity(activityOutputs);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -167,10 +167,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (prop1.IsSet && prop1.Value == null)
-                throw new ArgumentNullException(nameof(prop1), "Property is not nullable for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Property is not nullable for class ActivityOutputElementRepresentation: prop1.");
 
             if (prop2.IsSet && prop2.Value == null)
-                throw new ArgumentNullException(nameof(prop2), "Property is not nullable for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Property is not nullable for class ActivityOutputElementRepresentation: prop2.");
 
             return new ActivityOutputElementRepresentation(prop1, prop2);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -288,25 +288,25 @@ namespace Org.OpenAPITools.Model
             }
 
             if (emptyMap.IsSet && emptyMap.Value == null)
-                throw new ArgumentNullException(nameof(emptyMap), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: empty_map.");
 
             if (mapOfMapProperty.IsSet && mapOfMapProperty.Value == null)
-                throw new ArgumentNullException(nameof(mapOfMapProperty), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_of_map_property.");
 
             if (mapProperty.IsSet && mapProperty.Value == null)
-                throw new ArgumentNullException(nameof(mapProperty), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_property.");
 
             if (mapWithUndeclaredPropertiesAnytype1.IsSet && mapWithUndeclaredPropertiesAnytype1.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesAnytype1), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_anytype_1.");
 
             if (mapWithUndeclaredPropertiesAnytype2.IsSet && mapWithUndeclaredPropertiesAnytype2.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesAnytype2), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_anytype_2.");
 
             if (mapWithUndeclaredPropertiesAnytype3.IsSet && mapWithUndeclaredPropertiesAnytype3.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesAnytype3), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_anytype_3.");
 
             if (mapWithUndeclaredPropertiesString.IsSet && mapWithUndeclaredPropertiesString.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesString), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_string.");
 
             return new AdditionalPropertiesClass(anytype1, emptyMap, mapOfMapProperty, mapProperty, mapWithUndeclaredPropertiesAnytype1, mapWithUndeclaredPropertiesAnytype2, mapWithUndeclaredPropertiesAnytype3, mapWithUndeclaredPropertiesString);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Animal.cs
@@ -177,13 +177,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Animal.", nameof(className));
+                throw new JsonException("Property is required for class Animal: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Animal.");
+                throw new JsonException("Property is not nullable for class Animal: className.");
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Animal.");
+                throw new JsonException("Property is not nullable for class Animal: color.");
 
             return new Animal(color);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -187,13 +187,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (code.IsSet && code.Value == null)
-                throw new ArgumentNullException(nameof(code), "Property is not nullable for class ApiResponse.");
+                throw new JsonException("Property is not nullable for class ApiResponse: code.");
 
             if (message.IsSet && message.Value == null)
-                throw new ArgumentNullException(nameof(message), "Property is not nullable for class ApiResponse.");
+                throw new JsonException("Property is not nullable for class ApiResponse: message.");
 
             if (type.IsSet && type.Value == null)
-                throw new ArgumentNullException(nameof(type), "Property is not nullable for class ApiResponse.");
+                throw new JsonException("Property is not nullable for class ApiResponse: type.");
 
             return new ApiResponse(code, message, type);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Apple.cs
@@ -217,13 +217,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (colorCode.IsSet && colorCode.Value == null)
-                throw new ArgumentNullException(nameof(colorCode), "Property is not nullable for class Apple.");
+                throw new JsonException("Property is not nullable for class Apple: color_code.");
 
             if (cultivar.IsSet && cultivar.Value == null)
-                throw new ArgumentNullException(nameof(cultivar), "Property is not nullable for class Apple.");
+                throw new JsonException("Property is not nullable for class Apple: cultivar.");
 
             if (origin.IsSet && origin.Value == null)
-                throw new ArgumentNullException(nameof(origin), "Property is not nullable for class Apple.");
+                throw new JsonException("Property is not nullable for class Apple: origin.");
 
             return new Apple(colorCode, cultivar, origin);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -153,13 +153,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!cultivar.IsSet)
-                throw new ArgumentException("Property is required for class AppleReq.", nameof(cultivar));
+                throw new JsonException("Property is required for class AppleReq: cultivar.");
 
             if (cultivar.IsSet && cultivar.Value == null)
-                throw new ArgumentNullException(nameof(cultivar), "Property is not nullable for class AppleReq.");
+                throw new JsonException("Property is not nullable for class AppleReq: cultivar.");
 
             if (mealy.IsSet && mealy.Value == null)
-                throw new ArgumentNullException(nameof(mealy), "Property is not nullable for class AppleReq.");
+                throw new JsonException("Property is not nullable for class AppleReq: mealy.");
 
             return new AppleReq(cultivar.Value!, mealy);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayArrayNumber.IsSet && arrayArrayNumber.Value == null)
-                throw new ArgumentNullException(nameof(arrayArrayNumber), "Property is not nullable for class ArrayOfArrayOfNumberOnly.");
+                throw new JsonException("Property is not nullable for class ArrayOfArrayOfNumberOnly: ArrayArrayNumber.");
 
             return new ArrayOfArrayOfNumberOnly(arrayArrayNumber);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayNumber.IsSet && arrayNumber.Value == null)
-                throw new ArgumentNullException(nameof(arrayNumber), "Property is not nullable for class ArrayOfNumberOnly.");
+                throw new JsonException("Property is not nullable for class ArrayOfNumberOnly: ArrayNumber.");
 
             return new ArrayOfNumberOnly(arrayNumber);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -187,13 +187,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayArrayOfInteger.IsSet && arrayArrayOfInteger.Value == null)
-                throw new ArgumentNullException(nameof(arrayArrayOfInteger), "Property is not nullable for class ArrayTest.");
+                throw new JsonException("Property is not nullable for class ArrayTest: array_array_of_integer.");
 
             if (arrayArrayOfModel.IsSet && arrayArrayOfModel.Value == null)
-                throw new ArgumentNullException(nameof(arrayArrayOfModel), "Property is not nullable for class ArrayTest.");
+                throw new JsonException("Property is not nullable for class ArrayTest: array_array_of_model.");
 
             if (arrayOfString.IsSet && arrayOfString.Value == null)
-                throw new ArgumentNullException(nameof(arrayOfString), "Property is not nullable for class ArrayTest.");
+                throw new JsonException("Property is not nullable for class ArrayTest: array_of_string.");
 
             return new ArrayTest(arrayArrayOfInteger, arrayArrayOfModel, arrayOfString);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Banana.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (lengthCm.IsSet && lengthCm.Value == null)
-                throw new ArgumentNullException(nameof(lengthCm), "Property is not nullable for class Banana.");
+                throw new JsonException("Property is not nullable for class Banana: lengthCm.");
 
             return new Banana(lengthCm);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -153,13 +153,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!lengthCm.IsSet)
-                throw new ArgumentException("Property is required for class BananaReq.", nameof(lengthCm));
+                throw new JsonException("Property is required for class BananaReq: lengthCm.");
 
             if (lengthCm.IsSet && lengthCm.Value == null)
-                throw new ArgumentNullException(nameof(lengthCm), "Property is not nullable for class BananaReq.");
+                throw new JsonException("Property is not nullable for class BananaReq: lengthCm.");
 
             if (sweet.IsSet && sweet.Value == null)
-                throw new ArgumentNullException(nameof(sweet), "Property is not nullable for class BananaReq.");
+                throw new JsonException("Property is not nullable for class BananaReq: sweet.");
 
             return new BananaReq(lengthCm.Value!.Value!, sweet);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/BasquePig.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/BasquePig.cs
@@ -140,10 +140,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class BasquePig.", nameof(className));
+                throw new JsonException("Property is required for class BasquePig: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class BasquePig.");
+                throw new JsonException("Property is not nullable for class BasquePig: className.");
 
             return new BasquePig(className.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -248,22 +248,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (aTTNAME.IsSet && aTTNAME.Value == null)
-                throw new ArgumentNullException(nameof(aTTNAME), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: ATT_NAME.");
 
             if (capitalCamel.IsSet && capitalCamel.Value == null)
-                throw new ArgumentNullException(nameof(capitalCamel), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: CapitalCamel.");
 
             if (capitalSnake.IsSet && capitalSnake.Value == null)
-                throw new ArgumentNullException(nameof(capitalSnake), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: Capital_Snake.");
 
             if (sCAETHFlowPoints.IsSet && sCAETHFlowPoints.Value == null)
-                throw new ArgumentNullException(nameof(sCAETHFlowPoints), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: SCA_ETH_Flow_Points.");
 
             if (smallCamel.IsSet && smallCamel.Value == null)
-                throw new ArgumentNullException(nameof(smallCamel), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: smallCamel.");
 
             if (smallSnake.IsSet && smallSnake.Value == null)
-                throw new ArgumentNullException(nameof(smallSnake), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: small_Snake.");
 
             return new Capitalization(aTTNAME, capitalCamel, capitalSnake, sCAETHFlowPoints, smallCamel, smallSnake);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Cat.cs
@@ -140,16 +140,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Cat.", nameof(className));
+                throw new JsonException("Property is required for class Cat: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Cat.");
+                throw new JsonException("Property is not nullable for class Cat: className.");
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Cat.");
+                throw new JsonException("Property is not nullable for class Cat: color.");
 
             if (declawed.IsSet && declawed.Value == null)
-                throw new ArgumentNullException(nameof(declawed), "Property is not nullable for class Cat.");
+                throw new JsonException("Property is not nullable for class Cat: declawed.");
 
             return new Cat(color, declawed);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Category.cs
@@ -160,13 +160,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!name.IsSet)
-                throw new ArgumentException("Property is required for class Category.", nameof(name));
+                throw new JsonException("Property is required for class Category: name.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Category.");
+                throw new JsonException("Property is not nullable for class Category: id.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Category.");
+                throw new JsonException("Property is not nullable for class Category: name.");
 
             return new Category(id, name.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -202,13 +202,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!petType.IsSet)
-                throw new ArgumentException("Property is required for class ChildCat.", nameof(petType));
+                throw new JsonException("Property is required for class ChildCat: pet_type.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class ChildCat.");
+                throw new JsonException("Property is not nullable for class ChildCat: name.");
 
             if (petType.IsSet && petType.Value == null)
-                throw new ArgumentNullException(nameof(petType), "Property is not nullable for class ChildCat.");
+                throw new JsonException("Property is not nullable for class ChildCat: pet_type.");
 
             return new ChildCat(name);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varClass.IsSet && varClass.Value == null)
-                throw new ArgumentNullException(nameof(varClass), "Property is not nullable for class ClassModel.");
+                throw new JsonException("Property is not nullable for class ClassModel: _class.");
 
             return new ClassModel(varClass);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
@@ -153,16 +153,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class ComplexQuadrilateral.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class ComplexQuadrilateral: quadrilateralType.");
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ComplexQuadrilateral.", nameof(shapeType));
+                throw new JsonException("Property is required for class ComplexQuadrilateral: shapeType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class ComplexQuadrilateral.");
+                throw new JsonException("Property is not nullable for class ComplexQuadrilateral: quadrilateralType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ComplexQuadrilateral.");
+                throw new JsonException("Property is not nullable for class ComplexQuadrilateral: shapeType.");
 
             return new ComplexQuadrilateral(quadrilateralType.Value!, shapeType.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/CopyActivity.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/CopyActivity.cs
@@ -195,16 +195,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!copyActivitytt.IsSet)
-                throw new ArgumentException("Property is required for class CopyActivity.", nameof(copyActivitytt));
+                throw new JsonException("Property is required for class CopyActivity: copyActivitytt.");
 
             if (!schema.IsSet)
-                throw new ArgumentException("Property is required for class CopyActivity.", nameof(schema));
+                throw new JsonException("Property is required for class CopyActivity: $schema.");
 
             if (copyActivitytt.IsSet && copyActivitytt.Value == null)
-                throw new ArgumentNullException(nameof(copyActivitytt), "Property is not nullable for class CopyActivity.");
+                throw new JsonException("Property is not nullable for class CopyActivity: copyActivitytt.");
 
             if (schema.IsSet && schema.Value == null)
-                throw new ArgumentNullException(nameof(schema), "Property is not nullable for class CopyActivity.");
+                throw new JsonException("Property is not nullable for class CopyActivity: $schema.");
 
             return new CopyActivity(copyActivitytt.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/DanishPig.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/DanishPig.cs
@@ -140,10 +140,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class DanishPig.", nameof(className));
+                throw new JsonException("Property is required for class DanishPig: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class DanishPig.");
+                throw new JsonException("Property is not nullable for class DanishPig: className.");
 
             return new DanishPig(className.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -153,7 +153,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (dateOnlyProperty.IsSet && dateOnlyProperty.Value == null)
-                throw new ArgumentNullException(nameof(dateOnlyProperty), "Property is not nullable for class DateOnlyClass.");
+                throw new JsonException("Property is not nullable for class DateOnlyClass: dateOnlyProperty.");
 
             return new DateOnlyClass(dateOnlyProperty);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class DeprecatedObject.");
+                throw new JsonException("Property is not nullable for class DeprecatedObject: name.");
 
             return new DeprecatedObject(name);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Descendant1.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Descendant1.cs
@@ -140,22 +140,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!alternativeName.IsSet)
-                throw new ArgumentException("Property is required for class Descendant1.", nameof(alternativeName));
+                throw new JsonException("Property is required for class Descendant1: alternativeName.");
 
             if (!descendantName.IsSet)
-                throw new ArgumentException("Property is required for class Descendant1.", nameof(descendantName));
+                throw new JsonException("Property is required for class Descendant1: descendantName.");
 
             if (!objectType.IsSet)
-                throw new ArgumentException("Property is required for class Descendant1.", nameof(objectType));
+                throw new JsonException("Property is required for class Descendant1: objectType.");
 
             if (alternativeName.IsSet && alternativeName.Value == null)
-                throw new ArgumentNullException(nameof(alternativeName), "Property is not nullable for class Descendant1.");
+                throw new JsonException("Property is not nullable for class Descendant1: alternativeName.");
 
             if (descendantName.IsSet && descendantName.Value == null)
-                throw new ArgumentNullException(nameof(descendantName), "Property is not nullable for class Descendant1.");
+                throw new JsonException("Property is not nullable for class Descendant1: descendantName.");
 
             if (objectType.IsSet && objectType.Value == null)
-                throw new ArgumentNullException(nameof(objectType), "Property is not nullable for class Descendant1.");
+                throw new JsonException("Property is not nullable for class Descendant1: objectType.");
 
             return new Descendant1(alternativeName.Value!, descendantName.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Descendant2.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Descendant2.cs
@@ -140,22 +140,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!alternativeName.IsSet)
-                throw new ArgumentException("Property is required for class Descendant2.", nameof(alternativeName));
+                throw new JsonException("Property is required for class Descendant2: alternativeName.");
 
             if (!confidentiality.IsSet)
-                throw new ArgumentException("Property is required for class Descendant2.", nameof(confidentiality));
+                throw new JsonException("Property is required for class Descendant2: confidentiality.");
 
             if (!objectType.IsSet)
-                throw new ArgumentException("Property is required for class Descendant2.", nameof(objectType));
+                throw new JsonException("Property is required for class Descendant2: objectType.");
 
             if (alternativeName.IsSet && alternativeName.Value == null)
-                throw new ArgumentNullException(nameof(alternativeName), "Property is not nullable for class Descendant2.");
+                throw new JsonException("Property is not nullable for class Descendant2: alternativeName.");
 
             if (confidentiality.IsSet && confidentiality.Value == null)
-                throw new ArgumentNullException(nameof(confidentiality), "Property is not nullable for class Descendant2.");
+                throw new JsonException("Property is not nullable for class Descendant2: confidentiality.");
 
             if (objectType.IsSet && objectType.Value == null)
-                throw new ArgumentNullException(nameof(objectType), "Property is not nullable for class Descendant2.");
+                throw new JsonException("Property is not nullable for class Descendant2: objectType.");
 
             return new Descendant2(alternativeName.Value!, confidentiality.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Dog.cs
@@ -140,16 +140,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Dog.", nameof(className));
+                throw new JsonException("Property is required for class Dog: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Dog.");
+                throw new JsonException("Property is not nullable for class Dog: className.");
 
             if (breed.IsSet && breed.Value == null)
-                throw new ArgumentNullException(nameof(breed), "Property is not nullable for class Dog.");
+                throw new JsonException("Property is not nullable for class Dog: breed.");
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Dog.");
+                throw new JsonException("Property is not nullable for class Dog: color.");
 
             return new Dog(breed, color);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Drawing.cs
@@ -207,10 +207,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (mainShape.IsSet && mainShape.Value == null)
-                throw new ArgumentNullException(nameof(mainShape), "Property is not nullable for class Drawing.");
+                throw new JsonException("Property is not nullable for class Drawing: mainShape.");
 
             if (shapes.IsSet && shapes.Value == null)
-                throw new ArgumentNullException(nameof(shapes), "Property is not nullable for class Drawing.");
+                throw new JsonException("Property is not nullable for class Drawing: shapes.");
 
             return new Drawing(mainShape, nullableShape, shapeOrNull, shapes);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/EntityBase.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/EntityBase.cs
@@ -154,10 +154,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!schema.IsSet)
-                throw new ArgumentException("Property is required for class EntityBase.", nameof(schema));
+                throw new JsonException("Property is required for class EntityBase: $schema.");
 
             if (schema.IsSet && schema.Value == null)
-                throw new ArgumentNullException(nameof(schema), "Property is not nullable for class EntityBase.");
+                throw new JsonException("Property is not nullable for class EntityBase: $schema.");
 
             return new EntityBase();
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -306,10 +306,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayEnum.IsSet && arrayEnum.Value == null)
-                throw new ArgumentNullException(nameof(arrayEnum), "Property is not nullable for class EnumArrays.");
+                throw new JsonException("Property is not nullable for class EnumArrays: array_enum.");
 
             if (justSymbol.IsSet && justSymbol.Value == null)
-                throw new ArgumentNullException(nameof(justSymbol), "Property is not nullable for class EnumArrays.");
+                throw new JsonException("Property is not nullable for class EnumArrays: just_symbol.");
 
             return new EnumArrays(arrayEnum, justSymbol);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -824,31 +824,31 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!enumStringRequired.IsSet)
-                throw new ArgumentException("Property is required for class EnumTest.", nameof(enumStringRequired));
+                throw new JsonException("Property is required for class EnumTest: enum_string_required.");
 
             if (enumStringRequired.IsSet && enumStringRequired.Value == null)
-                throw new ArgumentNullException(nameof(enumStringRequired), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_string_required.");
 
             if (enumInteger.IsSet && enumInteger.Value == null)
-                throw new ArgumentNullException(nameof(enumInteger), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_integer.");
 
             if (enumIntegerOnly.IsSet && enumIntegerOnly.Value == null)
-                throw new ArgumentNullException(nameof(enumIntegerOnly), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_integer_only.");
 
             if (enumNumber.IsSet && enumNumber.Value == null)
-                throw new ArgumentNullException(nameof(enumNumber), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_number.");
 
             if (enumString.IsSet && enumString.Value == null)
-                throw new ArgumentNullException(nameof(enumString), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_string.");
 
             if (outerEnumDefaultValue.IsSet && outerEnumDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(outerEnumDefaultValue), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: outerEnumDefaultValue.");
 
             if (outerEnumInteger.IsSet && outerEnumInteger.Value == null)
-                throw new ArgumentNullException(nameof(outerEnumInteger), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: outerEnumInteger.");
 
             if (outerEnumIntegerDefaultValue.IsSet && outerEnumIntegerDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(outerEnumIntegerDefaultValue), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: outerEnumIntegerDefaultValue.");
 
             return new EnumTest(enumStringRequired.Value!.Value!, enumInteger, enumIntegerOnly, enumNumber, enumString, outerEnum, outerEnumDefaultValue, outerEnumInteger, outerEnumIntegerDefaultValue);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
@@ -153,16 +153,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class EquilateralTriangle.", nameof(shapeType));
+                throw new JsonException("Property is required for class EquilateralTriangle: shapeType.");
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class EquilateralTriangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class EquilateralTriangle: triangleType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class EquilateralTriangle.");
+                throw new JsonException("Property is not nullable for class EquilateralTriangle: shapeType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class EquilateralTriangle.");
+                throw new JsonException("Property is not nullable for class EquilateralTriangle: triangleType.");
 
             return new EquilateralTriangle(shapeType.Value!, triangleType.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/File.cs
@@ -148,7 +148,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (sourceURI.IsSet && sourceURI.Value == null)
-                throw new ArgumentNullException(nameof(sourceURI), "Property is not nullable for class File.");
+                throw new JsonException("Property is not nullable for class File: sourceURI.");
 
             return new File(sourceURI);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -167,10 +167,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (file.IsSet && file.Value == null)
-                throw new ArgumentNullException(nameof(file), "Property is not nullable for class FileSchemaTestClass.");
+                throw new JsonException("Property is not nullable for class FileSchemaTestClass: file.");
 
             if (files.IsSet && files.Value == null)
-                throw new ArgumentNullException(nameof(files), "Property is not nullable for class FileSchemaTestClass.");
+                throw new JsonException("Property is not nullable for class FileSchemaTestClass: files.");
 
             return new FileSchemaTestClass(file, files);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Foo.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bar.IsSet && bar.Value == null)
-                throw new ArgumentNullException(nameof(bar), "Property is not nullable for class Foo.");
+                throw new JsonException("Property is not nullable for class Foo: bar.");
 
             return new Foo(bar);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varString.IsSet && varString.Value == null)
-                throw new ArgumentNullException(nameof(varString), "Property is not nullable for class FooGetDefaultResponse.");
+                throw new JsonException("Property is not nullable for class FooGetDefaultResponse: string.");
 
             return new FooGetDefaultResponse(varString);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -828,103 +828,103 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!varByte.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(varByte));
+                throw new JsonException("Property is required for class FormatTest: byte.");
 
             if (!date.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(date));
+                throw new JsonException("Property is required for class FormatTest: date.");
 
             if (!number.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(number));
+                throw new JsonException("Property is required for class FormatTest: number.");
 
             if (!password.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(password));
+                throw new JsonException("Property is required for class FormatTest: password.");
 
             if (!stringFormattedAsDecimalRequired.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(stringFormattedAsDecimalRequired));
+                throw new JsonException("Property is required for class FormatTest: string_formatted_as_decimal_required.");
 
             if (varByte.IsSet && varByte.Value == null)
-                throw new ArgumentNullException(nameof(varByte), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: byte.");
 
             if (date.IsSet && date.Value == null)
-                throw new ArgumentNullException(nameof(date), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: date.");
 
             if (number.IsSet && number.Value == null)
-                throw new ArgumentNullException(nameof(number), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: number.");
 
             if (password.IsSet && password.Value == null)
-                throw new ArgumentNullException(nameof(password), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: password.");
 
             if (stringFormattedAsDecimalRequired.IsSet && stringFormattedAsDecimalRequired.Value == null)
-                throw new ArgumentNullException(nameof(stringFormattedAsDecimalRequired), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: string_formatted_as_decimal_required.");
 
             if (binary.IsSet && binary.Value == null)
-                throw new ArgumentNullException(nameof(binary), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: binary.");
 
             if (dateTime.IsSet && dateTime.Value == null)
-                throw new ArgumentNullException(nameof(dateTime), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: dateTime.");
 
             if (varDecimal.IsSet && varDecimal.Value == null)
-                throw new ArgumentNullException(nameof(varDecimal), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: decimal.");
 
             if (varDouble.IsSet && varDouble.Value == null)
-                throw new ArgumentNullException(nameof(varDouble), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: double.");
 
             if (duplicatePropertyName2.IsSet && duplicatePropertyName2.Value == null)
-                throw new ArgumentNullException(nameof(duplicatePropertyName2), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: duplicate_property_name.");
 
             if (duplicatePropertyName.IsSet && duplicatePropertyName.Value == null)
-                throw new ArgumentNullException(nameof(duplicatePropertyName), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: @duplicate_property_name.");
 
             if (varFloat.IsSet && varFloat.Value == null)
-                throw new ArgumentNullException(nameof(varFloat), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: float.");
 
             if (int32.IsSet && int32.Value == null)
-                throw new ArgumentNullException(nameof(int32), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int32.");
 
             if (int32Range.IsSet && int32Range.Value == null)
-                throw new ArgumentNullException(nameof(int32Range), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int32Range.");
 
             if (int64.IsSet && int64.Value == null)
-                throw new ArgumentNullException(nameof(int64), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64.");
 
             if (int64Negative.IsSet && int64Negative.Value == null)
-                throw new ArgumentNullException(nameof(int64Negative), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64Negative.");
 
             if (int64NegativeExclusive.IsSet && int64NegativeExclusive.Value == null)
-                throw new ArgumentNullException(nameof(int64NegativeExclusive), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64NegativeExclusive.");
 
             if (int64Positive.IsSet && int64Positive.Value == null)
-                throw new ArgumentNullException(nameof(int64Positive), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64Positive.");
 
             if (int64PositiveExclusive.IsSet && int64PositiveExclusive.Value == null)
-                throw new ArgumentNullException(nameof(int64PositiveExclusive), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64PositiveExclusive.");
 
             if (integer.IsSet && integer.Value == null)
-                throw new ArgumentNullException(nameof(integer), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: integer.");
 
             if (patternWithBackslash.IsSet && patternWithBackslash.Value == null)
-                throw new ArgumentNullException(nameof(patternWithBackslash), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: pattern_with_backslash.");
 
             if (patternWithDigits.IsSet && patternWithDigits.Value == null)
-                throw new ArgumentNullException(nameof(patternWithDigits), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: pattern_with_digits.");
 
             if (patternWithDigitsAndDelimiter.IsSet && patternWithDigitsAndDelimiter.Value == null)
-                throw new ArgumentNullException(nameof(patternWithDigitsAndDelimiter), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: pattern_with_digits_and_delimiter.");
 
             if (varString.IsSet && varString.Value == null)
-                throw new ArgumentNullException(nameof(varString), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: string.");
 
             if (stringFormattedAsDecimal.IsSet && stringFormattedAsDecimal.Value == null)
-                throw new ArgumentNullException(nameof(stringFormattedAsDecimal), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: string_formatted_as_decimal.");
 
             if (unsignedInteger.IsSet && unsignedInteger.Value == null)
-                throw new ArgumentNullException(nameof(unsignedInteger), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: unsigned_integer.");
 
             if (unsignedLong.IsSet && unsignedLong.Value == null)
-                throw new ArgumentNullException(nameof(unsignedLong), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: unsigned_long.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: uuid.");
 
             return new FormatTest(varByte.Value!, date.Value!.Value!, number.Value!.Value!, password.Value!, stringFormattedAsDecimalRequired.Value!.Value!, binary, dateTime, varDecimal, varDouble, duplicatePropertyName2, duplicatePropertyName, varFloat, int32, int32Range, int64, int64Negative, int64NegativeExclusive, int64Positive, int64PositiveExclusive, integer, patternWithBackslash, patternWithDigits, patternWithDigitsAndDelimiter, varString, stringFormattedAsDecimal, unsignedInteger, unsignedLong, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Fruit.cs
@@ -185,7 +185,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Fruit.");
+                throw new JsonException("Property is not nullable for class Fruit: color.");
 
             if (apple != null)
                 return new Fruit(apple, color);

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -189,7 +189,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class GmFruit.");
+                throw new JsonException("Property is not nullable for class GmFruit: color.");
 
             Option<Apple?> appleParsedValue = apple == null
                 ? default

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
@@ -157,10 +157,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!petType.IsSet)
-                throw new ArgumentException("Property is required for class GrandparentAnimal.", nameof(petType));
+                throw new JsonException("Property is required for class GrandparentAnimal: pet_type.");
 
             if (petType.IsSet && petType.Value == null)
-                throw new ArgumentNullException(nameof(petType), "Property is not nullable for class GrandparentAnimal.");
+                throw new JsonException("Property is not nullable for class GrandparentAnimal: pet_type.");
 
             return new GrandparentAnimal();
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -208,10 +208,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bar.IsSet && bar.Value == null)
-                throw new ArgumentNullException(nameof(bar), "Property is not nullable for class HasOnlyReadOnly.");
+                throw new JsonException("Property is not nullable for class HasOnlyReadOnly: bar.");
 
             if (foo.IsSet && foo.Value == null)
-                throw new ArgumentNullException(nameof(foo), "Property is not nullable for class HasOnlyReadOnly.");
+                throw new JsonException("Property is not nullable for class HasOnlyReadOnly: foo.");
 
             return new HasOnlyReadOnly(bar, foo);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
@@ -294,22 +294,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (potentiallyOverriddenPropertyAccessor.IsSet && potentiallyOverriddenPropertyAccessor.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyAccessor), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyAccessor.");
 
             if (potentiallyOverriddenPropertyToInternal.IsSet && potentiallyOverriddenPropertyToInternal.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyToInternal), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyToInternal.");
 
             if (potentiallyOverriddenPropertyToPrivate.IsSet && potentiallyOverriddenPropertyToPrivate.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyToPrivate), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyToPrivate.");
 
             if (potentiallyOverriddenPropertyToPublic.IsSet && potentiallyOverriddenPropertyToPublic.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyToPublic), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyToPublic.");
 
             if (unalteredProperty.IsSet && unalteredProperty.Value == null)
-                throw new ArgumentNullException(nameof(unalteredProperty), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: unalteredProperty.");
 
             if (unalteredPropertyAccessor.IsSet && unalteredPropertyAccessor.Value == null)
-                throw new ArgumentNullException(nameof(unalteredPropertyAccessor), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: unalteredPropertyAccessor.");
 
             return new InjectedVendorExtensionsTest(potentiallyOverriddenPropertyAccessor, potentiallyOverriddenPropertyToInternal, potentiallyOverriddenPropertyToPrivate, potentiallyOverriddenPropertyToPublic, unalteredProperty, unalteredPropertyAccessor);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
@@ -146,16 +146,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class IsoscelesTriangle.", nameof(shapeType));
+                throw new JsonException("Property is required for class IsoscelesTriangle: shapeType.");
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class IsoscelesTriangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class IsoscelesTriangle: triangleType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class IsoscelesTriangle.");
+                throw new JsonException("Property is not nullable for class IsoscelesTriangle: shapeType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class IsoscelesTriangle.");
+                throw new JsonException("Property is not nullable for class IsoscelesTriangle: triangleType.");
 
             return new IsoscelesTriangle(shapeType.Value!, triangleType.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/List.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (var123List.IsSet && var123List.Value == null)
-                throw new ArgumentNullException(nameof(var123List), "Property is not nullable for class List.");
+                throw new JsonException("Property is not nullable for class List: 123-list.");
 
             return new List(var123List);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -167,10 +167,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (escapedLiteralString.IsSet && escapedLiteralString.Value == null)
-                throw new ArgumentNullException(nameof(escapedLiteralString), "Property is not nullable for class LiteralStringClass.");
+                throw new JsonException("Property is not nullable for class LiteralStringClass: escapedLiteralString.");
 
             if (unescapedLiteralString.IsSet && unescapedLiteralString.Value == null)
-                throw new ArgumentNullException(nameof(unescapedLiteralString), "Property is not nullable for class LiteralStringClass.");
+                throw new JsonException("Property is not nullable for class LiteralStringClass: unescapedLiteralString.");
 
             return new LiteralStringClass(escapedLiteralString, unescapedLiteralString);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Mammal.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Mammal.cs
@@ -216,10 +216,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Mammal.", nameof(className));
+                throw new JsonException("Property is required for class Mammal: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Mammal.");
+                throw new JsonException("Property is not nullable for class Mammal: className.");
 
             if (pig != null)
                 return new Mammal(pig);

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/MapTest.cs
@@ -273,16 +273,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (directMap.IsSet && directMap.Value == null)
-                throw new ArgumentNullException(nameof(directMap), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: direct_map.");
 
             if (indirectMap.IsSet && indirectMap.Value == null)
-                throw new ArgumentNullException(nameof(indirectMap), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: indirect_map.");
 
             if (mapMapOfString.IsSet && mapMapOfString.Value == null)
-                throw new ArgumentNullException(nameof(mapMapOfString), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: map_map_of_string.");
 
             if (mapOfEnumString.IsSet && mapOfEnumString.Value == null)
-                throw new ArgumentNullException(nameof(mapOfEnumString), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: map_of_enum_string.");
 
             return new MapTest(directMap, indirectMap, mapMapOfString, mapOfEnumString);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedAnyOf.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedAnyOf.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (content.IsSet && content.Value == null)
-                throw new ArgumentNullException(nameof(content), "Property is not nullable for class MixedAnyOf.");
+                throw new JsonException("Property is not nullable for class MixedAnyOf: content.");
 
             return new MixedAnyOf(content);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedOneOf.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedOneOf.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (content.IsSet && content.Value == null)
-                throw new ArgumentNullException(nameof(content), "Property is not nullable for class MixedOneOf.");
+                throw new JsonException("Property is not nullable for class MixedOneOf: content.");
 
             return new MixedOneOf(content);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -219,16 +219,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (dateTime.IsSet && dateTime.Value == null)
-                throw new ArgumentNullException(nameof(dateTime), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: dateTime.");
 
             if (map.IsSet && map.Value == null)
-                throw new ArgumentNullException(nameof(map), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: map.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: uuid.");
 
             if (uuidWithPattern.IsSet && uuidWithPattern.Value == null)
-                throw new ArgumentNullException(nameof(uuidWithPattern), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: uuid_with_pattern.");
 
             return new MixedPropertiesAndAdditionalPropertiesClass(dateTime, map, uuid, uuidWithPattern);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedSubId.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedSubId.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class MixedSubId.");
+                throw new JsonException("Property is not nullable for class MixedSubId: id.");
 
             return new MixedSubId(id);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -167,10 +167,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varClass.IsSet && varClass.Value == null)
-                throw new ArgumentNullException(nameof(varClass), "Property is not nullable for class Model200Response.");
+                throw new JsonException("Property is not nullable for class Model200Response: class.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Model200Response.");
+                throw new JsonException("Property is not nullable for class Model200Response: name.");
 
             return new Model200Response(varClass, name);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varClient.IsSet && varClient.Value == null)
-                throw new ArgumentNullException(nameof(varClient), "Property is not nullable for class ModelClient.");
+                throw new JsonException("Property is not nullable for class ModelClient: client.");
 
             return new ModelClient(varClient);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Name.cs
@@ -241,19 +241,19 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!varName.IsSet)
-                throw new ArgumentException("Property is required for class Name.", nameof(varName));
+                throw new JsonException("Property is required for class Name: name.");
 
             if (varName.IsSet && varName.Value == null)
-                throw new ArgumentNullException(nameof(varName), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: name.");
 
             if (property.IsSet && property.Value == null)
-                throw new ArgumentNullException(nameof(property), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: property.");
 
             if (snakeCase.IsSet && snakeCase.Value == null)
-                throw new ArgumentNullException(nameof(snakeCase), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: snake_case.");
 
             if (var123Number.IsSet && var123Number.Value == null)
-                throw new ArgumentNullException(nameof(var123Number), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: 123Number.");
 
             return new Name(varName.Value!.Value!, property, snakeCase, var123Number);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
@@ -153,16 +153,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!aObjVariableobject.IsSet)
-                throw new ArgumentException("Property is required for class NotificationtestGetElementsV1ResponseMPayload.", nameof(aObjVariableobject));
+                throw new JsonException("Property is required for class NotificationtestGetElementsV1ResponseMPayload: a_objVariableobject.");
 
             if (!pkiNotificationtestID.IsSet)
-                throw new ArgumentException("Property is required for class NotificationtestGetElementsV1ResponseMPayload.", nameof(pkiNotificationtestID));
+                throw new JsonException("Property is required for class NotificationtestGetElementsV1ResponseMPayload: pkiNotificationtestID.");
 
             if (aObjVariableobject.IsSet && aObjVariableobject.Value == null)
-                throw new ArgumentNullException(nameof(aObjVariableobject), "Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload.");
+                throw new JsonException("Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload: a_objVariableobject.");
 
             if (pkiNotificationtestID.IsSet && pkiNotificationtestID.Value == null)
-                throw new ArgumentNullException(nameof(pkiNotificationtestID), "Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload.");
+                throw new JsonException("Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload: pkiNotificationtestID.");
 
             return new NotificationtestGetElementsV1ResponseMPayload(aObjVariableobject.Value!, pkiNotificationtestID.Value!.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -377,10 +377,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayItemsNullable.IsSet && arrayItemsNullable.Value == null)
-                throw new ArgumentNullException(nameof(arrayItemsNullable), "Property is not nullable for class NullableClass.");
+                throw new JsonException("Property is not nullable for class NullableClass: array_items_nullable.");
 
             if (objectItemsNullable.IsSet && objectItemsNullable.Value == null)
-                throw new ArgumentNullException(nameof(objectItemsNullable), "Property is not nullable for class NullableClass.");
+                throw new JsonException("Property is not nullable for class NullableClass: object_items_nullable.");
 
             return new NullableClass(arrayAndItemsNullableProp, arrayItemsNullable, arrayNullableProp, booleanProp, dateProp, datetimeProp, integerProp, numberProp, objectAndItemsNullableProp, objectItemsNullable, objectNullableProp, stringProp);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/NullableShape.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/NullableShape.cs
@@ -195,10 +195,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class NullableShape.", nameof(shapeType));
+                throw new JsonException("Property is required for class NullableShape: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class NullableShape.");
+                throw new JsonException("Property is not nullable for class NullableShape: shapeType.");
 
             if (quadrilateral != null)
                 return new NullableShape(quadrilateral);

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (justNumber.IsSet && justNumber.Value == null)
-                throw new ArgumentNullException(nameof(justNumber), "Property is not nullable for class NumberOnly.");
+                throw new JsonException("Property is not nullable for class NumberOnly: JustNumber.");
 
             return new NumberOnly(justNumber);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -210,16 +210,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bars.IsSet && bars.Value == null)
-                throw new ArgumentNullException(nameof(bars), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: bars.");
 
             if (deprecatedRef.IsSet && deprecatedRef.Value == null)
-                throw new ArgumentNullException(nameof(deprecatedRef), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: deprecatedRef.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: id.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: uuid.");
 
             return new ObjectWithDeprecatedFields(bars, deprecatedRef, id, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Order.cs
@@ -342,22 +342,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (complete.IsSet && complete.Value == null)
-                throw new ArgumentNullException(nameof(complete), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: complete.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: id.");
 
             if (petId.IsSet && petId.Value == null)
-                throw new ArgumentNullException(nameof(petId), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: petId.");
 
             if (quantity.IsSet && quantity.Value == null)
-                throw new ArgumentNullException(nameof(quantity), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: quantity.");
 
             if (shipDate.IsSet && shipDate.Value == null)
-                throw new ArgumentNullException(nameof(shipDate), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: shipDate.");
 
             if (status.IsSet && status.Value == null)
-                throw new ArgumentNullException(nameof(status), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: status.");
 
             return new Order(complete, id, petId, quantity, shipDate, status);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -187,13 +187,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (myBoolean.IsSet && myBoolean.Value == null)
-                throw new ArgumentNullException(nameof(myBoolean), "Property is not nullable for class OuterComposite.");
+                throw new JsonException("Property is not nullable for class OuterComposite: my_boolean.");
 
             if (myNumber.IsSet && myNumber.Value == null)
-                throw new ArgumentNullException(nameof(myNumber), "Property is not nullable for class OuterComposite.");
+                throw new JsonException("Property is not nullable for class OuterComposite: my_number.");
 
             if (myString.IsSet && myString.Value == null)
-                throw new ArgumentNullException(nameof(myString), "Property is not nullable for class OuterComposite.");
+                throw new JsonException("Property is not nullable for class OuterComposite: my_string.");
 
             return new OuterComposite(myBoolean, myNumber, myString);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ParentPet.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ParentPet.cs
@@ -120,10 +120,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!petType.IsSet)
-                throw new ArgumentException("Property is required for class ParentPet.", nameof(petType));
+                throw new JsonException("Property is required for class ParentPet: pet_type.");
 
             if (petType.IsSet && petType.Value == null)
-                throw new ArgumentNullException(nameof(petType), "Property is not nullable for class ParentPet.");
+                throw new JsonException("Property is not nullable for class ParentPet: pet_type.");
 
             return new ParentPet();
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Pet.cs
@@ -323,28 +323,28 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!name.IsSet)
-                throw new ArgumentException("Property is required for class Pet.", nameof(name));
+                throw new JsonException("Property is required for class Pet: name.");
 
             if (!photoUrls.IsSet)
-                throw new ArgumentException("Property is required for class Pet.", nameof(photoUrls));
+                throw new JsonException("Property is required for class Pet: photoUrls.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: name.");
 
             if (photoUrls.IsSet && photoUrls.Value == null)
-                throw new ArgumentNullException(nameof(photoUrls), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: photoUrls.");
 
             if (category.IsSet && category.Value == null)
-                throw new ArgumentNullException(nameof(category), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: category.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: id.");
 
             if (status.IsSet && status.Value == null)
-                throw new ArgumentNullException(nameof(status), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: status.");
 
             if (tags.IsSet && tags.Value == null)
-                throw new ArgumentNullException(nameof(tags), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: tags.");
 
             return new Pet(name.Value!, photoUrls.Value!, category, id, status, tags);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Pig.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Pig.cs
@@ -195,10 +195,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Pig.", nameof(className));
+                throw new JsonException("Property is required for class Pig: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Pig.");
+                throw new JsonException("Property is not nullable for class Pig: className.");
 
             if (basquePig != null)
                 return new Pig(basquePig);

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Quadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Quadrilateral.cs
@@ -195,10 +195,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class Quadrilateral.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class Quadrilateral: quadrilateralType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class Quadrilateral.");
+                throw new JsonException("Property is not nullable for class Quadrilateral: quadrilateralType.");
 
             if (complexQuadrilateral != null)
                 return new Quadrilateral(complexQuadrilateral);

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
@@ -140,10 +140,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class QuadrilateralInterface.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class QuadrilateralInterface: quadrilateralType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class QuadrilateralInterface.");
+                throw new JsonException("Property is not nullable for class QuadrilateralInterface: quadrilateralType.");
 
             return new QuadrilateralInterface(quadrilateralType.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -205,10 +205,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bar.IsSet && bar.Value == null)
-                throw new ArgumentNullException(nameof(bar), "Property is not nullable for class ReadOnlyFirst.");
+                throw new JsonException("Property is not nullable for class ReadOnlyFirst: bar.");
 
             if (baz.IsSet && baz.Value == null)
-                throw new ArgumentNullException(nameof(baz), "Property is not nullable for class ReadOnlyFirst.");
+                throw new JsonException("Property is not nullable for class ReadOnlyFirst: baz.");
 
             return new ReadOnlyFirst(bar, baz);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -2079,136 +2079,136 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!requiredNotNullableDateProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotNullableDateProp));
+                throw new JsonException("Property is required for class RequiredClass: required_not_nullable_date_prop.");
 
             if (!requiredNotnullableArrayOfString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableArrayOfString));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_array_of_string.");
 
             if (!requiredNotnullableBooleanProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableBooleanProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_boolean_prop.");
 
             if (!requiredNotnullableDatetimeProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableDatetimeProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_datetime_prop.");
 
             if (!requiredNotnullableEnumInteger.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableEnumInteger));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_enum_integer.");
 
             if (!requiredNotnullableEnumIntegerOnly.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableEnumIntegerOnly));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_enum_integer_only.");
 
             if (!requiredNotnullableEnumString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableEnumString));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_enum_string.");
 
             if (!requiredNotnullableOuterEnumDefaultValue.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableOuterEnumDefaultValue));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_outerEnumDefaultValue.");
 
             if (!requiredNotnullableStringProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableStringProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_string_prop.");
 
             if (!requiredNotnullableUuid.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableUuid));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_uuid.");
 
             if (!requiredNotnullableintegerProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableintegerProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullableinteger_prop.");
 
             if (!requiredNullableArrayOfString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableArrayOfString));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_array_of_string.");
 
             if (!requiredNullableBooleanProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableBooleanProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_boolean_prop.");
 
             if (!requiredNullableDateProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableDateProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_date_prop.");
 
             if (!requiredNullableDatetimeProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableDatetimeProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_datetime_prop.");
 
             if (!requiredNullableEnumInteger.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableEnumInteger));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_enum_integer.");
 
             if (!requiredNullableEnumIntegerOnly.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableEnumIntegerOnly));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_enum_integer_only.");
 
             if (!requiredNullableEnumString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableEnumString));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_enum_string.");
 
             if (!requiredNullableIntegerProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableIntegerProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_integer_prop.");
 
             if (!requiredNullableOuterEnumDefaultValue.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableOuterEnumDefaultValue));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_outerEnumDefaultValue.");
 
             if (!requiredNullableStringProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableStringProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_string_prop.");
 
             if (!requiredNullableUuid.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableUuid));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_uuid.");
 
             if (requiredNotNullableDateProp.IsSet && requiredNotNullableDateProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotNullableDateProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_not_nullable_date_prop.");
 
             if (requiredNotnullableArrayOfString.IsSet && requiredNotnullableArrayOfString.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableArrayOfString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_array_of_string.");
 
             if (requiredNotnullableBooleanProp.IsSet && requiredNotnullableBooleanProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableBooleanProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_boolean_prop.");
 
             if (requiredNotnullableDatetimeProp.IsSet && requiredNotnullableDatetimeProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableDatetimeProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_datetime_prop.");
 
             if (requiredNotnullableEnumInteger.IsSet && requiredNotnullableEnumInteger.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableEnumInteger), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_enum_integer.");
 
             if (requiredNotnullableEnumIntegerOnly.IsSet && requiredNotnullableEnumIntegerOnly.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableEnumIntegerOnly), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_enum_integer_only.");
 
             if (requiredNotnullableEnumString.IsSet && requiredNotnullableEnumString.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableEnumString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_enum_string.");
 
             if (requiredNotnullableOuterEnumDefaultValue.IsSet && requiredNotnullableOuterEnumDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableOuterEnumDefaultValue), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_outerEnumDefaultValue.");
 
             if (requiredNotnullableStringProp.IsSet && requiredNotnullableStringProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableStringProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_string_prop.");
 
             if (requiredNotnullableUuid.IsSet && requiredNotnullableUuid.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableUuid), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_uuid.");
 
             if (requiredNotnullableintegerProp.IsSet && requiredNotnullableintegerProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableintegerProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullableinteger_prop.");
 
             if (notRequiredNotnullableDateProp.IsSet && notRequiredNotnullableDateProp.Value == null)
-                throw new ArgumentNullException(nameof(notRequiredNotnullableDateProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: not_required_notnullable_date_prop.");
 
             if (notRequiredNotnullableintegerProp.IsSet && notRequiredNotnullableintegerProp.Value == null)
-                throw new ArgumentNullException(nameof(notRequiredNotnullableintegerProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: not_required_notnullableinteger_prop.");
 
             if (notrequiredNotnullableArrayOfString.IsSet && notrequiredNotnullableArrayOfString.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableArrayOfString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_array_of_string.");
 
             if (notrequiredNotnullableBooleanProp.IsSet && notrequiredNotnullableBooleanProp.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableBooleanProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_boolean_prop.");
 
             if (notrequiredNotnullableDatetimeProp.IsSet && notrequiredNotnullableDatetimeProp.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableDatetimeProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_datetime_prop.");
 
             if (notrequiredNotnullableEnumInteger.IsSet && notrequiredNotnullableEnumInteger.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableEnumInteger), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_enum_integer.");
 
             if (notrequiredNotnullableEnumIntegerOnly.IsSet && notrequiredNotnullableEnumIntegerOnly.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableEnumIntegerOnly), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_enum_integer_only.");
 
             if (notrequiredNotnullableEnumString.IsSet && notrequiredNotnullableEnumString.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableEnumString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_enum_string.");
 
             if (notrequiredNotnullableOuterEnumDefaultValue.IsSet && notrequiredNotnullableOuterEnumDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableOuterEnumDefaultValue), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_outerEnumDefaultValue.");
 
             if (notrequiredNotnullableStringProp.IsSet && notrequiredNotnullableStringProp.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableStringProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_string_prop.");
 
             if (notrequiredNotnullableUuid.IsSet && notrequiredNotnullableUuid.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableUuid), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_uuid.");
 
             return new RequiredClass(requiredNotNullableDateProp.Value!.Value!, requiredNotnullableArrayOfString.Value!, requiredNotnullableBooleanProp.Value!.Value!, requiredNotnullableDatetimeProp.Value!.Value!, requiredNotnullableEnumInteger.Value!.Value!, requiredNotnullableEnumIntegerOnly.Value!.Value!, requiredNotnullableEnumString.Value!.Value!, requiredNotnullableOuterEnumDefaultValue.Value!.Value!, requiredNotnullableStringProp.Value!, requiredNotnullableUuid.Value!.Value!, requiredNotnullableintegerProp.Value!.Value!, notRequiredNotnullableDateProp, notRequiredNotnullableintegerProp, notRequiredNullableDateProp, notRequiredNullableIntegerProp, notrequiredNotnullableArrayOfString, notrequiredNotnullableBooleanProp, notrequiredNotnullableDatetimeProp, notrequiredNotnullableEnumInteger, notrequiredNotnullableEnumIntegerOnly, notrequiredNotnullableEnumString, notrequiredNotnullableOuterEnumDefaultValue, notrequiredNotnullableStringProp, notrequiredNotnullableUuid, notrequiredNullableArrayOfString, notrequiredNullableBooleanProp, notrequiredNullableDatetimeProp, notrequiredNullableEnumInteger, notrequiredNullableEnumIntegerOnly, notrequiredNullableEnumString, notrequiredNullableOuterEnumDefaultValue, notrequiredNullableStringProp, notrequiredNullableUuid, requiredNullableArrayOfString.Value!, requiredNullableBooleanProp.Value!, requiredNullableDateProp.Value!, requiredNullableDatetimeProp.Value!, requiredNullableEnumInteger.Value!, requiredNullableEnumIntegerOnly.Value!, requiredNullableEnumString.Value!, requiredNullableIntegerProp.Value!, requiredNullableOuterEnumDefaultValue.Value!, requiredNullableStringProp.Value!, requiredNullableUuid.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Result.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Result.cs
@@ -190,13 +190,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (code.IsSet && code.Value == null)
-                throw new ArgumentNullException(nameof(code), "Property is not nullable for class Result.");
+                throw new JsonException("Property is not nullable for class Result: code.");
 
             if (data.IsSet && data.Value == null)
-                throw new ArgumentNullException(nameof(data), "Property is not nullable for class Result.");
+                throw new JsonException("Property is not nullable for class Result: data.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class Result.");
+                throw new JsonException("Property is not nullable for class Result: uuid.");
 
             return new Result(code, data, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Return.cs
@@ -193,19 +193,19 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!varLock.IsSet)
-                throw new ArgumentException("Property is required for class Return.", nameof(varLock));
+                throw new JsonException("Property is required for class Return: lock.");
 
             if (!varAbstract.IsSet)
-                throw new ArgumentException("Property is required for class Return.", nameof(varAbstract));
+                throw new JsonException("Property is required for class Return: abstract.");
 
             if (varLock.IsSet && varLock.Value == null)
-                throw new ArgumentNullException(nameof(varLock), "Property is not nullable for class Return.");
+                throw new JsonException("Property is not nullable for class Return: lock.");
 
             if (varReturn.IsSet && varReturn.Value == null)
-                throw new ArgumentNullException(nameof(varReturn), "Property is not nullable for class Return.");
+                throw new JsonException("Property is not nullable for class Return: return.");
 
             if (varUnsafe.IsSet && varUnsafe.Value == null)
-                throw new ArgumentNullException(nameof(varUnsafe), "Property is not nullable for class Return.");
+                throw new JsonException("Property is not nullable for class Return: unsafe.");
 
             return new Return(varLock.Value!, varAbstract.Value!, varReturn, varUnsafe);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -167,10 +167,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (role.IsSet && role.Value == null)
-                throw new ArgumentNullException(nameof(role), "Property is not nullable for class RolesReportsHash.");
+                throw new JsonException("Property is not nullable for class RolesReportsHash: role.");
 
             if (roleUuid.IsSet && roleUuid.Value == null)
-                throw new ArgumentNullException(nameof(roleUuid), "Property is not nullable for class RolesReportsHash.");
+                throw new JsonException("Property is not nullable for class RolesReportsHash: role_uuid.");
 
             return new RolesReportsHash(role, roleUuid);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class RolesReportsHashRole.");
+                throw new JsonException("Property is not nullable for class RolesReportsHashRole: name.");
 
             return new RolesReportsHashRole(name);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
@@ -153,16 +153,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ScaleneTriangle.", nameof(shapeType));
+                throw new JsonException("Property is required for class ScaleneTriangle: shapeType.");
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class ScaleneTriangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class ScaleneTriangle: triangleType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ScaleneTriangle.");
+                throw new JsonException("Property is not nullable for class ScaleneTriangle: shapeType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class ScaleneTriangle.");
+                throw new JsonException("Property is not nullable for class ScaleneTriangle: triangleType.");
 
             return new ScaleneTriangle(shapeType.Value!, triangleType.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Shape.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Shape.cs
@@ -195,10 +195,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class Shape.", nameof(shapeType));
+                throw new JsonException("Property is required for class Shape: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class Shape.");
+                throw new JsonException("Property is not nullable for class Shape: shapeType.");
 
             if (quadrilateral != null)
                 return new Shape(quadrilateral);

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ShapeInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ShapeInterface.cs
@@ -140,10 +140,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ShapeInterface.", nameof(shapeType));
+                throw new JsonException("Property is required for class ShapeInterface: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ShapeInterface.");
+                throw new JsonException("Property is not nullable for class ShapeInterface: shapeType.");
 
             return new ShapeInterface(shapeType.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ShapeOrNull.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ShapeOrNull.cs
@@ -195,10 +195,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ShapeOrNull.", nameof(shapeType));
+                throw new JsonException("Property is required for class ShapeOrNull: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ShapeOrNull.");
+                throw new JsonException("Property is not nullable for class ShapeOrNull: shapeType.");
 
             if (quadrilateral != null)
                 return new ShapeOrNull(quadrilateral);

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
@@ -153,16 +153,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class SimpleQuadrilateral.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class SimpleQuadrilateral: quadrilateralType.");
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class SimpleQuadrilateral.", nameof(shapeType));
+                throw new JsonException("Property is required for class SimpleQuadrilateral: shapeType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class SimpleQuadrilateral.");
+                throw new JsonException("Property is not nullable for class SimpleQuadrilateral: quadrilateralType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class SimpleQuadrilateral.");
+                throw new JsonException("Property is not nullable for class SimpleQuadrilateral: shapeType.");
 
             return new SimpleQuadrilateral(quadrilateralType.Value!, shapeType.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -167,10 +167,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varSpecialModelName.IsSet && varSpecialModelName.Value == null)
-                throw new ArgumentNullException(nameof(varSpecialModelName), "Property is not nullable for class SpecialModelName.");
+                throw new JsonException("Property is not nullable for class SpecialModelName: _special_model.name_.");
 
             if (specialPropertyName.IsSet && specialPropertyName.Value == null)
-                throw new ArgumentNullException(nameof(specialPropertyName), "Property is not nullable for class SpecialModelName.");
+                throw new JsonException("Property is not nullable for class SpecialModelName: $special[property.name].");
 
             return new SpecialModelName(varSpecialModelName, specialPropertyName);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Tag.cs
@@ -167,10 +167,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Tag.");
+                throw new JsonException("Property is not nullable for class Tag: id.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Tag.");
+                throw new JsonException("Property is not nullable for class Tag: name.");
 
             return new Tag(id, name);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (value.IsSet && value.Value == null)
-                throw new ArgumentNullException(nameof(value), "Property is not nullable for class TestCollectionEndingWithWordList.");
+                throw new JsonException("Property is not nullable for class TestCollectionEndingWithWordList: value.");
 
             return new TestCollectionEndingWithWordList(value);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (testCollectionEndingWithWordList.IsSet && testCollectionEndingWithWordList.Value == null)
-                throw new ArgumentNullException(nameof(testCollectionEndingWithWordList), "Property is not nullable for class TestCollectionEndingWithWordListObject.");
+                throw new JsonException("Property is not nullable for class TestCollectionEndingWithWordListObject: TestCollectionEndingWithWordList.");
 
             return new TestCollectionEndingWithWordListObject(testCollectionEndingWithWordList);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/TestDescendants.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/TestDescendants.cs
@@ -243,16 +243,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!alternativeName.IsSet)
-                throw new ArgumentException("Property is required for class TestDescendants.", nameof(alternativeName));
+                throw new JsonException("Property is required for class TestDescendants: alternativeName.");
 
             if (!objectType.IsSet)
-                throw new ArgumentException("Property is required for class TestDescendants.", nameof(objectType));
+                throw new JsonException("Property is required for class TestDescendants: objectType.");
 
             if (alternativeName.IsSet && alternativeName.Value == null)
-                throw new ArgumentNullException(nameof(alternativeName), "Property is not nullable for class TestDescendants.");
+                throw new JsonException("Property is not nullable for class TestDescendants: alternativeName.");
 
             if (objectType.IsSet && objectType.Value == null)
-                throw new ArgumentNullException(nameof(objectType), "Property is not nullable for class TestDescendants.");
+                throw new JsonException("Property is not nullable for class TestDescendants: objectType.");
 
             return new TestDescendants(alternativeName.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (someProperty.IsSet && someProperty.Value == null)
-                throw new ArgumentNullException(nameof(someProperty), "Property is not nullable for class TestInlineFreeformAdditionalPropertiesRequest.");
+                throw new JsonException("Property is not nullable for class TestInlineFreeformAdditionalPropertiesRequest: someProperty.");
 
             return new TestInlineFreeformAdditionalPropertiesRequest(someProperty);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/TestResult.cs
@@ -189,13 +189,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (code.IsSet && code.Value == null)
-                throw new ArgumentNullException(nameof(code), "Property is not nullable for class TestResult.");
+                throw new JsonException("Property is not nullable for class TestResult: code.");
 
             if (data.IsSet && data.Value == null)
-                throw new ArgumentNullException(nameof(data), "Property is not nullable for class TestResult.");
+                throw new JsonException("Property is not nullable for class TestResult: data.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class TestResult.");
+                throw new JsonException("Property is not nullable for class TestResult: uuid.");
 
             return new TestResult(code, data, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Triangle.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Triangle.cs
@@ -216,10 +216,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class Triangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class Triangle: triangleType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class Triangle.");
+                throw new JsonException("Property is not nullable for class Triangle: triangleType.");
 
             if (equilateralTriangle != null)
                 return new Triangle(equilateralTriangle);

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/TriangleInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/TriangleInterface.cs
@@ -140,10 +140,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class TriangleInterface.", nameof(triangleType));
+                throw new JsonException("Property is required for class TriangleInterface: triangleType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class TriangleInterface.");
+                throw new JsonException("Property is not nullable for class TriangleInterface: triangleType.");
 
             return new TriangleInterface(triangleType.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/User.cs
@@ -372,31 +372,31 @@ namespace Org.OpenAPITools.Model
             }
 
             if (email.IsSet && email.Value == null)
-                throw new ArgumentNullException(nameof(email), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: email.");
 
             if (firstName.IsSet && firstName.Value == null)
-                throw new ArgumentNullException(nameof(firstName), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: firstName.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: id.");
 
             if (lastName.IsSet && lastName.Value == null)
-                throw new ArgumentNullException(nameof(lastName), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: lastName.");
 
             if (objectWithNoDeclaredProps.IsSet && objectWithNoDeclaredProps.Value == null)
-                throw new ArgumentNullException(nameof(objectWithNoDeclaredProps), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: objectWithNoDeclaredProps.");
 
             if (password.IsSet && password.Value == null)
-                throw new ArgumentNullException(nameof(password), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: password.");
 
             if (phone.IsSet && phone.Value == null)
-                throw new ArgumentNullException(nameof(phone), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: phone.");
 
             if (userStatus.IsSet && userStatus.Value == null)
-                throw new ArgumentNullException(nameof(userStatus), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: userStatus.");
 
             if (username.IsSet && username.Value == null)
-                throw new ArgumentNullException(nameof(username), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: username.");
 
             return new User(anyTypeProp, anyTypePropNullable, email, firstName, id, lastName, objectWithNoDeclaredProps, objectWithNoDeclaredPropsNullable, password, phone, userStatus, username);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Whale.cs
@@ -180,16 +180,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Whale.", nameof(className));
+                throw new JsonException("Property is required for class Whale: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Whale.");
+                throw new JsonException("Property is not nullable for class Whale: className.");
 
             if (hasBaleen.IsSet && hasBaleen.Value == null)
-                throw new ArgumentNullException(nameof(hasBaleen), "Property is not nullable for class Whale.");
+                throw new JsonException("Property is not nullable for class Whale: hasBaleen.");
 
             if (hasTeeth.IsSet && hasTeeth.Value == null)
-                throw new ArgumentNullException(nameof(hasTeeth), "Property is not nullable for class Whale.");
+                throw new JsonException("Property is not nullable for class Whale: hasTeeth.");
 
             return new Whale(className.Value!, hasBaleen, hasTeeth);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Zebra.cs
@@ -247,13 +247,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Zebra.", nameof(className));
+                throw new JsonException("Property is required for class Zebra: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Zebra.");
+                throw new JsonException("Property is not nullable for class Zebra: className.");
 
             if (type.IsSet && type.Value == null)
-                throw new ArgumentNullException(nameof(type), "Property is not nullable for class Zebra.");
+                throw new JsonException("Property is not nullable for class Zebra: type.");
 
             return new Zebra(className.Value!, type);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
@@ -220,7 +220,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (zeroBasedEnum.IsSet && zeroBasedEnum.Value == null)
-                throw new ArgumentNullException(nameof(zeroBasedEnum), "Property is not nullable for class ZeroBasedEnumClass.");
+                throw new JsonException("Property is not nullable for class ZeroBasedEnumClass: ZeroBasedEnum.");
 
             return new ZeroBasedEnumClass(zeroBasedEnum);
         }

--- a/samples/client/petstore/csharp/generichost/net9/OneOf/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net9/OneOf/src/Org.OpenAPITools/Model/Apple.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (kind.IsSet && kind.Value == null)
-                throw new ArgumentNullException(nameof(kind), "Property is not nullable for class Apple.");
+                throw new JsonException("Property is not nullable for class Apple: kind.");
 
             return new Apple(kind);
         }

--- a/samples/client/petstore/csharp/generichost/net9/OneOf/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net9/OneOf/src/Org.OpenAPITools/Model/Banana.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (count.IsSet && count.Value == null)
-                throw new ArgumentNullException(nameof(count), "Property is not nullable for class Banana.");
+                throw new JsonException("Property is not nullable for class Banana: count.");
 
             return new Banana(count);
         }

--- a/samples/client/petstore/csharp/generichost/net9/OneOf/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net9/OneOf/src/Org.OpenAPITools/Model/Fruit.cs
@@ -213,7 +213,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Fruit.");
+                throw new JsonException("Property is not nullable for class Fruit: color.");
 
             if (apple != null)
                 return new Fruit(apple, color);

--- a/samples/client/petstore/csharp/generichost/net9/OneOf/src/Org.OpenAPITools/Model/Orange.cs
+++ b/samples/client/petstore/csharp/generichost/net9/OneOf/src/Org.OpenAPITools/Model/Orange.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (sweet.IsSet && sweet.Value == null)
-                throw new ArgumentNullException(nameof(sweet), "Property is not nullable for class Orange.");
+                throw new JsonException("Property is not nullable for class Orange: sweet.");
 
             return new Orange(sweet);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Activity.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (activityOutputs.IsSet && activityOutputs.Value == null)
-                throw new ArgumentNullException(nameof(activityOutputs), "Property is not nullable for class Activity.");
+                throw new JsonException("Property is not nullable for class Activity: activity_outputs.");
 
             return new Activity(activityOutputs);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (prop1.IsSet && prop1.Value == null)
-                throw new ArgumentNullException(nameof(prop1), "Property is not nullable for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Property is not nullable for class ActivityOutputElementRepresentation: prop1.");
 
             if (prop2.IsSet && prop2.Value == null)
-                throw new ArgumentNullException(nameof(prop2), "Property is not nullable for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Property is not nullable for class ActivityOutputElementRepresentation: prop2.");
 
             return new ActivityOutputElementRepresentation(prop1, prop2);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -286,25 +286,25 @@ namespace Org.OpenAPITools.Model
             }
 
             if (emptyMap.IsSet && emptyMap.Value == null)
-                throw new ArgumentNullException(nameof(emptyMap), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: empty_map.");
 
             if (mapOfMapProperty.IsSet && mapOfMapProperty.Value == null)
-                throw new ArgumentNullException(nameof(mapOfMapProperty), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_of_map_property.");
 
             if (mapProperty.IsSet && mapProperty.Value == null)
-                throw new ArgumentNullException(nameof(mapProperty), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_property.");
 
             if (mapWithUndeclaredPropertiesAnytype1.IsSet && mapWithUndeclaredPropertiesAnytype1.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesAnytype1), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_anytype_1.");
 
             if (mapWithUndeclaredPropertiesAnytype2.IsSet && mapWithUndeclaredPropertiesAnytype2.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesAnytype2), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_anytype_2.");
 
             if (mapWithUndeclaredPropertiesAnytype3.IsSet && mapWithUndeclaredPropertiesAnytype3.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesAnytype3), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_anytype_3.");
 
             if (mapWithUndeclaredPropertiesString.IsSet && mapWithUndeclaredPropertiesString.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesString), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_string.");
 
             return new AdditionalPropertiesClass(anytype1, emptyMap, mapOfMapProperty, mapProperty, mapWithUndeclaredPropertiesAnytype1, mapWithUndeclaredPropertiesAnytype2, mapWithUndeclaredPropertiesAnytype3, mapWithUndeclaredPropertiesString);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Animal.cs
@@ -175,13 +175,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Animal.", nameof(className));
+                throw new JsonException("Property is required for class Animal: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Animal.");
+                throw new JsonException("Property is not nullable for class Animal: className.");
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Animal.");
+                throw new JsonException("Property is not nullable for class Animal: color.");
 
             return new Animal(color);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -185,13 +185,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (code.IsSet && code.Value == null)
-                throw new ArgumentNullException(nameof(code), "Property is not nullable for class ApiResponse.");
+                throw new JsonException("Property is not nullable for class ApiResponse: code.");
 
             if (message.IsSet && message.Value == null)
-                throw new ArgumentNullException(nameof(message), "Property is not nullable for class ApiResponse.");
+                throw new JsonException("Property is not nullable for class ApiResponse: message.");
 
             if (type.IsSet && type.Value == null)
-                throw new ArgumentNullException(nameof(type), "Property is not nullable for class ApiResponse.");
+                throw new JsonException("Property is not nullable for class ApiResponse: type.");
 
             return new ApiResponse(code, message, type);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Apple.cs
@@ -215,13 +215,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (colorCode.IsSet && colorCode.Value == null)
-                throw new ArgumentNullException(nameof(colorCode), "Property is not nullable for class Apple.");
+                throw new JsonException("Property is not nullable for class Apple: color_code.");
 
             if (cultivar.IsSet && cultivar.Value == null)
-                throw new ArgumentNullException(nameof(cultivar), "Property is not nullable for class Apple.");
+                throw new JsonException("Property is not nullable for class Apple: cultivar.");
 
             if (origin.IsSet && origin.Value == null)
-                throw new ArgumentNullException(nameof(origin), "Property is not nullable for class Apple.");
+                throw new JsonException("Property is not nullable for class Apple: origin.");
 
             return new Apple(colorCode, cultivar, origin);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -151,13 +151,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!cultivar.IsSet)
-                throw new ArgumentException("Property is required for class AppleReq.", nameof(cultivar));
+                throw new JsonException("Property is required for class AppleReq: cultivar.");
 
             if (cultivar.IsSet && cultivar.Value == null)
-                throw new ArgumentNullException(nameof(cultivar), "Property is not nullable for class AppleReq.");
+                throw new JsonException("Property is not nullable for class AppleReq: cultivar.");
 
             if (mealy.IsSet && mealy.Value == null)
-                throw new ArgumentNullException(nameof(mealy), "Property is not nullable for class AppleReq.");
+                throw new JsonException("Property is not nullable for class AppleReq: mealy.");
 
             return new AppleReq(cultivar.Value, mealy);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayArrayNumber.IsSet && arrayArrayNumber.Value == null)
-                throw new ArgumentNullException(nameof(arrayArrayNumber), "Property is not nullable for class ArrayOfArrayOfNumberOnly.");
+                throw new JsonException("Property is not nullable for class ArrayOfArrayOfNumberOnly: ArrayArrayNumber.");
 
             return new ArrayOfArrayOfNumberOnly(arrayArrayNumber);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayNumber.IsSet && arrayNumber.Value == null)
-                throw new ArgumentNullException(nameof(arrayNumber), "Property is not nullable for class ArrayOfNumberOnly.");
+                throw new JsonException("Property is not nullable for class ArrayOfNumberOnly: ArrayNumber.");
 
             return new ArrayOfNumberOnly(arrayNumber);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -185,13 +185,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayArrayOfInteger.IsSet && arrayArrayOfInteger.Value == null)
-                throw new ArgumentNullException(nameof(arrayArrayOfInteger), "Property is not nullable for class ArrayTest.");
+                throw new JsonException("Property is not nullable for class ArrayTest: array_array_of_integer.");
 
             if (arrayArrayOfModel.IsSet && arrayArrayOfModel.Value == null)
-                throw new ArgumentNullException(nameof(arrayArrayOfModel), "Property is not nullable for class ArrayTest.");
+                throw new JsonException("Property is not nullable for class ArrayTest: array_array_of_model.");
 
             if (arrayOfString.IsSet && arrayOfString.Value == null)
-                throw new ArgumentNullException(nameof(arrayOfString), "Property is not nullable for class ArrayTest.");
+                throw new JsonException("Property is not nullable for class ArrayTest: array_of_string.");
 
             return new ArrayTest(arrayArrayOfInteger, arrayArrayOfModel, arrayOfString);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Banana.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (lengthCm.IsSet && lengthCm.Value == null)
-                throw new ArgumentNullException(nameof(lengthCm), "Property is not nullable for class Banana.");
+                throw new JsonException("Property is not nullable for class Banana: lengthCm.");
 
             return new Banana(lengthCm);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -151,13 +151,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!lengthCm.IsSet)
-                throw new ArgumentException("Property is required for class BananaReq.", nameof(lengthCm));
+                throw new JsonException("Property is required for class BananaReq: lengthCm.");
 
             if (lengthCm.IsSet && lengthCm.Value == null)
-                throw new ArgumentNullException(nameof(lengthCm), "Property is not nullable for class BananaReq.");
+                throw new JsonException("Property is not nullable for class BananaReq: lengthCm.");
 
             if (sweet.IsSet && sweet.Value == null)
-                throw new ArgumentNullException(nameof(sweet), "Property is not nullable for class BananaReq.");
+                throw new JsonException("Property is not nullable for class BananaReq: sweet.");
 
             return new BananaReq(lengthCm.Value.Value, sweet);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/BasquePig.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/BasquePig.cs
@@ -138,10 +138,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class BasquePig.", nameof(className));
+                throw new JsonException("Property is required for class BasquePig: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class BasquePig.");
+                throw new JsonException("Property is not nullable for class BasquePig: className.");
 
             return new BasquePig(className.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -246,22 +246,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (aTTNAME.IsSet && aTTNAME.Value == null)
-                throw new ArgumentNullException(nameof(aTTNAME), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: ATT_NAME.");
 
             if (capitalCamel.IsSet && capitalCamel.Value == null)
-                throw new ArgumentNullException(nameof(capitalCamel), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: CapitalCamel.");
 
             if (capitalSnake.IsSet && capitalSnake.Value == null)
-                throw new ArgumentNullException(nameof(capitalSnake), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: Capital_Snake.");
 
             if (sCAETHFlowPoints.IsSet && sCAETHFlowPoints.Value == null)
-                throw new ArgumentNullException(nameof(sCAETHFlowPoints), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: SCA_ETH_Flow_Points.");
 
             if (smallCamel.IsSet && smallCamel.Value == null)
-                throw new ArgumentNullException(nameof(smallCamel), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: smallCamel.");
 
             if (smallSnake.IsSet && smallSnake.Value == null)
-                throw new ArgumentNullException(nameof(smallSnake), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: small_Snake.");
 
             return new Capitalization(aTTNAME, capitalCamel, capitalSnake, sCAETHFlowPoints, smallCamel, smallSnake);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Cat.cs
@@ -138,16 +138,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Cat.", nameof(className));
+                throw new JsonException("Property is required for class Cat: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Cat.");
+                throw new JsonException("Property is not nullable for class Cat: className.");
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Cat.");
+                throw new JsonException("Property is not nullable for class Cat: color.");
 
             if (declawed.IsSet && declawed.Value == null)
-                throw new ArgumentNullException(nameof(declawed), "Property is not nullable for class Cat.");
+                throw new JsonException("Property is not nullable for class Cat: declawed.");
 
             return new Cat(color, declawed);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Category.cs
@@ -158,13 +158,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!name.IsSet)
-                throw new ArgumentException("Property is required for class Category.", nameof(name));
+                throw new JsonException("Property is required for class Category: name.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Category.");
+                throw new JsonException("Property is not nullable for class Category: id.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Category.");
+                throw new JsonException("Property is not nullable for class Category: name.");
 
             return new Category(id, name.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -200,13 +200,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!petType.IsSet)
-                throw new ArgumentException("Property is required for class ChildCat.", nameof(petType));
+                throw new JsonException("Property is required for class ChildCat: pet_type.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class ChildCat.");
+                throw new JsonException("Property is not nullable for class ChildCat: name.");
 
             if (petType.IsSet && petType.Value == null)
-                throw new ArgumentNullException(nameof(petType), "Property is not nullable for class ChildCat.");
+                throw new JsonException("Property is not nullable for class ChildCat: pet_type.");
 
             return new ChildCat(name);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varClass.IsSet && varClass.Value == null)
-                throw new ArgumentNullException(nameof(varClass), "Property is not nullable for class ClassModel.");
+                throw new JsonException("Property is not nullable for class ClassModel: _class.");
 
             return new ClassModel(varClass);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
@@ -151,16 +151,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class ComplexQuadrilateral.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class ComplexQuadrilateral: quadrilateralType.");
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ComplexQuadrilateral.", nameof(shapeType));
+                throw new JsonException("Property is required for class ComplexQuadrilateral: shapeType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class ComplexQuadrilateral.");
+                throw new JsonException("Property is not nullable for class ComplexQuadrilateral: quadrilateralType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ComplexQuadrilateral.");
+                throw new JsonException("Property is not nullable for class ComplexQuadrilateral: shapeType.");
 
             return new ComplexQuadrilateral(quadrilateralType.Value, shapeType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/CopyActivity.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/CopyActivity.cs
@@ -193,16 +193,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!copyActivitytt.IsSet)
-                throw new ArgumentException("Property is required for class CopyActivity.", nameof(copyActivitytt));
+                throw new JsonException("Property is required for class CopyActivity: copyActivitytt.");
 
             if (!schema.IsSet)
-                throw new ArgumentException("Property is required for class CopyActivity.", nameof(schema));
+                throw new JsonException("Property is required for class CopyActivity: $schema.");
 
             if (copyActivitytt.IsSet && copyActivitytt.Value == null)
-                throw new ArgumentNullException(nameof(copyActivitytt), "Property is not nullable for class CopyActivity.");
+                throw new JsonException("Property is not nullable for class CopyActivity: copyActivitytt.");
 
             if (schema.IsSet && schema.Value == null)
-                throw new ArgumentNullException(nameof(schema), "Property is not nullable for class CopyActivity.");
+                throw new JsonException("Property is not nullable for class CopyActivity: $schema.");
 
             return new CopyActivity(copyActivitytt.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/DanishPig.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/DanishPig.cs
@@ -138,10 +138,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class DanishPig.", nameof(className));
+                throw new JsonException("Property is required for class DanishPig: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class DanishPig.");
+                throw new JsonException("Property is not nullable for class DanishPig: className.");
 
             return new DanishPig(className.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -151,7 +151,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (dateOnlyProperty.IsSet && dateOnlyProperty.Value == null)
-                throw new ArgumentNullException(nameof(dateOnlyProperty), "Property is not nullable for class DateOnlyClass.");
+                throw new JsonException("Property is not nullable for class DateOnlyClass: dateOnlyProperty.");
 
             return new DateOnlyClass(dateOnlyProperty);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class DeprecatedObject.");
+                throw new JsonException("Property is not nullable for class DeprecatedObject: name.");
 
             return new DeprecatedObject(name);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Descendant1.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Descendant1.cs
@@ -138,22 +138,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!alternativeName.IsSet)
-                throw new ArgumentException("Property is required for class Descendant1.", nameof(alternativeName));
+                throw new JsonException("Property is required for class Descendant1: alternativeName.");
 
             if (!descendantName.IsSet)
-                throw new ArgumentException("Property is required for class Descendant1.", nameof(descendantName));
+                throw new JsonException("Property is required for class Descendant1: descendantName.");
 
             if (!objectType.IsSet)
-                throw new ArgumentException("Property is required for class Descendant1.", nameof(objectType));
+                throw new JsonException("Property is required for class Descendant1: objectType.");
 
             if (alternativeName.IsSet && alternativeName.Value == null)
-                throw new ArgumentNullException(nameof(alternativeName), "Property is not nullable for class Descendant1.");
+                throw new JsonException("Property is not nullable for class Descendant1: alternativeName.");
 
             if (descendantName.IsSet && descendantName.Value == null)
-                throw new ArgumentNullException(nameof(descendantName), "Property is not nullable for class Descendant1.");
+                throw new JsonException("Property is not nullable for class Descendant1: descendantName.");
 
             if (objectType.IsSet && objectType.Value == null)
-                throw new ArgumentNullException(nameof(objectType), "Property is not nullable for class Descendant1.");
+                throw new JsonException("Property is not nullable for class Descendant1: objectType.");
 
             return new Descendant1(alternativeName.Value, descendantName.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Descendant2.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Descendant2.cs
@@ -138,22 +138,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!alternativeName.IsSet)
-                throw new ArgumentException("Property is required for class Descendant2.", nameof(alternativeName));
+                throw new JsonException("Property is required for class Descendant2: alternativeName.");
 
             if (!confidentiality.IsSet)
-                throw new ArgumentException("Property is required for class Descendant2.", nameof(confidentiality));
+                throw new JsonException("Property is required for class Descendant2: confidentiality.");
 
             if (!objectType.IsSet)
-                throw new ArgumentException("Property is required for class Descendant2.", nameof(objectType));
+                throw new JsonException("Property is required for class Descendant2: objectType.");
 
             if (alternativeName.IsSet && alternativeName.Value == null)
-                throw new ArgumentNullException(nameof(alternativeName), "Property is not nullable for class Descendant2.");
+                throw new JsonException("Property is not nullable for class Descendant2: alternativeName.");
 
             if (confidentiality.IsSet && confidentiality.Value == null)
-                throw new ArgumentNullException(nameof(confidentiality), "Property is not nullable for class Descendant2.");
+                throw new JsonException("Property is not nullable for class Descendant2: confidentiality.");
 
             if (objectType.IsSet && objectType.Value == null)
-                throw new ArgumentNullException(nameof(objectType), "Property is not nullable for class Descendant2.");
+                throw new JsonException("Property is not nullable for class Descendant2: objectType.");
 
             return new Descendant2(alternativeName.Value, confidentiality.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Dog.cs
@@ -138,16 +138,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Dog.", nameof(className));
+                throw new JsonException("Property is required for class Dog: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Dog.");
+                throw new JsonException("Property is not nullable for class Dog: className.");
 
             if (breed.IsSet && breed.Value == null)
-                throw new ArgumentNullException(nameof(breed), "Property is not nullable for class Dog.");
+                throw new JsonException("Property is not nullable for class Dog: breed.");
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Dog.");
+                throw new JsonException("Property is not nullable for class Dog: color.");
 
             return new Dog(breed, color);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Drawing.cs
@@ -205,10 +205,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (mainShape.IsSet && mainShape.Value == null)
-                throw new ArgumentNullException(nameof(mainShape), "Property is not nullable for class Drawing.");
+                throw new JsonException("Property is not nullable for class Drawing: mainShape.");
 
             if (shapes.IsSet && shapes.Value == null)
-                throw new ArgumentNullException(nameof(shapes), "Property is not nullable for class Drawing.");
+                throw new JsonException("Property is not nullable for class Drawing: shapes.");
 
             return new Drawing(mainShape, nullableShape, shapeOrNull, shapes);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/EntityBase.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/EntityBase.cs
@@ -152,10 +152,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!schema.IsSet)
-                throw new ArgumentException("Property is required for class EntityBase.", nameof(schema));
+                throw new JsonException("Property is required for class EntityBase: $schema.");
 
             if (schema.IsSet && schema.Value == null)
-                throw new ArgumentNullException(nameof(schema), "Property is not nullable for class EntityBase.");
+                throw new JsonException("Property is not nullable for class EntityBase: $schema.");
 
             return new EntityBase();
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -304,10 +304,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayEnum.IsSet && arrayEnum.Value == null)
-                throw new ArgumentNullException(nameof(arrayEnum), "Property is not nullable for class EnumArrays.");
+                throw new JsonException("Property is not nullable for class EnumArrays: array_enum.");
 
             if (justSymbol.IsSet && justSymbol.Value == null)
-                throw new ArgumentNullException(nameof(justSymbol), "Property is not nullable for class EnumArrays.");
+                throw new JsonException("Property is not nullable for class EnumArrays: just_symbol.");
 
             return new EnumArrays(arrayEnum, justSymbol);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -822,31 +822,31 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!enumStringRequired.IsSet)
-                throw new ArgumentException("Property is required for class EnumTest.", nameof(enumStringRequired));
+                throw new JsonException("Property is required for class EnumTest: enum_string_required.");
 
             if (enumStringRequired.IsSet && enumStringRequired.Value == null)
-                throw new ArgumentNullException(nameof(enumStringRequired), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_string_required.");
 
             if (enumInteger.IsSet && enumInteger.Value == null)
-                throw new ArgumentNullException(nameof(enumInteger), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_integer.");
 
             if (enumIntegerOnly.IsSet && enumIntegerOnly.Value == null)
-                throw new ArgumentNullException(nameof(enumIntegerOnly), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_integer_only.");
 
             if (enumNumber.IsSet && enumNumber.Value == null)
-                throw new ArgumentNullException(nameof(enumNumber), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_number.");
 
             if (enumString.IsSet && enumString.Value == null)
-                throw new ArgumentNullException(nameof(enumString), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_string.");
 
             if (outerEnumDefaultValue.IsSet && outerEnumDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(outerEnumDefaultValue), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: outerEnumDefaultValue.");
 
             if (outerEnumInteger.IsSet && outerEnumInteger.Value == null)
-                throw new ArgumentNullException(nameof(outerEnumInteger), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: outerEnumInteger.");
 
             if (outerEnumIntegerDefaultValue.IsSet && outerEnumIntegerDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(outerEnumIntegerDefaultValue), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: outerEnumIntegerDefaultValue.");
 
             return new EnumTest(enumStringRequired.Value.Value, enumInteger, enumIntegerOnly, enumNumber, enumString, outerEnum, outerEnumDefaultValue, outerEnumInteger, outerEnumIntegerDefaultValue);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
@@ -151,16 +151,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class EquilateralTriangle.", nameof(shapeType));
+                throw new JsonException("Property is required for class EquilateralTriangle: shapeType.");
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class EquilateralTriangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class EquilateralTriangle: triangleType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class EquilateralTriangle.");
+                throw new JsonException("Property is not nullable for class EquilateralTriangle: shapeType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class EquilateralTriangle.");
+                throw new JsonException("Property is not nullable for class EquilateralTriangle: triangleType.");
 
             return new EquilateralTriangle(shapeType.Value, triangleType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/File.cs
@@ -146,7 +146,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (sourceURI.IsSet && sourceURI.Value == null)
-                throw new ArgumentNullException(nameof(sourceURI), "Property is not nullable for class File.");
+                throw new JsonException("Property is not nullable for class File: sourceURI.");
 
             return new File(sourceURI);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (file.IsSet && file.Value == null)
-                throw new ArgumentNullException(nameof(file), "Property is not nullable for class FileSchemaTestClass.");
+                throw new JsonException("Property is not nullable for class FileSchemaTestClass: file.");
 
             if (files.IsSet && files.Value == null)
-                throw new ArgumentNullException(nameof(files), "Property is not nullable for class FileSchemaTestClass.");
+                throw new JsonException("Property is not nullable for class FileSchemaTestClass: files.");
 
             return new FileSchemaTestClass(file, files);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Foo.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bar.IsSet && bar.Value == null)
-                throw new ArgumentNullException(nameof(bar), "Property is not nullable for class Foo.");
+                throw new JsonException("Property is not nullable for class Foo: bar.");
 
             return new Foo(bar);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varString.IsSet && varString.Value == null)
-                throw new ArgumentNullException(nameof(varString), "Property is not nullable for class FooGetDefaultResponse.");
+                throw new JsonException("Property is not nullable for class FooGetDefaultResponse: string.");
 
             return new FooGetDefaultResponse(varString);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -826,103 +826,103 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!varByte.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(varByte));
+                throw new JsonException("Property is required for class FormatTest: byte.");
 
             if (!date.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(date));
+                throw new JsonException("Property is required for class FormatTest: date.");
 
             if (!number.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(number));
+                throw new JsonException("Property is required for class FormatTest: number.");
 
             if (!password.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(password));
+                throw new JsonException("Property is required for class FormatTest: password.");
 
             if (!stringFormattedAsDecimalRequired.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(stringFormattedAsDecimalRequired));
+                throw new JsonException("Property is required for class FormatTest: string_formatted_as_decimal_required.");
 
             if (varByte.IsSet && varByte.Value == null)
-                throw new ArgumentNullException(nameof(varByte), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: byte.");
 
             if (date.IsSet && date.Value == null)
-                throw new ArgumentNullException(nameof(date), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: date.");
 
             if (number.IsSet && number.Value == null)
-                throw new ArgumentNullException(nameof(number), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: number.");
 
             if (password.IsSet && password.Value == null)
-                throw new ArgumentNullException(nameof(password), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: password.");
 
             if (stringFormattedAsDecimalRequired.IsSet && stringFormattedAsDecimalRequired.Value == null)
-                throw new ArgumentNullException(nameof(stringFormattedAsDecimalRequired), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: string_formatted_as_decimal_required.");
 
             if (binary.IsSet && binary.Value == null)
-                throw new ArgumentNullException(nameof(binary), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: binary.");
 
             if (dateTime.IsSet && dateTime.Value == null)
-                throw new ArgumentNullException(nameof(dateTime), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: dateTime.");
 
             if (varDecimal.IsSet && varDecimal.Value == null)
-                throw new ArgumentNullException(nameof(varDecimal), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: decimal.");
 
             if (varDouble.IsSet && varDouble.Value == null)
-                throw new ArgumentNullException(nameof(varDouble), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: double.");
 
             if (duplicatePropertyName2.IsSet && duplicatePropertyName2.Value == null)
-                throw new ArgumentNullException(nameof(duplicatePropertyName2), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: duplicate_property_name.");
 
             if (duplicatePropertyName.IsSet && duplicatePropertyName.Value == null)
-                throw new ArgumentNullException(nameof(duplicatePropertyName), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: @duplicate_property_name.");
 
             if (varFloat.IsSet && varFloat.Value == null)
-                throw new ArgumentNullException(nameof(varFloat), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: float.");
 
             if (int32.IsSet && int32.Value == null)
-                throw new ArgumentNullException(nameof(int32), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int32.");
 
             if (int32Range.IsSet && int32Range.Value == null)
-                throw new ArgumentNullException(nameof(int32Range), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int32Range.");
 
             if (int64.IsSet && int64.Value == null)
-                throw new ArgumentNullException(nameof(int64), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64.");
 
             if (int64Negative.IsSet && int64Negative.Value == null)
-                throw new ArgumentNullException(nameof(int64Negative), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64Negative.");
 
             if (int64NegativeExclusive.IsSet && int64NegativeExclusive.Value == null)
-                throw new ArgumentNullException(nameof(int64NegativeExclusive), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64NegativeExclusive.");
 
             if (int64Positive.IsSet && int64Positive.Value == null)
-                throw new ArgumentNullException(nameof(int64Positive), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64Positive.");
 
             if (int64PositiveExclusive.IsSet && int64PositiveExclusive.Value == null)
-                throw new ArgumentNullException(nameof(int64PositiveExclusive), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64PositiveExclusive.");
 
             if (integer.IsSet && integer.Value == null)
-                throw new ArgumentNullException(nameof(integer), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: integer.");
 
             if (patternWithBackslash.IsSet && patternWithBackslash.Value == null)
-                throw new ArgumentNullException(nameof(patternWithBackslash), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: pattern_with_backslash.");
 
             if (patternWithDigits.IsSet && patternWithDigits.Value == null)
-                throw new ArgumentNullException(nameof(patternWithDigits), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: pattern_with_digits.");
 
             if (patternWithDigitsAndDelimiter.IsSet && patternWithDigitsAndDelimiter.Value == null)
-                throw new ArgumentNullException(nameof(patternWithDigitsAndDelimiter), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: pattern_with_digits_and_delimiter.");
 
             if (varString.IsSet && varString.Value == null)
-                throw new ArgumentNullException(nameof(varString), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: string.");
 
             if (stringFormattedAsDecimal.IsSet && stringFormattedAsDecimal.Value == null)
-                throw new ArgumentNullException(nameof(stringFormattedAsDecimal), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: string_formatted_as_decimal.");
 
             if (unsignedInteger.IsSet && unsignedInteger.Value == null)
-                throw new ArgumentNullException(nameof(unsignedInteger), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: unsigned_integer.");
 
             if (unsignedLong.IsSet && unsignedLong.Value == null)
-                throw new ArgumentNullException(nameof(unsignedLong), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: unsigned_long.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: uuid.");
 
             return new FormatTest(varByte.Value, date.Value.Value, number.Value.Value, password.Value, stringFormattedAsDecimalRequired.Value.Value, binary, dateTime, varDecimal, varDouble, duplicatePropertyName2, duplicatePropertyName, varFloat, int32, int32Range, int64, int64Negative, int64NegativeExclusive, int64Positive, int64PositiveExclusive, integer, patternWithBackslash, patternWithDigits, patternWithDigitsAndDelimiter, varString, stringFormattedAsDecimal, unsignedInteger, unsignedLong, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
@@ -183,7 +183,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Fruit.");
+                throw new JsonException("Property is not nullable for class Fruit: color.");
 
             if (apple != null)
                 return new Fruit(apple, color);

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -187,7 +187,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class GmFruit.");
+                throw new JsonException("Property is not nullable for class GmFruit: color.");
 
             Option<Apple> appleParsedValue = apple == null
                 ? default

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
@@ -155,10 +155,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!petType.IsSet)
-                throw new ArgumentException("Property is required for class GrandparentAnimal.", nameof(petType));
+                throw new JsonException("Property is required for class GrandparentAnimal: pet_type.");
 
             if (petType.IsSet && petType.Value == null)
-                throw new ArgumentNullException(nameof(petType), "Property is not nullable for class GrandparentAnimal.");
+                throw new JsonException("Property is not nullable for class GrandparentAnimal: pet_type.");
 
             return new GrandparentAnimal();
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -206,10 +206,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bar.IsSet && bar.Value == null)
-                throw new ArgumentNullException(nameof(bar), "Property is not nullable for class HasOnlyReadOnly.");
+                throw new JsonException("Property is not nullable for class HasOnlyReadOnly: bar.");
 
             if (foo.IsSet && foo.Value == null)
-                throw new ArgumentNullException(nameof(foo), "Property is not nullable for class HasOnlyReadOnly.");
+                throw new JsonException("Property is not nullable for class HasOnlyReadOnly: foo.");
 
             return new HasOnlyReadOnly(bar, foo);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
@@ -292,22 +292,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (potentiallyOverriddenPropertyAccessor.IsSet && potentiallyOverriddenPropertyAccessor.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyAccessor), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyAccessor.");
 
             if (potentiallyOverriddenPropertyToInternal.IsSet && potentiallyOverriddenPropertyToInternal.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyToInternal), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyToInternal.");
 
             if (potentiallyOverriddenPropertyToPrivate.IsSet && potentiallyOverriddenPropertyToPrivate.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyToPrivate), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyToPrivate.");
 
             if (potentiallyOverriddenPropertyToPublic.IsSet && potentiallyOverriddenPropertyToPublic.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyToPublic), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyToPublic.");
 
             if (unalteredProperty.IsSet && unalteredProperty.Value == null)
-                throw new ArgumentNullException(nameof(unalteredProperty), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: unalteredProperty.");
 
             if (unalteredPropertyAccessor.IsSet && unalteredPropertyAccessor.Value == null)
-                throw new ArgumentNullException(nameof(unalteredPropertyAccessor), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: unalteredPropertyAccessor.");
 
             return new InjectedVendorExtensionsTest(potentiallyOverriddenPropertyAccessor, potentiallyOverriddenPropertyToInternal, potentiallyOverriddenPropertyToPrivate, potentiallyOverriddenPropertyToPublic, unalteredProperty, unalteredPropertyAccessor);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
@@ -144,16 +144,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class IsoscelesTriangle.", nameof(shapeType));
+                throw new JsonException("Property is required for class IsoscelesTriangle: shapeType.");
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class IsoscelesTriangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class IsoscelesTriangle: triangleType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class IsoscelesTriangle.");
+                throw new JsonException("Property is not nullable for class IsoscelesTriangle: shapeType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class IsoscelesTriangle.");
+                throw new JsonException("Property is not nullable for class IsoscelesTriangle: triangleType.");
 
             return new IsoscelesTriangle(shapeType.Value, triangleType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/List.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (var123List.IsSet && var123List.Value == null)
-                throw new ArgumentNullException(nameof(var123List), "Property is not nullable for class List.");
+                throw new JsonException("Property is not nullable for class List: 123-list.");
 
             return new List(var123List);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (escapedLiteralString.IsSet && escapedLiteralString.Value == null)
-                throw new ArgumentNullException(nameof(escapedLiteralString), "Property is not nullable for class LiteralStringClass.");
+                throw new JsonException("Property is not nullable for class LiteralStringClass: escapedLiteralString.");
 
             if (unescapedLiteralString.IsSet && unescapedLiteralString.Value == null)
-                throw new ArgumentNullException(nameof(unescapedLiteralString), "Property is not nullable for class LiteralStringClass.");
+                throw new JsonException("Property is not nullable for class LiteralStringClass: unescapedLiteralString.");
 
             return new LiteralStringClass(escapedLiteralString, unescapedLiteralString);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Mammal.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Mammal.cs
@@ -214,10 +214,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Mammal.", nameof(className));
+                throw new JsonException("Property is required for class Mammal: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Mammal.");
+                throw new JsonException("Property is not nullable for class Mammal: className.");
 
             if (pig != null)
                 return new Mammal(pig);

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/MapTest.cs
@@ -271,16 +271,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (directMap.IsSet && directMap.Value == null)
-                throw new ArgumentNullException(nameof(directMap), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: direct_map.");
 
             if (indirectMap.IsSet && indirectMap.Value == null)
-                throw new ArgumentNullException(nameof(indirectMap), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: indirect_map.");
 
             if (mapMapOfString.IsSet && mapMapOfString.Value == null)
-                throw new ArgumentNullException(nameof(mapMapOfString), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: map_map_of_string.");
 
             if (mapOfEnumString.IsSet && mapOfEnumString.Value == null)
-                throw new ArgumentNullException(nameof(mapOfEnumString), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: map_of_enum_string.");
 
             return new MapTest(directMap, indirectMap, mapMapOfString, mapOfEnumString);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/MixedAnyOf.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/MixedAnyOf.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (content.IsSet && content.Value == null)
-                throw new ArgumentNullException(nameof(content), "Property is not nullable for class MixedAnyOf.");
+                throw new JsonException("Property is not nullable for class MixedAnyOf: content.");
 
             return new MixedAnyOf(content);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/MixedOneOf.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/MixedOneOf.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (content.IsSet && content.Value == null)
-                throw new ArgumentNullException(nameof(content), "Property is not nullable for class MixedOneOf.");
+                throw new JsonException("Property is not nullable for class MixedOneOf: content.");
 
             return new MixedOneOf(content);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -217,16 +217,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (dateTime.IsSet && dateTime.Value == null)
-                throw new ArgumentNullException(nameof(dateTime), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: dateTime.");
 
             if (map.IsSet && map.Value == null)
-                throw new ArgumentNullException(nameof(map), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: map.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: uuid.");
 
             if (uuidWithPattern.IsSet && uuidWithPattern.Value == null)
-                throw new ArgumentNullException(nameof(uuidWithPattern), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: uuid_with_pattern.");
 
             return new MixedPropertiesAndAdditionalPropertiesClass(dateTime, map, uuid, uuidWithPattern);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/MixedSubId.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/MixedSubId.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class MixedSubId.");
+                throw new JsonException("Property is not nullable for class MixedSubId: id.");
 
             return new MixedSubId(id);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varClass.IsSet && varClass.Value == null)
-                throw new ArgumentNullException(nameof(varClass), "Property is not nullable for class Model200Response.");
+                throw new JsonException("Property is not nullable for class Model200Response: class.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Model200Response.");
+                throw new JsonException("Property is not nullable for class Model200Response: name.");
 
             return new Model200Response(varClass, name);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varClient.IsSet && varClient.Value == null)
-                throw new ArgumentNullException(nameof(varClient), "Property is not nullable for class ModelClient.");
+                throw new JsonException("Property is not nullable for class ModelClient: client.");
 
             return new ModelClient(varClient);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Name.cs
@@ -239,19 +239,19 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!varName.IsSet)
-                throw new ArgumentException("Property is required for class Name.", nameof(varName));
+                throw new JsonException("Property is required for class Name: name.");
 
             if (varName.IsSet && varName.Value == null)
-                throw new ArgumentNullException(nameof(varName), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: name.");
 
             if (property.IsSet && property.Value == null)
-                throw new ArgumentNullException(nameof(property), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: property.");
 
             if (snakeCase.IsSet && snakeCase.Value == null)
-                throw new ArgumentNullException(nameof(snakeCase), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: snake_case.");
 
             if (var123Number.IsSet && var123Number.Value == null)
-                throw new ArgumentNullException(nameof(var123Number), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: 123Number.");
 
             return new Name(varName.Value.Value, property, snakeCase, var123Number);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
@@ -151,16 +151,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!aObjVariableobject.IsSet)
-                throw new ArgumentException("Property is required for class NotificationtestGetElementsV1ResponseMPayload.", nameof(aObjVariableobject));
+                throw new JsonException("Property is required for class NotificationtestGetElementsV1ResponseMPayload: a_objVariableobject.");
 
             if (!pkiNotificationtestID.IsSet)
-                throw new ArgumentException("Property is required for class NotificationtestGetElementsV1ResponseMPayload.", nameof(pkiNotificationtestID));
+                throw new JsonException("Property is required for class NotificationtestGetElementsV1ResponseMPayload: pkiNotificationtestID.");
 
             if (aObjVariableobject.IsSet && aObjVariableobject.Value == null)
-                throw new ArgumentNullException(nameof(aObjVariableobject), "Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload.");
+                throw new JsonException("Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload: a_objVariableobject.");
 
             if (pkiNotificationtestID.IsSet && pkiNotificationtestID.Value == null)
-                throw new ArgumentNullException(nameof(pkiNotificationtestID), "Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload.");
+                throw new JsonException("Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload: pkiNotificationtestID.");
 
             return new NotificationtestGetElementsV1ResponseMPayload(aObjVariableobject.Value, pkiNotificationtestID.Value.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -375,10 +375,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayItemsNullable.IsSet && arrayItemsNullable.Value == null)
-                throw new ArgumentNullException(nameof(arrayItemsNullable), "Property is not nullable for class NullableClass.");
+                throw new JsonException("Property is not nullable for class NullableClass: array_items_nullable.");
 
             if (objectItemsNullable.IsSet && objectItemsNullable.Value == null)
-                throw new ArgumentNullException(nameof(objectItemsNullable), "Property is not nullable for class NullableClass.");
+                throw new JsonException("Property is not nullable for class NullableClass: object_items_nullable.");
 
             return new NullableClass(arrayAndItemsNullableProp, arrayItemsNullable, arrayNullableProp, booleanProp, dateProp, datetimeProp, integerProp, numberProp, objectAndItemsNullableProp, objectItemsNullable, objectNullableProp, stringProp);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/NullableShape.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/NullableShape.cs
@@ -193,10 +193,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class NullableShape.", nameof(shapeType));
+                throw new JsonException("Property is required for class NullableShape: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class NullableShape.");
+                throw new JsonException("Property is not nullable for class NullableShape: shapeType.");
 
             if (quadrilateral != null)
                 return new NullableShape(quadrilateral);

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (justNumber.IsSet && justNumber.Value == null)
-                throw new ArgumentNullException(nameof(justNumber), "Property is not nullable for class NumberOnly.");
+                throw new JsonException("Property is not nullable for class NumberOnly: JustNumber.");
 
             return new NumberOnly(justNumber);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -208,16 +208,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bars.IsSet && bars.Value == null)
-                throw new ArgumentNullException(nameof(bars), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: bars.");
 
             if (deprecatedRef.IsSet && deprecatedRef.Value == null)
-                throw new ArgumentNullException(nameof(deprecatedRef), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: deprecatedRef.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: id.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: uuid.");
 
             return new ObjectWithDeprecatedFields(bars, deprecatedRef, id, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Order.cs
@@ -340,22 +340,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (complete.IsSet && complete.Value == null)
-                throw new ArgumentNullException(nameof(complete), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: complete.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: id.");
 
             if (petId.IsSet && petId.Value == null)
-                throw new ArgumentNullException(nameof(petId), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: petId.");
 
             if (quantity.IsSet && quantity.Value == null)
-                throw new ArgumentNullException(nameof(quantity), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: quantity.");
 
             if (shipDate.IsSet && shipDate.Value == null)
-                throw new ArgumentNullException(nameof(shipDate), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: shipDate.");
 
             if (status.IsSet && status.Value == null)
-                throw new ArgumentNullException(nameof(status), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: status.");
 
             return new Order(complete, id, petId, quantity, shipDate, status);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -185,13 +185,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (myBoolean.IsSet && myBoolean.Value == null)
-                throw new ArgumentNullException(nameof(myBoolean), "Property is not nullable for class OuterComposite.");
+                throw new JsonException("Property is not nullable for class OuterComposite: my_boolean.");
 
             if (myNumber.IsSet && myNumber.Value == null)
-                throw new ArgumentNullException(nameof(myNumber), "Property is not nullable for class OuterComposite.");
+                throw new JsonException("Property is not nullable for class OuterComposite: my_number.");
 
             if (myString.IsSet && myString.Value == null)
-                throw new ArgumentNullException(nameof(myString), "Property is not nullable for class OuterComposite.");
+                throw new JsonException("Property is not nullable for class OuterComposite: my_string.");
 
             return new OuterComposite(myBoolean, myNumber, myString);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ParentPet.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ParentPet.cs
@@ -118,10 +118,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!petType.IsSet)
-                throw new ArgumentException("Property is required for class ParentPet.", nameof(petType));
+                throw new JsonException("Property is required for class ParentPet: pet_type.");
 
             if (petType.IsSet && petType.Value == null)
-                throw new ArgumentNullException(nameof(petType), "Property is not nullable for class ParentPet.");
+                throw new JsonException("Property is not nullable for class ParentPet: pet_type.");
 
             return new ParentPet();
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Pet.cs
@@ -321,28 +321,28 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!name.IsSet)
-                throw new ArgumentException("Property is required for class Pet.", nameof(name));
+                throw new JsonException("Property is required for class Pet: name.");
 
             if (!photoUrls.IsSet)
-                throw new ArgumentException("Property is required for class Pet.", nameof(photoUrls));
+                throw new JsonException("Property is required for class Pet: photoUrls.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: name.");
 
             if (photoUrls.IsSet && photoUrls.Value == null)
-                throw new ArgumentNullException(nameof(photoUrls), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: photoUrls.");
 
             if (category.IsSet && category.Value == null)
-                throw new ArgumentNullException(nameof(category), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: category.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: id.");
 
             if (status.IsSet && status.Value == null)
-                throw new ArgumentNullException(nameof(status), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: status.");
 
             if (tags.IsSet && tags.Value == null)
-                throw new ArgumentNullException(nameof(tags), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: tags.");
 
             return new Pet(name.Value, photoUrls.Value, category, id, status, tags);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Pig.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Pig.cs
@@ -193,10 +193,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Pig.", nameof(className));
+                throw new JsonException("Property is required for class Pig: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Pig.");
+                throw new JsonException("Property is not nullable for class Pig: className.");
 
             if (basquePig != null)
                 return new Pig(basquePig);

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Quadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Quadrilateral.cs
@@ -193,10 +193,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class Quadrilateral.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class Quadrilateral: quadrilateralType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class Quadrilateral.");
+                throw new JsonException("Property is not nullable for class Quadrilateral: quadrilateralType.");
 
             if (complexQuadrilateral != null)
                 return new Quadrilateral(complexQuadrilateral);

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
@@ -138,10 +138,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class QuadrilateralInterface.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class QuadrilateralInterface: quadrilateralType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class QuadrilateralInterface.");
+                throw new JsonException("Property is not nullable for class QuadrilateralInterface: quadrilateralType.");
 
             return new QuadrilateralInterface(quadrilateralType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -203,10 +203,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bar.IsSet && bar.Value == null)
-                throw new ArgumentNullException(nameof(bar), "Property is not nullable for class ReadOnlyFirst.");
+                throw new JsonException("Property is not nullable for class ReadOnlyFirst: bar.");
 
             if (baz.IsSet && baz.Value == null)
-                throw new ArgumentNullException(nameof(baz), "Property is not nullable for class ReadOnlyFirst.");
+                throw new JsonException("Property is not nullable for class ReadOnlyFirst: baz.");
 
             return new ReadOnlyFirst(bar, baz);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -2077,136 +2077,136 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!requiredNotNullableDateProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotNullableDateProp));
+                throw new JsonException("Property is required for class RequiredClass: required_not_nullable_date_prop.");
 
             if (!requiredNotnullableArrayOfString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableArrayOfString));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_array_of_string.");
 
             if (!requiredNotnullableBooleanProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableBooleanProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_boolean_prop.");
 
             if (!requiredNotnullableDatetimeProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableDatetimeProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_datetime_prop.");
 
             if (!requiredNotnullableEnumInteger.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableEnumInteger));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_enum_integer.");
 
             if (!requiredNotnullableEnumIntegerOnly.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableEnumIntegerOnly));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_enum_integer_only.");
 
             if (!requiredNotnullableEnumString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableEnumString));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_enum_string.");
 
             if (!requiredNotnullableOuterEnumDefaultValue.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableOuterEnumDefaultValue));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_outerEnumDefaultValue.");
 
             if (!requiredNotnullableStringProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableStringProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_string_prop.");
 
             if (!requiredNotnullableUuid.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableUuid));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_uuid.");
 
             if (!requiredNotnullableintegerProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableintegerProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullableinteger_prop.");
 
             if (!requiredNullableArrayOfString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableArrayOfString));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_array_of_string.");
 
             if (!requiredNullableBooleanProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableBooleanProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_boolean_prop.");
 
             if (!requiredNullableDateProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableDateProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_date_prop.");
 
             if (!requiredNullableDatetimeProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableDatetimeProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_datetime_prop.");
 
             if (!requiredNullableEnumInteger.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableEnumInteger));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_enum_integer.");
 
             if (!requiredNullableEnumIntegerOnly.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableEnumIntegerOnly));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_enum_integer_only.");
 
             if (!requiredNullableEnumString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableEnumString));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_enum_string.");
 
             if (!requiredNullableIntegerProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableIntegerProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_integer_prop.");
 
             if (!requiredNullableOuterEnumDefaultValue.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableOuterEnumDefaultValue));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_outerEnumDefaultValue.");
 
             if (!requiredNullableStringProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableStringProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_string_prop.");
 
             if (!requiredNullableUuid.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableUuid));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_uuid.");
 
             if (requiredNotNullableDateProp.IsSet && requiredNotNullableDateProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotNullableDateProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_not_nullable_date_prop.");
 
             if (requiredNotnullableArrayOfString.IsSet && requiredNotnullableArrayOfString.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableArrayOfString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_array_of_string.");
 
             if (requiredNotnullableBooleanProp.IsSet && requiredNotnullableBooleanProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableBooleanProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_boolean_prop.");
 
             if (requiredNotnullableDatetimeProp.IsSet && requiredNotnullableDatetimeProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableDatetimeProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_datetime_prop.");
 
             if (requiredNotnullableEnumInteger.IsSet && requiredNotnullableEnumInteger.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableEnumInteger), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_enum_integer.");
 
             if (requiredNotnullableEnumIntegerOnly.IsSet && requiredNotnullableEnumIntegerOnly.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableEnumIntegerOnly), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_enum_integer_only.");
 
             if (requiredNotnullableEnumString.IsSet && requiredNotnullableEnumString.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableEnumString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_enum_string.");
 
             if (requiredNotnullableOuterEnumDefaultValue.IsSet && requiredNotnullableOuterEnumDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableOuterEnumDefaultValue), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_outerEnumDefaultValue.");
 
             if (requiredNotnullableStringProp.IsSet && requiredNotnullableStringProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableStringProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_string_prop.");
 
             if (requiredNotnullableUuid.IsSet && requiredNotnullableUuid.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableUuid), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_uuid.");
 
             if (requiredNotnullableintegerProp.IsSet && requiredNotnullableintegerProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableintegerProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullableinteger_prop.");
 
             if (notRequiredNotnullableDateProp.IsSet && notRequiredNotnullableDateProp.Value == null)
-                throw new ArgumentNullException(nameof(notRequiredNotnullableDateProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: not_required_notnullable_date_prop.");
 
             if (notRequiredNotnullableintegerProp.IsSet && notRequiredNotnullableintegerProp.Value == null)
-                throw new ArgumentNullException(nameof(notRequiredNotnullableintegerProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: not_required_notnullableinteger_prop.");
 
             if (notrequiredNotnullableArrayOfString.IsSet && notrequiredNotnullableArrayOfString.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableArrayOfString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_array_of_string.");
 
             if (notrequiredNotnullableBooleanProp.IsSet && notrequiredNotnullableBooleanProp.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableBooleanProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_boolean_prop.");
 
             if (notrequiredNotnullableDatetimeProp.IsSet && notrequiredNotnullableDatetimeProp.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableDatetimeProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_datetime_prop.");
 
             if (notrequiredNotnullableEnumInteger.IsSet && notrequiredNotnullableEnumInteger.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableEnumInteger), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_enum_integer.");
 
             if (notrequiredNotnullableEnumIntegerOnly.IsSet && notrequiredNotnullableEnumIntegerOnly.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableEnumIntegerOnly), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_enum_integer_only.");
 
             if (notrequiredNotnullableEnumString.IsSet && notrequiredNotnullableEnumString.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableEnumString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_enum_string.");
 
             if (notrequiredNotnullableOuterEnumDefaultValue.IsSet && notrequiredNotnullableOuterEnumDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableOuterEnumDefaultValue), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_outerEnumDefaultValue.");
 
             if (notrequiredNotnullableStringProp.IsSet && notrequiredNotnullableStringProp.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableStringProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_string_prop.");
 
             if (notrequiredNotnullableUuid.IsSet && notrequiredNotnullableUuid.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableUuid), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_uuid.");
 
             return new RequiredClass(requiredNotNullableDateProp.Value.Value, requiredNotnullableArrayOfString.Value, requiredNotnullableBooleanProp.Value.Value, requiredNotnullableDatetimeProp.Value.Value, requiredNotnullableEnumInteger.Value.Value, requiredNotnullableEnumIntegerOnly.Value.Value, requiredNotnullableEnumString.Value.Value, requiredNotnullableOuterEnumDefaultValue.Value.Value, requiredNotnullableStringProp.Value, requiredNotnullableUuid.Value.Value, requiredNotnullableintegerProp.Value.Value, notRequiredNotnullableDateProp, notRequiredNotnullableintegerProp, notRequiredNullableDateProp, notRequiredNullableIntegerProp, notrequiredNotnullableArrayOfString, notrequiredNotnullableBooleanProp, notrequiredNotnullableDatetimeProp, notrequiredNotnullableEnumInteger, notrequiredNotnullableEnumIntegerOnly, notrequiredNotnullableEnumString, notrequiredNotnullableOuterEnumDefaultValue, notrequiredNotnullableStringProp, notrequiredNotnullableUuid, notrequiredNullableArrayOfString, notrequiredNullableBooleanProp, notrequiredNullableDatetimeProp, notrequiredNullableEnumInteger, notrequiredNullableEnumIntegerOnly, notrequiredNullableEnumString, notrequiredNullableOuterEnumDefaultValue, notrequiredNullableStringProp, notrequiredNullableUuid, requiredNullableArrayOfString.Value, requiredNullableBooleanProp.Value, requiredNullableDateProp.Value, requiredNullableDatetimeProp.Value, requiredNullableEnumInteger.Value, requiredNullableEnumIntegerOnly.Value, requiredNullableEnumString.Value, requiredNullableIntegerProp.Value, requiredNullableOuterEnumDefaultValue.Value, requiredNullableStringProp.Value, requiredNullableUuid.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Result.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Result.cs
@@ -188,13 +188,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (code.IsSet && code.Value == null)
-                throw new ArgumentNullException(nameof(code), "Property is not nullable for class Result.");
+                throw new JsonException("Property is not nullable for class Result: code.");
 
             if (data.IsSet && data.Value == null)
-                throw new ArgumentNullException(nameof(data), "Property is not nullable for class Result.");
+                throw new JsonException("Property is not nullable for class Result: data.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class Result.");
+                throw new JsonException("Property is not nullable for class Result: uuid.");
 
             return new Result(code, data, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Return.cs
@@ -191,19 +191,19 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!varLock.IsSet)
-                throw new ArgumentException("Property is required for class Return.", nameof(varLock));
+                throw new JsonException("Property is required for class Return: lock.");
 
             if (!varAbstract.IsSet)
-                throw new ArgumentException("Property is required for class Return.", nameof(varAbstract));
+                throw new JsonException("Property is required for class Return: abstract.");
 
             if (varLock.IsSet && varLock.Value == null)
-                throw new ArgumentNullException(nameof(varLock), "Property is not nullable for class Return.");
+                throw new JsonException("Property is not nullable for class Return: lock.");
 
             if (varReturn.IsSet && varReturn.Value == null)
-                throw new ArgumentNullException(nameof(varReturn), "Property is not nullable for class Return.");
+                throw new JsonException("Property is not nullable for class Return: return.");
 
             if (varUnsafe.IsSet && varUnsafe.Value == null)
-                throw new ArgumentNullException(nameof(varUnsafe), "Property is not nullable for class Return.");
+                throw new JsonException("Property is not nullable for class Return: unsafe.");
 
             return new Return(varLock.Value, varAbstract.Value, varReturn, varUnsafe);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (role.IsSet && role.Value == null)
-                throw new ArgumentNullException(nameof(role), "Property is not nullable for class RolesReportsHash.");
+                throw new JsonException("Property is not nullable for class RolesReportsHash: role.");
 
             if (roleUuid.IsSet && roleUuid.Value == null)
-                throw new ArgumentNullException(nameof(roleUuid), "Property is not nullable for class RolesReportsHash.");
+                throw new JsonException("Property is not nullable for class RolesReportsHash: role_uuid.");
 
             return new RolesReportsHash(role, roleUuid);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class RolesReportsHashRole.");
+                throw new JsonException("Property is not nullable for class RolesReportsHashRole: name.");
 
             return new RolesReportsHashRole(name);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
@@ -151,16 +151,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ScaleneTriangle.", nameof(shapeType));
+                throw new JsonException("Property is required for class ScaleneTriangle: shapeType.");
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class ScaleneTriangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class ScaleneTriangle: triangleType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ScaleneTriangle.");
+                throw new JsonException("Property is not nullable for class ScaleneTriangle: shapeType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class ScaleneTriangle.");
+                throw new JsonException("Property is not nullable for class ScaleneTriangle: triangleType.");
 
             return new ScaleneTriangle(shapeType.Value, triangleType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Shape.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Shape.cs
@@ -193,10 +193,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class Shape.", nameof(shapeType));
+                throw new JsonException("Property is required for class Shape: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class Shape.");
+                throw new JsonException("Property is not nullable for class Shape: shapeType.");
 
             if (quadrilateral != null)
                 return new Shape(quadrilateral);

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ShapeInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ShapeInterface.cs
@@ -138,10 +138,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ShapeInterface.", nameof(shapeType));
+                throw new JsonException("Property is required for class ShapeInterface: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ShapeInterface.");
+                throw new JsonException("Property is not nullable for class ShapeInterface: shapeType.");
 
             return new ShapeInterface(shapeType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ShapeOrNull.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ShapeOrNull.cs
@@ -193,10 +193,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ShapeOrNull.", nameof(shapeType));
+                throw new JsonException("Property is required for class ShapeOrNull: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ShapeOrNull.");
+                throw new JsonException("Property is not nullable for class ShapeOrNull: shapeType.");
 
             if (quadrilateral != null)
                 return new ShapeOrNull(quadrilateral);

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
@@ -151,16 +151,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class SimpleQuadrilateral.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class SimpleQuadrilateral: quadrilateralType.");
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class SimpleQuadrilateral.", nameof(shapeType));
+                throw new JsonException("Property is required for class SimpleQuadrilateral: shapeType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class SimpleQuadrilateral.");
+                throw new JsonException("Property is not nullable for class SimpleQuadrilateral: quadrilateralType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class SimpleQuadrilateral.");
+                throw new JsonException("Property is not nullable for class SimpleQuadrilateral: shapeType.");
 
             return new SimpleQuadrilateral(quadrilateralType.Value, shapeType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varSpecialModelName.IsSet && varSpecialModelName.Value == null)
-                throw new ArgumentNullException(nameof(varSpecialModelName), "Property is not nullable for class SpecialModelName.");
+                throw new JsonException("Property is not nullable for class SpecialModelName: _special_model.name_.");
 
             if (specialPropertyName.IsSet && specialPropertyName.Value == null)
-                throw new ArgumentNullException(nameof(specialPropertyName), "Property is not nullable for class SpecialModelName.");
+                throw new JsonException("Property is not nullable for class SpecialModelName: $special[property.name].");
 
             return new SpecialModelName(varSpecialModelName, specialPropertyName);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Tag.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Tag.");
+                throw new JsonException("Property is not nullable for class Tag: id.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Tag.");
+                throw new JsonException("Property is not nullable for class Tag: name.");
 
             return new Tag(id, name);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (value.IsSet && value.Value == null)
-                throw new ArgumentNullException(nameof(value), "Property is not nullable for class TestCollectionEndingWithWordList.");
+                throw new JsonException("Property is not nullable for class TestCollectionEndingWithWordList: value.");
 
             return new TestCollectionEndingWithWordList(value);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (testCollectionEndingWithWordList.IsSet && testCollectionEndingWithWordList.Value == null)
-                throw new ArgumentNullException(nameof(testCollectionEndingWithWordList), "Property is not nullable for class TestCollectionEndingWithWordListObject.");
+                throw new JsonException("Property is not nullable for class TestCollectionEndingWithWordListObject: TestCollectionEndingWithWordList.");
 
             return new TestCollectionEndingWithWordListObject(testCollectionEndingWithWordList);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/TestDescendants.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/TestDescendants.cs
@@ -241,16 +241,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!alternativeName.IsSet)
-                throw new ArgumentException("Property is required for class TestDescendants.", nameof(alternativeName));
+                throw new JsonException("Property is required for class TestDescendants: alternativeName.");
 
             if (!objectType.IsSet)
-                throw new ArgumentException("Property is required for class TestDescendants.", nameof(objectType));
+                throw new JsonException("Property is required for class TestDescendants: objectType.");
 
             if (alternativeName.IsSet && alternativeName.Value == null)
-                throw new ArgumentNullException(nameof(alternativeName), "Property is not nullable for class TestDescendants.");
+                throw new JsonException("Property is not nullable for class TestDescendants: alternativeName.");
 
             if (objectType.IsSet && objectType.Value == null)
-                throw new ArgumentNullException(nameof(objectType), "Property is not nullable for class TestDescendants.");
+                throw new JsonException("Property is not nullable for class TestDescendants: objectType.");
 
             return new TestDescendants(alternativeName.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (someProperty.IsSet && someProperty.Value == null)
-                throw new ArgumentNullException(nameof(someProperty), "Property is not nullable for class TestInlineFreeformAdditionalPropertiesRequest.");
+                throw new JsonException("Property is not nullable for class TestInlineFreeformAdditionalPropertiesRequest: someProperty.");
 
             return new TestInlineFreeformAdditionalPropertiesRequest(someProperty);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/TestResult.cs
@@ -187,13 +187,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (code.IsSet && code.Value == null)
-                throw new ArgumentNullException(nameof(code), "Property is not nullable for class TestResult.");
+                throw new JsonException("Property is not nullable for class TestResult: code.");
 
             if (data.IsSet && data.Value == null)
-                throw new ArgumentNullException(nameof(data), "Property is not nullable for class TestResult.");
+                throw new JsonException("Property is not nullable for class TestResult: data.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class TestResult.");
+                throw new JsonException("Property is not nullable for class TestResult: uuid.");
 
             return new TestResult(code, data, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Triangle.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Triangle.cs
@@ -214,10 +214,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class Triangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class Triangle: triangleType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class Triangle.");
+                throw new JsonException("Property is not nullable for class Triangle: triangleType.");
 
             if (equilateralTriangle != null)
                 return new Triangle(equilateralTriangle);

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/TriangleInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/TriangleInterface.cs
@@ -138,10 +138,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class TriangleInterface.", nameof(triangleType));
+                throw new JsonException("Property is required for class TriangleInterface: triangleType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class TriangleInterface.");
+                throw new JsonException("Property is not nullable for class TriangleInterface: triangleType.");
 
             return new TriangleInterface(triangleType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/User.cs
@@ -370,31 +370,31 @@ namespace Org.OpenAPITools.Model
             }
 
             if (email.IsSet && email.Value == null)
-                throw new ArgumentNullException(nameof(email), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: email.");
 
             if (firstName.IsSet && firstName.Value == null)
-                throw new ArgumentNullException(nameof(firstName), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: firstName.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: id.");
 
             if (lastName.IsSet && lastName.Value == null)
-                throw new ArgumentNullException(nameof(lastName), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: lastName.");
 
             if (objectWithNoDeclaredProps.IsSet && objectWithNoDeclaredProps.Value == null)
-                throw new ArgumentNullException(nameof(objectWithNoDeclaredProps), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: objectWithNoDeclaredProps.");
 
             if (password.IsSet && password.Value == null)
-                throw new ArgumentNullException(nameof(password), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: password.");
 
             if (phone.IsSet && phone.Value == null)
-                throw new ArgumentNullException(nameof(phone), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: phone.");
 
             if (userStatus.IsSet && userStatus.Value == null)
-                throw new ArgumentNullException(nameof(userStatus), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: userStatus.");
 
             if (username.IsSet && username.Value == null)
-                throw new ArgumentNullException(nameof(username), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: username.");
 
             return new User(anyTypeProp, anyTypePropNullable, email, firstName, id, lastName, objectWithNoDeclaredProps, objectWithNoDeclaredPropsNullable, password, phone, userStatus, username);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Whale.cs
@@ -178,16 +178,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Whale.", nameof(className));
+                throw new JsonException("Property is required for class Whale: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Whale.");
+                throw new JsonException("Property is not nullable for class Whale: className.");
 
             if (hasBaleen.IsSet && hasBaleen.Value == null)
-                throw new ArgumentNullException(nameof(hasBaleen), "Property is not nullable for class Whale.");
+                throw new JsonException("Property is not nullable for class Whale: hasBaleen.");
 
             if (hasTeeth.IsSet && hasTeeth.Value == null)
-                throw new ArgumentNullException(nameof(hasTeeth), "Property is not nullable for class Whale.");
+                throw new JsonException("Property is not nullable for class Whale: hasTeeth.");
 
             return new Whale(className.Value, hasBaleen, hasTeeth);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Zebra.cs
@@ -245,13 +245,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Zebra.", nameof(className));
+                throw new JsonException("Property is required for class Zebra: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Zebra.");
+                throw new JsonException("Property is not nullable for class Zebra: className.");
 
             if (type.IsSet && type.Value == null)
-                throw new ArgumentNullException(nameof(type), "Property is not nullable for class Zebra.");
+                throw new JsonException("Property is not nullable for class Zebra: type.");
 
             return new Zebra(className.Value, type);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
@@ -218,7 +218,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (zeroBasedEnum.IsSet && zeroBasedEnum.Value == null)
-                throw new ArgumentNullException(nameof(zeroBasedEnum), "Property is not nullable for class ZeroBasedEnumClass.");
+                throw new JsonException("Property is not nullable for class ZeroBasedEnumClass: ZeroBasedEnum.");
 
             return new ZeroBasedEnumClass(zeroBasedEnum);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Activity.cs
@@ -148,7 +148,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (activityOutputs.IsSet && activityOutputs.Value == null)
-                throw new ArgumentNullException(nameof(activityOutputs), "Property is not nullable for class Activity.");
+                throw new JsonException("Property is not nullable for class Activity: activity_outputs.");
 
             return new Activity(activityOutputs);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -168,10 +168,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (prop1.IsSet && prop1.Value == null)
-                throw new ArgumentNullException(nameof(prop1), "Property is not nullable for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Property is not nullable for class ActivityOutputElementRepresentation: prop1.");
 
             if (prop2.IsSet && prop2.Value == null)
-                throw new ArgumentNullException(nameof(prop2), "Property is not nullable for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Property is not nullable for class ActivityOutputElementRepresentation: prop2.");
 
             return new ActivityOutputElementRepresentation(prop1, prop2);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -289,25 +289,25 @@ namespace Org.OpenAPITools.Model
             }
 
             if (emptyMap.IsSet && emptyMap.Value == null)
-                throw new ArgumentNullException(nameof(emptyMap), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: empty_map.");
 
             if (mapOfMapProperty.IsSet && mapOfMapProperty.Value == null)
-                throw new ArgumentNullException(nameof(mapOfMapProperty), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_of_map_property.");
 
             if (mapProperty.IsSet && mapProperty.Value == null)
-                throw new ArgumentNullException(nameof(mapProperty), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_property.");
 
             if (mapWithUndeclaredPropertiesAnytype1.IsSet && mapWithUndeclaredPropertiesAnytype1.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesAnytype1), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_anytype_1.");
 
             if (mapWithUndeclaredPropertiesAnytype2.IsSet && mapWithUndeclaredPropertiesAnytype2.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesAnytype2), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_anytype_2.");
 
             if (mapWithUndeclaredPropertiesAnytype3.IsSet && mapWithUndeclaredPropertiesAnytype3.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesAnytype3), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_anytype_3.");
 
             if (mapWithUndeclaredPropertiesString.IsSet && mapWithUndeclaredPropertiesString.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesString), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_string.");
 
             return new AdditionalPropertiesClass(anytype1, emptyMap, mapOfMapProperty, mapProperty, mapWithUndeclaredPropertiesAnytype1, mapWithUndeclaredPropertiesAnytype2, mapWithUndeclaredPropertiesAnytype3, mapWithUndeclaredPropertiesString);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Animal.cs
@@ -178,13 +178,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Animal.", nameof(className));
+                throw new JsonException("Property is required for class Animal: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Animal.");
+                throw new JsonException("Property is not nullable for class Animal: className.");
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Animal.");
+                throw new JsonException("Property is not nullable for class Animal: color.");
 
             return new Animal(color);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -188,13 +188,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (code.IsSet && code.Value == null)
-                throw new ArgumentNullException(nameof(code), "Property is not nullable for class ApiResponse.");
+                throw new JsonException("Property is not nullable for class ApiResponse: code.");
 
             if (message.IsSet && message.Value == null)
-                throw new ArgumentNullException(nameof(message), "Property is not nullable for class ApiResponse.");
+                throw new JsonException("Property is not nullable for class ApiResponse: message.");
 
             if (type.IsSet && type.Value == null)
-                throw new ArgumentNullException(nameof(type), "Property is not nullable for class ApiResponse.");
+                throw new JsonException("Property is not nullable for class ApiResponse: type.");
 
             return new ApiResponse(code, message, type);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Apple.cs
@@ -218,13 +218,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (colorCode.IsSet && colorCode.Value == null)
-                throw new ArgumentNullException(nameof(colorCode), "Property is not nullable for class Apple.");
+                throw new JsonException("Property is not nullable for class Apple: color_code.");
 
             if (cultivar.IsSet && cultivar.Value == null)
-                throw new ArgumentNullException(nameof(cultivar), "Property is not nullable for class Apple.");
+                throw new JsonException("Property is not nullable for class Apple: cultivar.");
 
             if (origin.IsSet && origin.Value == null)
-                throw new ArgumentNullException(nameof(origin), "Property is not nullable for class Apple.");
+                throw new JsonException("Property is not nullable for class Apple: origin.");
 
             return new Apple(colorCode, cultivar, origin);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -154,13 +154,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!cultivar.IsSet)
-                throw new ArgumentException("Property is required for class AppleReq.", nameof(cultivar));
+                throw new JsonException("Property is required for class AppleReq: cultivar.");
 
             if (cultivar.IsSet && cultivar.Value == null)
-                throw new ArgumentNullException(nameof(cultivar), "Property is not nullable for class AppleReq.");
+                throw new JsonException("Property is not nullable for class AppleReq: cultivar.");
 
             if (mealy.IsSet && mealy.Value == null)
-                throw new ArgumentNullException(nameof(mealy), "Property is not nullable for class AppleReq.");
+                throw new JsonException("Property is not nullable for class AppleReq: mealy.");
 
             return new AppleReq(cultivar.Value!, mealy);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -148,7 +148,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayArrayNumber.IsSet && arrayArrayNumber.Value == null)
-                throw new ArgumentNullException(nameof(arrayArrayNumber), "Property is not nullable for class ArrayOfArrayOfNumberOnly.");
+                throw new JsonException("Property is not nullable for class ArrayOfArrayOfNumberOnly: ArrayArrayNumber.");
 
             return new ArrayOfArrayOfNumberOnly(arrayArrayNumber);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -148,7 +148,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayNumber.IsSet && arrayNumber.Value == null)
-                throw new ArgumentNullException(nameof(arrayNumber), "Property is not nullable for class ArrayOfNumberOnly.");
+                throw new JsonException("Property is not nullable for class ArrayOfNumberOnly: ArrayNumber.");
 
             return new ArrayOfNumberOnly(arrayNumber);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -188,13 +188,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayArrayOfInteger.IsSet && arrayArrayOfInteger.Value == null)
-                throw new ArgumentNullException(nameof(arrayArrayOfInteger), "Property is not nullable for class ArrayTest.");
+                throw new JsonException("Property is not nullable for class ArrayTest: array_array_of_integer.");
 
             if (arrayArrayOfModel.IsSet && arrayArrayOfModel.Value == null)
-                throw new ArgumentNullException(nameof(arrayArrayOfModel), "Property is not nullable for class ArrayTest.");
+                throw new JsonException("Property is not nullable for class ArrayTest: array_array_of_model.");
 
             if (arrayOfString.IsSet && arrayOfString.Value == null)
-                throw new ArgumentNullException(nameof(arrayOfString), "Property is not nullable for class ArrayTest.");
+                throw new JsonException("Property is not nullable for class ArrayTest: array_of_string.");
 
             return new ArrayTest(arrayArrayOfInteger, arrayArrayOfModel, arrayOfString);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Banana.cs
@@ -148,7 +148,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (lengthCm.IsSet && lengthCm.Value == null)
-                throw new ArgumentNullException(nameof(lengthCm), "Property is not nullable for class Banana.");
+                throw new JsonException("Property is not nullable for class Banana: lengthCm.");
 
             return new Banana(lengthCm);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -154,13 +154,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!lengthCm.IsSet)
-                throw new ArgumentException("Property is required for class BananaReq.", nameof(lengthCm));
+                throw new JsonException("Property is required for class BananaReq: lengthCm.");
 
             if (lengthCm.IsSet && lengthCm.Value == null)
-                throw new ArgumentNullException(nameof(lengthCm), "Property is not nullable for class BananaReq.");
+                throw new JsonException("Property is not nullable for class BananaReq: lengthCm.");
 
             if (sweet.IsSet && sweet.Value == null)
-                throw new ArgumentNullException(nameof(sweet), "Property is not nullable for class BananaReq.");
+                throw new JsonException("Property is not nullable for class BananaReq: sweet.");
 
             return new BananaReq(lengthCm.Value!.Value!, sweet);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/BasquePig.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/BasquePig.cs
@@ -141,10 +141,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class BasquePig.", nameof(className));
+                throw new JsonException("Property is required for class BasquePig: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class BasquePig.");
+                throw new JsonException("Property is not nullable for class BasquePig: className.");
 
             return new BasquePig(className.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -249,22 +249,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (aTTNAME.IsSet && aTTNAME.Value == null)
-                throw new ArgumentNullException(nameof(aTTNAME), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: ATT_NAME.");
 
             if (capitalCamel.IsSet && capitalCamel.Value == null)
-                throw new ArgumentNullException(nameof(capitalCamel), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: CapitalCamel.");
 
             if (capitalSnake.IsSet && capitalSnake.Value == null)
-                throw new ArgumentNullException(nameof(capitalSnake), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: Capital_Snake.");
 
             if (sCAETHFlowPoints.IsSet && sCAETHFlowPoints.Value == null)
-                throw new ArgumentNullException(nameof(sCAETHFlowPoints), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: SCA_ETH_Flow_Points.");
 
             if (smallCamel.IsSet && smallCamel.Value == null)
-                throw new ArgumentNullException(nameof(smallCamel), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: smallCamel.");
 
             if (smallSnake.IsSet && smallSnake.Value == null)
-                throw new ArgumentNullException(nameof(smallSnake), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: small_Snake.");
 
             return new Capitalization(aTTNAME, capitalCamel, capitalSnake, sCAETHFlowPoints, smallCamel, smallSnake);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Cat.cs
@@ -141,16 +141,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Cat.", nameof(className));
+                throw new JsonException("Property is required for class Cat: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Cat.");
+                throw new JsonException("Property is not nullable for class Cat: className.");
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Cat.");
+                throw new JsonException("Property is not nullable for class Cat: color.");
 
             if (declawed.IsSet && declawed.Value == null)
-                throw new ArgumentNullException(nameof(declawed), "Property is not nullable for class Cat.");
+                throw new JsonException("Property is not nullable for class Cat: declawed.");
 
             return new Cat(color, declawed);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Category.cs
@@ -161,13 +161,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!name.IsSet)
-                throw new ArgumentException("Property is required for class Category.", nameof(name));
+                throw new JsonException("Property is required for class Category: name.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Category.");
+                throw new JsonException("Property is not nullable for class Category: id.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Category.");
+                throw new JsonException("Property is not nullable for class Category: name.");
 
             return new Category(id, name.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -203,13 +203,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!petType.IsSet)
-                throw new ArgumentException("Property is required for class ChildCat.", nameof(petType));
+                throw new JsonException("Property is required for class ChildCat: pet_type.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class ChildCat.");
+                throw new JsonException("Property is not nullable for class ChildCat: name.");
 
             if (petType.IsSet && petType.Value == null)
-                throw new ArgumentNullException(nameof(petType), "Property is not nullable for class ChildCat.");
+                throw new JsonException("Property is not nullable for class ChildCat: pet_type.");
 
             return new ChildCat(name);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -148,7 +148,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varClass.IsSet && varClass.Value == null)
-                throw new ArgumentNullException(nameof(varClass), "Property is not nullable for class ClassModel.");
+                throw new JsonException("Property is not nullable for class ClassModel: _class.");
 
             return new ClassModel(varClass);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
@@ -154,16 +154,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class ComplexQuadrilateral.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class ComplexQuadrilateral: quadrilateralType.");
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ComplexQuadrilateral.", nameof(shapeType));
+                throw new JsonException("Property is required for class ComplexQuadrilateral: shapeType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class ComplexQuadrilateral.");
+                throw new JsonException("Property is not nullable for class ComplexQuadrilateral: quadrilateralType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ComplexQuadrilateral.");
+                throw new JsonException("Property is not nullable for class ComplexQuadrilateral: shapeType.");
 
             return new ComplexQuadrilateral(quadrilateralType.Value!, shapeType.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/CopyActivity.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/CopyActivity.cs
@@ -196,16 +196,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!copyActivitytt.IsSet)
-                throw new ArgumentException("Property is required for class CopyActivity.", nameof(copyActivitytt));
+                throw new JsonException("Property is required for class CopyActivity: copyActivitytt.");
 
             if (!schema.IsSet)
-                throw new ArgumentException("Property is required for class CopyActivity.", nameof(schema));
+                throw new JsonException("Property is required for class CopyActivity: $schema.");
 
             if (copyActivitytt.IsSet && copyActivitytt.Value == null)
-                throw new ArgumentNullException(nameof(copyActivitytt), "Property is not nullable for class CopyActivity.");
+                throw new JsonException("Property is not nullable for class CopyActivity: copyActivitytt.");
 
             if (schema.IsSet && schema.Value == null)
-                throw new ArgumentNullException(nameof(schema), "Property is not nullable for class CopyActivity.");
+                throw new JsonException("Property is not nullable for class CopyActivity: $schema.");
 
             return new CopyActivity(copyActivitytt.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/DanishPig.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/DanishPig.cs
@@ -141,10 +141,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class DanishPig.", nameof(className));
+                throw new JsonException("Property is required for class DanishPig: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class DanishPig.");
+                throw new JsonException("Property is not nullable for class DanishPig: className.");
 
             return new DanishPig(className.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -154,7 +154,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (dateOnlyProperty.IsSet && dateOnlyProperty.Value == null)
-                throw new ArgumentNullException(nameof(dateOnlyProperty), "Property is not nullable for class DateOnlyClass.");
+                throw new JsonException("Property is not nullable for class DateOnlyClass: dateOnlyProperty.");
 
             return new DateOnlyClass(dateOnlyProperty);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -148,7 +148,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class DeprecatedObject.");
+                throw new JsonException("Property is not nullable for class DeprecatedObject: name.");
 
             return new DeprecatedObject(name);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Descendant1.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Descendant1.cs
@@ -141,22 +141,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!alternativeName.IsSet)
-                throw new ArgumentException("Property is required for class Descendant1.", nameof(alternativeName));
+                throw new JsonException("Property is required for class Descendant1: alternativeName.");
 
             if (!descendantName.IsSet)
-                throw new ArgumentException("Property is required for class Descendant1.", nameof(descendantName));
+                throw new JsonException("Property is required for class Descendant1: descendantName.");
 
             if (!objectType.IsSet)
-                throw new ArgumentException("Property is required for class Descendant1.", nameof(objectType));
+                throw new JsonException("Property is required for class Descendant1: objectType.");
 
             if (alternativeName.IsSet && alternativeName.Value == null)
-                throw new ArgumentNullException(nameof(alternativeName), "Property is not nullable for class Descendant1.");
+                throw new JsonException("Property is not nullable for class Descendant1: alternativeName.");
 
             if (descendantName.IsSet && descendantName.Value == null)
-                throw new ArgumentNullException(nameof(descendantName), "Property is not nullable for class Descendant1.");
+                throw new JsonException("Property is not nullable for class Descendant1: descendantName.");
 
             if (objectType.IsSet && objectType.Value == null)
-                throw new ArgumentNullException(nameof(objectType), "Property is not nullable for class Descendant1.");
+                throw new JsonException("Property is not nullable for class Descendant1: objectType.");
 
             return new Descendant1(alternativeName.Value!, descendantName.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Descendant2.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Descendant2.cs
@@ -141,22 +141,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!alternativeName.IsSet)
-                throw new ArgumentException("Property is required for class Descendant2.", nameof(alternativeName));
+                throw new JsonException("Property is required for class Descendant2: alternativeName.");
 
             if (!confidentiality.IsSet)
-                throw new ArgumentException("Property is required for class Descendant2.", nameof(confidentiality));
+                throw new JsonException("Property is required for class Descendant2: confidentiality.");
 
             if (!objectType.IsSet)
-                throw new ArgumentException("Property is required for class Descendant2.", nameof(objectType));
+                throw new JsonException("Property is required for class Descendant2: objectType.");
 
             if (alternativeName.IsSet && alternativeName.Value == null)
-                throw new ArgumentNullException(nameof(alternativeName), "Property is not nullable for class Descendant2.");
+                throw new JsonException("Property is not nullable for class Descendant2: alternativeName.");
 
             if (confidentiality.IsSet && confidentiality.Value == null)
-                throw new ArgumentNullException(nameof(confidentiality), "Property is not nullable for class Descendant2.");
+                throw new JsonException("Property is not nullable for class Descendant2: confidentiality.");
 
             if (objectType.IsSet && objectType.Value == null)
-                throw new ArgumentNullException(nameof(objectType), "Property is not nullable for class Descendant2.");
+                throw new JsonException("Property is not nullable for class Descendant2: objectType.");
 
             return new Descendant2(alternativeName.Value!, confidentiality.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Dog.cs
@@ -141,16 +141,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Dog.", nameof(className));
+                throw new JsonException("Property is required for class Dog: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Dog.");
+                throw new JsonException("Property is not nullable for class Dog: className.");
 
             if (breed.IsSet && breed.Value == null)
-                throw new ArgumentNullException(nameof(breed), "Property is not nullable for class Dog.");
+                throw new JsonException("Property is not nullable for class Dog: breed.");
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Dog.");
+                throw new JsonException("Property is not nullable for class Dog: color.");
 
             return new Dog(breed, color);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Drawing.cs
@@ -208,10 +208,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (mainShape.IsSet && mainShape.Value == null)
-                throw new ArgumentNullException(nameof(mainShape), "Property is not nullable for class Drawing.");
+                throw new JsonException("Property is not nullable for class Drawing: mainShape.");
 
             if (shapes.IsSet && shapes.Value == null)
-                throw new ArgumentNullException(nameof(shapes), "Property is not nullable for class Drawing.");
+                throw new JsonException("Property is not nullable for class Drawing: shapes.");
 
             return new Drawing(mainShape, nullableShape, shapeOrNull, shapes);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/EntityBase.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/EntityBase.cs
@@ -155,10 +155,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!schema.IsSet)
-                throw new ArgumentException("Property is required for class EntityBase.", nameof(schema));
+                throw new JsonException("Property is required for class EntityBase: $schema.");
 
             if (schema.IsSet && schema.Value == null)
-                throw new ArgumentNullException(nameof(schema), "Property is not nullable for class EntityBase.");
+                throw new JsonException("Property is not nullable for class EntityBase: $schema.");
 
             return new EntityBase();
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -307,10 +307,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayEnum.IsSet && arrayEnum.Value == null)
-                throw new ArgumentNullException(nameof(arrayEnum), "Property is not nullable for class EnumArrays.");
+                throw new JsonException("Property is not nullable for class EnumArrays: array_enum.");
 
             if (justSymbol.IsSet && justSymbol.Value == null)
-                throw new ArgumentNullException(nameof(justSymbol), "Property is not nullable for class EnumArrays.");
+                throw new JsonException("Property is not nullable for class EnumArrays: just_symbol.");
 
             return new EnumArrays(arrayEnum, justSymbol);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -825,31 +825,31 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!enumStringRequired.IsSet)
-                throw new ArgumentException("Property is required for class EnumTest.", nameof(enumStringRequired));
+                throw new JsonException("Property is required for class EnumTest: enum_string_required.");
 
             if (enumStringRequired.IsSet && enumStringRequired.Value == null)
-                throw new ArgumentNullException(nameof(enumStringRequired), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_string_required.");
 
             if (enumInteger.IsSet && enumInteger.Value == null)
-                throw new ArgumentNullException(nameof(enumInteger), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_integer.");
 
             if (enumIntegerOnly.IsSet && enumIntegerOnly.Value == null)
-                throw new ArgumentNullException(nameof(enumIntegerOnly), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_integer_only.");
 
             if (enumNumber.IsSet && enumNumber.Value == null)
-                throw new ArgumentNullException(nameof(enumNumber), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_number.");
 
             if (enumString.IsSet && enumString.Value == null)
-                throw new ArgumentNullException(nameof(enumString), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_string.");
 
             if (outerEnumDefaultValue.IsSet && outerEnumDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(outerEnumDefaultValue), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: outerEnumDefaultValue.");
 
             if (outerEnumInteger.IsSet && outerEnumInteger.Value == null)
-                throw new ArgumentNullException(nameof(outerEnumInteger), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: outerEnumInteger.");
 
             if (outerEnumIntegerDefaultValue.IsSet && outerEnumIntegerDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(outerEnumIntegerDefaultValue), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: outerEnumIntegerDefaultValue.");
 
             return new EnumTest(enumStringRequired.Value!.Value!, enumInteger, enumIntegerOnly, enumNumber, enumString, outerEnum, outerEnumDefaultValue, outerEnumInteger, outerEnumIntegerDefaultValue);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
@@ -154,16 +154,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class EquilateralTriangle.", nameof(shapeType));
+                throw new JsonException("Property is required for class EquilateralTriangle: shapeType.");
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class EquilateralTriangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class EquilateralTriangle: triangleType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class EquilateralTriangle.");
+                throw new JsonException("Property is not nullable for class EquilateralTriangle: shapeType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class EquilateralTriangle.");
+                throw new JsonException("Property is not nullable for class EquilateralTriangle: triangleType.");
 
             return new EquilateralTriangle(shapeType.Value!, triangleType.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/File.cs
@@ -149,7 +149,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (sourceURI.IsSet && sourceURI.Value == null)
-                throw new ArgumentNullException(nameof(sourceURI), "Property is not nullable for class File.");
+                throw new JsonException("Property is not nullable for class File: sourceURI.");
 
             return new File(sourceURI);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -168,10 +168,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (file.IsSet && file.Value == null)
-                throw new ArgumentNullException(nameof(file), "Property is not nullable for class FileSchemaTestClass.");
+                throw new JsonException("Property is not nullable for class FileSchemaTestClass: file.");
 
             if (files.IsSet && files.Value == null)
-                throw new ArgumentNullException(nameof(files), "Property is not nullable for class FileSchemaTestClass.");
+                throw new JsonException("Property is not nullable for class FileSchemaTestClass: files.");
 
             return new FileSchemaTestClass(file, files);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Foo.cs
@@ -148,7 +148,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bar.IsSet && bar.Value == null)
-                throw new ArgumentNullException(nameof(bar), "Property is not nullable for class Foo.");
+                throw new JsonException("Property is not nullable for class Foo: bar.");
 
             return new Foo(bar);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -148,7 +148,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varString.IsSet && varString.Value == null)
-                throw new ArgumentNullException(nameof(varString), "Property is not nullable for class FooGetDefaultResponse.");
+                throw new JsonException("Property is not nullable for class FooGetDefaultResponse: string.");
 
             return new FooGetDefaultResponse(varString);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -829,103 +829,103 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!varByte.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(varByte));
+                throw new JsonException("Property is required for class FormatTest: byte.");
 
             if (!date.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(date));
+                throw new JsonException("Property is required for class FormatTest: date.");
 
             if (!number.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(number));
+                throw new JsonException("Property is required for class FormatTest: number.");
 
             if (!password.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(password));
+                throw new JsonException("Property is required for class FormatTest: password.");
 
             if (!stringFormattedAsDecimalRequired.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(stringFormattedAsDecimalRequired));
+                throw new JsonException("Property is required for class FormatTest: string_formatted_as_decimal_required.");
 
             if (varByte.IsSet && varByte.Value == null)
-                throw new ArgumentNullException(nameof(varByte), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: byte.");
 
             if (date.IsSet && date.Value == null)
-                throw new ArgumentNullException(nameof(date), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: date.");
 
             if (number.IsSet && number.Value == null)
-                throw new ArgumentNullException(nameof(number), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: number.");
 
             if (password.IsSet && password.Value == null)
-                throw new ArgumentNullException(nameof(password), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: password.");
 
             if (stringFormattedAsDecimalRequired.IsSet && stringFormattedAsDecimalRequired.Value == null)
-                throw new ArgumentNullException(nameof(stringFormattedAsDecimalRequired), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: string_formatted_as_decimal_required.");
 
             if (binary.IsSet && binary.Value == null)
-                throw new ArgumentNullException(nameof(binary), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: binary.");
 
             if (dateTime.IsSet && dateTime.Value == null)
-                throw new ArgumentNullException(nameof(dateTime), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: dateTime.");
 
             if (varDecimal.IsSet && varDecimal.Value == null)
-                throw new ArgumentNullException(nameof(varDecimal), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: decimal.");
 
             if (varDouble.IsSet && varDouble.Value == null)
-                throw new ArgumentNullException(nameof(varDouble), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: double.");
 
             if (duplicatePropertyName2.IsSet && duplicatePropertyName2.Value == null)
-                throw new ArgumentNullException(nameof(duplicatePropertyName2), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: duplicate_property_name.");
 
             if (duplicatePropertyName.IsSet && duplicatePropertyName.Value == null)
-                throw new ArgumentNullException(nameof(duplicatePropertyName), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: @duplicate_property_name.");
 
             if (varFloat.IsSet && varFloat.Value == null)
-                throw new ArgumentNullException(nameof(varFloat), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: float.");
 
             if (int32.IsSet && int32.Value == null)
-                throw new ArgumentNullException(nameof(int32), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int32.");
 
             if (int32Range.IsSet && int32Range.Value == null)
-                throw new ArgumentNullException(nameof(int32Range), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int32Range.");
 
             if (int64.IsSet && int64.Value == null)
-                throw new ArgumentNullException(nameof(int64), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64.");
 
             if (int64Negative.IsSet && int64Negative.Value == null)
-                throw new ArgumentNullException(nameof(int64Negative), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64Negative.");
 
             if (int64NegativeExclusive.IsSet && int64NegativeExclusive.Value == null)
-                throw new ArgumentNullException(nameof(int64NegativeExclusive), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64NegativeExclusive.");
 
             if (int64Positive.IsSet && int64Positive.Value == null)
-                throw new ArgumentNullException(nameof(int64Positive), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64Positive.");
 
             if (int64PositiveExclusive.IsSet && int64PositiveExclusive.Value == null)
-                throw new ArgumentNullException(nameof(int64PositiveExclusive), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64PositiveExclusive.");
 
             if (integer.IsSet && integer.Value == null)
-                throw new ArgumentNullException(nameof(integer), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: integer.");
 
             if (patternWithBackslash.IsSet && patternWithBackslash.Value == null)
-                throw new ArgumentNullException(nameof(patternWithBackslash), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: pattern_with_backslash.");
 
             if (patternWithDigits.IsSet && patternWithDigits.Value == null)
-                throw new ArgumentNullException(nameof(patternWithDigits), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: pattern_with_digits.");
 
             if (patternWithDigitsAndDelimiter.IsSet && patternWithDigitsAndDelimiter.Value == null)
-                throw new ArgumentNullException(nameof(patternWithDigitsAndDelimiter), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: pattern_with_digits_and_delimiter.");
 
             if (varString.IsSet && varString.Value == null)
-                throw new ArgumentNullException(nameof(varString), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: string.");
 
             if (stringFormattedAsDecimal.IsSet && stringFormattedAsDecimal.Value == null)
-                throw new ArgumentNullException(nameof(stringFormattedAsDecimal), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: string_formatted_as_decimal.");
 
             if (unsignedInteger.IsSet && unsignedInteger.Value == null)
-                throw new ArgumentNullException(nameof(unsignedInteger), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: unsigned_integer.");
 
             if (unsignedLong.IsSet && unsignedLong.Value == null)
-                throw new ArgumentNullException(nameof(unsignedLong), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: unsigned_long.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: uuid.");
 
             return new FormatTest(varByte.Value!, date.Value!.Value!, number.Value!.Value!, password.Value!, stringFormattedAsDecimalRequired.Value!.Value!, binary, dateTime, varDecimal, varDouble, duplicatePropertyName2, duplicatePropertyName, varFloat, int32, int32Range, int64, int64Negative, int64NegativeExclusive, int64Positive, int64PositiveExclusive, integer, patternWithBackslash, patternWithDigits, patternWithDigitsAndDelimiter, varString, stringFormattedAsDecimal, unsignedInteger, unsignedLong, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Fruit.cs
@@ -186,7 +186,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Fruit.");
+                throw new JsonException("Property is not nullable for class Fruit: color.");
 
             if (apple != null)
                 return new Fruit(apple, color);

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -190,7 +190,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class GmFruit.");
+                throw new JsonException("Property is not nullable for class GmFruit: color.");
 
             Option<Apple?> appleParsedValue = apple == null
                 ? default

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
@@ -158,10 +158,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!petType.IsSet)
-                throw new ArgumentException("Property is required for class GrandparentAnimal.", nameof(petType));
+                throw new JsonException("Property is required for class GrandparentAnimal: pet_type.");
 
             if (petType.IsSet && petType.Value == null)
-                throw new ArgumentNullException(nameof(petType), "Property is not nullable for class GrandparentAnimal.");
+                throw new JsonException("Property is not nullable for class GrandparentAnimal: pet_type.");
 
             return new GrandparentAnimal();
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -209,10 +209,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bar.IsSet && bar.Value == null)
-                throw new ArgumentNullException(nameof(bar), "Property is not nullable for class HasOnlyReadOnly.");
+                throw new JsonException("Property is not nullable for class HasOnlyReadOnly: bar.");
 
             if (foo.IsSet && foo.Value == null)
-                throw new ArgumentNullException(nameof(foo), "Property is not nullable for class HasOnlyReadOnly.");
+                throw new JsonException("Property is not nullable for class HasOnlyReadOnly: foo.");
 
             return new HasOnlyReadOnly(bar, foo);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
@@ -295,22 +295,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (potentiallyOverriddenPropertyAccessor.IsSet && potentiallyOverriddenPropertyAccessor.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyAccessor), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyAccessor.");
 
             if (potentiallyOverriddenPropertyToInternal.IsSet && potentiallyOverriddenPropertyToInternal.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyToInternal), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyToInternal.");
 
             if (potentiallyOverriddenPropertyToPrivate.IsSet && potentiallyOverriddenPropertyToPrivate.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyToPrivate), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyToPrivate.");
 
             if (potentiallyOverriddenPropertyToPublic.IsSet && potentiallyOverriddenPropertyToPublic.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyToPublic), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyToPublic.");
 
             if (unalteredProperty.IsSet && unalteredProperty.Value == null)
-                throw new ArgumentNullException(nameof(unalteredProperty), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: unalteredProperty.");
 
             if (unalteredPropertyAccessor.IsSet && unalteredPropertyAccessor.Value == null)
-                throw new ArgumentNullException(nameof(unalteredPropertyAccessor), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: unalteredPropertyAccessor.");
 
             return new InjectedVendorExtensionsTest(potentiallyOverriddenPropertyAccessor, potentiallyOverriddenPropertyToInternal, potentiallyOverriddenPropertyToPrivate, potentiallyOverriddenPropertyToPublic, unalteredProperty, unalteredPropertyAccessor);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
@@ -147,16 +147,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class IsoscelesTriangle.", nameof(shapeType));
+                throw new JsonException("Property is required for class IsoscelesTriangle: shapeType.");
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class IsoscelesTriangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class IsoscelesTriangle: triangleType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class IsoscelesTriangle.");
+                throw new JsonException("Property is not nullable for class IsoscelesTriangle: shapeType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class IsoscelesTriangle.");
+                throw new JsonException("Property is not nullable for class IsoscelesTriangle: triangleType.");
 
             return new IsoscelesTriangle(shapeType.Value!, triangleType.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/List.cs
@@ -148,7 +148,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (var123List.IsSet && var123List.Value == null)
-                throw new ArgumentNullException(nameof(var123List), "Property is not nullable for class List.");
+                throw new JsonException("Property is not nullable for class List: 123-list.");
 
             return new List(var123List);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -168,10 +168,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (escapedLiteralString.IsSet && escapedLiteralString.Value == null)
-                throw new ArgumentNullException(nameof(escapedLiteralString), "Property is not nullable for class LiteralStringClass.");
+                throw new JsonException("Property is not nullable for class LiteralStringClass: escapedLiteralString.");
 
             if (unescapedLiteralString.IsSet && unescapedLiteralString.Value == null)
-                throw new ArgumentNullException(nameof(unescapedLiteralString), "Property is not nullable for class LiteralStringClass.");
+                throw new JsonException("Property is not nullable for class LiteralStringClass: unescapedLiteralString.");
 
             return new LiteralStringClass(escapedLiteralString, unescapedLiteralString);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Mammal.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Mammal.cs
@@ -217,10 +217,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Mammal.", nameof(className));
+                throw new JsonException("Property is required for class Mammal: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Mammal.");
+                throw new JsonException("Property is not nullable for class Mammal: className.");
 
             if (pig != null)
                 return new Mammal(pig);

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/MapTest.cs
@@ -274,16 +274,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (directMap.IsSet && directMap.Value == null)
-                throw new ArgumentNullException(nameof(directMap), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: direct_map.");
 
             if (indirectMap.IsSet && indirectMap.Value == null)
-                throw new ArgumentNullException(nameof(indirectMap), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: indirect_map.");
 
             if (mapMapOfString.IsSet && mapMapOfString.Value == null)
-                throw new ArgumentNullException(nameof(mapMapOfString), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: map_map_of_string.");
 
             if (mapOfEnumString.IsSet && mapOfEnumString.Value == null)
-                throw new ArgumentNullException(nameof(mapOfEnumString), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: map_of_enum_string.");
 
             return new MapTest(directMap, indirectMap, mapMapOfString, mapOfEnumString);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/MixedAnyOf.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/MixedAnyOf.cs
@@ -148,7 +148,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (content.IsSet && content.Value == null)
-                throw new ArgumentNullException(nameof(content), "Property is not nullable for class MixedAnyOf.");
+                throw new JsonException("Property is not nullable for class MixedAnyOf: content.");
 
             return new MixedAnyOf(content);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/MixedOneOf.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/MixedOneOf.cs
@@ -148,7 +148,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (content.IsSet && content.Value == null)
-                throw new ArgumentNullException(nameof(content), "Property is not nullable for class MixedOneOf.");
+                throw new JsonException("Property is not nullable for class MixedOneOf: content.");
 
             return new MixedOneOf(content);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -220,16 +220,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (dateTime.IsSet && dateTime.Value == null)
-                throw new ArgumentNullException(nameof(dateTime), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: dateTime.");
 
             if (map.IsSet && map.Value == null)
-                throw new ArgumentNullException(nameof(map), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: map.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: uuid.");
 
             if (uuidWithPattern.IsSet && uuidWithPattern.Value == null)
-                throw new ArgumentNullException(nameof(uuidWithPattern), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: uuid_with_pattern.");
 
             return new MixedPropertiesAndAdditionalPropertiesClass(dateTime, map, uuid, uuidWithPattern);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/MixedSubId.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/MixedSubId.cs
@@ -148,7 +148,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class MixedSubId.");
+                throw new JsonException("Property is not nullable for class MixedSubId: id.");
 
             return new MixedSubId(id);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -168,10 +168,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varClass.IsSet && varClass.Value == null)
-                throw new ArgumentNullException(nameof(varClass), "Property is not nullable for class Model200Response.");
+                throw new JsonException("Property is not nullable for class Model200Response: class.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Model200Response.");
+                throw new JsonException("Property is not nullable for class Model200Response: name.");
 
             return new Model200Response(varClass, name);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -148,7 +148,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varClient.IsSet && varClient.Value == null)
-                throw new ArgumentNullException(nameof(varClient), "Property is not nullable for class ModelClient.");
+                throw new JsonException("Property is not nullable for class ModelClient: client.");
 
             return new ModelClient(varClient);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Name.cs
@@ -242,19 +242,19 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!varName.IsSet)
-                throw new ArgumentException("Property is required for class Name.", nameof(varName));
+                throw new JsonException("Property is required for class Name: name.");
 
             if (varName.IsSet && varName.Value == null)
-                throw new ArgumentNullException(nameof(varName), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: name.");
 
             if (property.IsSet && property.Value == null)
-                throw new ArgumentNullException(nameof(property), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: property.");
 
             if (snakeCase.IsSet && snakeCase.Value == null)
-                throw new ArgumentNullException(nameof(snakeCase), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: snake_case.");
 
             if (var123Number.IsSet && var123Number.Value == null)
-                throw new ArgumentNullException(nameof(var123Number), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: 123Number.");
 
             return new Name(varName.Value!.Value!, property, snakeCase, var123Number);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
@@ -154,16 +154,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!aObjVariableobject.IsSet)
-                throw new ArgumentException("Property is required for class NotificationtestGetElementsV1ResponseMPayload.", nameof(aObjVariableobject));
+                throw new JsonException("Property is required for class NotificationtestGetElementsV1ResponseMPayload: a_objVariableobject.");
 
             if (!pkiNotificationtestID.IsSet)
-                throw new ArgumentException("Property is required for class NotificationtestGetElementsV1ResponseMPayload.", nameof(pkiNotificationtestID));
+                throw new JsonException("Property is required for class NotificationtestGetElementsV1ResponseMPayload: pkiNotificationtestID.");
 
             if (aObjVariableobject.IsSet && aObjVariableobject.Value == null)
-                throw new ArgumentNullException(nameof(aObjVariableobject), "Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload.");
+                throw new JsonException("Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload: a_objVariableobject.");
 
             if (pkiNotificationtestID.IsSet && pkiNotificationtestID.Value == null)
-                throw new ArgumentNullException(nameof(pkiNotificationtestID), "Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload.");
+                throw new JsonException("Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload: pkiNotificationtestID.");
 
             return new NotificationtestGetElementsV1ResponseMPayload(aObjVariableobject.Value!, pkiNotificationtestID.Value!.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -378,10 +378,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayItemsNullable.IsSet && arrayItemsNullable.Value == null)
-                throw new ArgumentNullException(nameof(arrayItemsNullable), "Property is not nullable for class NullableClass.");
+                throw new JsonException("Property is not nullable for class NullableClass: array_items_nullable.");
 
             if (objectItemsNullable.IsSet && objectItemsNullable.Value == null)
-                throw new ArgumentNullException(nameof(objectItemsNullable), "Property is not nullable for class NullableClass.");
+                throw new JsonException("Property is not nullable for class NullableClass: object_items_nullable.");
 
             return new NullableClass(arrayAndItemsNullableProp, arrayItemsNullable, arrayNullableProp, booleanProp, dateProp, datetimeProp, integerProp, numberProp, objectAndItemsNullableProp, objectItemsNullable, objectNullableProp, stringProp);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/NullableShape.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/NullableShape.cs
@@ -196,10 +196,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class NullableShape.", nameof(shapeType));
+                throw new JsonException("Property is required for class NullableShape: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class NullableShape.");
+                throw new JsonException("Property is not nullable for class NullableShape: shapeType.");
 
             if (quadrilateral != null)
                 return new NullableShape(quadrilateral);

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -148,7 +148,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (justNumber.IsSet && justNumber.Value == null)
-                throw new ArgumentNullException(nameof(justNumber), "Property is not nullable for class NumberOnly.");
+                throw new JsonException("Property is not nullable for class NumberOnly: JustNumber.");
 
             return new NumberOnly(justNumber);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -211,16 +211,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bars.IsSet && bars.Value == null)
-                throw new ArgumentNullException(nameof(bars), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: bars.");
 
             if (deprecatedRef.IsSet && deprecatedRef.Value == null)
-                throw new ArgumentNullException(nameof(deprecatedRef), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: deprecatedRef.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: id.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: uuid.");
 
             return new ObjectWithDeprecatedFields(bars, deprecatedRef, id, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Order.cs
@@ -343,22 +343,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (complete.IsSet && complete.Value == null)
-                throw new ArgumentNullException(nameof(complete), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: complete.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: id.");
 
             if (petId.IsSet && petId.Value == null)
-                throw new ArgumentNullException(nameof(petId), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: petId.");
 
             if (quantity.IsSet && quantity.Value == null)
-                throw new ArgumentNullException(nameof(quantity), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: quantity.");
 
             if (shipDate.IsSet && shipDate.Value == null)
-                throw new ArgumentNullException(nameof(shipDate), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: shipDate.");
 
             if (status.IsSet && status.Value == null)
-                throw new ArgumentNullException(nameof(status), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: status.");
 
             return new Order(complete, id, petId, quantity, shipDate, status);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -188,13 +188,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (myBoolean.IsSet && myBoolean.Value == null)
-                throw new ArgumentNullException(nameof(myBoolean), "Property is not nullable for class OuterComposite.");
+                throw new JsonException("Property is not nullable for class OuterComposite: my_boolean.");
 
             if (myNumber.IsSet && myNumber.Value == null)
-                throw new ArgumentNullException(nameof(myNumber), "Property is not nullable for class OuterComposite.");
+                throw new JsonException("Property is not nullable for class OuterComposite: my_number.");
 
             if (myString.IsSet && myString.Value == null)
-                throw new ArgumentNullException(nameof(myString), "Property is not nullable for class OuterComposite.");
+                throw new JsonException("Property is not nullable for class OuterComposite: my_string.");
 
             return new OuterComposite(myBoolean, myNumber, myString);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ParentPet.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ParentPet.cs
@@ -121,10 +121,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!petType.IsSet)
-                throw new ArgumentException("Property is required for class ParentPet.", nameof(petType));
+                throw new JsonException("Property is required for class ParentPet: pet_type.");
 
             if (petType.IsSet && petType.Value == null)
-                throw new ArgumentNullException(nameof(petType), "Property is not nullable for class ParentPet.");
+                throw new JsonException("Property is not nullable for class ParentPet: pet_type.");
 
             return new ParentPet();
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Pet.cs
@@ -324,28 +324,28 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!name.IsSet)
-                throw new ArgumentException("Property is required for class Pet.", nameof(name));
+                throw new JsonException("Property is required for class Pet: name.");
 
             if (!photoUrls.IsSet)
-                throw new ArgumentException("Property is required for class Pet.", nameof(photoUrls));
+                throw new JsonException("Property is required for class Pet: photoUrls.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: name.");
 
             if (photoUrls.IsSet && photoUrls.Value == null)
-                throw new ArgumentNullException(nameof(photoUrls), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: photoUrls.");
 
             if (category.IsSet && category.Value == null)
-                throw new ArgumentNullException(nameof(category), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: category.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: id.");
 
             if (status.IsSet && status.Value == null)
-                throw new ArgumentNullException(nameof(status), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: status.");
 
             if (tags.IsSet && tags.Value == null)
-                throw new ArgumentNullException(nameof(tags), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: tags.");
 
             return new Pet(name.Value!, photoUrls.Value!, category, id, status, tags);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Pig.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Pig.cs
@@ -196,10 +196,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Pig.", nameof(className));
+                throw new JsonException("Property is required for class Pig: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Pig.");
+                throw new JsonException("Property is not nullable for class Pig: className.");
 
             if (basquePig != null)
                 return new Pig(basquePig);

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Quadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Quadrilateral.cs
@@ -196,10 +196,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class Quadrilateral.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class Quadrilateral: quadrilateralType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class Quadrilateral.");
+                throw new JsonException("Property is not nullable for class Quadrilateral: quadrilateralType.");
 
             if (complexQuadrilateral != null)
                 return new Quadrilateral(complexQuadrilateral);

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
@@ -141,10 +141,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class QuadrilateralInterface.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class QuadrilateralInterface: quadrilateralType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class QuadrilateralInterface.");
+                throw new JsonException("Property is not nullable for class QuadrilateralInterface: quadrilateralType.");
 
             return new QuadrilateralInterface(quadrilateralType.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -206,10 +206,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bar.IsSet && bar.Value == null)
-                throw new ArgumentNullException(nameof(bar), "Property is not nullable for class ReadOnlyFirst.");
+                throw new JsonException("Property is not nullable for class ReadOnlyFirst: bar.");
 
             if (baz.IsSet && baz.Value == null)
-                throw new ArgumentNullException(nameof(baz), "Property is not nullable for class ReadOnlyFirst.");
+                throw new JsonException("Property is not nullable for class ReadOnlyFirst: baz.");
 
             return new ReadOnlyFirst(bar, baz);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -2080,136 +2080,136 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!requiredNotNullableDateProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotNullableDateProp));
+                throw new JsonException("Property is required for class RequiredClass: required_not_nullable_date_prop.");
 
             if (!requiredNotnullableArrayOfString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableArrayOfString));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_array_of_string.");
 
             if (!requiredNotnullableBooleanProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableBooleanProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_boolean_prop.");
 
             if (!requiredNotnullableDatetimeProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableDatetimeProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_datetime_prop.");
 
             if (!requiredNotnullableEnumInteger.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableEnumInteger));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_enum_integer.");
 
             if (!requiredNotnullableEnumIntegerOnly.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableEnumIntegerOnly));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_enum_integer_only.");
 
             if (!requiredNotnullableEnumString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableEnumString));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_enum_string.");
 
             if (!requiredNotnullableOuterEnumDefaultValue.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableOuterEnumDefaultValue));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_outerEnumDefaultValue.");
 
             if (!requiredNotnullableStringProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableStringProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_string_prop.");
 
             if (!requiredNotnullableUuid.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableUuid));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_uuid.");
 
             if (!requiredNotnullableintegerProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableintegerProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullableinteger_prop.");
 
             if (!requiredNullableArrayOfString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableArrayOfString));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_array_of_string.");
 
             if (!requiredNullableBooleanProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableBooleanProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_boolean_prop.");
 
             if (!requiredNullableDateProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableDateProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_date_prop.");
 
             if (!requiredNullableDatetimeProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableDatetimeProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_datetime_prop.");
 
             if (!requiredNullableEnumInteger.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableEnumInteger));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_enum_integer.");
 
             if (!requiredNullableEnumIntegerOnly.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableEnumIntegerOnly));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_enum_integer_only.");
 
             if (!requiredNullableEnumString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableEnumString));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_enum_string.");
 
             if (!requiredNullableIntegerProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableIntegerProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_integer_prop.");
 
             if (!requiredNullableOuterEnumDefaultValue.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableOuterEnumDefaultValue));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_outerEnumDefaultValue.");
 
             if (!requiredNullableStringProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableStringProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_string_prop.");
 
             if (!requiredNullableUuid.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableUuid));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_uuid.");
 
             if (requiredNotNullableDateProp.IsSet && requiredNotNullableDateProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotNullableDateProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_not_nullable_date_prop.");
 
             if (requiredNotnullableArrayOfString.IsSet && requiredNotnullableArrayOfString.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableArrayOfString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_array_of_string.");
 
             if (requiredNotnullableBooleanProp.IsSet && requiredNotnullableBooleanProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableBooleanProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_boolean_prop.");
 
             if (requiredNotnullableDatetimeProp.IsSet && requiredNotnullableDatetimeProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableDatetimeProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_datetime_prop.");
 
             if (requiredNotnullableEnumInteger.IsSet && requiredNotnullableEnumInteger.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableEnumInteger), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_enum_integer.");
 
             if (requiredNotnullableEnumIntegerOnly.IsSet && requiredNotnullableEnumIntegerOnly.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableEnumIntegerOnly), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_enum_integer_only.");
 
             if (requiredNotnullableEnumString.IsSet && requiredNotnullableEnumString.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableEnumString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_enum_string.");
 
             if (requiredNotnullableOuterEnumDefaultValue.IsSet && requiredNotnullableOuterEnumDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableOuterEnumDefaultValue), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_outerEnumDefaultValue.");
 
             if (requiredNotnullableStringProp.IsSet && requiredNotnullableStringProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableStringProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_string_prop.");
 
             if (requiredNotnullableUuid.IsSet && requiredNotnullableUuid.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableUuid), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_uuid.");
 
             if (requiredNotnullableintegerProp.IsSet && requiredNotnullableintegerProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableintegerProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullableinteger_prop.");
 
             if (notRequiredNotnullableDateProp.IsSet && notRequiredNotnullableDateProp.Value == null)
-                throw new ArgumentNullException(nameof(notRequiredNotnullableDateProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: not_required_notnullable_date_prop.");
 
             if (notRequiredNotnullableintegerProp.IsSet && notRequiredNotnullableintegerProp.Value == null)
-                throw new ArgumentNullException(nameof(notRequiredNotnullableintegerProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: not_required_notnullableinteger_prop.");
 
             if (notrequiredNotnullableArrayOfString.IsSet && notrequiredNotnullableArrayOfString.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableArrayOfString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_array_of_string.");
 
             if (notrequiredNotnullableBooleanProp.IsSet && notrequiredNotnullableBooleanProp.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableBooleanProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_boolean_prop.");
 
             if (notrequiredNotnullableDatetimeProp.IsSet && notrequiredNotnullableDatetimeProp.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableDatetimeProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_datetime_prop.");
 
             if (notrequiredNotnullableEnumInteger.IsSet && notrequiredNotnullableEnumInteger.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableEnumInteger), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_enum_integer.");
 
             if (notrequiredNotnullableEnumIntegerOnly.IsSet && notrequiredNotnullableEnumIntegerOnly.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableEnumIntegerOnly), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_enum_integer_only.");
 
             if (notrequiredNotnullableEnumString.IsSet && notrequiredNotnullableEnumString.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableEnumString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_enum_string.");
 
             if (notrequiredNotnullableOuterEnumDefaultValue.IsSet && notrequiredNotnullableOuterEnumDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableOuterEnumDefaultValue), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_outerEnumDefaultValue.");
 
             if (notrequiredNotnullableStringProp.IsSet && notrequiredNotnullableStringProp.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableStringProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_string_prop.");
 
             if (notrequiredNotnullableUuid.IsSet && notrequiredNotnullableUuid.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableUuid), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_uuid.");
 
             return new RequiredClass(requiredNotNullableDateProp.Value!.Value!, requiredNotnullableArrayOfString.Value!, requiredNotnullableBooleanProp.Value!.Value!, requiredNotnullableDatetimeProp.Value!.Value!, requiredNotnullableEnumInteger.Value!.Value!, requiredNotnullableEnumIntegerOnly.Value!.Value!, requiredNotnullableEnumString.Value!.Value!, requiredNotnullableOuterEnumDefaultValue.Value!.Value!, requiredNotnullableStringProp.Value!, requiredNotnullableUuid.Value!.Value!, requiredNotnullableintegerProp.Value!.Value!, notRequiredNotnullableDateProp, notRequiredNotnullableintegerProp, notRequiredNullableDateProp, notRequiredNullableIntegerProp, notrequiredNotnullableArrayOfString, notrequiredNotnullableBooleanProp, notrequiredNotnullableDatetimeProp, notrequiredNotnullableEnumInteger, notrequiredNotnullableEnumIntegerOnly, notrequiredNotnullableEnumString, notrequiredNotnullableOuterEnumDefaultValue, notrequiredNotnullableStringProp, notrequiredNotnullableUuid, notrequiredNullableArrayOfString, notrequiredNullableBooleanProp, notrequiredNullableDatetimeProp, notrequiredNullableEnumInteger, notrequiredNullableEnumIntegerOnly, notrequiredNullableEnumString, notrequiredNullableOuterEnumDefaultValue, notrequiredNullableStringProp, notrequiredNullableUuid, requiredNullableArrayOfString.Value!, requiredNullableBooleanProp.Value!, requiredNullableDateProp.Value!, requiredNullableDatetimeProp.Value!, requiredNullableEnumInteger.Value!, requiredNullableEnumIntegerOnly.Value!, requiredNullableEnumString.Value!, requiredNullableIntegerProp.Value!, requiredNullableOuterEnumDefaultValue.Value!, requiredNullableStringProp.Value!, requiredNullableUuid.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Result.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Result.cs
@@ -191,13 +191,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (code.IsSet && code.Value == null)
-                throw new ArgumentNullException(nameof(code), "Property is not nullable for class Result.");
+                throw new JsonException("Property is not nullable for class Result: code.");
 
             if (data.IsSet && data.Value == null)
-                throw new ArgumentNullException(nameof(data), "Property is not nullable for class Result.");
+                throw new JsonException("Property is not nullable for class Result: data.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class Result.");
+                throw new JsonException("Property is not nullable for class Result: uuid.");
 
             return new Result(code, data, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Return.cs
@@ -194,19 +194,19 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!varLock.IsSet)
-                throw new ArgumentException("Property is required for class Return.", nameof(varLock));
+                throw new JsonException("Property is required for class Return: lock.");
 
             if (!varAbstract.IsSet)
-                throw new ArgumentException("Property is required for class Return.", nameof(varAbstract));
+                throw new JsonException("Property is required for class Return: abstract.");
 
             if (varLock.IsSet && varLock.Value == null)
-                throw new ArgumentNullException(nameof(varLock), "Property is not nullable for class Return.");
+                throw new JsonException("Property is not nullable for class Return: lock.");
 
             if (varReturn.IsSet && varReturn.Value == null)
-                throw new ArgumentNullException(nameof(varReturn), "Property is not nullable for class Return.");
+                throw new JsonException("Property is not nullable for class Return: return.");
 
             if (varUnsafe.IsSet && varUnsafe.Value == null)
-                throw new ArgumentNullException(nameof(varUnsafe), "Property is not nullable for class Return.");
+                throw new JsonException("Property is not nullable for class Return: unsafe.");
 
             return new Return(varLock.Value!, varAbstract.Value!, varReturn, varUnsafe);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -168,10 +168,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (role.IsSet && role.Value == null)
-                throw new ArgumentNullException(nameof(role), "Property is not nullable for class RolesReportsHash.");
+                throw new JsonException("Property is not nullable for class RolesReportsHash: role.");
 
             if (roleUuid.IsSet && roleUuid.Value == null)
-                throw new ArgumentNullException(nameof(roleUuid), "Property is not nullable for class RolesReportsHash.");
+                throw new JsonException("Property is not nullable for class RolesReportsHash: role_uuid.");
 
             return new RolesReportsHash(role, roleUuid);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
@@ -148,7 +148,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class RolesReportsHashRole.");
+                throw new JsonException("Property is not nullable for class RolesReportsHashRole: name.");
 
             return new RolesReportsHashRole(name);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
@@ -154,16 +154,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ScaleneTriangle.", nameof(shapeType));
+                throw new JsonException("Property is required for class ScaleneTriangle: shapeType.");
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class ScaleneTriangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class ScaleneTriangle: triangleType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ScaleneTriangle.");
+                throw new JsonException("Property is not nullable for class ScaleneTriangle: shapeType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class ScaleneTriangle.");
+                throw new JsonException("Property is not nullable for class ScaleneTriangle: triangleType.");
 
             return new ScaleneTriangle(shapeType.Value!, triangleType.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Shape.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Shape.cs
@@ -196,10 +196,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class Shape.", nameof(shapeType));
+                throw new JsonException("Property is required for class Shape: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class Shape.");
+                throw new JsonException("Property is not nullable for class Shape: shapeType.");
 
             if (quadrilateral != null)
                 return new Shape(quadrilateral);

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ShapeInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ShapeInterface.cs
@@ -141,10 +141,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ShapeInterface.", nameof(shapeType));
+                throw new JsonException("Property is required for class ShapeInterface: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ShapeInterface.");
+                throw new JsonException("Property is not nullable for class ShapeInterface: shapeType.");
 
             return new ShapeInterface(shapeType.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ShapeOrNull.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ShapeOrNull.cs
@@ -196,10 +196,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ShapeOrNull.", nameof(shapeType));
+                throw new JsonException("Property is required for class ShapeOrNull: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ShapeOrNull.");
+                throw new JsonException("Property is not nullable for class ShapeOrNull: shapeType.");
 
             if (quadrilateral != null)
                 return new ShapeOrNull(quadrilateral);

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
@@ -154,16 +154,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class SimpleQuadrilateral.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class SimpleQuadrilateral: quadrilateralType.");
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class SimpleQuadrilateral.", nameof(shapeType));
+                throw new JsonException("Property is required for class SimpleQuadrilateral: shapeType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class SimpleQuadrilateral.");
+                throw new JsonException("Property is not nullable for class SimpleQuadrilateral: quadrilateralType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class SimpleQuadrilateral.");
+                throw new JsonException("Property is not nullable for class SimpleQuadrilateral: shapeType.");
 
             return new SimpleQuadrilateral(quadrilateralType.Value!, shapeType.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -168,10 +168,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varSpecialModelName.IsSet && varSpecialModelName.Value == null)
-                throw new ArgumentNullException(nameof(varSpecialModelName), "Property is not nullable for class SpecialModelName.");
+                throw new JsonException("Property is not nullable for class SpecialModelName: _special_model.name_.");
 
             if (specialPropertyName.IsSet && specialPropertyName.Value == null)
-                throw new ArgumentNullException(nameof(specialPropertyName), "Property is not nullable for class SpecialModelName.");
+                throw new JsonException("Property is not nullable for class SpecialModelName: $special[property.name].");
 
             return new SpecialModelName(varSpecialModelName, specialPropertyName);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Tag.cs
@@ -168,10 +168,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Tag.");
+                throw new JsonException("Property is not nullable for class Tag: id.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Tag.");
+                throw new JsonException("Property is not nullable for class Tag: name.");
 
             return new Tag(id, name);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -148,7 +148,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (value.IsSet && value.Value == null)
-                throw new ArgumentNullException(nameof(value), "Property is not nullable for class TestCollectionEndingWithWordList.");
+                throw new JsonException("Property is not nullable for class TestCollectionEndingWithWordList: value.");
 
             return new TestCollectionEndingWithWordList(value);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -148,7 +148,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (testCollectionEndingWithWordList.IsSet && testCollectionEndingWithWordList.Value == null)
-                throw new ArgumentNullException(nameof(testCollectionEndingWithWordList), "Property is not nullable for class TestCollectionEndingWithWordListObject.");
+                throw new JsonException("Property is not nullable for class TestCollectionEndingWithWordListObject: TestCollectionEndingWithWordList.");
 
             return new TestCollectionEndingWithWordListObject(testCollectionEndingWithWordList);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/TestDescendants.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/TestDescendants.cs
@@ -244,16 +244,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!alternativeName.IsSet)
-                throw new ArgumentException("Property is required for class TestDescendants.", nameof(alternativeName));
+                throw new JsonException("Property is required for class TestDescendants: alternativeName.");
 
             if (!objectType.IsSet)
-                throw new ArgumentException("Property is required for class TestDescendants.", nameof(objectType));
+                throw new JsonException("Property is required for class TestDescendants: objectType.");
 
             if (alternativeName.IsSet && alternativeName.Value == null)
-                throw new ArgumentNullException(nameof(alternativeName), "Property is not nullable for class TestDescendants.");
+                throw new JsonException("Property is not nullable for class TestDescendants: alternativeName.");
 
             if (objectType.IsSet && objectType.Value == null)
-                throw new ArgumentNullException(nameof(objectType), "Property is not nullable for class TestDescendants.");
+                throw new JsonException("Property is not nullable for class TestDescendants: objectType.");
 
             return new TestDescendants(alternativeName.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
@@ -148,7 +148,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (someProperty.IsSet && someProperty.Value == null)
-                throw new ArgumentNullException(nameof(someProperty), "Property is not nullable for class TestInlineFreeformAdditionalPropertiesRequest.");
+                throw new JsonException("Property is not nullable for class TestInlineFreeformAdditionalPropertiesRequest: someProperty.");
 
             return new TestInlineFreeformAdditionalPropertiesRequest(someProperty);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/TestResult.cs
@@ -190,13 +190,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (code.IsSet && code.Value == null)
-                throw new ArgumentNullException(nameof(code), "Property is not nullable for class TestResult.");
+                throw new JsonException("Property is not nullable for class TestResult: code.");
 
             if (data.IsSet && data.Value == null)
-                throw new ArgumentNullException(nameof(data), "Property is not nullable for class TestResult.");
+                throw new JsonException("Property is not nullable for class TestResult: data.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class TestResult.");
+                throw new JsonException("Property is not nullable for class TestResult: uuid.");
 
             return new TestResult(code, data, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Triangle.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Triangle.cs
@@ -217,10 +217,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class Triangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class Triangle: triangleType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class Triangle.");
+                throw new JsonException("Property is not nullable for class Triangle: triangleType.");
 
             if (equilateralTriangle != null)
                 return new Triangle(equilateralTriangle);

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/TriangleInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/TriangleInterface.cs
@@ -141,10 +141,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class TriangleInterface.", nameof(triangleType));
+                throw new JsonException("Property is required for class TriangleInterface: triangleType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class TriangleInterface.");
+                throw new JsonException("Property is not nullable for class TriangleInterface: triangleType.");
 
             return new TriangleInterface(triangleType.Value!);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/User.cs
@@ -373,31 +373,31 @@ namespace Org.OpenAPITools.Model
             }
 
             if (email.IsSet && email.Value == null)
-                throw new ArgumentNullException(nameof(email), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: email.");
 
             if (firstName.IsSet && firstName.Value == null)
-                throw new ArgumentNullException(nameof(firstName), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: firstName.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: id.");
 
             if (lastName.IsSet && lastName.Value == null)
-                throw new ArgumentNullException(nameof(lastName), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: lastName.");
 
             if (objectWithNoDeclaredProps.IsSet && objectWithNoDeclaredProps.Value == null)
-                throw new ArgumentNullException(nameof(objectWithNoDeclaredProps), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: objectWithNoDeclaredProps.");
 
             if (password.IsSet && password.Value == null)
-                throw new ArgumentNullException(nameof(password), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: password.");
 
             if (phone.IsSet && phone.Value == null)
-                throw new ArgumentNullException(nameof(phone), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: phone.");
 
             if (userStatus.IsSet && userStatus.Value == null)
-                throw new ArgumentNullException(nameof(userStatus), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: userStatus.");
 
             if (username.IsSet && username.Value == null)
-                throw new ArgumentNullException(nameof(username), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: username.");
 
             return new User(anyTypeProp, anyTypePropNullable, email, firstName, id, lastName, objectWithNoDeclaredProps, objectWithNoDeclaredPropsNullable, password, phone, userStatus, username);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Whale.cs
@@ -181,16 +181,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Whale.", nameof(className));
+                throw new JsonException("Property is required for class Whale: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Whale.");
+                throw new JsonException("Property is not nullable for class Whale: className.");
 
             if (hasBaleen.IsSet && hasBaleen.Value == null)
-                throw new ArgumentNullException(nameof(hasBaleen), "Property is not nullable for class Whale.");
+                throw new JsonException("Property is not nullable for class Whale: hasBaleen.");
 
             if (hasTeeth.IsSet && hasTeeth.Value == null)
-                throw new ArgumentNullException(nameof(hasTeeth), "Property is not nullable for class Whale.");
+                throw new JsonException("Property is not nullable for class Whale: hasTeeth.");
 
             return new Whale(className.Value!, hasBaleen, hasTeeth);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Zebra.cs
@@ -248,13 +248,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Zebra.", nameof(className));
+                throw new JsonException("Property is required for class Zebra: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Zebra.");
+                throw new JsonException("Property is not nullable for class Zebra: className.");
 
             if (type.IsSet && type.Value == null)
-                throw new ArgumentNullException(nameof(type), "Property is not nullable for class Zebra.");
+                throw new JsonException("Property is not nullable for class Zebra: type.");
 
             return new Zebra(className.Value!, type);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
@@ -221,7 +221,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (zeroBasedEnum.IsSet && zeroBasedEnum.Value == null)
-                throw new ArgumentNullException(nameof(zeroBasedEnum), "Property is not nullable for class ZeroBasedEnumClass.");
+                throw new JsonException("Property is not nullable for class ZeroBasedEnumClass: ZeroBasedEnum.");
 
             return new ZeroBasedEnumClass(zeroBasedEnum);
         }

--- a/samples/client/petstore/csharp/generichost/net9/UseDateTimeForDate/src/Org.OpenAPITools/Model/NowGet200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net9/UseDateTimeForDate/src/Org.OpenAPITools/Model/NowGet200Response.cs
@@ -169,10 +169,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (now.IsSet && now.Value == null)
-                throw new ArgumentNullException(nameof(now), "Property is not nullable for class NowGet200Response.");
+                throw new JsonException("Property is not nullable for class NowGet200Response: now.");
 
             if (today.IsSet && today.Value == null)
-                throw new ArgumentNullException(nameof(today), "Property is not nullable for class NowGet200Response.");
+                throw new JsonException("Property is not nullable for class NowGet200Response: today.");
 
             return new NowGet200Response(now, today);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Activity.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (activityOutputs.IsSet && activityOutputs.Value == null)
-                throw new ArgumentNullException(nameof(activityOutputs), "Property is not nullable for class Activity.");
+                throw new JsonException("Property is not nullable for class Activity: activity_outputs.");
 
             return new Activity(activityOutputs);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (prop1.IsSet && prop1.Value == null)
-                throw new ArgumentNullException(nameof(prop1), "Property is not nullable for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Property is not nullable for class ActivityOutputElementRepresentation: prop1.");
 
             if (prop2.IsSet && prop2.Value == null)
-                throw new ArgumentNullException(nameof(prop2), "Property is not nullable for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Property is not nullable for class ActivityOutputElementRepresentation: prop2.");
 
             return new ActivityOutputElementRepresentation(prop1, prop2);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -286,25 +286,25 @@ namespace Org.OpenAPITools.Model
             }
 
             if (emptyMap.IsSet && emptyMap.Value == null)
-                throw new ArgumentNullException(nameof(emptyMap), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: empty_map.");
 
             if (mapOfMapProperty.IsSet && mapOfMapProperty.Value == null)
-                throw new ArgumentNullException(nameof(mapOfMapProperty), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_of_map_property.");
 
             if (mapProperty.IsSet && mapProperty.Value == null)
-                throw new ArgumentNullException(nameof(mapProperty), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_property.");
 
             if (mapWithUndeclaredPropertiesAnytype1.IsSet && mapWithUndeclaredPropertiesAnytype1.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesAnytype1), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_anytype_1.");
 
             if (mapWithUndeclaredPropertiesAnytype2.IsSet && mapWithUndeclaredPropertiesAnytype2.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesAnytype2), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_anytype_2.");
 
             if (mapWithUndeclaredPropertiesAnytype3.IsSet && mapWithUndeclaredPropertiesAnytype3.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesAnytype3), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_anytype_3.");
 
             if (mapWithUndeclaredPropertiesString.IsSet && mapWithUndeclaredPropertiesString.Value == null)
-                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesString), "Property is not nullable for class AdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class AdditionalPropertiesClass: map_with_undeclared_properties_string.");
 
             return new AdditionalPropertiesClass(anytype1, emptyMap, mapOfMapProperty, mapProperty, mapWithUndeclaredPropertiesAnytype1, mapWithUndeclaredPropertiesAnytype2, mapWithUndeclaredPropertiesAnytype3, mapWithUndeclaredPropertiesString);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Animal.cs
@@ -175,13 +175,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Animal.", nameof(className));
+                throw new JsonException("Property is required for class Animal: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Animal.");
+                throw new JsonException("Property is not nullable for class Animal: className.");
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Animal.");
+                throw new JsonException("Property is not nullable for class Animal: color.");
 
             return new Animal(color);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -185,13 +185,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (code.IsSet && code.Value == null)
-                throw new ArgumentNullException(nameof(code), "Property is not nullable for class ApiResponse.");
+                throw new JsonException("Property is not nullable for class ApiResponse: code.");
 
             if (message.IsSet && message.Value == null)
-                throw new ArgumentNullException(nameof(message), "Property is not nullable for class ApiResponse.");
+                throw new JsonException("Property is not nullable for class ApiResponse: message.");
 
             if (type.IsSet && type.Value == null)
-                throw new ArgumentNullException(nameof(type), "Property is not nullable for class ApiResponse.");
+                throw new JsonException("Property is not nullable for class ApiResponse: type.");
 
             return new ApiResponse(code, message, type);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Apple.cs
@@ -215,13 +215,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (colorCode.IsSet && colorCode.Value == null)
-                throw new ArgumentNullException(nameof(colorCode), "Property is not nullable for class Apple.");
+                throw new JsonException("Property is not nullable for class Apple: color_code.");
 
             if (cultivar.IsSet && cultivar.Value == null)
-                throw new ArgumentNullException(nameof(cultivar), "Property is not nullable for class Apple.");
+                throw new JsonException("Property is not nullable for class Apple: cultivar.");
 
             if (origin.IsSet && origin.Value == null)
-                throw new ArgumentNullException(nameof(origin), "Property is not nullable for class Apple.");
+                throw new JsonException("Property is not nullable for class Apple: origin.");
 
             return new Apple(colorCode, cultivar, origin);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -151,13 +151,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!cultivar.IsSet)
-                throw new ArgumentException("Property is required for class AppleReq.", nameof(cultivar));
+                throw new JsonException("Property is required for class AppleReq: cultivar.");
 
             if (cultivar.IsSet && cultivar.Value == null)
-                throw new ArgumentNullException(nameof(cultivar), "Property is not nullable for class AppleReq.");
+                throw new JsonException("Property is not nullable for class AppleReq: cultivar.");
 
             if (mealy.IsSet && mealy.Value == null)
-                throw new ArgumentNullException(nameof(mealy), "Property is not nullable for class AppleReq.");
+                throw new JsonException("Property is not nullable for class AppleReq: mealy.");
 
             return new AppleReq(cultivar.Value, mealy);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayArrayNumber.IsSet && arrayArrayNumber.Value == null)
-                throw new ArgumentNullException(nameof(arrayArrayNumber), "Property is not nullable for class ArrayOfArrayOfNumberOnly.");
+                throw new JsonException("Property is not nullable for class ArrayOfArrayOfNumberOnly: ArrayArrayNumber.");
 
             return new ArrayOfArrayOfNumberOnly(arrayArrayNumber);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayNumber.IsSet && arrayNumber.Value == null)
-                throw new ArgumentNullException(nameof(arrayNumber), "Property is not nullable for class ArrayOfNumberOnly.");
+                throw new JsonException("Property is not nullable for class ArrayOfNumberOnly: ArrayNumber.");
 
             return new ArrayOfNumberOnly(arrayNumber);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -185,13 +185,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayArrayOfInteger.IsSet && arrayArrayOfInteger.Value == null)
-                throw new ArgumentNullException(nameof(arrayArrayOfInteger), "Property is not nullable for class ArrayTest.");
+                throw new JsonException("Property is not nullable for class ArrayTest: array_array_of_integer.");
 
             if (arrayArrayOfModel.IsSet && arrayArrayOfModel.Value == null)
-                throw new ArgumentNullException(nameof(arrayArrayOfModel), "Property is not nullable for class ArrayTest.");
+                throw new JsonException("Property is not nullable for class ArrayTest: array_array_of_model.");
 
             if (arrayOfString.IsSet && arrayOfString.Value == null)
-                throw new ArgumentNullException(nameof(arrayOfString), "Property is not nullable for class ArrayTest.");
+                throw new JsonException("Property is not nullable for class ArrayTest: array_of_string.");
 
             return new ArrayTest(arrayArrayOfInteger, arrayArrayOfModel, arrayOfString);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Banana.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (lengthCm.IsSet && lengthCm.Value == null)
-                throw new ArgumentNullException(nameof(lengthCm), "Property is not nullable for class Banana.");
+                throw new JsonException("Property is not nullable for class Banana: lengthCm.");
 
             return new Banana(lengthCm);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -151,13 +151,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!lengthCm.IsSet)
-                throw new ArgumentException("Property is required for class BananaReq.", nameof(lengthCm));
+                throw new JsonException("Property is required for class BananaReq: lengthCm.");
 
             if (lengthCm.IsSet && lengthCm.Value == null)
-                throw new ArgumentNullException(nameof(lengthCm), "Property is not nullable for class BananaReq.");
+                throw new JsonException("Property is not nullable for class BananaReq: lengthCm.");
 
             if (sweet.IsSet && sweet.Value == null)
-                throw new ArgumentNullException(nameof(sweet), "Property is not nullable for class BananaReq.");
+                throw new JsonException("Property is not nullable for class BananaReq: sweet.");
 
             return new BananaReq(lengthCm.Value.Value, sweet);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/BasquePig.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/BasquePig.cs
@@ -138,10 +138,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class BasquePig.", nameof(className));
+                throw new JsonException("Property is required for class BasquePig: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class BasquePig.");
+                throw new JsonException("Property is not nullable for class BasquePig: className.");
 
             return new BasquePig(className.Value);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -246,22 +246,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (aTTNAME.IsSet && aTTNAME.Value == null)
-                throw new ArgumentNullException(nameof(aTTNAME), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: ATT_NAME.");
 
             if (capitalCamel.IsSet && capitalCamel.Value == null)
-                throw new ArgumentNullException(nameof(capitalCamel), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: CapitalCamel.");
 
             if (capitalSnake.IsSet && capitalSnake.Value == null)
-                throw new ArgumentNullException(nameof(capitalSnake), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: Capital_Snake.");
 
             if (sCAETHFlowPoints.IsSet && sCAETHFlowPoints.Value == null)
-                throw new ArgumentNullException(nameof(sCAETHFlowPoints), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: SCA_ETH_Flow_Points.");
 
             if (smallCamel.IsSet && smallCamel.Value == null)
-                throw new ArgumentNullException(nameof(smallCamel), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: smallCamel.");
 
             if (smallSnake.IsSet && smallSnake.Value == null)
-                throw new ArgumentNullException(nameof(smallSnake), "Property is not nullable for class Capitalization.");
+                throw new JsonException("Property is not nullable for class Capitalization: small_Snake.");
 
             return new Capitalization(aTTNAME, capitalCamel, capitalSnake, sCAETHFlowPoints, smallCamel, smallSnake);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Cat.cs
@@ -138,16 +138,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Cat.", nameof(className));
+                throw new JsonException("Property is required for class Cat: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Cat.");
+                throw new JsonException("Property is not nullable for class Cat: className.");
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Cat.");
+                throw new JsonException("Property is not nullable for class Cat: color.");
 
             if (declawed.IsSet && declawed.Value == null)
-                throw new ArgumentNullException(nameof(declawed), "Property is not nullable for class Cat.");
+                throw new JsonException("Property is not nullable for class Cat: declawed.");
 
             return new Cat(color, declawed);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Category.cs
@@ -158,13 +158,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!name.IsSet)
-                throw new ArgumentException("Property is required for class Category.", nameof(name));
+                throw new JsonException("Property is required for class Category: name.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Category.");
+                throw new JsonException("Property is not nullable for class Category: id.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Category.");
+                throw new JsonException("Property is not nullable for class Category: name.");
 
             return new Category(id, name.Value);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -200,13 +200,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!petType.IsSet)
-                throw new ArgumentException("Property is required for class ChildCat.", nameof(petType));
+                throw new JsonException("Property is required for class ChildCat: pet_type.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class ChildCat.");
+                throw new JsonException("Property is not nullable for class ChildCat: name.");
 
             if (petType.IsSet && petType.Value == null)
-                throw new ArgumentNullException(nameof(petType), "Property is not nullable for class ChildCat.");
+                throw new JsonException("Property is not nullable for class ChildCat: pet_type.");
 
             return new ChildCat(name);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varClass.IsSet && varClass.Value == null)
-                throw new ArgumentNullException(nameof(varClass), "Property is not nullable for class ClassModel.");
+                throw new JsonException("Property is not nullable for class ClassModel: _class.");
 
             return new ClassModel(varClass);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
@@ -151,16 +151,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class ComplexQuadrilateral.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class ComplexQuadrilateral: quadrilateralType.");
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ComplexQuadrilateral.", nameof(shapeType));
+                throw new JsonException("Property is required for class ComplexQuadrilateral: shapeType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class ComplexQuadrilateral.");
+                throw new JsonException("Property is not nullable for class ComplexQuadrilateral: quadrilateralType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ComplexQuadrilateral.");
+                throw new JsonException("Property is not nullable for class ComplexQuadrilateral: shapeType.");
 
             return new ComplexQuadrilateral(quadrilateralType.Value, shapeType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/CopyActivity.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/CopyActivity.cs
@@ -193,16 +193,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!copyActivitytt.IsSet)
-                throw new ArgumentException("Property is required for class CopyActivity.", nameof(copyActivitytt));
+                throw new JsonException("Property is required for class CopyActivity: copyActivitytt.");
 
             if (!schema.IsSet)
-                throw new ArgumentException("Property is required for class CopyActivity.", nameof(schema));
+                throw new JsonException("Property is required for class CopyActivity: $schema.");
 
             if (copyActivitytt.IsSet && copyActivitytt.Value == null)
-                throw new ArgumentNullException(nameof(copyActivitytt), "Property is not nullable for class CopyActivity.");
+                throw new JsonException("Property is not nullable for class CopyActivity: copyActivitytt.");
 
             if (schema.IsSet && schema.Value == null)
-                throw new ArgumentNullException(nameof(schema), "Property is not nullable for class CopyActivity.");
+                throw new JsonException("Property is not nullable for class CopyActivity: $schema.");
 
             return new CopyActivity(copyActivitytt.Value);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/DanishPig.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/DanishPig.cs
@@ -138,10 +138,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class DanishPig.", nameof(className));
+                throw new JsonException("Property is required for class DanishPig: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class DanishPig.");
+                throw new JsonException("Property is not nullable for class DanishPig: className.");
 
             return new DanishPig(className.Value);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -151,7 +151,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (dateOnlyProperty.IsSet && dateOnlyProperty.Value == null)
-                throw new ArgumentNullException(nameof(dateOnlyProperty), "Property is not nullable for class DateOnlyClass.");
+                throw new JsonException("Property is not nullable for class DateOnlyClass: dateOnlyProperty.");
 
             return new DateOnlyClass(dateOnlyProperty);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class DeprecatedObject.");
+                throw new JsonException("Property is not nullable for class DeprecatedObject: name.");
 
             return new DeprecatedObject(name);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Descendant1.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Descendant1.cs
@@ -138,22 +138,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!alternativeName.IsSet)
-                throw new ArgumentException("Property is required for class Descendant1.", nameof(alternativeName));
+                throw new JsonException("Property is required for class Descendant1: alternativeName.");
 
             if (!descendantName.IsSet)
-                throw new ArgumentException("Property is required for class Descendant1.", nameof(descendantName));
+                throw new JsonException("Property is required for class Descendant1: descendantName.");
 
             if (!objectType.IsSet)
-                throw new ArgumentException("Property is required for class Descendant1.", nameof(objectType));
+                throw new JsonException("Property is required for class Descendant1: objectType.");
 
             if (alternativeName.IsSet && alternativeName.Value == null)
-                throw new ArgumentNullException(nameof(alternativeName), "Property is not nullable for class Descendant1.");
+                throw new JsonException("Property is not nullable for class Descendant1: alternativeName.");
 
             if (descendantName.IsSet && descendantName.Value == null)
-                throw new ArgumentNullException(nameof(descendantName), "Property is not nullable for class Descendant1.");
+                throw new JsonException("Property is not nullable for class Descendant1: descendantName.");
 
             if (objectType.IsSet && objectType.Value == null)
-                throw new ArgumentNullException(nameof(objectType), "Property is not nullable for class Descendant1.");
+                throw new JsonException("Property is not nullable for class Descendant1: objectType.");
 
             return new Descendant1(alternativeName.Value, descendantName.Value);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Descendant2.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Descendant2.cs
@@ -138,22 +138,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!alternativeName.IsSet)
-                throw new ArgumentException("Property is required for class Descendant2.", nameof(alternativeName));
+                throw new JsonException("Property is required for class Descendant2: alternativeName.");
 
             if (!confidentiality.IsSet)
-                throw new ArgumentException("Property is required for class Descendant2.", nameof(confidentiality));
+                throw new JsonException("Property is required for class Descendant2: confidentiality.");
 
             if (!objectType.IsSet)
-                throw new ArgumentException("Property is required for class Descendant2.", nameof(objectType));
+                throw new JsonException("Property is required for class Descendant2: objectType.");
 
             if (alternativeName.IsSet && alternativeName.Value == null)
-                throw new ArgumentNullException(nameof(alternativeName), "Property is not nullable for class Descendant2.");
+                throw new JsonException("Property is not nullable for class Descendant2: alternativeName.");
 
             if (confidentiality.IsSet && confidentiality.Value == null)
-                throw new ArgumentNullException(nameof(confidentiality), "Property is not nullable for class Descendant2.");
+                throw new JsonException("Property is not nullable for class Descendant2: confidentiality.");
 
             if (objectType.IsSet && objectType.Value == null)
-                throw new ArgumentNullException(nameof(objectType), "Property is not nullable for class Descendant2.");
+                throw new JsonException("Property is not nullable for class Descendant2: objectType.");
 
             return new Descendant2(alternativeName.Value, confidentiality.Value);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Dog.cs
@@ -138,16 +138,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Dog.", nameof(className));
+                throw new JsonException("Property is required for class Dog: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Dog.");
+                throw new JsonException("Property is not nullable for class Dog: className.");
 
             if (breed.IsSet && breed.Value == null)
-                throw new ArgumentNullException(nameof(breed), "Property is not nullable for class Dog.");
+                throw new JsonException("Property is not nullable for class Dog: breed.");
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Dog.");
+                throw new JsonException("Property is not nullable for class Dog: color.");
 
             return new Dog(breed, color);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Drawing.cs
@@ -205,10 +205,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (mainShape.IsSet && mainShape.Value == null)
-                throw new ArgumentNullException(nameof(mainShape), "Property is not nullable for class Drawing.");
+                throw new JsonException("Property is not nullable for class Drawing: mainShape.");
 
             if (shapes.IsSet && shapes.Value == null)
-                throw new ArgumentNullException(nameof(shapes), "Property is not nullable for class Drawing.");
+                throw new JsonException("Property is not nullable for class Drawing: shapes.");
 
             return new Drawing(mainShape, nullableShape, shapeOrNull, shapes);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/EntityBase.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/EntityBase.cs
@@ -152,10 +152,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!schema.IsSet)
-                throw new ArgumentException("Property is required for class EntityBase.", nameof(schema));
+                throw new JsonException("Property is required for class EntityBase: $schema.");
 
             if (schema.IsSet && schema.Value == null)
-                throw new ArgumentNullException(nameof(schema), "Property is not nullable for class EntityBase.");
+                throw new JsonException("Property is not nullable for class EntityBase: $schema.");
 
             return new EntityBase();
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -304,10 +304,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayEnum.IsSet && arrayEnum.Value == null)
-                throw new ArgumentNullException(nameof(arrayEnum), "Property is not nullable for class EnumArrays.");
+                throw new JsonException("Property is not nullable for class EnumArrays: array_enum.");
 
             if (justSymbol.IsSet && justSymbol.Value == null)
-                throw new ArgumentNullException(nameof(justSymbol), "Property is not nullable for class EnumArrays.");
+                throw new JsonException("Property is not nullable for class EnumArrays: just_symbol.");
 
             return new EnumArrays(arrayEnum, justSymbol);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -822,31 +822,31 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!enumStringRequired.IsSet)
-                throw new ArgumentException("Property is required for class EnumTest.", nameof(enumStringRequired));
+                throw new JsonException("Property is required for class EnumTest: enum_string_required.");
 
             if (enumStringRequired.IsSet && enumStringRequired.Value == null)
-                throw new ArgumentNullException(nameof(enumStringRequired), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_string_required.");
 
             if (enumInteger.IsSet && enumInteger.Value == null)
-                throw new ArgumentNullException(nameof(enumInteger), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_integer.");
 
             if (enumIntegerOnly.IsSet && enumIntegerOnly.Value == null)
-                throw new ArgumentNullException(nameof(enumIntegerOnly), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_integer_only.");
 
             if (enumNumber.IsSet && enumNumber.Value == null)
-                throw new ArgumentNullException(nameof(enumNumber), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_number.");
 
             if (enumString.IsSet && enumString.Value == null)
-                throw new ArgumentNullException(nameof(enumString), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: enum_string.");
 
             if (outerEnumDefaultValue.IsSet && outerEnumDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(outerEnumDefaultValue), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: outerEnumDefaultValue.");
 
             if (outerEnumInteger.IsSet && outerEnumInteger.Value == null)
-                throw new ArgumentNullException(nameof(outerEnumInteger), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: outerEnumInteger.");
 
             if (outerEnumIntegerDefaultValue.IsSet && outerEnumIntegerDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(outerEnumIntegerDefaultValue), "Property is not nullable for class EnumTest.");
+                throw new JsonException("Property is not nullable for class EnumTest: outerEnumIntegerDefaultValue.");
 
             return new EnumTest(enumStringRequired.Value.Value, enumInteger, enumIntegerOnly, enumNumber, enumString, outerEnum, outerEnumDefaultValue, outerEnumInteger, outerEnumIntegerDefaultValue);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
@@ -151,16 +151,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class EquilateralTriangle.", nameof(shapeType));
+                throw new JsonException("Property is required for class EquilateralTriangle: shapeType.");
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class EquilateralTriangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class EquilateralTriangle: triangleType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class EquilateralTriangle.");
+                throw new JsonException("Property is not nullable for class EquilateralTriangle: shapeType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class EquilateralTriangle.");
+                throw new JsonException("Property is not nullable for class EquilateralTriangle: triangleType.");
 
             return new EquilateralTriangle(shapeType.Value, triangleType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/File.cs
@@ -146,7 +146,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (sourceURI.IsSet && sourceURI.Value == null)
-                throw new ArgumentNullException(nameof(sourceURI), "Property is not nullable for class File.");
+                throw new JsonException("Property is not nullable for class File: sourceURI.");
 
             return new File(sourceURI);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (file.IsSet && file.Value == null)
-                throw new ArgumentNullException(nameof(file), "Property is not nullable for class FileSchemaTestClass.");
+                throw new JsonException("Property is not nullable for class FileSchemaTestClass: file.");
 
             if (files.IsSet && files.Value == null)
-                throw new ArgumentNullException(nameof(files), "Property is not nullable for class FileSchemaTestClass.");
+                throw new JsonException("Property is not nullable for class FileSchemaTestClass: files.");
 
             return new FileSchemaTestClass(file, files);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Foo.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bar.IsSet && bar.Value == null)
-                throw new ArgumentNullException(nameof(bar), "Property is not nullable for class Foo.");
+                throw new JsonException("Property is not nullable for class Foo: bar.");
 
             return new Foo(bar);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varString.IsSet && varString.Value == null)
-                throw new ArgumentNullException(nameof(varString), "Property is not nullable for class FooGetDefaultResponse.");
+                throw new JsonException("Property is not nullable for class FooGetDefaultResponse: string.");
 
             return new FooGetDefaultResponse(varString);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -826,103 +826,103 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!varByte.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(varByte));
+                throw new JsonException("Property is required for class FormatTest: byte.");
 
             if (!date.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(date));
+                throw new JsonException("Property is required for class FormatTest: date.");
 
             if (!number.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(number));
+                throw new JsonException("Property is required for class FormatTest: number.");
 
             if (!password.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(password));
+                throw new JsonException("Property is required for class FormatTest: password.");
 
             if (!stringFormattedAsDecimalRequired.IsSet)
-                throw new ArgumentException("Property is required for class FormatTest.", nameof(stringFormattedAsDecimalRequired));
+                throw new JsonException("Property is required for class FormatTest: string_formatted_as_decimal_required.");
 
             if (varByte.IsSet && varByte.Value == null)
-                throw new ArgumentNullException(nameof(varByte), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: byte.");
 
             if (date.IsSet && date.Value == null)
-                throw new ArgumentNullException(nameof(date), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: date.");
 
             if (number.IsSet && number.Value == null)
-                throw new ArgumentNullException(nameof(number), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: number.");
 
             if (password.IsSet && password.Value == null)
-                throw new ArgumentNullException(nameof(password), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: password.");
 
             if (stringFormattedAsDecimalRequired.IsSet && stringFormattedAsDecimalRequired.Value == null)
-                throw new ArgumentNullException(nameof(stringFormattedAsDecimalRequired), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: string_formatted_as_decimal_required.");
 
             if (binary.IsSet && binary.Value == null)
-                throw new ArgumentNullException(nameof(binary), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: binary.");
 
             if (dateTime.IsSet && dateTime.Value == null)
-                throw new ArgumentNullException(nameof(dateTime), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: dateTime.");
 
             if (varDecimal.IsSet && varDecimal.Value == null)
-                throw new ArgumentNullException(nameof(varDecimal), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: decimal.");
 
             if (varDouble.IsSet && varDouble.Value == null)
-                throw new ArgumentNullException(nameof(varDouble), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: double.");
 
             if (duplicatePropertyName2.IsSet && duplicatePropertyName2.Value == null)
-                throw new ArgumentNullException(nameof(duplicatePropertyName2), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: duplicate_property_name.");
 
             if (duplicatePropertyName.IsSet && duplicatePropertyName.Value == null)
-                throw new ArgumentNullException(nameof(duplicatePropertyName), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: @duplicate_property_name.");
 
             if (varFloat.IsSet && varFloat.Value == null)
-                throw new ArgumentNullException(nameof(varFloat), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: float.");
 
             if (int32.IsSet && int32.Value == null)
-                throw new ArgumentNullException(nameof(int32), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int32.");
 
             if (int32Range.IsSet && int32Range.Value == null)
-                throw new ArgumentNullException(nameof(int32Range), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int32Range.");
 
             if (int64.IsSet && int64.Value == null)
-                throw new ArgumentNullException(nameof(int64), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64.");
 
             if (int64Negative.IsSet && int64Negative.Value == null)
-                throw new ArgumentNullException(nameof(int64Negative), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64Negative.");
 
             if (int64NegativeExclusive.IsSet && int64NegativeExclusive.Value == null)
-                throw new ArgumentNullException(nameof(int64NegativeExclusive), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64NegativeExclusive.");
 
             if (int64Positive.IsSet && int64Positive.Value == null)
-                throw new ArgumentNullException(nameof(int64Positive), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64Positive.");
 
             if (int64PositiveExclusive.IsSet && int64PositiveExclusive.Value == null)
-                throw new ArgumentNullException(nameof(int64PositiveExclusive), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: int64PositiveExclusive.");
 
             if (integer.IsSet && integer.Value == null)
-                throw new ArgumentNullException(nameof(integer), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: integer.");
 
             if (patternWithBackslash.IsSet && patternWithBackslash.Value == null)
-                throw new ArgumentNullException(nameof(patternWithBackslash), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: pattern_with_backslash.");
 
             if (patternWithDigits.IsSet && patternWithDigits.Value == null)
-                throw new ArgumentNullException(nameof(patternWithDigits), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: pattern_with_digits.");
 
             if (patternWithDigitsAndDelimiter.IsSet && patternWithDigitsAndDelimiter.Value == null)
-                throw new ArgumentNullException(nameof(patternWithDigitsAndDelimiter), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: pattern_with_digits_and_delimiter.");
 
             if (varString.IsSet && varString.Value == null)
-                throw new ArgumentNullException(nameof(varString), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: string.");
 
             if (stringFormattedAsDecimal.IsSet && stringFormattedAsDecimal.Value == null)
-                throw new ArgumentNullException(nameof(stringFormattedAsDecimal), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: string_formatted_as_decimal.");
 
             if (unsignedInteger.IsSet && unsignedInteger.Value == null)
-                throw new ArgumentNullException(nameof(unsignedInteger), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: unsigned_integer.");
 
             if (unsignedLong.IsSet && unsignedLong.Value == null)
-                throw new ArgumentNullException(nameof(unsignedLong), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: unsigned_long.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class FormatTest.");
+                throw new JsonException("Property is not nullable for class FormatTest: uuid.");
 
             return new FormatTest(varByte.Value, date.Value.Value, number.Value.Value, password.Value, stringFormattedAsDecimalRequired.Value.Value, binary, dateTime, varDecimal, varDouble, duplicatePropertyName2, duplicatePropertyName, varFloat, int32, int32Range, int64, int64Negative, int64NegativeExclusive, int64Positive, int64PositiveExclusive, integer, patternWithBackslash, patternWithDigits, patternWithDigitsAndDelimiter, varString, stringFormattedAsDecimal, unsignedInteger, unsignedLong, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
@@ -183,7 +183,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class Fruit.");
+                throw new JsonException("Property is not nullable for class Fruit: color.");
 
             if (apple != null)
                 return new Fruit(apple, color);

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -187,7 +187,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (color.IsSet && color.Value == null)
-                throw new ArgumentNullException(nameof(color), "Property is not nullable for class GmFruit.");
+                throw new JsonException("Property is not nullable for class GmFruit: color.");
 
             Option<Apple> appleParsedValue = apple == null
                 ? default

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
@@ -155,10 +155,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!petType.IsSet)
-                throw new ArgumentException("Property is required for class GrandparentAnimal.", nameof(petType));
+                throw new JsonException("Property is required for class GrandparentAnimal: pet_type.");
 
             if (petType.IsSet && petType.Value == null)
-                throw new ArgumentNullException(nameof(petType), "Property is not nullable for class GrandparentAnimal.");
+                throw new JsonException("Property is not nullable for class GrandparentAnimal: pet_type.");
 
             return new GrandparentAnimal();
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -206,10 +206,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bar.IsSet && bar.Value == null)
-                throw new ArgumentNullException(nameof(bar), "Property is not nullable for class HasOnlyReadOnly.");
+                throw new JsonException("Property is not nullable for class HasOnlyReadOnly: bar.");
 
             if (foo.IsSet && foo.Value == null)
-                throw new ArgumentNullException(nameof(foo), "Property is not nullable for class HasOnlyReadOnly.");
+                throw new JsonException("Property is not nullable for class HasOnlyReadOnly: foo.");
 
             return new HasOnlyReadOnly(bar, foo);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
@@ -292,22 +292,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (potentiallyOverriddenPropertyAccessor.IsSet && potentiallyOverriddenPropertyAccessor.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyAccessor), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyAccessor.");
 
             if (potentiallyOverriddenPropertyToInternal.IsSet && potentiallyOverriddenPropertyToInternal.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyToInternal), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyToInternal.");
 
             if (potentiallyOverriddenPropertyToPrivate.IsSet && potentiallyOverriddenPropertyToPrivate.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyToPrivate), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyToPrivate.");
 
             if (potentiallyOverriddenPropertyToPublic.IsSet && potentiallyOverriddenPropertyToPublic.Value == null)
-                throw new ArgumentNullException(nameof(potentiallyOverriddenPropertyToPublic), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: potentiallyOverriddenPropertyToPublic.");
 
             if (unalteredProperty.IsSet && unalteredProperty.Value == null)
-                throw new ArgumentNullException(nameof(unalteredProperty), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: unalteredProperty.");
 
             if (unalteredPropertyAccessor.IsSet && unalteredPropertyAccessor.Value == null)
-                throw new ArgumentNullException(nameof(unalteredPropertyAccessor), "Property is not nullable for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Property is not nullable for class InjectedVendorExtensionsTest: unalteredPropertyAccessor.");
 
             return new InjectedVendorExtensionsTest(potentiallyOverriddenPropertyAccessor, potentiallyOverriddenPropertyToInternal, potentiallyOverriddenPropertyToPrivate, potentiallyOverriddenPropertyToPublic, unalteredProperty, unalteredPropertyAccessor);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
@@ -144,16 +144,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class IsoscelesTriangle.", nameof(shapeType));
+                throw new JsonException("Property is required for class IsoscelesTriangle: shapeType.");
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class IsoscelesTriangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class IsoscelesTriangle: triangleType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class IsoscelesTriangle.");
+                throw new JsonException("Property is not nullable for class IsoscelesTriangle: shapeType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class IsoscelesTriangle.");
+                throw new JsonException("Property is not nullable for class IsoscelesTriangle: triangleType.");
 
             return new IsoscelesTriangle(shapeType.Value, triangleType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/List.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (var123List.IsSet && var123List.Value == null)
-                throw new ArgumentNullException(nameof(var123List), "Property is not nullable for class List.");
+                throw new JsonException("Property is not nullable for class List: 123-list.");
 
             return new List(var123List);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (escapedLiteralString.IsSet && escapedLiteralString.Value == null)
-                throw new ArgumentNullException(nameof(escapedLiteralString), "Property is not nullable for class LiteralStringClass.");
+                throw new JsonException("Property is not nullable for class LiteralStringClass: escapedLiteralString.");
 
             if (unescapedLiteralString.IsSet && unescapedLiteralString.Value == null)
-                throw new ArgumentNullException(nameof(unescapedLiteralString), "Property is not nullable for class LiteralStringClass.");
+                throw new JsonException("Property is not nullable for class LiteralStringClass: unescapedLiteralString.");
 
             return new LiteralStringClass(escapedLiteralString, unescapedLiteralString);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Mammal.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Mammal.cs
@@ -214,10 +214,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Mammal.", nameof(className));
+                throw new JsonException("Property is required for class Mammal: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Mammal.");
+                throw new JsonException("Property is not nullable for class Mammal: className.");
 
             if (pig != null)
                 return new Mammal(pig);

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/MapTest.cs
@@ -271,16 +271,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (directMap.IsSet && directMap.Value == null)
-                throw new ArgumentNullException(nameof(directMap), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: direct_map.");
 
             if (indirectMap.IsSet && indirectMap.Value == null)
-                throw new ArgumentNullException(nameof(indirectMap), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: indirect_map.");
 
             if (mapMapOfString.IsSet && mapMapOfString.Value == null)
-                throw new ArgumentNullException(nameof(mapMapOfString), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: map_map_of_string.");
 
             if (mapOfEnumString.IsSet && mapOfEnumString.Value == null)
-                throw new ArgumentNullException(nameof(mapOfEnumString), "Property is not nullable for class MapTest.");
+                throw new JsonException("Property is not nullable for class MapTest: map_of_enum_string.");
 
             return new MapTest(directMap, indirectMap, mapMapOfString, mapOfEnumString);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/MixedAnyOf.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/MixedAnyOf.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (content.IsSet && content.Value == null)
-                throw new ArgumentNullException(nameof(content), "Property is not nullable for class MixedAnyOf.");
+                throw new JsonException("Property is not nullable for class MixedAnyOf: content.");
 
             return new MixedAnyOf(content);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/MixedOneOf.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/MixedOneOf.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (content.IsSet && content.Value == null)
-                throw new ArgumentNullException(nameof(content), "Property is not nullable for class MixedOneOf.");
+                throw new JsonException("Property is not nullable for class MixedOneOf: content.");
 
             return new MixedOneOf(content);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -217,16 +217,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (dateTime.IsSet && dateTime.Value == null)
-                throw new ArgumentNullException(nameof(dateTime), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: dateTime.");
 
             if (map.IsSet && map.Value == null)
-                throw new ArgumentNullException(nameof(map), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: map.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: uuid.");
 
             if (uuidWithPattern.IsSet && uuidWithPattern.Value == null)
-                throw new ArgumentNullException(nameof(uuidWithPattern), "Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Property is not nullable for class MixedPropertiesAndAdditionalPropertiesClass: uuid_with_pattern.");
 
             return new MixedPropertiesAndAdditionalPropertiesClass(dateTime, map, uuid, uuidWithPattern);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/MixedSubId.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/MixedSubId.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class MixedSubId.");
+                throw new JsonException("Property is not nullable for class MixedSubId: id.");
 
             return new MixedSubId(id);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varClass.IsSet && varClass.Value == null)
-                throw new ArgumentNullException(nameof(varClass), "Property is not nullable for class Model200Response.");
+                throw new JsonException("Property is not nullable for class Model200Response: class.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Model200Response.");
+                throw new JsonException("Property is not nullable for class Model200Response: name.");
 
             return new Model200Response(varClass, name);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varClient.IsSet && varClient.Value == null)
-                throw new ArgumentNullException(nameof(varClient), "Property is not nullable for class ModelClient.");
+                throw new JsonException("Property is not nullable for class ModelClient: client.");
 
             return new ModelClient(varClient);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Name.cs
@@ -239,19 +239,19 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!varName.IsSet)
-                throw new ArgumentException("Property is required for class Name.", nameof(varName));
+                throw new JsonException("Property is required for class Name: name.");
 
             if (varName.IsSet && varName.Value == null)
-                throw new ArgumentNullException(nameof(varName), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: name.");
 
             if (property.IsSet && property.Value == null)
-                throw new ArgumentNullException(nameof(property), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: property.");
 
             if (snakeCase.IsSet && snakeCase.Value == null)
-                throw new ArgumentNullException(nameof(snakeCase), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: snake_case.");
 
             if (var123Number.IsSet && var123Number.Value == null)
-                throw new ArgumentNullException(nameof(var123Number), "Property is not nullable for class Name.");
+                throw new JsonException("Property is not nullable for class Name: 123Number.");
 
             return new Name(varName.Value.Value, property, snakeCase, var123Number);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
@@ -151,16 +151,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!aObjVariableobject.IsSet)
-                throw new ArgumentException("Property is required for class NotificationtestGetElementsV1ResponseMPayload.", nameof(aObjVariableobject));
+                throw new JsonException("Property is required for class NotificationtestGetElementsV1ResponseMPayload: a_objVariableobject.");
 
             if (!pkiNotificationtestID.IsSet)
-                throw new ArgumentException("Property is required for class NotificationtestGetElementsV1ResponseMPayload.", nameof(pkiNotificationtestID));
+                throw new JsonException("Property is required for class NotificationtestGetElementsV1ResponseMPayload: pkiNotificationtestID.");
 
             if (aObjVariableobject.IsSet && aObjVariableobject.Value == null)
-                throw new ArgumentNullException(nameof(aObjVariableobject), "Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload.");
+                throw new JsonException("Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload: a_objVariableobject.");
 
             if (pkiNotificationtestID.IsSet && pkiNotificationtestID.Value == null)
-                throw new ArgumentNullException(nameof(pkiNotificationtestID), "Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload.");
+                throw new JsonException("Property is not nullable for class NotificationtestGetElementsV1ResponseMPayload: pkiNotificationtestID.");
 
             return new NotificationtestGetElementsV1ResponseMPayload(aObjVariableobject.Value, pkiNotificationtestID.Value.Value);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -375,10 +375,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (arrayItemsNullable.IsSet && arrayItemsNullable.Value == null)
-                throw new ArgumentNullException(nameof(arrayItemsNullable), "Property is not nullable for class NullableClass.");
+                throw new JsonException("Property is not nullable for class NullableClass: array_items_nullable.");
 
             if (objectItemsNullable.IsSet && objectItemsNullable.Value == null)
-                throw new ArgumentNullException(nameof(objectItemsNullable), "Property is not nullable for class NullableClass.");
+                throw new JsonException("Property is not nullable for class NullableClass: object_items_nullable.");
 
             return new NullableClass(arrayAndItemsNullableProp, arrayItemsNullable, arrayNullableProp, booleanProp, dateProp, datetimeProp, integerProp, numberProp, objectAndItemsNullableProp, objectItemsNullable, objectNullableProp, stringProp);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/NullableShape.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/NullableShape.cs
@@ -193,10 +193,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class NullableShape.", nameof(shapeType));
+                throw new JsonException("Property is required for class NullableShape: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class NullableShape.");
+                throw new JsonException("Property is not nullable for class NullableShape: shapeType.");
 
             if (quadrilateral != null)
                 return new NullableShape(quadrilateral);

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (justNumber.IsSet && justNumber.Value == null)
-                throw new ArgumentNullException(nameof(justNumber), "Property is not nullable for class NumberOnly.");
+                throw new JsonException("Property is not nullable for class NumberOnly: JustNumber.");
 
             return new NumberOnly(justNumber);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -208,16 +208,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bars.IsSet && bars.Value == null)
-                throw new ArgumentNullException(nameof(bars), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: bars.");
 
             if (deprecatedRef.IsSet && deprecatedRef.Value == null)
-                throw new ArgumentNullException(nameof(deprecatedRef), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: deprecatedRef.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: id.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Property is not nullable for class ObjectWithDeprecatedFields: uuid.");
 
             return new ObjectWithDeprecatedFields(bars, deprecatedRef, id, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Order.cs
@@ -340,22 +340,22 @@ namespace Org.OpenAPITools.Model
             }
 
             if (complete.IsSet && complete.Value == null)
-                throw new ArgumentNullException(nameof(complete), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: complete.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: id.");
 
             if (petId.IsSet && petId.Value == null)
-                throw new ArgumentNullException(nameof(petId), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: petId.");
 
             if (quantity.IsSet && quantity.Value == null)
-                throw new ArgumentNullException(nameof(quantity), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: quantity.");
 
             if (shipDate.IsSet && shipDate.Value == null)
-                throw new ArgumentNullException(nameof(shipDate), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: shipDate.");
 
             if (status.IsSet && status.Value == null)
-                throw new ArgumentNullException(nameof(status), "Property is not nullable for class Order.");
+                throw new JsonException("Property is not nullable for class Order: status.");
 
             return new Order(complete, id, petId, quantity, shipDate, status);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -185,13 +185,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (myBoolean.IsSet && myBoolean.Value == null)
-                throw new ArgumentNullException(nameof(myBoolean), "Property is not nullable for class OuterComposite.");
+                throw new JsonException("Property is not nullable for class OuterComposite: my_boolean.");
 
             if (myNumber.IsSet && myNumber.Value == null)
-                throw new ArgumentNullException(nameof(myNumber), "Property is not nullable for class OuterComposite.");
+                throw new JsonException("Property is not nullable for class OuterComposite: my_number.");
 
             if (myString.IsSet && myString.Value == null)
-                throw new ArgumentNullException(nameof(myString), "Property is not nullable for class OuterComposite.");
+                throw new JsonException("Property is not nullable for class OuterComposite: my_string.");
 
             return new OuterComposite(myBoolean, myNumber, myString);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ParentPet.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ParentPet.cs
@@ -118,10 +118,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!petType.IsSet)
-                throw new ArgumentException("Property is required for class ParentPet.", nameof(petType));
+                throw new JsonException("Property is required for class ParentPet: pet_type.");
 
             if (petType.IsSet && petType.Value == null)
-                throw new ArgumentNullException(nameof(petType), "Property is not nullable for class ParentPet.");
+                throw new JsonException("Property is not nullable for class ParentPet: pet_type.");
 
             return new ParentPet();
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Pet.cs
@@ -321,28 +321,28 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!name.IsSet)
-                throw new ArgumentException("Property is required for class Pet.", nameof(name));
+                throw new JsonException("Property is required for class Pet: name.");
 
             if (!photoUrls.IsSet)
-                throw new ArgumentException("Property is required for class Pet.", nameof(photoUrls));
+                throw new JsonException("Property is required for class Pet: photoUrls.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: name.");
 
             if (photoUrls.IsSet && photoUrls.Value == null)
-                throw new ArgumentNullException(nameof(photoUrls), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: photoUrls.");
 
             if (category.IsSet && category.Value == null)
-                throw new ArgumentNullException(nameof(category), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: category.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: id.");
 
             if (status.IsSet && status.Value == null)
-                throw new ArgumentNullException(nameof(status), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: status.");
 
             if (tags.IsSet && tags.Value == null)
-                throw new ArgumentNullException(nameof(tags), "Property is not nullable for class Pet.");
+                throw new JsonException("Property is not nullable for class Pet: tags.");
 
             return new Pet(name.Value, photoUrls.Value, category, id, status, tags);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Pig.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Pig.cs
@@ -193,10 +193,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Pig.", nameof(className));
+                throw new JsonException("Property is required for class Pig: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Pig.");
+                throw new JsonException("Property is not nullable for class Pig: className.");
 
             if (basquePig != null)
                 return new Pig(basquePig);

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Quadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Quadrilateral.cs
@@ -193,10 +193,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class Quadrilateral.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class Quadrilateral: quadrilateralType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class Quadrilateral.");
+                throw new JsonException("Property is not nullable for class Quadrilateral: quadrilateralType.");
 
             if (complexQuadrilateral != null)
                 return new Quadrilateral(complexQuadrilateral);

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
@@ -138,10 +138,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class QuadrilateralInterface.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class QuadrilateralInterface: quadrilateralType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class QuadrilateralInterface.");
+                throw new JsonException("Property is not nullable for class QuadrilateralInterface: quadrilateralType.");
 
             return new QuadrilateralInterface(quadrilateralType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -203,10 +203,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (bar.IsSet && bar.Value == null)
-                throw new ArgumentNullException(nameof(bar), "Property is not nullable for class ReadOnlyFirst.");
+                throw new JsonException("Property is not nullable for class ReadOnlyFirst: bar.");
 
             if (baz.IsSet && baz.Value == null)
-                throw new ArgumentNullException(nameof(baz), "Property is not nullable for class ReadOnlyFirst.");
+                throw new JsonException("Property is not nullable for class ReadOnlyFirst: baz.");
 
             return new ReadOnlyFirst(bar, baz);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -2077,136 +2077,136 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!requiredNotNullableDateProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotNullableDateProp));
+                throw new JsonException("Property is required for class RequiredClass: required_not_nullable_date_prop.");
 
             if (!requiredNotnullableArrayOfString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableArrayOfString));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_array_of_string.");
 
             if (!requiredNotnullableBooleanProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableBooleanProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_boolean_prop.");
 
             if (!requiredNotnullableDatetimeProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableDatetimeProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_datetime_prop.");
 
             if (!requiredNotnullableEnumInteger.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableEnumInteger));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_enum_integer.");
 
             if (!requiredNotnullableEnumIntegerOnly.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableEnumIntegerOnly));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_enum_integer_only.");
 
             if (!requiredNotnullableEnumString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableEnumString));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_enum_string.");
 
             if (!requiredNotnullableOuterEnumDefaultValue.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableOuterEnumDefaultValue));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_outerEnumDefaultValue.");
 
             if (!requiredNotnullableStringProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableStringProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_string_prop.");
 
             if (!requiredNotnullableUuid.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableUuid));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullable_uuid.");
 
             if (!requiredNotnullableintegerProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNotnullableintegerProp));
+                throw new JsonException("Property is required for class RequiredClass: required_notnullableinteger_prop.");
 
             if (!requiredNullableArrayOfString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableArrayOfString));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_array_of_string.");
 
             if (!requiredNullableBooleanProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableBooleanProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_boolean_prop.");
 
             if (!requiredNullableDateProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableDateProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_date_prop.");
 
             if (!requiredNullableDatetimeProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableDatetimeProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_datetime_prop.");
 
             if (!requiredNullableEnumInteger.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableEnumInteger));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_enum_integer.");
 
             if (!requiredNullableEnumIntegerOnly.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableEnumIntegerOnly));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_enum_integer_only.");
 
             if (!requiredNullableEnumString.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableEnumString));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_enum_string.");
 
             if (!requiredNullableIntegerProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableIntegerProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_integer_prop.");
 
             if (!requiredNullableOuterEnumDefaultValue.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableOuterEnumDefaultValue));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_outerEnumDefaultValue.");
 
             if (!requiredNullableStringProp.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableStringProp));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_string_prop.");
 
             if (!requiredNullableUuid.IsSet)
-                throw new ArgumentException("Property is required for class RequiredClass.", nameof(requiredNullableUuid));
+                throw new JsonException("Property is required for class RequiredClass: required_nullable_uuid.");
 
             if (requiredNotNullableDateProp.IsSet && requiredNotNullableDateProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotNullableDateProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_not_nullable_date_prop.");
 
             if (requiredNotnullableArrayOfString.IsSet && requiredNotnullableArrayOfString.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableArrayOfString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_array_of_string.");
 
             if (requiredNotnullableBooleanProp.IsSet && requiredNotnullableBooleanProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableBooleanProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_boolean_prop.");
 
             if (requiredNotnullableDatetimeProp.IsSet && requiredNotnullableDatetimeProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableDatetimeProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_datetime_prop.");
 
             if (requiredNotnullableEnumInteger.IsSet && requiredNotnullableEnumInteger.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableEnumInteger), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_enum_integer.");
 
             if (requiredNotnullableEnumIntegerOnly.IsSet && requiredNotnullableEnumIntegerOnly.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableEnumIntegerOnly), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_enum_integer_only.");
 
             if (requiredNotnullableEnumString.IsSet && requiredNotnullableEnumString.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableEnumString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_enum_string.");
 
             if (requiredNotnullableOuterEnumDefaultValue.IsSet && requiredNotnullableOuterEnumDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableOuterEnumDefaultValue), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_outerEnumDefaultValue.");
 
             if (requiredNotnullableStringProp.IsSet && requiredNotnullableStringProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableStringProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_string_prop.");
 
             if (requiredNotnullableUuid.IsSet && requiredNotnullableUuid.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableUuid), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullable_uuid.");
 
             if (requiredNotnullableintegerProp.IsSet && requiredNotnullableintegerProp.Value == null)
-                throw new ArgumentNullException(nameof(requiredNotnullableintegerProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: required_notnullableinteger_prop.");
 
             if (notRequiredNotnullableDateProp.IsSet && notRequiredNotnullableDateProp.Value == null)
-                throw new ArgumentNullException(nameof(notRequiredNotnullableDateProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: not_required_notnullable_date_prop.");
 
             if (notRequiredNotnullableintegerProp.IsSet && notRequiredNotnullableintegerProp.Value == null)
-                throw new ArgumentNullException(nameof(notRequiredNotnullableintegerProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: not_required_notnullableinteger_prop.");
 
             if (notrequiredNotnullableArrayOfString.IsSet && notrequiredNotnullableArrayOfString.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableArrayOfString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_array_of_string.");
 
             if (notrequiredNotnullableBooleanProp.IsSet && notrequiredNotnullableBooleanProp.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableBooleanProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_boolean_prop.");
 
             if (notrequiredNotnullableDatetimeProp.IsSet && notrequiredNotnullableDatetimeProp.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableDatetimeProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_datetime_prop.");
 
             if (notrequiredNotnullableEnumInteger.IsSet && notrequiredNotnullableEnumInteger.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableEnumInteger), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_enum_integer.");
 
             if (notrequiredNotnullableEnumIntegerOnly.IsSet && notrequiredNotnullableEnumIntegerOnly.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableEnumIntegerOnly), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_enum_integer_only.");
 
             if (notrequiredNotnullableEnumString.IsSet && notrequiredNotnullableEnumString.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableEnumString), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_enum_string.");
 
             if (notrequiredNotnullableOuterEnumDefaultValue.IsSet && notrequiredNotnullableOuterEnumDefaultValue.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableOuterEnumDefaultValue), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_outerEnumDefaultValue.");
 
             if (notrequiredNotnullableStringProp.IsSet && notrequiredNotnullableStringProp.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableStringProp), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_string_prop.");
 
             if (notrequiredNotnullableUuid.IsSet && notrequiredNotnullableUuid.Value == null)
-                throw new ArgumentNullException(nameof(notrequiredNotnullableUuid), "Property is not nullable for class RequiredClass.");
+                throw new JsonException("Property is not nullable for class RequiredClass: notrequired_notnullable_uuid.");
 
             return new RequiredClass(requiredNotNullableDateProp.Value.Value, requiredNotnullableArrayOfString.Value, requiredNotnullableBooleanProp.Value.Value, requiredNotnullableDatetimeProp.Value.Value, requiredNotnullableEnumInteger.Value.Value, requiredNotnullableEnumIntegerOnly.Value.Value, requiredNotnullableEnumString.Value.Value, requiredNotnullableOuterEnumDefaultValue.Value.Value, requiredNotnullableStringProp.Value, requiredNotnullableUuid.Value.Value, requiredNotnullableintegerProp.Value.Value, notRequiredNotnullableDateProp, notRequiredNotnullableintegerProp, notRequiredNullableDateProp, notRequiredNullableIntegerProp, notrequiredNotnullableArrayOfString, notrequiredNotnullableBooleanProp, notrequiredNotnullableDatetimeProp, notrequiredNotnullableEnumInteger, notrequiredNotnullableEnumIntegerOnly, notrequiredNotnullableEnumString, notrequiredNotnullableOuterEnumDefaultValue, notrequiredNotnullableStringProp, notrequiredNotnullableUuid, notrequiredNullableArrayOfString, notrequiredNullableBooleanProp, notrequiredNullableDatetimeProp, notrequiredNullableEnumInteger, notrequiredNullableEnumIntegerOnly, notrequiredNullableEnumString, notrequiredNullableOuterEnumDefaultValue, notrequiredNullableStringProp, notrequiredNullableUuid, requiredNullableArrayOfString.Value, requiredNullableBooleanProp.Value, requiredNullableDateProp.Value, requiredNullableDatetimeProp.Value, requiredNullableEnumInteger.Value, requiredNullableEnumIntegerOnly.Value, requiredNullableEnumString.Value, requiredNullableIntegerProp.Value, requiredNullableOuterEnumDefaultValue.Value, requiredNullableStringProp.Value, requiredNullableUuid.Value);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Result.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Result.cs
@@ -188,13 +188,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (code.IsSet && code.Value == null)
-                throw new ArgumentNullException(nameof(code), "Property is not nullable for class Result.");
+                throw new JsonException("Property is not nullable for class Result: code.");
 
             if (data.IsSet && data.Value == null)
-                throw new ArgumentNullException(nameof(data), "Property is not nullable for class Result.");
+                throw new JsonException("Property is not nullable for class Result: data.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class Result.");
+                throw new JsonException("Property is not nullable for class Result: uuid.");
 
             return new Result(code, data, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Return.cs
@@ -191,19 +191,19 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!varLock.IsSet)
-                throw new ArgumentException("Property is required for class Return.", nameof(varLock));
+                throw new JsonException("Property is required for class Return: lock.");
 
             if (!varAbstract.IsSet)
-                throw new ArgumentException("Property is required for class Return.", nameof(varAbstract));
+                throw new JsonException("Property is required for class Return: abstract.");
 
             if (varLock.IsSet && varLock.Value == null)
-                throw new ArgumentNullException(nameof(varLock), "Property is not nullable for class Return.");
+                throw new JsonException("Property is not nullable for class Return: lock.");
 
             if (varReturn.IsSet && varReturn.Value == null)
-                throw new ArgumentNullException(nameof(varReturn), "Property is not nullable for class Return.");
+                throw new JsonException("Property is not nullable for class Return: return.");
 
             if (varUnsafe.IsSet && varUnsafe.Value == null)
-                throw new ArgumentNullException(nameof(varUnsafe), "Property is not nullable for class Return.");
+                throw new JsonException("Property is not nullable for class Return: unsafe.");
 
             return new Return(varLock.Value, varAbstract.Value, varReturn, varUnsafe);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (role.IsSet && role.Value == null)
-                throw new ArgumentNullException(nameof(role), "Property is not nullable for class RolesReportsHash.");
+                throw new JsonException("Property is not nullable for class RolesReportsHash: role.");
 
             if (roleUuid.IsSet && roleUuid.Value == null)
-                throw new ArgumentNullException(nameof(roleUuid), "Property is not nullable for class RolesReportsHash.");
+                throw new JsonException("Property is not nullable for class RolesReportsHash: role_uuid.");
 
             return new RolesReportsHash(role, roleUuid);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class RolesReportsHashRole.");
+                throw new JsonException("Property is not nullable for class RolesReportsHashRole: name.");
 
             return new RolesReportsHashRole(name);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
@@ -151,16 +151,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ScaleneTriangle.", nameof(shapeType));
+                throw new JsonException("Property is required for class ScaleneTriangle: shapeType.");
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class ScaleneTriangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class ScaleneTriangle: triangleType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ScaleneTriangle.");
+                throw new JsonException("Property is not nullable for class ScaleneTriangle: shapeType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class ScaleneTriangle.");
+                throw new JsonException("Property is not nullable for class ScaleneTriangle: triangleType.");
 
             return new ScaleneTriangle(shapeType.Value, triangleType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Shape.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Shape.cs
@@ -193,10 +193,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class Shape.", nameof(shapeType));
+                throw new JsonException("Property is required for class Shape: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class Shape.");
+                throw new JsonException("Property is not nullable for class Shape: shapeType.");
 
             if (quadrilateral != null)
                 return new Shape(quadrilateral);

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ShapeInterface.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ShapeInterface.cs
@@ -138,10 +138,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ShapeInterface.", nameof(shapeType));
+                throw new JsonException("Property is required for class ShapeInterface: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ShapeInterface.");
+                throw new JsonException("Property is not nullable for class ShapeInterface: shapeType.");
 
             return new ShapeInterface(shapeType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ShapeOrNull.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ShapeOrNull.cs
@@ -193,10 +193,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class ShapeOrNull.", nameof(shapeType));
+                throw new JsonException("Property is required for class ShapeOrNull: shapeType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class ShapeOrNull.");
+                throw new JsonException("Property is not nullable for class ShapeOrNull: shapeType.");
 
             if (quadrilateral != null)
                 return new ShapeOrNull(quadrilateral);

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
@@ -151,16 +151,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!quadrilateralType.IsSet)
-                throw new ArgumentException("Property is required for class SimpleQuadrilateral.", nameof(quadrilateralType));
+                throw new JsonException("Property is required for class SimpleQuadrilateral: quadrilateralType.");
 
             if (!shapeType.IsSet)
-                throw new ArgumentException("Property is required for class SimpleQuadrilateral.", nameof(shapeType));
+                throw new JsonException("Property is required for class SimpleQuadrilateral: shapeType.");
 
             if (quadrilateralType.IsSet && quadrilateralType.Value == null)
-                throw new ArgumentNullException(nameof(quadrilateralType), "Property is not nullable for class SimpleQuadrilateral.");
+                throw new JsonException("Property is not nullable for class SimpleQuadrilateral: quadrilateralType.");
 
             if (shapeType.IsSet && shapeType.Value == null)
-                throw new ArgumentNullException(nameof(shapeType), "Property is not nullable for class SimpleQuadrilateral.");
+                throw new JsonException("Property is not nullable for class SimpleQuadrilateral: shapeType.");
 
             return new SimpleQuadrilateral(quadrilateralType.Value, shapeType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (varSpecialModelName.IsSet && varSpecialModelName.Value == null)
-                throw new ArgumentNullException(nameof(varSpecialModelName), "Property is not nullable for class SpecialModelName.");
+                throw new JsonException("Property is not nullable for class SpecialModelName: _special_model.name_.");
 
             if (specialPropertyName.IsSet && specialPropertyName.Value == null)
-                throw new ArgumentNullException(nameof(specialPropertyName), "Property is not nullable for class SpecialModelName.");
+                throw new JsonException("Property is not nullable for class SpecialModelName: $special[property.name].");
 
             return new SpecialModelName(varSpecialModelName, specialPropertyName);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Tag.cs
@@ -165,10 +165,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class Tag.");
+                throw new JsonException("Property is not nullable for class Tag: id.");
 
             if (name.IsSet && name.Value == null)
-                throw new ArgumentNullException(nameof(name), "Property is not nullable for class Tag.");
+                throw new JsonException("Property is not nullable for class Tag: name.");
 
             return new Tag(id, name);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (value.IsSet && value.Value == null)
-                throw new ArgumentNullException(nameof(value), "Property is not nullable for class TestCollectionEndingWithWordList.");
+                throw new JsonException("Property is not nullable for class TestCollectionEndingWithWordList: value.");
 
             return new TestCollectionEndingWithWordList(value);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (testCollectionEndingWithWordList.IsSet && testCollectionEndingWithWordList.Value == null)
-                throw new ArgumentNullException(nameof(testCollectionEndingWithWordList), "Property is not nullable for class TestCollectionEndingWithWordListObject.");
+                throw new JsonException("Property is not nullable for class TestCollectionEndingWithWordListObject: TestCollectionEndingWithWordList.");
 
             return new TestCollectionEndingWithWordListObject(testCollectionEndingWithWordList);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/TestDescendants.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/TestDescendants.cs
@@ -241,16 +241,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!alternativeName.IsSet)
-                throw new ArgumentException("Property is required for class TestDescendants.", nameof(alternativeName));
+                throw new JsonException("Property is required for class TestDescendants: alternativeName.");
 
             if (!objectType.IsSet)
-                throw new ArgumentException("Property is required for class TestDescendants.", nameof(objectType));
+                throw new JsonException("Property is required for class TestDescendants: objectType.");
 
             if (alternativeName.IsSet && alternativeName.Value == null)
-                throw new ArgumentNullException(nameof(alternativeName), "Property is not nullable for class TestDescendants.");
+                throw new JsonException("Property is not nullable for class TestDescendants: alternativeName.");
 
             if (objectType.IsSet && objectType.Value == null)
-                throw new ArgumentNullException(nameof(objectType), "Property is not nullable for class TestDescendants.");
+                throw new JsonException("Property is not nullable for class TestDescendants: objectType.");
 
             return new TestDescendants(alternativeName.Value);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (someProperty.IsSet && someProperty.Value == null)
-                throw new ArgumentNullException(nameof(someProperty), "Property is not nullable for class TestInlineFreeformAdditionalPropertiesRequest.");
+                throw new JsonException("Property is not nullable for class TestInlineFreeformAdditionalPropertiesRequest: someProperty.");
 
             return new TestInlineFreeformAdditionalPropertiesRequest(someProperty);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/TestResult.cs
@@ -187,13 +187,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (code.IsSet && code.Value == null)
-                throw new ArgumentNullException(nameof(code), "Property is not nullable for class TestResult.");
+                throw new JsonException("Property is not nullable for class TestResult: code.");
 
             if (data.IsSet && data.Value == null)
-                throw new ArgumentNullException(nameof(data), "Property is not nullable for class TestResult.");
+                throw new JsonException("Property is not nullable for class TestResult: data.");
 
             if (uuid.IsSet && uuid.Value == null)
-                throw new ArgumentNullException(nameof(uuid), "Property is not nullable for class TestResult.");
+                throw new JsonException("Property is not nullable for class TestResult: uuid.");
 
             return new TestResult(code, data, uuid);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Triangle.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Triangle.cs
@@ -214,10 +214,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class Triangle.", nameof(triangleType));
+                throw new JsonException("Property is required for class Triangle: triangleType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class Triangle.");
+                throw new JsonException("Property is not nullable for class Triangle: triangleType.");
 
             if (equilateralTriangle != null)
                 return new Triangle(equilateralTriangle);

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/TriangleInterface.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/TriangleInterface.cs
@@ -138,10 +138,10 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!triangleType.IsSet)
-                throw new ArgumentException("Property is required for class TriangleInterface.", nameof(triangleType));
+                throw new JsonException("Property is required for class TriangleInterface: triangleType.");
 
             if (triangleType.IsSet && triangleType.Value == null)
-                throw new ArgumentNullException(nameof(triangleType), "Property is not nullable for class TriangleInterface.");
+                throw new JsonException("Property is not nullable for class TriangleInterface: triangleType.");
 
             return new TriangleInterface(triangleType.Value);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/User.cs
@@ -370,31 +370,31 @@ namespace Org.OpenAPITools.Model
             }
 
             if (email.IsSet && email.Value == null)
-                throw new ArgumentNullException(nameof(email), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: email.");
 
             if (firstName.IsSet && firstName.Value == null)
-                throw new ArgumentNullException(nameof(firstName), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: firstName.");
 
             if (id.IsSet && id.Value == null)
-                throw new ArgumentNullException(nameof(id), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: id.");
 
             if (lastName.IsSet && lastName.Value == null)
-                throw new ArgumentNullException(nameof(lastName), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: lastName.");
 
             if (objectWithNoDeclaredProps.IsSet && objectWithNoDeclaredProps.Value == null)
-                throw new ArgumentNullException(nameof(objectWithNoDeclaredProps), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: objectWithNoDeclaredProps.");
 
             if (password.IsSet && password.Value == null)
-                throw new ArgumentNullException(nameof(password), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: password.");
 
             if (phone.IsSet && phone.Value == null)
-                throw new ArgumentNullException(nameof(phone), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: phone.");
 
             if (userStatus.IsSet && userStatus.Value == null)
-                throw new ArgumentNullException(nameof(userStatus), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: userStatus.");
 
             if (username.IsSet && username.Value == null)
-                throw new ArgumentNullException(nameof(username), "Property is not nullable for class User.");
+                throw new JsonException("Property is not nullable for class User: username.");
 
             return new User(anyTypeProp, anyTypePropNullable, email, firstName, id, lastName, objectWithNoDeclaredProps, objectWithNoDeclaredPropsNullable, password, phone, userStatus, username);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Whale.cs
@@ -178,16 +178,16 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Whale.", nameof(className));
+                throw new JsonException("Property is required for class Whale: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Whale.");
+                throw new JsonException("Property is not nullable for class Whale: className.");
 
             if (hasBaleen.IsSet && hasBaleen.Value == null)
-                throw new ArgumentNullException(nameof(hasBaleen), "Property is not nullable for class Whale.");
+                throw new JsonException("Property is not nullable for class Whale: hasBaleen.");
 
             if (hasTeeth.IsSet && hasTeeth.Value == null)
-                throw new ArgumentNullException(nameof(hasTeeth), "Property is not nullable for class Whale.");
+                throw new JsonException("Property is not nullable for class Whale: hasTeeth.");
 
             return new Whale(className.Value, hasBaleen, hasTeeth);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Zebra.cs
@@ -245,13 +245,13 @@ namespace Org.OpenAPITools.Model
             }
 
             if (!className.IsSet)
-                throw new ArgumentException("Property is required for class Zebra.", nameof(className));
+                throw new JsonException("Property is required for class Zebra: className.");
 
             if (className.IsSet && className.Value == null)
-                throw new ArgumentNullException(nameof(className), "Property is not nullable for class Zebra.");
+                throw new JsonException("Property is not nullable for class Zebra: className.");
 
             if (type.IsSet && type.Value == null)
-                throw new ArgumentNullException(nameof(type), "Property is not nullable for class Zebra.");
+                throw new JsonException("Property is not nullable for class Zebra: type.");
 
             return new Zebra(className.Value, type);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
@@ -218,7 +218,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (zeroBasedEnum.IsSet && zeroBasedEnum.Value == null)
-                throw new ArgumentNullException(nameof(zeroBasedEnum), "Property is not nullable for class ZeroBasedEnumClass.");
+                throw new JsonException("Property is not nullable for class ZeroBasedEnumClass: ZeroBasedEnum.");
 
             return new ZeroBasedEnumClass(zeroBasedEnum);
         }


### PR DESCRIPTION
Fixes #24345.

The post-loop validation in generated `JsonConverter<T>.Read()` threw `ArgumentException` when a required property was missing, and `ArgumentNullException` when a non-nullable property was null:

```csharp
if (!name.IsSet)
    throw new ArgumentException("Property is required for class Pet.", nameof(name));

if (name.IsSet && name.Value == null)
    throw new ArgumentNullException(nameof(name), "Property is not nullable for class Pet.");
```

Both violate the `System.Text.Json` converter contract, with two practical consequences:

- `System.Text.Json` only enriches a `JsonException` with the JSON path of the failure, so for these two errors the path was lost and the caller got no indication of *which* element failed.
- Callers wrapping deserialization in `catch (JsonException)` did not catch them, so a malformed payload surfaced as an unhandled `ArgumentException` rather than a deserialization failure.

### Change

Both now throw `JsonException`, naming the property in the message since `JsonException` carries no parameter name:

```csharp
if (!name.IsSet)
    throw new JsonException("Property is required for class Pet: name.");

if (name.IsSet && name.Value == null)
    throw new JsonException("Property is not nullable for class Pet: name.");
```

`Read()` already documented `<exception cref="JsonException">`, so this also makes the generated documentation accurate.

### What is deliberately unchanged

`WriteProperties` still throws `ArgumentNullException`. That check validates an object handed in by the caller during serialization, not JSON being parsed, so an argument exception is the correct choice there and the issue explicitly scopes the change to the `Read()` post-loop blocks. Generated models still carry those calls.

### Samples

Regenerated with `./bin/generate-samples.sh ./bin/configs/csharp-generichost-*.yaml` — all 50 generichost configs. 1688 files, 5888 insertions and 5888 deletions: every changed line is one of the two throws being replaced, with no other churn.

I do not have a .NET toolchain on this machine, so I have not compiled the regenerated samples locally; the change is confined to the two throw statements described above.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Generated C# converters now throw `JsonException` from `JsonConverter<T>.Read()` when a required property is missing or a non-nullable property is null, replacing the previous `ArgumentException` and `ArgumentNullException`. Fixes #24345.

Because `System.Text.Json` only adds the JSON path to `JsonException`, the old exceptions lost the failing element's location and escaped callers' `catch (JsonException)` blocks.

**Deliberately unchanged**

- `WriteProperties` still throws `ArgumentNullException` because it validates caller-supplied objects during serialization, not parsed JSON.

<sup>Written for commit f2b3e860c4c6ed6dd5f0b7c9d2fc0186a475d79e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24820?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

