### PR TITLE
[php] fix: enumUnknownDefaultCase declares the unknown-default member but never deserializes to it

### DIFF
--- a/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
@@ -485,6 +485,12 @@ class ObjectSerializer
 
         if (method_exists($class, 'getAllowableEnumValues')) {
             if (!in_array($data, $class::getAllowableEnumValues(), true)) {
+                {{#enumUnknownDefaultCase}}
+                if (defined("$class::UNKNOWN_DEFAULT_OPEN_API")) {
+                    return constant("$class::UNKNOWN_DEFAULT_OPEN_API");
+                }
+
+                {{/enumUnknownDefaultCase}}
                 $imploded = implode("', '", $class::getAllowableEnumValues());
                 throw new \InvalidArgumentException("Invalid value for enum '$class', must be one of: '$imploded'");
             }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/PhpClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/PhpClientCodegenTest.java
@@ -136,6 +136,15 @@ public class PhpClientCodegenTest {
 
         Assert.assertListContains(modelContent, a -> a.equals("$color = self::COLOR_UNKNOWN_DEFAULT_OPEN_API;"), "");
         Assert.assertListNotContains(modelContent, a -> a.equals("\"Invalid value '%s' for 'color', must be one of '%s'\","), "");
+
+        List<String> serializerContent = Files
+                .readAllLines(files.get("ObjectSerializer.php").toPath())
+                .stream()
+                .map(String::trim)
+                .collect(Collectors.toList());
+
+        Assert.assertListContains(serializerContent, a -> a.equals("if (defined(\"$class::UNKNOWN_DEFAULT_OPEN_API\")) {"), "");
+        Assert.assertListContains(serializerContent, a -> a.equals("return constant(\"$class::UNKNOWN_DEFAULT_OPEN_API\");"), "");
     }
 
     @Test
@@ -164,6 +173,15 @@ public class PhpClientCodegenTest {
 
         Assert.assertListNotContains(modelContent, a -> a.equals("$color = self::COLOR_UNKNOWN_DEFAULT_OPEN_API;"), "");
         Assert.assertListContains(modelContent, a -> a.equalsIgnoreCase("\"Invalid value '%s' for 'color', must be one of '%s'\","), "");
+
+        List<String> serializerContent = Files
+                .readAllLines(files.get("ObjectSerializer.php").toPath())
+                .stream()
+                .map(String::trim)
+                .collect(Collectors.toList());
+
+        Assert.assertListNotContains(serializerContent, a -> a.equals("if (defined(\"$class::UNKNOWN_DEFAULT_OPEN_API\")) {"), "");
+        Assert.assertListNotContains(serializerContent, a -> a.equals("return constant(\"$class::UNKNOWN_DEFAULT_OPEN_API\");"), "");
     }
     @Test
     public void testDateTimeLengthValidationIsNotGenerated() throws Exception {


### PR DESCRIPTION
`enumUnknownDefaultCase=true` promises that one new enum value from the server no longer
destroys the whole response. In the `php` client the flag adds the
`UNKNOWN_DEFAULT_OPEN_API` constant to every enum class — and then
`ObjectSerializer::deserialize` throws `InvalidArgumentException` for any wire value
outside the list anyway. The error message even advertises the member it refuses to
produce:

```
InvalidArgumentException: Invalid value for enum 'OpenAPI\Client\Model\DomainStatus',
must be one of: 'ACTIVE', 'INACTIVE', 'unknown_default_open_api'
```

#20594 fixed one of the two deserialization paths: an *inline* enum property falls back to
the unknown-default member in the model's constructor. A standalone enum schema referenced
with `$ref` — the common shape for a shared status enum — never reaches that code: it is
its own `$class` with `getAllowableEnumValues()`, and `ObjectSerializer::deserialize`
rejects the value before any model sees it. So with the flag on, the flag changes nothing
observable for `$ref`'d enums, in a response body or deserialized directly. Found while
comparing generators against a production registry API on v7.15.0 (java's `fromValue`
under the same flag is the reference behavior); reproduced on current master.

### The fix

`ObjectSerializer.mustache`, the enum branch of `deserialize`, guarded twice:

```php
if (method_exists($class, 'getAllowableEnumValues')) {
    if (!in_array($data, $class::getAllowableEnumValues(), true)) {
        {{#enumUnknownDefaultCase}}
        if (defined("$class::UNKNOWN_DEFAULT_OPEN_API")) {
            return constant("$class::UNKNOWN_DEFAULT_OPEN_API");
        }

        {{/enumUnknownDefaultCase}}
        ...throw...
```

- generation-time: the branch only exists in clients generated with
  `enumUnknownDefaultCase=true` — a client generated without the flag is **byte-identical**
  to before (verified by diffing full generated clients);
- runtime: it only fires for enum classes that actually declare the unknown-default member,
  so a hand-written or foreign enum class without it keeps throwing.

### Executed before/after, php:8, same spec (`DomainStatus: [ACTIVE, INACTIVE]`, `Domain.status: $ref`)

| | master template, flag on | this PR, flag on | this PR, no flag |
| --- | --- | --- | --- |
| `deserialize('SOMETHING_NEW', DomainStatus::class)` | throws `InvalidArgumentException` | returns `'unknown_default_open_api'` | throws `InvalidArgumentException` |
| `deserialize(payload, Domain::class)` with `status: "SOMETHING_NEW"` | throws `InvalidArgumentException` | `getStatus()` returns `'unknown_default_open_api'` | throws `InvalidArgumentException` |
| known value `'ACTIVE'` | returns `'ACTIVE'` | returns `'ACTIVE'` | returns `'ACTIVE'` |

> Sibling of the ruby change in #24879 — same flag, same half-implementation, per-language
> PRs. The two share no `main/` code.

### Out of scope, noted for honesty

`php-nextgen` has the same defect in its own `ObjectSerializer.mustache` (its enums are
native `\BackedEnum`s rejected via `tryFrom`), but the fix there has different mechanics —
enum cases instead of class constants — so it deserves its own change rather than a
copy-paste into this one.

### Tests

The two `PhpClientCodegenTest` cases from #20594 are extended:

- `testEnumUnknownDefaultCaseDeserializationEnabled` — the generated `ObjectSerializer.php`
  carries the fallback branch. Fails without the template fix (verified by stashing only
  the template change).
- `testEnumUnknownDefaultCaseDeserializationDisabled` — without the flag the branch is not
  generated.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Built the project and updated samples (`./bin/generate-samples.sh ./bin/configs/php*.yaml`).
      No sample files changed: no php sample config enables `enumUnknownDefaultCase`, and
      without the flag the template renders byte-identical output.
- [x] Technical committee: @jebentier @dkarlovi @mandrean @jfastnacht @ybelenko @renepardon

---

Generated with Claude Code


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes PHP enum deserialization when `enumUnknownDefaultCase` is enabled: unrecognized enum values now return the unknown-default member instead of throwing `InvalidArgumentException`.

**Details**

- The fallback in `ObjectSerializer::deserialize` returns the enum's `UNKNOWN_DEFAULT_OPEN_API` constant only when that constant is defined, and only in clients generated with the flag; other clients are byte-identical.
- Adds tests covering both enabled and disabled flag states.

<sup>Written for commit 3b0eb03903574c58b139ab9734450524b6f47981. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24878?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

