### PR TITLE
[ruby] fix: enumUnknownDefaultCase declares the unknown-default member but never deserializes to it

### DIFF
--- a/modules/openapi-generator/src/main/resources/ruby-client/partial_model_enum_class.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/partial_model_enum_class.mustache
@@ -18,6 +18,11 @@
     # @return [String] The enum value
     def build_from_hash(value)
       return value if {{classname}}.all_vars.include?(value)
+      {{#enumUnknownDefaultCase}}
+      {{#allowableValues}}{{#enumVars}}{{#-last}}{{{name}}}{{/-last}}{{/enumVars}}{{/allowableValues}}
+      {{/enumUnknownDefaultCase}}
+      {{^enumUnknownDefaultCase}}
       raise "Invalid ENUM value #{value} for class #{{{classname}}}"
+      {{/enumUnknownDefaultCase}}
     end
   end

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/ruby/RubyClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/ruby/RubyClientCodegenTest.java
@@ -762,4 +762,58 @@ public class RubyClientCodegenTest {
         assertTrue(op.queryParams.stream().allMatch(p -> p.queryIsJsonMimeType),
                 "All content:application/json query params should have queryIsJsonMimeType=true");
     }
+
+    @Test(description = "enumUnknownDefaultCase=true makes build_from_hash fall back to the unknown default member")
+    public void testEnumUnknownDefaultCaseBuildFromHashFallback() throws Exception {
+        final File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/enum.yaml");
+        CodegenConfig codegenConfig = new RubyClientCodegen();
+        codegenConfig.additionalProperties().put(CodegenConstants.ENUM_UNKNOWN_DEFAULT_CASE, "true");
+        codegenConfig.setOutputDir(output.getAbsolutePath());
+
+        ClientOptInput clientOptInput = new ClientOptInput().openAPI(openAPI).config(codegenConfig);
+        new DefaultGenerator().opts(clientOptInput).generate();
+
+        java.nio.file.Path stringEnum = new File(output, "lib/openapi_client/models/type.rb").toPath();
+        TestUtils.assertFileContains(stringEnum, "UNKNOWN_DEFAULT_OPEN_API = \"unknown_default_open_api\".freeze");
+        TestUtils.assertFileContains(stringEnum,
+                "def build_from_hash(value)\n" +
+                "      return value if Type.all_vars.include?(value)\n" +
+                "      UNKNOWN_DEFAULT_OPEN_API\n" +
+                "    end");
+        TestUtils.assertFileNotContains(stringEnum, "raise \"Invalid ENUM value");
+
+        // the integer enum's unknown-default member keeps its (pre-existing) numeric-prefixed name
+        java.nio.file.Path integerEnum = new File(output, "lib/openapi_client/models/integer_enum.rb").toPath();
+        TestUtils.assertFileContains(integerEnum, "Nunknown_default_open_api = 11184809.freeze");
+        TestUtils.assertFileContains(integerEnum,
+                "def build_from_hash(value)\n" +
+                "      return value if IntegerEnum.all_vars.include?(value)\n" +
+                "      Nunknown_default_open_api\n" +
+                "    end");
+        TestUtils.assertFileNotContains(integerEnum, "raise \"Invalid ENUM value");
+    }
+
+    @Test(description = "without enumUnknownDefaultCase build_from_hash still raises on unknown values")
+    public void testEnumBuildFromHashRaisesByDefault() throws Exception {
+        final File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/enum.yaml");
+        CodegenConfig codegenConfig = new RubyClientCodegen();
+        codegenConfig.setOutputDir(output.getAbsolutePath());
+
+        ClientOptInput clientOptInput = new ClientOptInput().openAPI(openAPI).config(codegenConfig);
+        new DefaultGenerator().opts(clientOptInput).generate();
+
+        java.nio.file.Path stringEnum = new File(output, "lib/openapi_client/models/type.rb").toPath();
+        TestUtils.assertFileNotContains(stringEnum, "UNKNOWN_DEFAULT_OPEN_API");
+        TestUtils.assertFileContains(stringEnum,
+                "def build_from_hash(value)\n" +
+                "      return value if Type.all_vars.include?(value)\n" +
+                "      raise \"Invalid ENUM value #{value} for class #Type\"\n" +
+                "    end");
+    }
 }


### PR DESCRIPTION
`enumUnknownDefaultCase=true` promises that one new enum value from the server no longer
destroys the whole response. In the `ruby` client the flag adds
`UNKNOWN_DEFAULT_OPEN_API` to every enum class's constants and `all_vars` — and then the
enum's own `build_from_hash` raises for any wire value outside the list anyway:

```
RuntimeError: Invalid ENUM value SOMETHING_NEW for class #DomainStatus
```

The member is declared but unreachable, so with the flag on, deserializing a response that
carries a newer enum value still fails wholesale. Found while comparing generators against
a production registry API on v7.15.0 (java's `fromValue` under the same flag is the
reference behavior); reproduced on current master.

### The fix

`partial_model_enum_class.mustache` — the tolerance lives in each generated enum class,
not in any shared serializer:

```ruby
def build_from_hash(value)
  return value if DomainStatus.all_vars.include?(value)
  UNKNOWN_DEFAULT_OPEN_API
end
```

The fallback names the enum's last declared member, which under
`enumUnknownDefaultCase=true` is always the appended unknown-default one (for an integer
enum it keeps its pre-existing generated name, e.g. `Nunknown_default_open_api = 11184809`).
Without the flag the `raise` line is generated exactly as before — a client generated
without the flag is **byte-identical** to before (verified by diffing full generated
clients).

### Executed before/after, ruby:3.3, same spec (`DomainStatus: [ACTIVE, INACTIVE]`, `Domain.status: $ref`)

| | master template, flag on | this PR, flag on | this PR, no flag |
| --- | --- | --- | --- |
| `DomainStatus.build_from_hash('SOMETHING_NEW')` | raises `RuntimeError` | returns `"unknown_default_open_api"` | raises `RuntimeError` |
| `Domain.build_from_hash('status' => 'SOMETHING_NEW')` | raises `RuntimeError` | `status` is `"unknown_default_open_api"` | raises `RuntimeError` |
| known value `'ACTIVE'` | returns `"ACTIVE"` | returns `"ACTIVE"` | returns `"ACTIVE"` |

> Sibling of the php change in #24878 — same flag, same half-implementation, per-language
> PRs. The two share no `main/` code.

### Tests

Two new cases in `RubyClientCodegenTest`, generating from the existing `3_0/enum.yaml`
fixture (string and integer enums):

- `testEnumUnknownDefaultCaseBuildFromHashFallback` — with the flag, both enum classes
  declare the member and `build_from_hash` falls back to it instead of raising. Fails
  without the template fix (verified by stashing only the template change).
- `testEnumBuildFromHashRaisesByDefault` — without the flag the member is absent and
  `build_from_hash` still raises, character for character as today.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Built the project and updated samples (`./bin/generate-samples.sh ./bin/configs/ruby*.yaml`).
      No sample files changed: no ruby sample config enables `enumUnknownDefaultCase`, and
      without the flag the template renders byte-identical output.
- [x] Technical committee: @cliffano @zlx @autopp

---

Generated with Claude Code


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Ruby client's `enumUnknownDefaultCase` handling so unknown enum values deserialize to the unknown-default member instead of raising, preserving the flag's promise that new server values don't break the whole response.

- With `enumUnknownDefaultCase=true`, `build_from_hash` now returns the unknown-default enum member instead of raising `RuntimeError`.
- Without the flag, generated code is byte-identical to before and still raises on unknown values.
- Adds tests covering both flag-on and flag-off paths.

<sup>Written for commit 0a5f76e31c52eb0411fb388b0f7da1611a7cedfa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24879?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

