### PR TITLE
[ruby] fix: explode object query parameters

### DIFF
--- a/modules/openapi-generator/src/main/resources/ruby-client/api.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/api.mustache
@@ -180,7 +180,23 @@ module {{moduleName}}
       query_params[:'{{{baseName}}}'] = {{{paramName}}}.to_json
       {{/queryIsJsonMimeType}}
       {{^queryIsJsonMimeType}}
+      {{#isMap}}
+      {{#isExplode}}
+      {{^isDeepObject}}
+      # form style explodes an object into one query parameter per entry, keyed by the property name alone
+      {{{paramName}}}.each { |name, value| query_params[name.to_s] = value }
+      {{/isDeepObject}}
+      {{#isDeepObject}}
+      query_params[:'{{{baseName}}}'] = {{{paramName}}}
+      {{/isDeepObject}}
+      {{/isExplode}}
+      {{^isExplode}}
+      query_params[:'{{{baseName}}}'] = {{{paramName}}}
+      {{/isExplode}}
+      {{/isMap}}
+      {{^isMap}}
       query_params[:'{{{baseName}}}'] = {{#collectionFormat}}@api_client.build_collection_param({{{paramName}}}, :{{{collectionFormat}}}){{/collectionFormat}}{{^collectionFormat}}{{{paramName}}}{{/collectionFormat}}
+      {{/isMap}}
       {{/queryIsJsonMimeType}}
       {{/required}}
       {{/queryParams}}
@@ -190,7 +206,23 @@ module {{moduleName}}
       query_params[:'{{{baseName}}}'] = opts[:'{{{paramName}}}'].to_json if !opts[:'{{{paramName}}}'].nil?
       {{/queryIsJsonMimeType}}
       {{^queryIsJsonMimeType}}
+      {{#isMap}}
+      {{#isExplode}}
+      {{^isDeepObject}}
+      # form style explodes an object into one query parameter per entry, keyed by the property name alone
+      opts[:'{{{paramName}}}'].each { |name, value| query_params[name.to_s] = value } if !opts[:'{{{paramName}}}'].nil?
+      {{/isDeepObject}}
+      {{#isDeepObject}}
+      query_params[:'{{{baseName}}}'] = opts[:'{{{paramName}}}'] if !opts[:'{{{paramName}}}'].nil?
+      {{/isDeepObject}}
+      {{/isExplode}}
+      {{^isExplode}}
+      query_params[:'{{{baseName}}}'] = opts[:'{{{paramName}}}'] if !opts[:'{{{paramName}}}'].nil?
+      {{/isExplode}}
+      {{/isMap}}
+      {{^isMap}}
       query_params[:'{{{baseName}}}'] = {{#collectionFormat}}@api_client.build_collection_param(opts[:'{{{paramName}}}'], :{{{collectionFormat}}}){{/collectionFormat}}{{^collectionFormat}}opts[:'{{{paramName}}}']{{/collectionFormat}} if !opts[:'{{{paramName}}}'].nil?
+      {{/isMap}}
       {{/queryIsJsonMimeType}}
       {{/required}}
       {{/queryParams}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/ruby/RubyClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/ruby/RubyClientCodegenTest.java
@@ -71,6 +71,42 @@ public class RubyClientCodegenTest {
         }
     }
 
+    @Test(description = "Verify an object query parameter is exploded, whether or not it declares its properties")
+    public void testExplodedObjectQueryParameter() throws Exception {
+        final File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/exploded-object-query-param.yaml");
+        RubyClientCodegen codegen = new RubyClientCodegen();
+        codegen.setOutputDir(output.getAbsolutePath());
+
+        ClientOptInput clientOptInput = new ClientOptInput().openAPI(openAPI).config(codegen);
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> files = generator.opts(clientOptInput).generate();
+        files.forEach(File::deleteOnExit);
+
+        File apiFile = files.stream()
+                .filter(f -> f.getName().equals("default_api.rb"))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("default_api.rb not found in generated files"));
+
+        // form style with explode - the default - puts every entry on the wire under its own
+        // property name. Assigning the whole hash under the parameter name left the http
+        // library to serialize it in bracket style, which is what used to happen.
+        TestUtils.assertFileContains(apiFile.toPath(),
+                "opts[:'filter'].each { |name, value| query_params[name.to_s] = value } if !opts[:'filter'].nil?");
+        TestUtils.assertFileNotContains(apiFile.toPath(), "query_params[:'filter']");
+
+        // a declared map behaves the same way
+        TestUtils.assertFileContains(apiFile.toPath(),
+                "opts[:'typed_filter'].each { |name, value| query_params[name.to_s] = value } if !opts[:'typed_filter'].nil?");
+
+        // deepObject and form without explode both keep a single parameter
+        TestUtils.assertFileContains(apiFile.toPath(),
+                "query_params[:'deepFilter'] = opts[:'deep_filter'] if !opts[:'deep_filter'].nil?",
+                "query_params[:'flatFilter'] = opts[:'flat_filter'] if !opts[:'flat_filter'].nil?");
+    }
+
     @Test
     public void testInitialConfigValues() {
         final RubyClientCodegen codegen = new RubyClientCodegen();

--- a/modules/openapi-generator/src/test/resources/3_0/exploded-object-query-param.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/exploded-object-query-param.yaml
@@ -1,0 +1,51 @@
+openapi: 3.0.3
+info:
+  title: Exploded object query parameters
+  description: >
+    Object typed query parameters, covering the four combinations of style and explode that
+    decide how an object is put on the wire. The free-form variants matter because a
+    free-form object is flagged isMap but not isContainer.
+  version: 1.0.0
+servers:
+  - url: localhost:8080
+paths:
+  /items:
+    get:
+      operationId: listItems
+      parameters:
+        # style and explode both left out, so the form/true defaults apply: every entry
+        # becomes its own parameter, keyed by the property name alone.
+        - in: query
+          name: filter
+          schema:
+            type: object
+        # the same, but declared as a map rather than as a free-form object
+        - in: query
+          name: typedFilter
+          schema:
+            type: object
+            additionalProperties:
+              type: string
+        # deepObject nests each entry under the parameter name: deepFilter[key]=value
+        - in: query
+          name: deepFilter
+          style: deepObject
+          explode: true
+          schema:
+            type: object
+        # form without explode keeps a single parameter carrying the whole object
+        - in: query
+          name: flatFilter
+          style: form
+          explode: false
+          schema:
+            type: object
+      responses:
+        '200':
+          description: a list of items
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string

--- a/samples/client/petstore/ruby-autoload/lib/petstore/api/fake_api.rb
+++ b/samples/client/petstore/ruby-autoload/lib/petstore/api/fake_api.rb
@@ -1556,7 +1556,8 @@ module Petstore
       query_params[:'url'] = @api_client.build_collection_param(url, :csv)
       query_params[:'context'] = @api_client.build_collection_param(context, :multi)
       query_params[:'allowEmpty'] = allow_empty
-      query_params[:'language'] = opts[:'language'] if !opts[:'language'].nil?
+      # form style explodes an object into one query parameter per entry, keyed by the property name alone
+      opts[:'language'].each { |name, value| query_params[name.to_s] = value } if !opts[:'language'].nil?
 
       # header parameters
       header_params = opts[:header_params] || {}

--- a/samples/client/petstore/ruby-faraday/lib/petstore/api/fake_api.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/api/fake_api.rb
@@ -1571,7 +1571,8 @@ module Petstore
       query_params[:'url'] = @api_client.build_collection_param(url, :csv)
       query_params[:'context'] = @api_client.build_collection_param(context, :multi)
       query_params[:'allowEmpty'] = allow_empty
-      query_params[:'language'] = opts[:'language'] if !opts[:'language'].nil?
+      # form style explodes an object into one query parameter per entry, keyed by the property name alone
+      opts[:'language'].each { |name, value| query_params[name.to_s] = value } if !opts[:'language'].nil?
 
       # header parameters
       header_params = opts[:header_params] || {}

--- a/samples/client/petstore/ruby-httpx/lib/petstore/api/fake_api.rb
+++ b/samples/client/petstore/ruby-httpx/lib/petstore/api/fake_api.rb
@@ -1571,7 +1571,8 @@ module Petstore
       query_params[:'url'] = @api_client.build_collection_param(url, :csv)
       query_params[:'context'] = @api_client.build_collection_param(context, :multi)
       query_params[:'allowEmpty'] = allow_empty
-      query_params[:'language'] = opts[:'language'] if !opts[:'language'].nil?
+      # form style explodes an object into one query parameter per entry, keyed by the property name alone
+      opts[:'language'].each { |name, value| query_params[name.to_s] = value } if !opts[:'language'].nil?
 
       # header parameters
       header_params = opts[:header_params] || {}

--- a/samples/client/petstore/ruby/lib/petstore/api/fake_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/fake_api.rb
@@ -1571,7 +1571,8 @@ module Petstore
       query_params[:'url'] = @api_client.build_collection_param(url, :csv)
       query_params[:'context'] = @api_client.build_collection_param(context, :multi)
       query_params[:'allowEmpty'] = allow_empty
-      query_params[:'language'] = opts[:'language'] if !opts[:'language'].nil?
+      # form style explodes an object into one query parameter per entry, keyed by the property name alone
+      opts[:'language'].each { |name, value| query_params[name.to_s] = value } if !opts[:'language'].nil?
 
       # header parameters
       header_params = opts[:header_params] || {}


### PR DESCRIPTION
A query parameter whose schema is an object and whose `style`/`explode` are left at their
defaults — `style: form`, `explode: true` — must go on the wire as one parameter per entry,
keyed by the property name alone. The `ruby` client assigned the whole hash under the
parameter name and left the http library to serialize it, which comes out in rails bracket
style, while `csharp`, `java` and `php` got it right.

Given:

```yaml
parameters:
  - in: query
    name: filter
    schema:
      type: object
```

called with `{"tld": "com", "createdDate:gte": "2023-01-01"}`:

| generator | on the wire |
| --- | --- |
| expected | `tld=com&createdDate%3Agte=2023-01-01` |
| ruby | `filter%5Btld%5D=com&filter%5BcreatedDate%3Agte%5D=2023-01-01` |
| csharp, java, php | correct |

> Sibling of #24797 (go), #24802 (python) and #24803 (typescript-fetch), one PR per language
> per the maintainer's request on #24797. This PR is independent of the other three — no
> shared `main/` code. It adds the same test fixture at the same path with identical content,
> so whichever lands first, the others rebase cleanly.

### The cause

**`ruby-client/api.mustache`** — the generated api put the hash into `query_params` whole
(`query_params[:'filter'] = opts[:'filter']`), and no style or explode ever reaches the
runtime: typhoeus, faraday and httpx all encode a nested hash in bracket style.

The fix merges an exploded map into `query_params` entry by entry at the call site —

```ruby
opts[:'filter'].each { |name, value| query_params[name.to_s] = value } if !opts[:'filter'].nil?
```

— which fixes all three http libraries at once, since they all consume the `query_params`
hash the api builds. `deepObject` and `explode: false` parameters keep the exact line they
produced before, and so does every other parameter shape (`build_collection_param` for
arrays, `to_json` for json-content parameters).

**Name collisions.** An exploded entry is a plain `query_params[name.to_s] = value`, so what
happens when an entry is named like a declared sibling parameter depends on the http library.
Declared parameters use symbol keys (`query_params[:'context']`) and exploded entries use
string keys, so the hash holds both:

- typhoeus and httpx send both, the same as the go reference port (#24797), which `Add`s
  exploded entries to `url.Values`;
- faraday copies `query_params` into its string-keyed `Faraday::Utils::ParamsHash`, so the two
  collapse into one key and whichever was assigned later in the generated method wins.

Checked against the regenerated `ruby`, `ruby-faraday` and `ruby-httpx` petstore samples by
calling `test_query_parameter_collection_format` with `language: {"context" => "exploded"}`
next to the declared `context`: typhoeus sent `context%5B0%5D=declared&…&context=exploded`,
httpx `context%5B%5D=declared&…&context=exploded`, faraday only `context=exploded`. Two
exploded maps sharing an entry name, or an entry repeating a string key passed in through
`opts[:query_params]`, overwrite each other in every library (the later assignment wins). The
spec leaves such collisions undefined; this PR doesn't try to reconcile them.

There is no equivalent of the python collection-format lookup here
(`build_collection_param` is only ever emitted for declared array parameters), so the
runtime-name collision that bit #24802 has no ruby counterpart.

### Verified on the wire, not just asserted

The client was generated from the new fixture and pointed at a server that echoes its own raw
request line back (typhoeus, the default library):

| parameter | before | after |
| --- | --- | --- |
| `filter` (object, defaults) | `filter%5Btld%5D=com&filter%5BcreatedDate%3Agte%5D=2023-01-01` | `tld=com&createdDate%3Agte=2023-01-01` |
| `typedFilter` (map, defaults) | same bracket shape | `tld=com&createdDate%3Agte=2023-01-01` |
| `deepFilter` (`style: deepObject`) | `deepFilter%5Btld%5D=com&…` | unchanged, byte for byte |
| `flatFilter` (`explode: false`) | `flatFilter%5Btld%5D=com&…` | unchanged, byte for byte |

The `deepFilter` row is worth a note: the accidental bracket encoding *is* the declared
deepObject format, so deepObject parameters were already correct here and stay untouched.

### Known gaps, called out deliberately

**`explode: false`** keeps its previous bracket encoding. The spec asks for
`flatFilter=tld,com,createdDate:gte,2023-01-01`; it was bracketed before and is bracketed
after, byte for byte — same scoping as the sibling PRs, left for a follow-up to keep this
reviewable.

**Declared object models.** A `$ref`ed object model as a query parameter is `isModel`, not
`isMap`, so it still goes on the wire whole. Pre-existing, and the same gap the sibling PRs
document. Left for a follow-up.

### Tests

`modules/openapi-generator/src/test/resources/3_0/exploded-object-query-param.yaml` covers
the four combinations that decide the wire format:

- `RubyClientCodegenTest#testExplodedObjectQueryParameter`

It fails without the fix (verified by stashing only the template change). All 26 tests in
`RubyClientCodegenTest` pass.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Built the project and updated samples (`./bin/generate-samples.sh` for
      `bin/configs/ruby*.yaml`; `./bin/utils/export_docs_generators.sh` produced no diff).
      4 sample files changed, all `fake_api.rb` (ruby, ruby-autoload, ruby-faraday,
      ruby-httpx), from the petstore fixture's `language` parameter — a declared map with the
      default style, the same parameter that changed in the python sibling.
- [x] Technical committee: @meganemura @dkliban @honeyryderchuck



---

Generated with Claude Code
