### PR TITLE
fix: set isOverridden from the model's own properties rather than only when unset

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -6331,8 +6331,12 @@ public class DefaultCodegen implements CodegenConfig {
                     cp = fromProperty(key, prop, mandatory.contains(key));
                 }
 
-                if (cm != null && cm.allVars == vars && cp.isOverridden == null) { // processing allVars and it's a parent property
-                    cp.isOverridden = true;
+                if (cm != null && cm.allVars == vars) {
+                    // Processing allVars: a property is overridden when it comes from the parent rather than
+                    // being declared by this model. fromProperty caches CodegenProperty instances, so the flag
+                    // must be assigned rather than only filled in when unset - a cached instance may already
+                    // carry a value from whichever model happened to be processed first.
+                    cp.isOverridden = !varsMap.containsKey(key);
                 }
 
                 vars.add(cp);

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -2363,6 +2363,23 @@ public class JavaClientCodegenTest {
     }
 
     @Test
+    public void testOverrideSetterWhenChildIsDeclaredBeforeParent() {
+        final Path output = newTempFolder();
+        OpenAPI openAPI = new OpenAPIParser()
+                .readLocation("src/test/resources/3_0/allOf_composition_discriminator_child_first.yaml", null, null)
+                .getOpenAPI();
+
+        JavaClientCodegen codegen = new JavaClientCodegen();
+        codegen.setOutputDir(output.toString());
+        codegen.setLibrary(JavaClientCodegen.APACHE);
+
+        new DefaultGenerator().opts(new ClientOptInput().openAPI(openAPI).config(codegen)).generate();
+
+        assertThat(output.resolve("src/main/java/org/openapitools/client/model/Cat.java")).content()
+                .contains("  @Override\n  public Cat petType(@javax.annotation.Nonnull String petType) {");
+    }
+
+    @Test
     public void testForJavaApacheHttpClientOverrideSetter() {
         final Path output = newTempFolder();
         OpenAPI openAPI = new OpenAPIParser()

--- a/modules/openapi-generator/src/test/resources/3_0/allOf_composition_discriminator_child_first.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/allOf_composition_discriminator_child_first.yaml
@@ -1,0 +1,52 @@
+openapi: 3.0.2
+info:
+  title: OAI Specification example for Polymorphism
+  version: 1.0.0
+paths:
+  /pet:
+    get:
+      responses:
+        '200':
+          description: desc
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+components:
+  schemas:
+    MyPets:
+      oneOf:
+        - $ref: '#/components/schemas/Cat'
+        - $ref: '#/components/schemas/Dog'
+      discriminator:
+        propertyName: petType
+    Pet:
+      type: object
+      required:
+        - petType
+      properties:
+        petType:
+          type: string
+      discriminator:
+        propertyName: petType
+    Cat:
+      allOf:
+        - $ref: '#/components/schemas/Pet'
+        - type: object
+          properties:
+            name:
+              type: string
+            characteristics:
+              $ref: '#/components/schemas/Characteristics'
+    Dog:
+      allOf:
+        - $ref: '#/components/schemas/Pet'
+        - type: object
+          properties:
+            bark:
+              type: string
+    Characteristics:
+      type: object
+      properties:
+        canHunt:
+          type: boolean

--- a/samples/client/others/java/restclient-sealedInterface/src/main/java/org/openapitools/client/model/BarRef.java
+++ b/samples/client/others/java/restclient-sealedInterface/src/main/java/org/openapitools/client/model/BarRef.java
@@ -80,6 +80,18 @@ public final class BarRef extends EntityRef implements Serializable, BarRefOrVal
   }
 
   @Override
+  public BarRef name(@jakarta.annotation.Nullable String name) {
+    this.setName(name);
+    return this;
+  }
+
+  @Override
+  public BarRef atReferredType(@jakarta.annotation.Nullable String atReferredType) {
+    this.setAtReferredType(atReferredType);
+    return this;
+  }
+
+  @Override
   public boolean equals(Object o) {
     if (this == o) {
       return true;

--- a/samples/client/others/java/restclient-sealedInterface/src/main/java/org/openapitools/client/model/FooRef.java
+++ b/samples/client/others/java/restclient-sealedInterface/src/main/java/org/openapitools/client/model/FooRef.java
@@ -110,6 +110,18 @@ public final class FooRef extends EntityRef implements Serializable, FooRefOrVal
   }
 
   @Override
+  public FooRef name(@jakarta.annotation.Nullable String name) {
+    this.setName(name);
+    return this;
+  }
+
+  @Override
+  public FooRef atReferredType(@jakarta.annotation.Nullable String atReferredType) {
+    this.setAtReferredType(atReferredType);
+    return this;
+  }
+
+  @Override
   public boolean equals(Object o) {
     if (this == o) {
       return true;

--- a/samples/client/others/java/restclient-sealedInterface/src/main/java/org/openapitools/client/model/PizzaSpeziale.java
+++ b/samples/client/others/java/restclient-sealedInterface/src/main/java/org/openapitools/client/model/PizzaSpeziale.java
@@ -111,6 +111,12 @@ public final class PizzaSpeziale extends Pizza implements Serializable {
   }
 
   @Override
+  public PizzaSpeziale pizzaSize(@jakarta.annotation.Nullable BigDecimal pizzaSize) {
+    this.setPizzaSize(pizzaSize);
+    return this;
+  }
+
+  @Override
   public boolean equals(Object o) {
     if (this == o) {
       return true;

--- a/samples/client/others/java/webclient-sealedInterface/src/main/java/org/openapitools/client/model/Bar.java
+++ b/samples/client/others/java/webclient-sealedInterface/src/main/java/org/openapitools/client/model/Bar.java
@@ -167,6 +167,30 @@ public final class Bar extends Entity implements BarRefOrValue {
 
 
   @Override
+  public Bar href(@javax.annotation.Nullable String href) {
+    this.setHref(href);
+    return this;
+  }
+
+  @Override
+  public Bar atSchemaLocation(@javax.annotation.Nullable String atSchemaLocation) {
+    this.setAtSchemaLocation(atSchemaLocation);
+    return this;
+  }
+
+  @Override
+  public Bar atBaseType(@javax.annotation.Nullable String atBaseType) {
+    this.setAtBaseType(atBaseType);
+    return this;
+  }
+
+  @Override
+  public Bar atType(@javax.annotation.Nonnull String atType) {
+    this.setAtType(atType);
+    return this;
+  }
+
+  @Override
   public boolean equals(Object o) {
     if (this == o) {
       return true;

--- a/samples/client/others/java/webclient-sealedInterface/src/main/java/org/openapitools/client/model/BarCreate.java
+++ b/samples/client/others/java/webclient-sealedInterface/src/main/java/org/openapitools/client/model/BarCreate.java
@@ -138,6 +138,36 @@ public class BarCreate extends Entity {
 
 
   @Override
+  public BarCreate href(@javax.annotation.Nullable String href) {
+    this.setHref(href);
+    return this;
+  }
+
+  @Override
+  public BarCreate id(@javax.annotation.Nullable String id) {
+    this.setId(id);
+    return this;
+  }
+
+  @Override
+  public BarCreate atSchemaLocation(@javax.annotation.Nullable String atSchemaLocation) {
+    this.setAtSchemaLocation(atSchemaLocation);
+    return this;
+  }
+
+  @Override
+  public BarCreate atBaseType(@javax.annotation.Nullable String atBaseType) {
+    this.setAtBaseType(atBaseType);
+    return this;
+  }
+
+  @Override
+  public BarCreate atType(@javax.annotation.Nonnull String atType) {
+    this.setAtType(atType);
+    return this;
+  }
+
+  @Override
   public boolean equals(Object o) {
     if (this == o) {
       return true;

--- a/samples/client/others/java/webclient-sealedInterface/src/main/java/org/openapitools/client/model/BarRef.java
+++ b/samples/client/others/java/webclient-sealedInterface/src/main/java/org/openapitools/client/model/BarRef.java
@@ -46,6 +46,48 @@ public final class BarRef extends EntityRef implements BarRefOrValue {
 
 
   @Override
+  public BarRef href(@javax.annotation.Nullable String href) {
+    this.setHref(href);
+    return this;
+  }
+
+  @Override
+  public BarRef id(@javax.annotation.Nullable String id) {
+    this.setId(id);
+    return this;
+  }
+
+  @Override
+  public BarRef atSchemaLocation(@javax.annotation.Nullable String atSchemaLocation) {
+    this.setAtSchemaLocation(atSchemaLocation);
+    return this;
+  }
+
+  @Override
+  public BarRef atBaseType(@javax.annotation.Nullable String atBaseType) {
+    this.setAtBaseType(atBaseType);
+    return this;
+  }
+
+  @Override
+  public BarRef atType(@javax.annotation.Nonnull String atType) {
+    this.setAtType(atType);
+    return this;
+  }
+
+  @Override
+  public BarRef name(@javax.annotation.Nullable String name) {
+    this.setName(name);
+    return this;
+  }
+
+  @Override
+  public BarRef atReferredType(@javax.annotation.Nullable String atReferredType) {
+    this.setAtReferredType(atReferredType);
+    return this;
+  }
+
+  @Override
   public boolean equals(Object o) {
     if (this == o) {
       return true;

--- a/samples/client/others/java/webclient-sealedInterface/src/main/java/org/openapitools/client/model/Foo.java
+++ b/samples/client/others/java/webclient-sealedInterface/src/main/java/org/openapitools/client/model/Foo.java
@@ -106,6 +106,36 @@ public final class Foo extends Entity implements FooRefOrValue {
 
 
   @Override
+  public Foo href(@javax.annotation.Nullable String href) {
+    this.setHref(href);
+    return this;
+  }
+
+  @Override
+  public Foo id(@javax.annotation.Nullable String id) {
+    this.setId(id);
+    return this;
+  }
+
+  @Override
+  public Foo atSchemaLocation(@javax.annotation.Nullable String atSchemaLocation) {
+    this.setAtSchemaLocation(atSchemaLocation);
+    return this;
+  }
+
+  @Override
+  public Foo atBaseType(@javax.annotation.Nullable String atBaseType) {
+    this.setAtBaseType(atBaseType);
+    return this;
+  }
+
+  @Override
+  public Foo atType(@javax.annotation.Nonnull String atType) {
+    this.setAtType(atType);
+    return this;
+  }
+
+  @Override
   public boolean equals(Object o) {
     if (this == o) {
       return true;

--- a/samples/client/others/java/webclient-sealedInterface/src/main/java/org/openapitools/client/model/FooRef.java
+++ b/samples/client/others/java/webclient-sealedInterface/src/main/java/org/openapitools/client/model/FooRef.java
@@ -76,6 +76,48 @@ public final class FooRef extends EntityRef implements FooRefOrValue {
 
 
   @Override
+  public FooRef href(@javax.annotation.Nullable String href) {
+    this.setHref(href);
+    return this;
+  }
+
+  @Override
+  public FooRef id(@javax.annotation.Nullable String id) {
+    this.setId(id);
+    return this;
+  }
+
+  @Override
+  public FooRef atSchemaLocation(@javax.annotation.Nullable String atSchemaLocation) {
+    this.setAtSchemaLocation(atSchemaLocation);
+    return this;
+  }
+
+  @Override
+  public FooRef atBaseType(@javax.annotation.Nullable String atBaseType) {
+    this.setAtBaseType(atBaseType);
+    return this;
+  }
+
+  @Override
+  public FooRef atType(@javax.annotation.Nonnull String atType) {
+    this.setAtType(atType);
+    return this;
+  }
+
+  @Override
+  public FooRef name(@javax.annotation.Nullable String name) {
+    this.setName(name);
+    return this;
+  }
+
+  @Override
+  public FooRef atReferredType(@javax.annotation.Nullable String atReferredType) {
+    this.setAtReferredType(atReferredType);
+    return this;
+  }
+
+  @Override
   public boolean equals(Object o) {
     if (this == o) {
       return true;

--- a/samples/client/others/java/webclient-sealedInterface/src/main/java/org/openapitools/client/model/Pasta.java
+++ b/samples/client/others/java/webclient-sealedInterface/src/main/java/org/openapitools/client/model/Pasta.java
@@ -76,6 +76,36 @@ public class Pasta extends Entity {
 
 
   @Override
+  public Pasta href(@javax.annotation.Nullable String href) {
+    this.setHref(href);
+    return this;
+  }
+
+  @Override
+  public Pasta id(@javax.annotation.Nullable String id) {
+    this.setId(id);
+    return this;
+  }
+
+  @Override
+  public Pasta atSchemaLocation(@javax.annotation.Nullable String atSchemaLocation) {
+    this.setAtSchemaLocation(atSchemaLocation);
+    return this;
+  }
+
+  @Override
+  public Pasta atBaseType(@javax.annotation.Nullable String atBaseType) {
+    this.setAtBaseType(atBaseType);
+    return this;
+  }
+
+  @Override
+  public Pasta atType(@javax.annotation.Nonnull String atType) {
+    this.setAtType(atType);
+    return this;
+  }
+
+  @Override
   public boolean equals(Object o) {
     if (this == o) {
       return true;

--- a/samples/client/others/java/webclient-sealedInterface/src/main/java/org/openapitools/client/model/Pizza.java
+++ b/samples/client/others/java/webclient-sealedInterface/src/main/java/org/openapitools/client/model/Pizza.java
@@ -80,6 +80,36 @@ public class Pizza extends Entity {
 
 
   @Override
+  public Pizza href(@javax.annotation.Nullable String href) {
+    this.setHref(href);
+    return this;
+  }
+
+  @Override
+  public Pizza id(@javax.annotation.Nullable String id) {
+    this.setId(id);
+    return this;
+  }
+
+  @Override
+  public Pizza atSchemaLocation(@javax.annotation.Nullable String atSchemaLocation) {
+    this.setAtSchemaLocation(atSchemaLocation);
+    return this;
+  }
+
+  @Override
+  public Pizza atBaseType(@javax.annotation.Nullable String atBaseType) {
+    this.setAtBaseType(atBaseType);
+    return this;
+  }
+
+  @Override
+  public Pizza atType(@javax.annotation.Nonnull String atType) {
+    this.setAtType(atType);
+    return this;
+  }
+
+  @Override
   public boolean equals(Object o) {
     if (this == o) {
       return true;

--- a/samples/client/others/java/webclient-sealedInterface/src/main/java/org/openapitools/client/model/PizzaSpeziale.java
+++ b/samples/client/others/java/webclient-sealedInterface/src/main/java/org/openapitools/client/model/PizzaSpeziale.java
@@ -77,6 +77,42 @@ public class PizzaSpeziale extends Pizza {
 
 
   @Override
+  public PizzaSpeziale href(@javax.annotation.Nullable String href) {
+    this.setHref(href);
+    return this;
+  }
+
+  @Override
+  public PizzaSpeziale id(@javax.annotation.Nullable String id) {
+    this.setId(id);
+    return this;
+  }
+
+  @Override
+  public PizzaSpeziale atSchemaLocation(@javax.annotation.Nullable String atSchemaLocation) {
+    this.setAtSchemaLocation(atSchemaLocation);
+    return this;
+  }
+
+  @Override
+  public PizzaSpeziale atBaseType(@javax.annotation.Nullable String atBaseType) {
+    this.setAtBaseType(atBaseType);
+    return this;
+  }
+
+  @Override
+  public PizzaSpeziale atType(@javax.annotation.Nonnull String atType) {
+    this.setAtType(atType);
+    return this;
+  }
+
+  @Override
+  public PizzaSpeziale pizzaSize(@javax.annotation.Nullable BigDecimal pizzaSize) {
+    this.setPizzaSize(pizzaSize);
+    return this;
+  }
+
+  @Override
   public boolean equals(Object o) {
     if (this == o) {
       return true;

--- a/samples/client/others/java/webclient-sealedInterface_3_1/src/main/java/org/openapitools/client/model/BarRef.java
+++ b/samples/client/others/java/webclient-sealedInterface_3_1/src/main/java/org/openapitools/client/model/BarRef.java
@@ -76,6 +76,18 @@ public final class BarRef extends EntityRef implements BarRefOrValue {
   }
 
   @Override
+  public BarRef name(@javax.annotation.Nullable String name) {
+    this.setName(name);
+    return this;
+  }
+
+  @Override
+  public BarRef atReferredType(@javax.annotation.Nullable String atReferredType) {
+    this.setAtReferredType(atReferredType);
+    return this;
+  }
+
+  @Override
   public boolean equals(Object o) {
     if (this == o) {
       return true;

--- a/samples/client/others/java/webclient-sealedInterface_3_1/src/main/java/org/openapitools/client/model/FooRef.java
+++ b/samples/client/others/java/webclient-sealedInterface_3_1/src/main/java/org/openapitools/client/model/FooRef.java
@@ -106,6 +106,18 @@ public final class FooRef extends EntityRef implements FooRefOrValue {
   }
 
   @Override
+  public FooRef name(@javax.annotation.Nullable String name) {
+    this.setName(name);
+    return this;
+  }
+
+  @Override
+  public FooRef atReferredType(@javax.annotation.Nullable String atReferredType) {
+    this.setAtReferredType(atReferredType);
+    return this;
+  }
+
+  @Override
   public boolean equals(Object o) {
     if (this == o) {
       return true;

--- a/samples/client/others/java/webclient-sealedInterface_3_1/src/main/java/org/openapitools/client/model/PizzaSpeziale.java
+++ b/samples/client/others/java/webclient-sealedInterface_3_1/src/main/java/org/openapitools/client/model/PizzaSpeziale.java
@@ -107,6 +107,12 @@ public class PizzaSpeziale extends Pizza {
   }
 
   @Override
+  public PizzaSpeziale pizzaSize(@javax.annotation.Nullable BigDecimal pizzaSize) {
+    this.setPizzaSize(pizzaSize);
+    return this;
+  }
+
+  @Override
   public boolean equals(Object o) {
     if (this == o) {
       return true;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/BigCat.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/BigCat.java
@@ -127,6 +127,12 @@ public class BigCat extends Cat {
   }
 
   @Override
+  public BigCat declawed(@javax.annotation.Nullable Boolean declawed) {
+    this.setDeclawed(declawed);
+    return this;
+  }
+
+  @Override
   public boolean equals(Object o) {
     if (this == o) {
       return true;

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/BigCat.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/BigCat.java
@@ -131,6 +131,12 @@ public class BigCat extends Cat {
   }
 
   @Override
+  public BigCat declawed(@javax.annotation.Nullable Boolean declawed) {
+    this.setDeclawed(declawed);
+    return this;
+  }
+
+  @Override
   public boolean equals(Object o) {
     if (this == o) {
       return true;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/BigCat.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/BigCat.java
@@ -127,6 +127,12 @@ public class BigCat extends Cat {
   }
 
   @Override
+  public BigCat declawed(@javax.annotation.Nullable Boolean declawed) {
+    this.setDeclawed(declawed);
+    return this;
+  }
+
+  @Override
   public boolean equals(Object o) {
     if (this == o) {
       return true;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/BigCat.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/BigCat.java
@@ -130,6 +130,12 @@ public class BigCat extends Cat {
   }
 
   @Override
+  public BigCat declawed(@jakarta.annotation.Nullable Boolean declawed) {
+    this.setDeclawed(declawed);
+    return this;
+  }
+
+  @Override
   public boolean equals(Object o) {
     if (this == o) {
       return true;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/BigCat.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/BigCat.java
@@ -123,6 +123,12 @@ public class BigCat extends Cat {
   }
 
   @Override
+  public BigCat declawed(@javax.annotation.Nullable Boolean declawed) {
+    this.setDeclawed(declawed);
+    return this;
+  }
+
+  @Override
   public boolean equals(Object o) {
     if (this == o) {
       return true;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/BigCat.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/BigCat.java
@@ -123,6 +123,12 @@ public class BigCat extends Cat {
   }
 
   @Override
+  public BigCat declawed(@javax.annotation.Nullable Boolean declawed) {
+    this.setDeclawed(declawed);
+    return this;
+  }
+
+  @Override
   public boolean equals(Object o) {
     if (this == o) {
       return true;

--- a/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/BigCat.java
+++ b/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/BigCat.java
@@ -123,6 +123,12 @@ public class BigCat extends Cat {
   }
 
   @Override
+  public BigCat declawed(@javax.annotation.Nullable Boolean declawed) {
+    this.setDeclawed(declawed);
+    return this;
+  }
+
+  @Override
   public boolean equals(Object o) {
     if (this == o) {
       return true;

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/BigCat.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/BigCat.java
@@ -127,6 +127,12 @@ public class BigCat extends Cat {
   }
 
   @Override
+  public BigCat declawed(@javax.annotation.Nullable Boolean declawed) {
+    this.setDeclawed(declawed);
+    return this;
+  }
+
+  @Override
   public boolean equals(Object o) {
     if (this == o) {
       return true;


### PR DESCRIPTION
Fixes #24778.

A property inherited through `allOf` only produced an overriding fluent setter when the parent schema happened to be declared before the child. Moving `MyPets` above `Pet` in the reporter's spec drops `Cat`'s setter entirely — the generated class still extends `Pet`, but the `@Override public Cat petType(...)` method is gone.

### Cause

`addVars` marked a parent property as overridden only when the flag was still unset:

```java
if (cm != null && cm.allVars == vars && cp.isOverridden == null) {
    cp.isOverridden = true;
}
```

`fromProperty` caches `CodegenProperty` instances in `schemaCodegenPropertyCache`, so the instance a child model receives for an inherited property is frequently the same object another model already processed. Once any model has set the flag to `false`, the `== null` guard no longer applies and the property is never marked as overridden. Which model reaches the cached instance first depends on the order the schemas appear in the document, which is what makes the symptom order-dependent.

### Change

Assign the flag from the condition it actually expresses — a property in `allVars` is overridden when the model did not declare it itself:

```java
if (cm != null && cm.allVars == vars) {
    cp.isOverridden = !varsMap.containsKey(key);
}
```

`varsMap` is already built from `cm.vars` a few lines above for exactly this purpose, so this reuses the information rather than depending on the mutable state of a shared instance.

### Test

`testOverrideSetterWhenChildIsDeclaredBeforeParent` generates from `allOf_composition_discriminator_child_first.yaml`, which is the reporter's spec with `MyPets` moved above `Pet`, and asserts `Cat` gets the overriding setter. It fails on master and passes with this change.

The existing `testForJavaApacheHttpClientOverrideSetter` covers the opposite order and still passes, including its assertion that `Pet` declares `petType` *without* `@Override` — so the parent side is unaffected.

### Verification

Full `modules/openapi-generator` suite: 4952 tests, 0 failures. The single error is `KotlinTestUtilsTest.testNormalCompile`, which fails identically on unmodified master on my machine because my checkout path contains a space and the Kotlin compiler receives it percent-encoded (`/C:/Users/VIVEK%20KUMAR/...`). It is unrelated to this change.

No samples needed regenerating: every committed sample keeps its current declaration order, so none of the generated output changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes inherited `allOf` properties losing their overriding fluent setter when the child schema is declared before the parent (#24778). The old logic only marked a property as overridden when `isOverridden` was still null, but `fromProperty` caches shared `CodegenProperty` instances, so whichever model was processed first left the flag `false`. The flag is now derived from whether the model declared the property itself via the existing `varsMap`.

Adds a regression test using a child-first spec that asserts `Cat` generates the overriding `petType` setter. Committed Java samples were regenerated to restore the missing overriding fluent setters; all sample diffs are additions, so only the restored setters change.

<sup>Written for commit ba72da81a919ede5eb1455998bf057424b1a8765. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24823?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

