### PR TITLE
[kotlin] register service-loaded Jackson modules with useJackson3

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/jvm-common/infrastructure/Serializer.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/jvm-common/infrastructure/Serializer.kt.mustache
@@ -147,6 +147,7 @@ import java.util.concurrent.atomic.AtomicLong
 {{#useJackson3}}
     @JvmStatic
     val jacksonObjectMapper: JsonMapper = jsonMapper {
+        findAndAddModules()
         addModule(kotlinModule())
         changeDefaultPropertyInclusion { it.withValueInclusion(JsonInclude.Include.NON_ABSENT) }
         {{#enumUnknownDefaultCase}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinClientCodegenModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinClientCodegenModelTest.java
@@ -1297,6 +1297,27 @@ public class KotlinClientCodegenModelTest {
         TestUtils.assertFileNotContains(serializerPath, "com.fasterxml.jackson.databind");
     }
 
+    @Test(description = "useJackson3 keeps the Jackson 2 behaviour of registering service-loaded modules")
+    public void shouldFindAndAddModulesWithJackson3() throws IOException {
+        File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("kotlin")
+                .setInputSpec("src/test/resources/3_0/petstore.yaml")
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"))
+                .addAdditionalProperty(CodegenConstants.SERIALIZATION_LIBRARY, "jackson")
+                .addAdditionalProperty(KotlinClientCodegen.USE_JACKSON_3, true);
+
+        DefaultGenerator generator = new DefaultGenerator();
+        generator.opts(configurator.toClientOptInput()).generate();
+
+        Path serializerPath = Paths.get(output.getAbsolutePath() + "/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt");
+        // the Jackson 2 branch calls findAndRegisterModules(), so third-party modules published
+        // through META-INF/services must be picked up on the Jackson 3 branch as well
+        TestUtils.assertFileContains(serializerPath, "findAndAddModules()");
+    }
+
     @Test(description = "useJackson3 swaps the Jackson 2 Gradle dependencies for their Jackson 3 equivalents")
     public void shouldGenerateBuildGradleWithJackson3Deps() throws IOException {
         File output = Files.createTempDirectory("test").toFile();

--- a/samples/client/petstore/kotlin-jackson3/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-jackson3/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -11,6 +11,7 @@ import tools.jackson.module.kotlin.kotlinModule
 object Serializer {
     @JvmStatic
     val jacksonObjectMapper: JsonMapper = jsonMapper {
+        findAndAddModules()
         addModule(kotlinModule())
         changeDefaultPropertyInclusion { it.withValueInclusion(JsonInclude.Include.NON_ABSENT) }
         enable(EnumFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)

--- a/samples/client/petstore/kotlin-jvm-spring-4-restclient-jackson3/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-4-restclient-jackson3/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -11,6 +11,7 @@ import tools.jackson.module.kotlin.kotlinModule
 object Serializer {
     @JvmStatic
     val jacksonObjectMapper: JsonMapper = jsonMapper {
+        findAndAddModules()
         addModule(kotlinModule())
         changeDefaultPropertyInclusion { it.withValueInclusion(JsonInclude.Include.NON_ABSENT) }
         enable(EnumFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)


### PR DESCRIPTION
The Jackson 2 branch of `Serializer.kt.mustache` calls `findAndRegisterModules()`, so modules published via `META-INF/services` are registered. The Jackson 3 branch added in #24709 only calls `addModule(kotlinModule())`, so they are silently dropped.

Measured with jackson-databind 3.1.5 and `jackson-databind-nullable:0.2.11`, which ships that service file:

- `JsonMapper.builder().build()` -> `{"name":{"present":true,"undefined":false}}`
- `.findAndAddModules().build()` -> `{"name":"x"}`

Adding a module explicitly and by discovery registers it once, so `addModule(kotlinModule())` stays.

Both jackson3 samples regenerated; `./gradlew compileKotlin` on kotlin-jackson3 passes. The new test fails on master.

Fixes #24859

/cc @jimschubert @stefankoppier


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Registers service-loaded Jackson modules when generating Kotlin clients with `useJackson3`, fixing #24859.

The Jackson 3 branch of `Serializer.kt` only added the Kotlin module, so third-party modules published via `META-INF/services` were silently dropped. It now calls `findAndAddModules()` to match Jackson 2 behavior. Explicit module registration is still deduplicated, so `addModule(kotlinModule())` remains.

<sup>Written for commit 70a8db95d8d66ccfd484c9fee8b6fa0955cb8422. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24876?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

