### PR TITLE
[rust] fix: free-form object query parameters reference a nonexistent models::serde_json

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustClientCodegen.java
@@ -783,6 +783,16 @@ public class RustClientCodegen extends AbstractRustCodegen implements CodegenCon
                     param.isPrimitiveType = true;
                     param.isString = true;
                 }
+
+                // Free-form objects are typed `serde_json::Value`, which does not live in the
+                // generated `models` module. Mark them as primitive so the templates do not
+                // qualify the type with a `models::` prefix, mirroring what
+                // `DefaultCodegen.updateRequestBodyForObject` already does for free-form body
+                // parameters. Free-form schemas with `additionalProperties` map to a container
+                // type (`HashMap`) and must keep their existing handling.
+                if (param.isFreeFormObject && !param.isContainer) {
+                    param.isPrimitiveType = true;
+                }
             }
 
             if (operation.pathParams != null && operation.pathParams.size() > 0) {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/rust/RustClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/rust/RustClientCodegenTest.java
@@ -294,6 +294,30 @@ public class RustClientCodegenTest {
     }
 
     @Test
+    public void testFreeFormObjectQueryParam() throws IOException {
+        Path target = Files.createTempDirectory("test");
+        target.toFile().deleteOnExit();
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("rust")
+                .setInputSpec("src/test/resources/3_0/rust/free-form-object-query-param.yaml")
+                .setSkipOverwrite(false)
+                .setOutputDir(target.toAbsolutePath().toString().replace("\\", "/"));
+        List<File> files = new DefaultGenerator().opts(configurator.toClientOptInput()).generate();
+        files.forEach(File::deleteOnExit);
+        Path outputPath = Path.of(target.toString(), "/src/apis/default_api.rs");
+        TestUtils.assertFileExists(outputPath);
+        // A free-form object query parameter maps to `serde_json::Value`, which lives
+        // outside of the `models` module.
+        TestUtils.assertFileContains(outputPath, "filter: Option<serde_json::Value>");
+        TestUtils.assertFileNotContains(outputPath, "models::serde_json");
+        // A free-form object with additionalProperties stays a map.
+        TestUtils.assertFileContains(outputPath, "tags: Option<std::collections::HashMap<String, String>>");
+        TestUtils.assertFileContains(outputPath, "meta: Option<std::collections::HashMap<String, serde_json::Value>>");
+        // Maps keep their JSON serialization (`HashMap` does not implement `Display`).
+        TestUtils.assertFileContains(outputPath, "req_builder.query(&[(\"meta\", &serde_json::to_string(param_value)?)])");
+    }
+
+    @Test
     public void testArrayWithObjectEnumValues() throws IOException {
         Path target = Files.createTempDirectory("test");
         target.toFile().deleteOnExit();

--- a/modules/openapi-generator/src/test/resources/3_0/rust/free-form-object-query-param.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/rust/free-form-object-query-param.yaml
@@ -1,0 +1,36 @@
+openapi: 3.0.0
+info:
+  title: Free-form object query parameter
+  version: 1.0.0
+paths:
+  /things:
+    get:
+      operationId: listThings
+      parameters:
+        - name: filter
+          in: query
+          description: A free-form object query parameter.
+          schema:
+            type: object
+        - name: tags
+          in: query
+          description: A free-form object with typed additionalProperties (a map).
+          schema:
+            type: object
+            additionalProperties:
+              type: string
+        - name: meta
+          in: query
+          description: A free-form object with additionalProperties true (also a map).
+          schema:
+            type: object
+            additionalProperties: true
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string


### PR DESCRIPTION
A free-form object parameter — `type: object` with no properties — is typed
`Option<models::serde_json::Value>` in every generated api module, but `models` re-exports no
`serde_json`, so the crate fails to compile with one `E0433` per operation that uses one:

```yaml
parameters:
  - in: query
    name: filter
    schema:
      type: object
```

```rust
pub async fn list_things(configuration: &configuration::Configuration, filter: Option<models::serde_json::Value>, ...)
```

```
error[E0433]: failed to resolve: could not find `serde_json` in `models`
```

Free-form **body** parameters are typed `serde_json::Value` and compile fine; only query, path,
and header parameters are affected. All four `rust` client libraries (`reqwest`, `reqwest-trait`,
`hyper`, `hyper0x`) share the bug.

### The cause

The api templates qualify a parameter's type with `models::` unless it is a string, uuid,
primitive, or container — `rust/reqwest/api.mustache` and the same pattern in the other three
libraries:

```
{{^isString}}{{^isUuid}}{{^isPrimitiveType}}{{^isContainer}}models::{{/isContainer}}{{/isPrimitiveType}}{{{dataType}}}{{/isUuid}}{{/isString}}
```

A free-form object maps to `serde_json::Value` (`typeMapping.put("object", "serde_json::Value")`),
which lives outside `models`. Body parameters escape because
`DefaultCodegen.updateRequestBodyForObject` marks free-form bodies `isPrimitiveType = true`,
while `fromParameter` sets only `isFreeFormObject` — so the prefix lands on non-body parameters.

### The fix

`RustClientCodegen.postProcessOperationsWithModels` now marks free-form, non-container
parameters as primitive — the treatment free-form bodies already get — right next to the
existing `isAnyType` special case. One codegen change covers all four libraries' templates.

Non-container matters: a free-form schema with `additionalProperties` is typed
`HashMap<String, …>`, is already exempt from the prefix as a container, and must keep its
`serde_json::to_string` query serialization since `HashMap` has no `Display`.

Wire behavior is unchanged: the query serialization branch for these parameters is chosen by
`isObject`/`isMap`/`isDeepObject`, not `isPrimitiveType`, and the required-parameter path
always used `.to_string()` (for `serde_json::Value`, `Display` *is* its JSON serialization).

### Tests

`RustClientCodegenTest#testFreeFormObjectQueryParam`, generating from the new fixture
`3_0/rust/free-form-object-query-param.yaml`, locks in:

- `filter: Option<serde_json::Value>` and no `models::serde_json` anywhere;
- `type: object` with typed `additionalProperties` staying `HashMap<String, String>`;
- `additionalProperties: true` (free-form *and* a map) staying
  `HashMap<String, serde_json::Value>` with `serde_json::to_string` serialization.

It fails without the `main/` change.

### Verified by compiling generated clients

Clients generated from a spec with optional, required, and map-typed object query parameters:

| library | `cargo build` |
| --- | --- |
| reqwest (sync) | clean |
| reqwest (async) | clean |
| hyper | clean |
| reqwest-trait | clean for the free-form parameters this PR touches |

Two adjacent breakages exist identically on master and in v7.15.0, i.e. before this change,
and are left out of scope: `reqwest-trait` calls `.to_string()` on *map-typed* query
parameters (which this PR does not touch), and the exploded `style: deepObject` free-form
branch iterates a `serde_json::Value` (`.len()`/`.iter()`), which does not compile either way.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Built the project and updated samples: `./bin/generate-samples.sh ./bin/configs/rust-*`
      regenerated all 39 rust configs with zero diffs (no sample spec has a free-form object
      parameter outside a body); `./bin/utils/export_docs_generators.sh` produced no diff.
- [x] Technical committee (Rust): @frol @farcaller @richardwhiuk @paladinzh @jacob-pro @dsteeley

---

Generated with Claude Code

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes generated Rust clients failing to compile when an operation uses a free-form object query, path, or header parameter. These were typed `models::serde_json::Value`, which doesn't exist; they're now `serde_json::Value`, matching free-form body parameters.

- One codegen change covers all four Rust generators (`reqwest`, `reqwest-trait`, `hyper`, `hyper0x`).
- Free-form objects with `additionalProperties` stay `HashMap`-typed and keep their existing query serialization; no wire behavior changes.
- Adds a regression test covering plain, typed-map, and `additionalProperties: true` free-form object query parameters.

<sup>Written for commit 1a9f8757398846d62802ea7711e8c7264145c37e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24866?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

