### PR TITLE
[dart] fix: handle multiline x-enum-descriptions

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractDartCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractDartCodegen.java
@@ -1,6 +1,8 @@
 package org.openapitools.codegen.languages;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
+import com.samskivert.mustache.Mustache.Lambda;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.media.Schema;
@@ -18,6 +20,8 @@ import org.openapitools.codegen.model.ModelMap;
 import org.openapitools.codegen.model.ModelsMap;
 import org.openapitools.codegen.model.OperationMap;
 import org.openapitools.codegen.model.OperationsMap;
+import org.openapitools.codegen.templating.mustache.IndentedLambda;
+import org.openapitools.codegen.templating.mustache.PrefixLambda;
 import org.openapitools.codegen.utils.ModelUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -349,6 +353,13 @@ public abstract class AbstractDartCodegen extends DefaultCodegen {
         if (templateDir == null) {
             embeddedTemplateDir = templateDir = "dart2";
         }
+    }
+
+    @Override
+    protected ImmutableMap.Builder<String, Lambda> addMustacheLambdas() {
+        return super.addMustacheLambdas()
+                .put("dartdoc", new PrefixLambda(" * ", false))
+                .put("dartdoc_2", new IndentedLambda(2, " ", " * ", false, false));
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/templating/mustache/PrefixLambda.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/templating/mustache/PrefixLambda.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 OpenAPI-Generator Contributors (https://openapi-generator.tech)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openapitools.codegen.templating.mustache;
+
+import com.samskivert.mustache.Mustache;
+import com.samskivert.mustache.Template;
+
+import java.io.IOException;
+import java.io.Writer;
+
+/**
+ * Prefixes rendered fragment lines without applying additional indentation.
+ */
+public class PrefixLambda implements Mustache.Lambda {
+    private final String prefix;
+    private final boolean prefixFirstLine;
+
+    public PrefixLambda(String prefix, boolean prefixFirstLine) {
+        this.prefix = prefix;
+        this.prefixFirstLine = prefixFirstLine;
+    }
+
+    @Override
+    public void execute(Template.Fragment fragment, Writer writer) throws IOException {
+        String text = fragment.execute();
+        if (text == null || text.isEmpty()) {
+            return;
+        }
+
+        String[] lines = text.split("\n", -1);
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < lines.length; i++) {
+            if (prefixFirstLine || i > 0) {
+                sb.append(prefix);
+            }
+            sb.append(lines[i]);
+            if (i < lines.length - 1) {
+                sb.append("\n");
+            }
+        }
+
+        writer.write(sb.toString());
+    }
+}
+

--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/built_value/enum.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/built_value/enum.mustache
@@ -13,13 +13,15 @@ part '{{classFilename}}.g.dart';
 class {{classname}} extends EnumClass {
 
   {{#allowableValues}}
-    {{#enumVars}}
-      {{#enumDescription}}
-  /// {{{.}}}
-      {{/enumDescription}}
+  {{#enumVars}}
+  {{#enumDescription}}
+  /**
+   * {{#lambda.dartdoc_2}}{{{.}}}{{/lambda.dartdoc_2}}
+   */
+  {{/enumDescription}}
   @BuiltValueEnumConst({{#isInteger}}wireNumber: {{{value}}}{{/isInteger}}{{#isLong}}wireNumber: {{{value}}}{{/isLong}}{{^isInteger}}{{^isLong}}wireName: r{{{value}}}{{/isLong}}{{/isInteger}}{{#enumUnknownDefaultCase}}{{#-last}}, fallback: true{{/-last}}{{/enumUnknownDefaultCase}})
   static const {{classname}} {{name}} = _${{name}};
-    {{/enumVars}}
+  {{/enumVars}}
   {{/allowableValues}}
 
   static Serializer<{{classname}}> get serializer => _${{#lambda.camelcase}}{{{classname}}}{{/lambda.camelcase}}Serializer;

--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/built_value/enum_inline.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/built_value/enum_inline.mustache
@@ -7,13 +7,15 @@
 class {{{enumName}}} extends EnumClass {
 
   {{#allowableValues}}
-    {{#enumVars}}
-      {{#enumDescription}}
-  /// {{{.}}}
-      {{/enumDescription}}
+  {{#enumVars}}
+  {{#enumDescription}}
+  /**
+   * {{#lambda.dartdoc_2}}{{{.}}}{{/lambda.dartdoc_2}}
+   */
+  {{/enumDescription}}
   @BuiltValueEnumConst({{#isInteger}}wireNumber: {{{value}}}{{/isInteger}}{{#isLong}}wireNumber: {{{value}}}{{/isLong}}{{^isInteger}}{{^isLong}}wireName: r{{{value}}}{{/isLong}}{{/isInteger}}{{#enumUnknownDefaultCase}}{{#-last}}, fallback: true{{/-last}}{{/enumUnknownDefaultCase}})
   static const {{{enumName}}} {{name}} = _${{#lambda.camelcase}}{{{enumName}}}{{/lambda.camelcase}}_{{name}};
-    {{/enumVars}}
+  {{/enumVars}}
   {{/allowableValues}}
 
   static Serializer<{{{enumName}}}> get serializer => _${{#lambda.camelcase}}{{{enumName}}}{{/lambda.camelcase}}Serializer;

--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/json_serializable/enum.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/json_serializable/enum.mustache
@@ -10,11 +10,13 @@ enum {{{classname}}} {
 {{#allowableValues}}
 {{#enumVars}}
   {{^isNull}}
-      {{#enumDescription}}
-          /// {{{.}}}
-      {{/enumDescription}}
-      @JsonValue({{#isString}}r{{/isString}}{{{value}}})
-      {{{name}}}({{^isString}}'{{/isString}}{{#isString}}r{{/isString}}{{{value}}}{{^isString}}'{{/isString}}){{^-last}},{{/-last}}{{#-last}};{{/-last}}
+  {{#enumDescription}}
+  /**
+   * {{#lambda.dartdoc_2}}{{{.}}}{{/lambda.dartdoc_2}}
+   */
+  {{/enumDescription}}
+  @JsonValue({{#isString}}r{{/isString}}{{{value}}})
+  {{{name}}}({{^isString}}'{{/isString}}{{#isString}}r{{/isString}}{{{value}}}{{^isString}}'{{/isString}}){{^-last}},{{/-last}}{{#-last}};{{/-last}}
   {{/isNull}}
 {{/enumVars}}
 {{/allowableValues}}

--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/json_serializable/enum_inline.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/json_serializable/enum_inline.mustache
@@ -10,7 +10,9 @@ enum {{{ enumName }}} {
 {{#enumVars}}
 {{^isNull}}
 {{#enumDescription}}
-    /// {{{.}}}
+/**
+ * {{#lambda.dartdoc}}{{{.}}}{{/lambda.dartdoc}}
+ */
 {{/enumDescription}}
 @JsonValue({{#isString}}r{{/isString}}{{{value}}})
 {{{name}}}({{^isString}}'{{/isString}}{{#isString}}r{{/isString}}{{{value}}}{{^isString}}'{{/isString}}){{^-last}},{{/-last}}{{#-last}};{{/-last}}

--- a/modules/openapi-generator/src/test/resources/3_0/dart/petstore-with-fake-endpoints-models-for-testing.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/dart/petstore-with-fake-endpoints-models-for-testing.yaml
@@ -637,6 +637,16 @@ paths:
               - '-efg'
               - (xyz)
             default: '-efg'
+            x-enum-descriptions:
+              - |
+                line1
+                line2
+              - |
+                line3
+                line4
+              - |
+                line5
+                line6
         - name: enum_query_string_array
           in: query
           description: Query parameter enum test (string array)
@@ -1427,6 +1437,16 @@ components:
             - placed
             - approved
             - delivered
+          x-enum-descriptions:
+            - |
+              line1
+              line2
+            - |
+              line3
+              line4
+            - |
+              line5
+              line6
         complete:
           type: boolean
           default: false
@@ -2088,6 +2108,16 @@ components:
         - ''
         - 'value_one'
         - 'value_two'
+      x-enum-descriptions:
+        - |
+          line1
+          line2
+        - |
+          line3
+          line4
+        - |
+          line5
+          line6
       title: TestEnum
     ObjectWithEnum:
       type: object

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/model/model_enum_class.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/model/model_enum_class.dart
@@ -6,14 +6,14 @@
 import 'package:json_annotation/json_annotation.dart';
 
 enum ModelEnumClass {
-      @JsonValue(r'_abc')
-      abc(r'_abc'),
-      @JsonValue(r'-efg')
-      efg(r'-efg'),
-      @JsonValue(r'(xyz)')
-      leftParenthesisXyzRightParenthesis(r'(xyz)'),
-      @JsonValue(r'unknown_default_open_api')
-      unknownDefaultOpenApi(r'unknown_default_open_api');
+  @JsonValue(r'_abc')
+  abc(r'_abc'),
+  @JsonValue(r'-efg')
+  efg(r'-efg'),
+  @JsonValue(r'(xyz)')
+  leftParenthesisXyzRightParenthesis(r'(xyz)'),
+  @JsonValue(r'unknown_default_open_api')
+  unknownDefaultOpenApi(r'unknown_default_open_api');
 
   const ModelEnumClass(this.value);
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/model/order.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/model/order.dart
@@ -140,10 +140,25 @@ class Order {
 
 /// Order Status
 enum OrderStatusEnum {
+/**
+ * line1
+ * line2
+ * 
+ */
 @JsonValue(r'placed')
 placed(r'placed'),
+/**
+ * line3
+ * line4
+ * 
+ */
 @JsonValue(r'approved')
 approved(r'approved'),
+/**
+ * line5
+ * line6
+ * 
+ */
 @JsonValue(r'delivered')
 delivered(r'delivered'),
 @JsonValue(r'unknown_default_open_api')

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/model/outer_enum.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/model/outer_enum.dart
@@ -6,14 +6,14 @@
 import 'package:json_annotation/json_annotation.dart';
 
 enum OuterEnum {
-      @JsonValue(r'placed')
-      placed(r'placed'),
-      @JsonValue(r'approved')
-      approved(r'approved'),
-      @JsonValue(r'delivered')
-      delivered(r'delivered'),
-      @JsonValue(r'unknown_default_open_api')
-      unknownDefaultOpenApi(r'unknown_default_open_api');
+  @JsonValue(r'placed')
+  placed(r'placed'),
+  @JsonValue(r'approved')
+  approved(r'approved'),
+  @JsonValue(r'delivered')
+  delivered(r'delivered'),
+  @JsonValue(r'unknown_default_open_api')
+  unknownDefaultOpenApi(r'unknown_default_open_api');
 
   const OuterEnum(this.value);
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/model/outer_enum_default_value.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/model/outer_enum_default_value.dart
@@ -6,14 +6,14 @@
 import 'package:json_annotation/json_annotation.dart';
 
 enum OuterEnumDefaultValue {
-      @JsonValue(r'placed')
-      placed(r'placed'),
-      @JsonValue(r'approved')
-      approved(r'approved'),
-      @JsonValue(r'delivered')
-      delivered(r'delivered'),
-      @JsonValue(r'unknown_default_open_api')
-      unknownDefaultOpenApi(r'unknown_default_open_api');
+  @JsonValue(r'placed')
+  placed(r'placed'),
+  @JsonValue(r'approved')
+  approved(r'approved'),
+  @JsonValue(r'delivered')
+  delivered(r'delivered'),
+  @JsonValue(r'unknown_default_open_api')
+  unknownDefaultOpenApi(r'unknown_default_open_api');
 
   const OuterEnumDefaultValue(this.value);
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/model/outer_enum_integer.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/model/outer_enum_integer.dart
@@ -6,14 +6,14 @@
 import 'package:json_annotation/json_annotation.dart';
 
 enum OuterEnumInteger {
-      @JsonValue(0)
-      number0('0'),
-      @JsonValue(1)
-      number1('1'),
-      @JsonValue(2)
-      number2('2'),
-      @JsonValue(11184809)
-      unknownDefaultOpenApi('11184809');
+  @JsonValue(0)
+  number0('0'),
+  @JsonValue(1)
+  number1('1'),
+  @JsonValue(2)
+  number2('2'),
+  @JsonValue(11184809)
+  unknownDefaultOpenApi('11184809');
 
   const OuterEnumInteger(this.value);
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/model/outer_enum_integer_default_value.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/model/outer_enum_integer_default_value.dart
@@ -6,14 +6,14 @@
 import 'package:json_annotation/json_annotation.dart';
 
 enum OuterEnumIntegerDefaultValue {
-      @JsonValue(0)
-      number0('0'),
-      @JsonValue(1)
-      number1('1'),
-      @JsonValue(2)
-      number2('2'),
-      @JsonValue(11184809)
-      unknownDefaultOpenApi('11184809');
+  @JsonValue(0)
+  number0('0'),
+  @JsonValue(1)
+  number1('1'),
+  @JsonValue(2)
+  number2('2'),
+  @JsonValue(11184809)
+  unknownDefaultOpenApi('11184809');
 
   const OuterEnumIntegerDefaultValue(this.value);
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/model/single_ref_type.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/model/single_ref_type.dart
@@ -6,12 +6,12 @@
 import 'package:json_annotation/json_annotation.dart';
 
 enum SingleRefType {
-      @JsonValue(r'admin')
-      admin(r'admin'),
-      @JsonValue(r'user')
-      user(r'user'),
-      @JsonValue(r'unknown_default_open_api')
-      unknownDefaultOpenApi(r'unknown_default_open_api');
+  @JsonValue(r'admin')
+  admin(r'admin'),
+  @JsonValue(r'user')
+  user(r'user'),
+  @JsonValue(r'unknown_default_open_api')
+  unknownDefaultOpenApi(r'unknown_default_open_api');
 
   const SingleRefType(this.value);
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/model/test_enum.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/model/test_enum.dart
@@ -6,14 +6,29 @@
 import 'package:json_annotation/json_annotation.dart';
 
 enum TestEnum {
-      @JsonValue(r'')
-      empty(r''),
-      @JsonValue(r'value_one')
-      valueOne(r'value_one'),
-      @JsonValue(r'value_two')
-      valueTwo(r'value_two'),
-      @JsonValue(r'unknown_default_open_api')
-      unknownDefaultOpenApi(r'unknown_default_open_api');
+  /**
+   * line1
+   * line2
+   * 
+   */
+  @JsonValue(r'')
+  empty(r''),
+  /**
+   * line3
+   * line4
+   * 
+   */
+  @JsonValue(r'value_one')
+  valueOne(r'value_one'),
+  /**
+   * line5
+   * line6
+   * 
+   */
+  @JsonValue(r'value_two')
+  valueTwo(r'value_two'),
+  @JsonValue(r'unknown_default_open_api')
+  unknownDefaultOpenApi(r'unknown_default_open_api');
 
   const TestEnum(this.value);
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/order.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/order.dart
@@ -210,10 +210,25 @@ class _$OrderSerializer implements PrimitiveSerializer<Order> {
 /// Order Status
 class OrderStatusEnum extends EnumClass {
 
+  /**
+   * line1
+   * line2
+   * 
+   */
   @BuiltValueEnumConst(wireName: r'placed')
   static const OrderStatusEnum placed = _$orderStatusEnum_placed;
+  /**
+   * line3
+   * line4
+   * 
+   */
   @BuiltValueEnumConst(wireName: r'approved')
   static const OrderStatusEnum approved = _$orderStatusEnum_approved;
+  /**
+   * line5
+   * line6
+   * 
+   */
   @BuiltValueEnumConst(wireName: r'delivered')
   static const OrderStatusEnum delivered = _$orderStatusEnum_delivered;
   @BuiltValueEnumConst(wireName: r'unknown_default_open_api', fallback: true)

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/test_enum.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/test_enum.dart
@@ -11,10 +11,25 @@ part 'test_enum.g.dart';
 
 class TestEnum extends EnumClass {
 
+  /**
+   * line1
+   * line2
+   * 
+   */
   @BuiltValueEnumConst(wireName: r'')
   static const TestEnum empty = _$empty;
+  /**
+   * line3
+   * line4
+   * 
+   */
   @BuiltValueEnumConst(wireName: r'value_one')
   static const TestEnum valueOne = _$valueOne;
+  /**
+   * line5
+   * line6
+   * 
+   */
   @BuiltValueEnumConst(wireName: r'value_two')
   static const TestEnum valueTwo = _$valueTwo;
   @BuiltValueEnumConst(wireName: r'unknown_default_open_api', fallback: true)


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Fixes so that dart can handle multiline `x-enum-descriptions`. This is done by changing the doc to `/** ... */` and introducing a lambda to prefix each line with a `*`. Note that `*` is technically superfluous, and it is for example not used in the Java handling.

Reverted strange indent changes to `enum.mustache` from [here](https://github.com/Mattias-Sehlstedt/openapi-generator/commit/3d15864eacc2d1bce16b4147cb1b1ee64152209a#diff-e80e6f66c07198fac6d6e1f2e0503db8c1e45bcf9dc2421f59d8924d2d410fde), and instead made it a two-step indent as per every other definition in the template.

Fixes #24858

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Dart generator emitting broken doc comments for multiline `x-enum-descriptions` by switching from `///` to `/** ... */` block comments and prefixing each line with `*` via new Mustache lambdas.

**Details**
- Adds `PrefixLambda` and the `dartdoc`/`dartdoc_2` lambdas in `AbstractDartCodegen`.
- Uses block comments in the `built_value` and `json_serializable` enum templates.
- Adds multiline enum descriptions to the Dart petstore test spec and regenerates samples.
- Resolves #24858.

<sup>Written for commit 7073cc2cfde069e7c8b315a59e3af3ee94c917d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24881?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



