### PR TITLE
[go] read rfc7807 title and detail through their pointers

### DIFF
--- a/modules/openapi-generator/src/main/resources/go/client.mustache
+++ b/modules/openapi-generator/src/main/resources/go/client.mustache
@@ -753,20 +753,51 @@ func (e GenericOpenAPIError) Model() interface{} {
 
 // format error message using title and detail when model implements rfc7807
 func formatErrorMessage(status string, v interface{}) string {
-	str := ""
-	metaValue := reflect.ValueOf(v).Elem()
+	title := rfc7807Field(v, "Title")
+	detail := rfc7807Field(v, "Detail")
 
-	if metaValue.Kind() == reflect.Struct {
-		field := metaValue.FieldByName("Title")
-		if field != (reflect.Value{}) {
-			str = fmt.Sprintf("%s", field.Interface())
-		}
-
-		field = metaValue.FieldByName("Detail")
-		if field != (reflect.Value{}) {
-			str = fmt.Sprintf("%s (%s)", str, field.Interface())
-		}
+	var str string
+	switch {
+	case title != "" && detail != "":
+		str = title + " (" + detail + ")"
+	case title != "":
+		str = title
+	default:
+		str = detail
 	}
 
-	return strings.TrimSpace(fmt.Sprintf("%s %s", status, str))
+	return strings.TrimSpace(status + " " + str)
+}
+
+// rfc7807Field reads a string member of an rfc7807 model, following one level of pointer
+// indirection so that an optional field declared as *string yields its value rather than its
+// address. It returns the empty string when the member is absent, is a nil pointer, or holds the
+// empty string, so a member that was not set contributes nothing to the message.
+func rfc7807Field(v interface{}, name string) string {
+	value := reflect.ValueOf(v)
+	if value.Kind() == reflect.Pointer {
+		if value.IsNil() {
+			return ""
+		}
+		value = value.Elem()
+	}
+	if value.Kind() != reflect.Struct {
+		return ""
+	}
+
+	field := value.FieldByName(name)
+	if !field.IsValid() {
+		return ""
+	}
+	if field.Kind() == reflect.Pointer {
+		if field.IsNil() {
+			return ""
+		}
+		field = field.Elem()
+	}
+	if field.Kind() != reflect.String {
+		return ""
+	}
+
+	return field.String()
 }

--- a/samples/client/echo_api/go-external-refs/client.go
+++ b/samples/client/echo_api/go-external-refs/client.go
@@ -669,20 +669,51 @@ func (e GenericOpenAPIError) Model() interface{} {
 
 // format error message using title and detail when model implements rfc7807
 func formatErrorMessage(status string, v interface{}) string {
-	str := ""
-	metaValue := reflect.ValueOf(v).Elem()
+	title := rfc7807Field(v, "Title")
+	detail := rfc7807Field(v, "Detail")
 
-	if metaValue.Kind() == reflect.Struct {
-		field := metaValue.FieldByName("Title")
-		if field != (reflect.Value{}) {
-			str = fmt.Sprintf("%s", field.Interface())
-		}
-
-		field = metaValue.FieldByName("Detail")
-		if field != (reflect.Value{}) {
-			str = fmt.Sprintf("%s (%s)", str, field.Interface())
-		}
+	var str string
+	switch {
+	case title != "" && detail != "":
+		str = title + " (" + detail + ")"
+	case title != "":
+		str = title
+	default:
+		str = detail
 	}
 
-	return strings.TrimSpace(fmt.Sprintf("%s %s", status, str))
+	return strings.TrimSpace(status + " " + str)
+}
+
+// rfc7807Field reads a string member of an rfc7807 model, following one level of pointer
+// indirection so that an optional field declared as *string yields its value rather than its
+// address. It returns the empty string when the member is absent, is a nil pointer, or holds the
+// empty string, so a member that was not set contributes nothing to the message.
+func rfc7807Field(v interface{}, name string) string {
+	value := reflect.ValueOf(v)
+	if value.Kind() == reflect.Pointer {
+		if value.IsNil() {
+			return ""
+		}
+		value = value.Elem()
+	}
+	if value.Kind() != reflect.Struct {
+		return ""
+	}
+
+	field := value.FieldByName(name)
+	if !field.IsValid() {
+		return ""
+	}
+	if field.Kind() == reflect.Pointer {
+		if field.IsNil() {
+			return ""
+		}
+		field = field.Elem()
+	}
+	if field.Kind() != reflect.String {
+		return ""
+	}
+
+	return field.String()
 }

--- a/samples/client/echo_api/go/client.go
+++ b/samples/client/echo_api/go/client.go
@@ -669,20 +669,51 @@ func (e GenericOpenAPIError) Model() interface{} {
 
 // format error message using title and detail when model implements rfc7807
 func formatErrorMessage(status string, v interface{}) string {
-	str := ""
-	metaValue := reflect.ValueOf(v).Elem()
+	title := rfc7807Field(v, "Title")
+	detail := rfc7807Field(v, "Detail")
 
-	if metaValue.Kind() == reflect.Struct {
-		field := metaValue.FieldByName("Title")
-		if field != (reflect.Value{}) {
-			str = fmt.Sprintf("%s", field.Interface())
-		}
-
-		field = metaValue.FieldByName("Detail")
-		if field != (reflect.Value{}) {
-			str = fmt.Sprintf("%s (%s)", str, field.Interface())
-		}
+	var str string
+	switch {
+	case title != "" && detail != "":
+		str = title + " (" + detail + ")"
+	case title != "":
+		str = title
+	default:
+		str = detail
 	}
 
-	return strings.TrimSpace(fmt.Sprintf("%s %s", status, str))
+	return strings.TrimSpace(status + " " + str)
+}
+
+// rfc7807Field reads a string member of an rfc7807 model, following one level of pointer
+// indirection so that an optional field declared as *string yields its value rather than its
+// address. It returns the empty string when the member is absent, is a nil pointer, or holds the
+// empty string, so a member that was not set contributes nothing to the message.
+func rfc7807Field(v interface{}, name string) string {
+	value := reflect.ValueOf(v)
+	if value.Kind() == reflect.Pointer {
+		if value.IsNil() {
+			return ""
+		}
+		value = value.Elem()
+	}
+	if value.Kind() != reflect.Struct {
+		return ""
+	}
+
+	field := value.FieldByName(name)
+	if !field.IsValid() {
+		return ""
+	}
+	if field.Kind() == reflect.Pointer {
+		if field.IsNil() {
+			return ""
+		}
+		field = field.Elem()
+	}
+	if field.Kind() != reflect.String {
+		return ""
+	}
+
+	return field.String()
 }

--- a/samples/client/others/go/allof_multiple_ref_and_discriminator/client.go
+++ b/samples/client/others/go/allof_multiple_ref_and_discriminator/client.go
@@ -640,20 +640,51 @@ func (e GenericOpenAPIError) Model() interface{} {
 
 // format error message using title and detail when model implements rfc7807
 func formatErrorMessage(status string, v interface{}) string {
-	str := ""
-	metaValue := reflect.ValueOf(v).Elem()
+	title := rfc7807Field(v, "Title")
+	detail := rfc7807Field(v, "Detail")
 
-	if metaValue.Kind() == reflect.Struct {
-		field := metaValue.FieldByName("Title")
-		if field != (reflect.Value{}) {
-			str = fmt.Sprintf("%s", field.Interface())
-		}
-
-		field = metaValue.FieldByName("Detail")
-		if field != (reflect.Value{}) {
-			str = fmt.Sprintf("%s (%s)", str, field.Interface())
-		}
+	var str string
+	switch {
+	case title != "" && detail != "":
+		str = title + " (" + detail + ")"
+	case title != "":
+		str = title
+	default:
+		str = detail
 	}
 
-	return strings.TrimSpace(fmt.Sprintf("%s %s", status, str))
+	return strings.TrimSpace(status + " " + str)
+}
+
+// rfc7807Field reads a string member of an rfc7807 model, following one level of pointer
+// indirection so that an optional field declared as *string yields its value rather than its
+// address. It returns the empty string when the member is absent, is a nil pointer, or holds the
+// empty string, so a member that was not set contributes nothing to the message.
+func rfc7807Field(v interface{}, name string) string {
+	value := reflect.ValueOf(v)
+	if value.Kind() == reflect.Pointer {
+		if value.IsNil() {
+			return ""
+		}
+		value = value.Elem()
+	}
+	if value.Kind() != reflect.Struct {
+		return ""
+	}
+
+	field := value.FieldByName(name)
+	if !field.IsValid() {
+		return ""
+	}
+	if field.Kind() == reflect.Pointer {
+		if field.IsNil() {
+			return ""
+		}
+		field = field.Elem()
+	}
+	if field.Kind() != reflect.String {
+		return ""
+	}
+
+	return field.String()
 }

--- a/samples/client/others/go/issue_20079_go_regex_wrongly_translated/client.go
+++ b/samples/client/others/go/issue_20079_go_regex_wrongly_translated/client.go
@@ -643,20 +643,51 @@ func (e GenericOpenAPIError) Model() interface{} {
 
 // format error message using title and detail when model implements rfc7807
 func formatErrorMessage(status string, v interface{}) string {
-	str := ""
-	metaValue := reflect.ValueOf(v).Elem()
+	title := rfc7807Field(v, "Title")
+	detail := rfc7807Field(v, "Detail")
 
-	if metaValue.Kind() == reflect.Struct {
-		field := metaValue.FieldByName("Title")
-		if field != (reflect.Value{}) {
-			str = fmt.Sprintf("%s", field.Interface())
-		}
-
-		field = metaValue.FieldByName("Detail")
-		if field != (reflect.Value{}) {
-			str = fmt.Sprintf("%s (%s)", str, field.Interface())
-		}
+	var str string
+	switch {
+	case title != "" && detail != "":
+		str = title + " (" + detail + ")"
+	case title != "":
+		str = title
+	default:
+		str = detail
 	}
 
-	return strings.TrimSpace(fmt.Sprintf("%s %s", status, str))
+	return strings.TrimSpace(status + " " + str)
+}
+
+// rfc7807Field reads a string member of an rfc7807 model, following one level of pointer
+// indirection so that an optional field declared as *string yields its value rather than its
+// address. It returns the empty string when the member is absent, is a nil pointer, or holds the
+// empty string, so a member that was not set contributes nothing to the message.
+func rfc7807Field(v interface{}, name string) string {
+	value := reflect.ValueOf(v)
+	if value.Kind() == reflect.Pointer {
+		if value.IsNil() {
+			return ""
+		}
+		value = value.Elem()
+	}
+	if value.Kind() != reflect.Struct {
+		return ""
+	}
+
+	field := value.FieldByName(name)
+	if !field.IsValid() {
+		return ""
+	}
+	if field.Kind() == reflect.Pointer {
+		if field.IsNil() {
+			return ""
+		}
+		field = field.Elem()
+	}
+	if field.Kind() != reflect.String {
+		return ""
+	}
+
+	return field.String()
 }

--- a/samples/client/others/go/oneof-anyof-required/client.go
+++ b/samples/client/others/go/oneof-anyof-required/client.go
@@ -640,20 +640,51 @@ func (e GenericOpenAPIError) Model() interface{} {
 
 // format error message using title and detail when model implements rfc7807
 func formatErrorMessage(status string, v interface{}) string {
-	str := ""
-	metaValue := reflect.ValueOf(v).Elem()
+	title := rfc7807Field(v, "Title")
+	detail := rfc7807Field(v, "Detail")
 
-	if metaValue.Kind() == reflect.Struct {
-		field := metaValue.FieldByName("Title")
-		if field != (reflect.Value{}) {
-			str = fmt.Sprintf("%s", field.Interface())
-		}
-
-		field = metaValue.FieldByName("Detail")
-		if field != (reflect.Value{}) {
-			str = fmt.Sprintf("%s (%s)", str, field.Interface())
-		}
+	var str string
+	switch {
+	case title != "" && detail != "":
+		str = title + " (" + detail + ")"
+	case title != "":
+		str = title
+	default:
+		str = detail
 	}
 
-	return strings.TrimSpace(fmt.Sprintf("%s %s", status, str))
+	return strings.TrimSpace(status + " " + str)
+}
+
+// rfc7807Field reads a string member of an rfc7807 model, following one level of pointer
+// indirection so that an optional field declared as *string yields its value rather than its
+// address. It returns the empty string when the member is absent, is a nil pointer, or holds the
+// empty string, so a member that was not set contributes nothing to the message.
+func rfc7807Field(v interface{}, name string) string {
+	value := reflect.ValueOf(v)
+	if value.Kind() == reflect.Pointer {
+		if value.IsNil() {
+			return ""
+		}
+		value = value.Elem()
+	}
+	if value.Kind() != reflect.Struct {
+		return ""
+	}
+
+	field := value.FieldByName(name)
+	if !field.IsValid() {
+		return ""
+	}
+	if field.Kind() == reflect.Pointer {
+		if field.IsNil() {
+			return ""
+		}
+		field = field.Elem()
+	}
+	if field.Kind() != reflect.String {
+		return ""
+	}
+
+	return field.String()
 }

--- a/samples/client/others/go/oneof-discriminator-lookup/client.go
+++ b/samples/client/others/go/oneof-discriminator-lookup/client.go
@@ -640,20 +640,51 @@ func (e GenericOpenAPIError) Model() interface{} {
 
 // format error message using title and detail when model implements rfc7807
 func formatErrorMessage(status string, v interface{}) string {
-	str := ""
-	metaValue := reflect.ValueOf(v).Elem()
+	title := rfc7807Field(v, "Title")
+	detail := rfc7807Field(v, "Detail")
 
-	if metaValue.Kind() == reflect.Struct {
-		field := metaValue.FieldByName("Title")
-		if field != (reflect.Value{}) {
-			str = fmt.Sprintf("%s", field.Interface())
-		}
-
-		field = metaValue.FieldByName("Detail")
-		if field != (reflect.Value{}) {
-			str = fmt.Sprintf("%s (%s)", str, field.Interface())
-		}
+	var str string
+	switch {
+	case title != "" && detail != "":
+		str = title + " (" + detail + ")"
+	case title != "":
+		str = title
+	default:
+		str = detail
 	}
 
-	return strings.TrimSpace(fmt.Sprintf("%s %s", status, str))
+	return strings.TrimSpace(status + " " + str)
+}
+
+// rfc7807Field reads a string member of an rfc7807 model, following one level of pointer
+// indirection so that an optional field declared as *string yields its value rather than its
+// address. It returns the empty string when the member is absent, is a nil pointer, or holds the
+// empty string, so a member that was not set contributes nothing to the message.
+func rfc7807Field(v interface{}, name string) string {
+	value := reflect.ValueOf(v)
+	if value.Kind() == reflect.Pointer {
+		if value.IsNil() {
+			return ""
+		}
+		value = value.Elem()
+	}
+	if value.Kind() != reflect.Struct {
+		return ""
+	}
+
+	field := value.FieldByName(name)
+	if !field.IsValid() {
+		return ""
+	}
+	if field.Kind() == reflect.Pointer {
+		if field.IsNil() {
+			return ""
+		}
+		field = field.Elem()
+	}
+	if field.Kind() != reflect.String {
+		return ""
+	}
+
+	return field.String()
 }

--- a/samples/client/petstore/go/go-petstore/client.go
+++ b/samples/client/petstore/go/go-petstore/client.go
@@ -675,20 +675,51 @@ func (e GenericOpenAPIError) Model() interface{} {
 
 // format error message using title and detail when model implements rfc7807
 func formatErrorMessage(status string, v interface{}) string {
-	str := ""
-	metaValue := reflect.ValueOf(v).Elem()
+	title := rfc7807Field(v, "Title")
+	detail := rfc7807Field(v, "Detail")
 
-	if metaValue.Kind() == reflect.Struct {
-		field := metaValue.FieldByName("Title")
-		if field != (reflect.Value{}) {
-			str = fmt.Sprintf("%s", field.Interface())
-		}
-
-		field = metaValue.FieldByName("Detail")
-		if field != (reflect.Value{}) {
-			str = fmt.Sprintf("%s (%s)", str, field.Interface())
-		}
+	var str string
+	switch {
+	case title != "" && detail != "":
+		str = title + " (" + detail + ")"
+	case title != "":
+		str = title
+	default:
+		str = detail
 	}
 
-	return strings.TrimSpace(fmt.Sprintf("%s %s", status, str))
+	return strings.TrimSpace(status + " " + str)
+}
+
+// rfc7807Field reads a string member of an rfc7807 model, following one level of pointer
+// indirection so that an optional field declared as *string yields its value rather than its
+// address. It returns the empty string when the member is absent, is a nil pointer, or holds the
+// empty string, so a member that was not set contributes nothing to the message.
+func rfc7807Field(v interface{}, name string) string {
+	value := reflect.ValueOf(v)
+	if value.Kind() == reflect.Pointer {
+		if value.IsNil() {
+			return ""
+		}
+		value = value.Elem()
+	}
+	if value.Kind() != reflect.Struct {
+		return ""
+	}
+
+	field := value.FieldByName(name)
+	if !field.IsValid() {
+		return ""
+	}
+	if field.Kind() == reflect.Pointer {
+		if field.IsNil() {
+			return ""
+		}
+		field = field.Elem()
+	}
+	if field.Kind() != reflect.String {
+		return ""
+	}
+
+	return field.String()
 }

--- a/samples/openapi3/client/extensions/x-auth-id-alias/go-experimental/client.go
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/go-experimental/client.go
@@ -643,20 +643,51 @@ func (e GenericOpenAPIError) Model() interface{} {
 
 // format error message using title and detail when model implements rfc7807
 func formatErrorMessage(status string, v interface{}) string {
-	str := ""
-	metaValue := reflect.ValueOf(v).Elem()
+	title := rfc7807Field(v, "Title")
+	detail := rfc7807Field(v, "Detail")
 
-	if metaValue.Kind() == reflect.Struct {
-		field := metaValue.FieldByName("Title")
-		if field != (reflect.Value{}) {
-			str = fmt.Sprintf("%s", field.Interface())
-		}
-
-		field = metaValue.FieldByName("Detail")
-		if field != (reflect.Value{}) {
-			str = fmt.Sprintf("%s (%s)", str, field.Interface())
-		}
+	var str string
+	switch {
+	case title != "" && detail != "":
+		str = title + " (" + detail + ")"
+	case title != "":
+		str = title
+	default:
+		str = detail
 	}
 
-	return strings.TrimSpace(fmt.Sprintf("%s %s", status, str))
+	return strings.TrimSpace(status + " " + str)
+}
+
+// rfc7807Field reads a string member of an rfc7807 model, following one level of pointer
+// indirection so that an optional field declared as *string yields its value rather than its
+// address. It returns the empty string when the member is absent, is a nil pointer, or holds the
+// empty string, so a member that was not set contributes nothing to the message.
+func rfc7807Field(v interface{}, name string) string {
+	value := reflect.ValueOf(v)
+	if value.Kind() == reflect.Pointer {
+		if value.IsNil() {
+			return ""
+		}
+		value = value.Elem()
+	}
+	if value.Kind() != reflect.Struct {
+		return ""
+	}
+
+	field := value.FieldByName(name)
+	if !field.IsValid() {
+		return ""
+	}
+	if field.Kind() == reflect.Pointer {
+		if field.IsNil() {
+			return ""
+		}
+		field = field.Elem()
+	}
+	if field.Kind() != reflect.String {
+		return ""
+	}
+
+	return field.String()
 }

--- a/samples/openapi3/client/petstore/go-petstore-generateMarshalJSON-false/client.go
+++ b/samples/openapi3/client/petstore/go-petstore-generateMarshalJSON-false/client.go
@@ -655,20 +655,51 @@ func (e GenericOpenAPIError) Model() interface{} {
 
 // format error message using title and detail when model implements rfc7807
 func formatErrorMessage(status string, v interface{}) string {
-	str := ""
-	metaValue := reflect.ValueOf(v).Elem()
+	title := rfc7807Field(v, "Title")
+	detail := rfc7807Field(v, "Detail")
 
-	if metaValue.Kind() == reflect.Struct {
-		field := metaValue.FieldByName("Title")
-		if field != (reflect.Value{}) {
-			str = fmt.Sprintf("%s", field.Interface())
-		}
-
-		field = metaValue.FieldByName("Detail")
-		if field != (reflect.Value{}) {
-			str = fmt.Sprintf("%s (%s)", str, field.Interface())
-		}
+	var str string
+	switch {
+	case title != "" && detail != "":
+		str = title + " (" + detail + ")"
+	case title != "":
+		str = title
+	default:
+		str = detail
 	}
 
-	return strings.TrimSpace(fmt.Sprintf("%s %s", status, str))
+	return strings.TrimSpace(status + " " + str)
+}
+
+// rfc7807Field reads a string member of an rfc7807 model, following one level of pointer
+// indirection so that an optional field declared as *string yields its value rather than its
+// address. It returns the empty string when the member is absent, is a nil pointer, or holds the
+// empty string, so a member that was not set contributes nothing to the message.
+func rfc7807Field(v interface{}, name string) string {
+	value := reflect.ValueOf(v)
+	if value.Kind() == reflect.Pointer {
+		if value.IsNil() {
+			return ""
+		}
+		value = value.Elem()
+	}
+	if value.Kind() != reflect.Struct {
+		return ""
+	}
+
+	field := value.FieldByName(name)
+	if !field.IsValid() {
+		return ""
+	}
+	if field.Kind() == reflect.Pointer {
+		if field.IsNil() {
+			return ""
+		}
+		field = field.Elem()
+	}
+	if field.Kind() != reflect.String {
+		return ""
+	}
+
+	return field.String()
 }

--- a/samples/openapi3/client/petstore/go-petstore-withXml/client.go
+++ b/samples/openapi3/client/petstore/go-petstore-withXml/client.go
@@ -655,20 +655,51 @@ func (e GenericOpenAPIError) Model() interface{} {
 
 // format error message using title and detail when model implements rfc7807
 func formatErrorMessage(status string, v interface{}) string {
-	str := ""
-	metaValue := reflect.ValueOf(v).Elem()
+	title := rfc7807Field(v, "Title")
+	detail := rfc7807Field(v, "Detail")
 
-	if metaValue.Kind() == reflect.Struct {
-		field := metaValue.FieldByName("Title")
-		if field != (reflect.Value{}) {
-			str = fmt.Sprintf("%s", field.Interface())
-		}
-
-		field = metaValue.FieldByName("Detail")
-		if field != (reflect.Value{}) {
-			str = fmt.Sprintf("%s (%s)", str, field.Interface())
-		}
+	var str string
+	switch {
+	case title != "" && detail != "":
+		str = title + " (" + detail + ")"
+	case title != "":
+		str = title
+	default:
+		str = detail
 	}
 
-	return strings.TrimSpace(fmt.Sprintf("%s %s", status, str))
+	return strings.TrimSpace(status + " " + str)
+}
+
+// rfc7807Field reads a string member of an rfc7807 model, following one level of pointer
+// indirection so that an optional field declared as *string yields its value rather than its
+// address. It returns the empty string when the member is absent, is a nil pointer, or holds the
+// empty string, so a member that was not set contributes nothing to the message.
+func rfc7807Field(v interface{}, name string) string {
+	value := reflect.ValueOf(v)
+	if value.Kind() == reflect.Pointer {
+		if value.IsNil() {
+			return ""
+		}
+		value = value.Elem()
+	}
+	if value.Kind() != reflect.Struct {
+		return ""
+	}
+
+	field := value.FieldByName(name)
+	if !field.IsValid() {
+		return ""
+	}
+	if field.Kind() == reflect.Pointer {
+		if field.IsNil() {
+			return ""
+		}
+		field = field.Elem()
+	}
+	if field.Kind() != reflect.String {
+		return ""
+	}
+
+	return field.String()
 }

--- a/samples/openapi3/client/petstore/go/go-petstore-aws-signature/client.go
+++ b/samples/openapi3/client/petstore/go/go-petstore-aws-signature/client.go
@@ -697,20 +697,51 @@ func (e GenericOpenAPIError) Model() interface{} {
 
 // format error message using title and detail when model implements rfc7807
 func formatErrorMessage(status string, v interface{}) string {
-	str := ""
-	metaValue := reflect.ValueOf(v).Elem()
+	title := rfc7807Field(v, "Title")
+	detail := rfc7807Field(v, "Detail")
 
-	if metaValue.Kind() == reflect.Struct {
-		field := metaValue.FieldByName("Title")
-		if field != (reflect.Value{}) {
-			str = fmt.Sprintf("%s", field.Interface())
-		}
-
-		field = metaValue.FieldByName("Detail")
-		if field != (reflect.Value{}) {
-			str = fmt.Sprintf("%s (%s)", str, field.Interface())
-		}
+	var str string
+	switch {
+	case title != "" && detail != "":
+		str = title + " (" + detail + ")"
+	case title != "":
+		str = title
+	default:
+		str = detail
 	}
 
-	return strings.TrimSpace(fmt.Sprintf("%s %s", status, str))
+	return strings.TrimSpace(status + " " + str)
+}
+
+// rfc7807Field reads a string member of an rfc7807 model, following one level of pointer
+// indirection so that an optional field declared as *string yields its value rather than its
+// address. It returns the empty string when the member is absent, is a nil pointer, or holds the
+// empty string, so a member that was not set contributes nothing to the message.
+func rfc7807Field(v interface{}, name string) string {
+	value := reflect.ValueOf(v)
+	if value.Kind() == reflect.Pointer {
+		if value.IsNil() {
+			return ""
+		}
+		value = value.Elem()
+	}
+	if value.Kind() != reflect.Struct {
+		return ""
+	}
+
+	field := value.FieldByName(name)
+	if !field.IsValid() {
+		return ""
+	}
+	if field.Kind() == reflect.Pointer {
+		if field.IsNil() {
+			return ""
+		}
+		field = field.Elem()
+	}
+	if field.Kind() != reflect.String {
+		return ""
+	}
+
+	return field.String()
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/client.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/client.go
@@ -693,20 +693,51 @@ func (e GenericOpenAPIError) Model() interface{} {
 
 // format error message using title and detail when model implements rfc7807
 func formatErrorMessage(status string, v interface{}) string {
-	str := ""
-	metaValue := reflect.ValueOf(v).Elem()
+	title := rfc7807Field(v, "Title")
+	detail := rfc7807Field(v, "Detail")
 
-	if metaValue.Kind() == reflect.Struct {
-		field := metaValue.FieldByName("Title")
-		if field != (reflect.Value{}) {
-			str = fmt.Sprintf("%s", field.Interface())
-		}
-
-		field = metaValue.FieldByName("Detail")
-		if field != (reflect.Value{}) {
-			str = fmt.Sprintf("%s (%s)", str, field.Interface())
-		}
+	var str string
+	switch {
+	case title != "" && detail != "":
+		str = title + " (" + detail + ")"
+	case title != "":
+		str = title
+	default:
+		str = detail
 	}
 
-	return strings.TrimSpace(fmt.Sprintf("%s %s", status, str))
+	return strings.TrimSpace(status + " " + str)
+}
+
+// rfc7807Field reads a string member of an rfc7807 model, following one level of pointer
+// indirection so that an optional field declared as *string yields its value rather than its
+// address. It returns the empty string when the member is absent, is a nil pointer, or holds the
+// empty string, so a member that was not set contributes nothing to the message.
+func rfc7807Field(v interface{}, name string) string {
+	value := reflect.ValueOf(v)
+	if value.Kind() == reflect.Pointer {
+		if value.IsNil() {
+			return ""
+		}
+		value = value.Elem()
+	}
+	if value.Kind() != reflect.Struct {
+		return ""
+	}
+
+	field := value.FieldByName(name)
+	if !field.IsValid() {
+		return ""
+	}
+	if field.Kind() == reflect.Pointer {
+		if field.IsNil() {
+			return ""
+		}
+		field = field.Elem()
+	}
+	if field.Kind() != reflect.String {
+		return ""
+	}
+
+	return field.String()
 }


### PR DESCRIPTION
Fixes #20553.

## The defect

`formatErrorMessage` formats the field's `Interface()` with `%s`. Optional rfc7807 members are
generated as `*string`, and `%s` on a pointer renders the address — so the text the function exists
to surface is replaced by it in the error a caller prints. Reproducing the issue's example against
a client generated from `master`:

```
400 Bad Request %!s(*string=0x14000114510) (%!s(*string=0x14000114520))
```

Both states were wrong, not only the populated one. Every rfc7807 member is optional, so a model
carrying just a status has both nil, and the old code printed the nils:

```
400 Bad Request %!s(*string=<nil>) (%!s(*string=<nil>))
```

The test it used, `field != (reflect.Value{})`, also cannot distinguish a member that is *absent*
from one that is *present and unset*. Of the three states a member can be in, only the first was
handled.

## The fix

`rfc7807Field` follows a single level of pointer indirection and returns the empty string for all
three "nothing to say" cases: no such field, a nil pointer, an empty string. The message is then
assembled from the members that have something in them, so an unset detail no longer contributes an
empty `()`.

Same client, after:

| model | before | after |
|---|---|---|
| title and detail set | `400 Bad Request %!s(*string=0x…) (%!s(*string=0x…))` | `400 Bad Request Bad Request (id must be positive)` |
| both unset | `400 Bad Request %!s(*string=<nil>) (%!s(*string=<nil>))` | `400 Bad Request` |
| title set, detail unset | `400 Bad Request %!s(*string=0x…) (%!s(*string=<nil>))` | `400 Bad Request Bad Request` |
| model passed by value | panics, `reflect: call of reflect.Value.Elem on struct Value` | `400 Bad Request Bad Request` |
| untyped nil | panics, `reflect: call of reflect.Value.Elem on zero Value` | `400 Bad Request` |

Non-pointer `string` members keep their existing output. The one deliberate behaviour change is
that a member with nothing in it is omitted rather than rendered.

The last two rows are a side effect rather than the point: the unconditional `Elem()` panicked for
a non-pointer or nil `v`. Generated code always passes `&v`, so that is hygiene rather than a
reachable defect, and it costs nothing because reading through a pointer member needs the `Kind`
checks anyway. A typed nil pointer was already safe and still is. This is the same area as #15154,
which added the `Kind() == reflect.Struct` guard for #15147.

Returning only the status was considered and rejected: it removes the symptom by discarding the
detail, which is the information the function exists to carry.

## Samples

Updated for the 12 Go clients that carry this function. I do not have a JVM on this machine, so I
could not run `./mvnw clean package` — instead the sample edits were **proved equal to regeneration
output** rather than assumed:

- generated the same spec twice with `openapi-generator generate -g go -t <templates>`, once with
  `master`'s `go` templates and once with this branch's, per the `-t` note in CONTRIBUTING;
- exactly one file differs between the two generations, `client.go`, and its delta is exactly this
  function change;
- the changed region of all 13 committed files — the template and all 12 samples — is
  byte-identical to that generated output.

The function contains no mustache tags, which is why the substitution is identical in the template
and in every sample. Nothing else in the samples is touched, and no `go.mod`/`go.sum` is modified.

Static checks on the generated output, each compared against `master` rather than read on its own:

- `go vet` on a client generated from the fixed template: clean.
- `staticcheck` v0.8.1 on the same: **8 findings before the change and the same 8 after**, an
  identical set, none of them in the changed functions.
- `gofmt` wants no change in the new code. It does list these `client.go` files, but it does so on
  `master` too — the generated output has pre-existing spacing quirks such as
  `strings.NewReplacer( "%5B", ... )`, none of them in this diff.
- 11 of the 12 changed samples build. The twelfth,
  `samples/openapi3/client/petstore/go/go-petstore-aws-signature`, fails **identically before and
  after** this change (`missing go.sum entry for github.com/aws/aws-sdk-go-v2`), so its `go.sum` is
  incomplete on `master`; unrelated to this diff and left alone.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Samples updated for every Go client carrying the changed function, and verified equal to
      generator output as described above.
- [x] Filed against `master`, a non-breaking change.
- [x] Technical committee for Go: @antihax @grokify @kemokemo @jirikuncar @ph4r5h4d @lwj5
