### PR TITLE
[typescript-angular] - Remove legacy constructor decorators in favor of native Angular inject() Fn

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-angular/api.module.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/api.module.mustache
@@ -26,8 +26,8 @@ export class {{apiModuleClassName}} {
         };
     }
 
-    private parentModule: {{apiModuleClassName}} = inject({{apiModuleClassName}}, { optional: true, skipSelf: true });
-    private http: HttpClient = inject(HttpClient, { optional: true });
+    private parentModule: {{apiModuleClassName}} | null = inject({{apiModuleClassName}}, { optional: true, skipSelf: true });
+    private http: HttpClient | null = inject(HttpClient, { optional: true });
 
     constructor() {
         if (this.parentModule) {

--- a/modules/openapi-generator/src/main/resources/typescript-angular/api.module.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/api.module.mustache
@@ -1,4 +1,4 @@
-import { NgModule, ModuleWithProviders, SkipSelf, Optional } from '@angular/core';
+import { NgModule, ModuleWithProviders, inject } from '@angular/core';
 import { {{configurationClassName}} } from './configuration';
 import { HttpClient } from '@angular/common/http';
 
@@ -26,12 +26,14 @@ export class {{apiModuleClassName}} {
         };
     }
 
-    constructor( @Optional() @SkipSelf() parentModule: {{apiModuleClassName}},
-                 @Optional() http: HttpClient) {
-        if (parentModule) {
+    private parentModule: {{apiModuleClassName}} = inject({{apiModuleClassName}}, { optional: true, skipSelf: true });
+    private http: HttpClient = inject(HttpClient, { optional: true });
+
+    constructor() {
+        if (this.parentModule) {
             throw new Error('{{apiModuleClassName}} is already loaded. Import in your base AppModule only.');
         }
-        if (!http) {
+        if (!this.http) {
             throw new Error('You need to import the HttpClientModule in your AppModule! \n' +
             'See also https://github.com/angular/angular/issues/20575');
         }

--- a/modules/openapi-generator/src/main/resources/typescript-angular/api.service.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/api.service.mustache
@@ -1,7 +1,7 @@
 {{>licenseInfo}}
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
+import { inject, Injectable }                      from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
          HttpResponse, HttpEvent{{#httpContextInOptions}}, HttpContext {{/httpContextInOptions}}
         }       from '@angular/common/http';
@@ -62,8 +62,13 @@ export class {{classname}} extends BaseService implements {{classname}}Interface
 export class {{classname}} extends BaseService {
 {{/withInterfaces}}
 
-    constructor(protected httpClient: HttpClient, @Optional() @Inject(BASE_PATH) basePath: string|string[], @Optional() configuration?: {{configurationClassName}}) {
-        super(basePath, configuration);
+    protected httpClient: HttpClient = inject(HttpClient);
+
+    constructor() {
+        super(
+          inject(BASE_PATH, { optional: true }) ?? undefined,
+          inject({{configurationClassName}}, { optional: true }) ?? undefined
+        );
     }
 
 {{#operation}}

--- a/samples/client/others/typescript-angular-v20/builds/query-param-deep-object/api.module.ts
+++ b/samples/client/others/typescript-angular-v20/builds/query-param-deep-object/api.module.ts
@@ -1,4 +1,4 @@
-import { NgModule, ModuleWithProviders, SkipSelf, Optional } from '@angular/core';
+import { NgModule, ModuleWithProviders, inject } from '@angular/core';
 import { Configuration } from './configuration';
 import { HttpClient } from '@angular/common/http';
 
@@ -17,12 +17,14 @@ export class ApiModule {
         };
     }
 
-    constructor( @Optional() @SkipSelf() parentModule: ApiModule,
-                 @Optional() http: HttpClient) {
-        if (parentModule) {
+    private parentModule: ApiModule = inject(ApiModule, { optional: true, skipSelf: true });
+    private http: HttpClient = inject(HttpClient, { optional: true });
+
+    constructor() {
+        if (this.parentModule) {
             throw new Error('ApiModule is already loaded. Import in your base AppModule only.');
         }
-        if (!http) {
+        if (!this.http) {
             throw new Error('You need to import the HttpClientModule in your AppModule! \n' +
             'See also https://github.com/angular/angular/issues/20575');
         }

--- a/samples/client/others/typescript-angular-v20/builds/query-param-deep-object/api/default.service.ts
+++ b/samples/client/others/typescript-angular-v20/builds/query-param-deep-object/api/default.service.ts
@@ -9,7 +9,7 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
+import { inject, Injectable }                      from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
          HttpResponse, HttpEvent, HttpContext 
         }       from '@angular/common/http';
@@ -33,8 +33,13 @@ import { BaseService } from '../api.base.service';
 })
 export class DefaultService extends BaseService {
 
-    constructor(protected httpClient: HttpClient, @Optional() @Inject(BASE_PATH) basePath: string|string[], @Optional() configuration?: Configuration) {
-        super(basePath, configuration);
+    protected httpClient: HttpClient = inject(HttpClient);
+
+    constructor() {
+        super(
+          inject(BASE_PATH, { optional: true }) ?? undefined,
+          inject(Configuration, { optional: true }) ?? undefined
+        );
     }
 
     /**

--- a/samples/client/others/typescript-angular-v20/builds/query-param-form/api.module.ts
+++ b/samples/client/others/typescript-angular-v20/builds/query-param-form/api.module.ts
@@ -1,4 +1,4 @@
-import { NgModule, ModuleWithProviders, SkipSelf, Optional } from '@angular/core';
+import { NgModule, ModuleWithProviders, inject } from '@angular/core';
 import { Configuration } from './configuration';
 import { HttpClient } from '@angular/common/http';
 
@@ -17,12 +17,14 @@ export class ApiModule {
         };
     }
 
-    constructor( @Optional() @SkipSelf() parentModule: ApiModule,
-                 @Optional() http: HttpClient) {
-        if (parentModule) {
+    private parentModule: ApiModule = inject(ApiModule, { optional: true, skipSelf: true });
+    private http: HttpClient = inject(HttpClient, { optional: true });
+
+    constructor() {
+        if (this.parentModule) {
             throw new Error('ApiModule is already loaded. Import in your base AppModule only.');
         }
-        if (!http) {
+        if (!this.http) {
             throw new Error('You need to import the HttpClientModule in your AppModule! \n' +
             'See also https://github.com/angular/angular/issues/20575');
         }

--- a/samples/client/others/typescript-angular-v20/builds/query-param-form/api/default.service.ts
+++ b/samples/client/others/typescript-angular-v20/builds/query-param-form/api/default.service.ts
@@ -9,7 +9,7 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
+import { inject, Injectable }                      from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
          HttpResponse, HttpEvent, HttpContext 
         }       from '@angular/common/http';
@@ -33,8 +33,13 @@ import { BaseService } from '../api.base.service';
 })
 export class DefaultService extends BaseService {
 
-    constructor(protected httpClient: HttpClient, @Optional() @Inject(BASE_PATH) basePath: string|string[], @Optional() configuration?: Configuration) {
-        super(basePath, configuration);
+    protected httpClient: HttpClient = inject(HttpClient);
+
+    constructor() {
+        super(
+          inject(BASE_PATH, { optional: true }) ?? undefined,
+          inject(Configuration, { optional: true }) ?? undefined
+        );
     }
 
     /**

--- a/samples/client/others/typescript-angular-v20/builds/query-param-json/api.module.ts
+++ b/samples/client/others/typescript-angular-v20/builds/query-param-json/api.module.ts
@@ -1,4 +1,4 @@
-import { NgModule, ModuleWithProviders, SkipSelf, Optional } from '@angular/core';
+import { NgModule, ModuleWithProviders, inject } from '@angular/core';
 import { Configuration } from './configuration';
 import { HttpClient } from '@angular/common/http';
 
@@ -17,12 +17,14 @@ export class ApiModule {
         };
     }
 
-    constructor( @Optional() @SkipSelf() parentModule: ApiModule,
-                 @Optional() http: HttpClient) {
-        if (parentModule) {
+    private parentModule: ApiModule = inject(ApiModule, { optional: true, skipSelf: true });
+    private http: HttpClient = inject(HttpClient, { optional: true });
+
+    constructor() {
+        if (this.parentModule) {
             throw new Error('ApiModule is already loaded. Import in your base AppModule only.');
         }
-        if (!http) {
+        if (!this.http) {
             throw new Error('You need to import the HttpClientModule in your AppModule! \n' +
             'See also https://github.com/angular/angular/issues/20575');
         }

--- a/samples/client/others/typescript-angular-v20/builds/query-param-json/api/default.service.ts
+++ b/samples/client/others/typescript-angular-v20/builds/query-param-json/api/default.service.ts
@@ -9,7 +9,7 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
+import { inject, Injectable }                      from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
          HttpResponse, HttpEvent, HttpContext 
         }       from '@angular/common/http';
@@ -33,8 +33,13 @@ import { BaseService } from '../api.base.service';
 })
 export class DefaultService extends BaseService {
 
-    constructor(protected httpClient: HttpClient, @Optional() @Inject(BASE_PATH) basePath: string|string[], @Optional() configuration?: Configuration) {
-        super(basePath, configuration);
+    protected httpClient: HttpClient = inject(HttpClient);
+
+    constructor() {
+        super(
+          inject(BASE_PATH, { optional: true }) ?? undefined,
+          inject(Configuration, { optional: true }) ?? undefined
+        );
     }
 
     /**

--- a/samples/client/others/typescript-angular/builds/composed-schemas-tagged-unions/api.module.ts
+++ b/samples/client/others/typescript-angular/builds/composed-schemas-tagged-unions/api.module.ts
@@ -1,4 +1,4 @@
-import { NgModule, ModuleWithProviders, SkipSelf, Optional } from '@angular/core';
+import { NgModule, ModuleWithProviders, inject } from '@angular/core';
 import { Configuration } from './configuration';
 import { HttpClient } from '@angular/common/http';
 
@@ -17,12 +17,14 @@ export class ApiModule {
         };
     }
 
-    constructor( @Optional() @SkipSelf() parentModule: ApiModule,
-                 @Optional() http: HttpClient) {
-        if (parentModule) {
+    private parentModule: ApiModule = inject(ApiModule, { optional: true, skipSelf: true });
+    private http: HttpClient = inject(HttpClient, { optional: true });
+
+    constructor() {
+        if (this.parentModule) {
             throw new Error('ApiModule is already loaded. Import in your base AppModule only.');
         }
-        if (!http) {
+        if (!this.http) {
             throw new Error('You need to import the HttpClientModule in your AppModule! \n' +
             'See also https://github.com/angular/angular/issues/20575');
         }

--- a/samples/client/others/typescript-angular/builds/composed-schemas-tagged-unions/api/pet.service.ts
+++ b/samples/client/others/typescript-angular/builds/composed-schemas-tagged-unions/api/pet.service.ts
@@ -9,7 +9,7 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
+import { inject, Injectable }                      from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
          HttpResponse, HttpEvent, HttpContext 
         }       from '@angular/common/http';
@@ -31,8 +31,13 @@ import { BaseService } from '../api.base.service';
 })
 export class PetService extends BaseService {
 
-    constructor(protected httpClient: HttpClient, @Optional() @Inject(BASE_PATH) basePath: string|string[], @Optional() configuration?: Configuration) {
-        super(basePath, configuration);
+    protected httpClient: HttpClient = inject(HttpClient);
+
+    constructor() {
+        super(
+          inject(BASE_PATH, { optional: true }) ?? undefined,
+          inject(Configuration, { optional: true }) ?? undefined
+        );
     }
 
     /**

--- a/samples/client/others/typescript-angular/builds/composed-schemas/api.module.ts
+++ b/samples/client/others/typescript-angular/builds/composed-schemas/api.module.ts
@@ -1,4 +1,4 @@
-import { NgModule, ModuleWithProviders, SkipSelf, Optional } from '@angular/core';
+import { NgModule, ModuleWithProviders, inject } from '@angular/core';
 import { Configuration } from './configuration';
 import { HttpClient } from '@angular/common/http';
 
@@ -17,12 +17,14 @@ export class ApiModule {
         };
     }
 
-    constructor( @Optional() @SkipSelf() parentModule: ApiModule,
-                 @Optional() http: HttpClient) {
-        if (parentModule) {
+    private parentModule: ApiModule = inject(ApiModule, { optional: true, skipSelf: true });
+    private http: HttpClient = inject(HttpClient, { optional: true });
+
+    constructor() {
+        if (this.parentModule) {
             throw new Error('ApiModule is already loaded. Import in your base AppModule only.');
         }
-        if (!http) {
+        if (!this.http) {
             throw new Error('You need to import the HttpClientModule in your AppModule! \n' +
             'See also https://github.com/angular/angular/issues/20575');
         }

--- a/samples/client/others/typescript-angular/builds/composed-schemas/api/pet.service.ts
+++ b/samples/client/others/typescript-angular/builds/composed-schemas/api/pet.service.ts
@@ -9,7 +9,7 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
+import { inject, Injectable }                      from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
          HttpResponse, HttpEvent, HttpContext 
         }       from '@angular/common/http';
@@ -31,8 +31,13 @@ import { BaseService } from '../api.base.service';
 })
 export class PetService extends BaseService {
 
-    constructor(protected httpClient: HttpClient, @Optional() @Inject(BASE_PATH) basePath: string|string[], @Optional() configuration?: Configuration) {
-        super(basePath, configuration);
+    protected httpClient: HttpClient = inject(HttpClient);
+
+    constructor() {
+        super(
+          inject(BASE_PATH, { optional: true }) ?? undefined,
+          inject(Configuration, { optional: true }) ?? undefined
+        );
     }
 
     /**

--- a/samples/client/petstore/typescript-angular-v18-provided-in-root/builds/default/api.module.ts
+++ b/samples/client/petstore/typescript-angular-v18-provided-in-root/builds/default/api.module.ts
@@ -1,4 +1,4 @@
-import { NgModule, ModuleWithProviders, SkipSelf, Optional } from '@angular/core';
+import { NgModule, ModuleWithProviders, inject } from '@angular/core';
 import { Configuration } from './configuration';
 import { HttpClient } from '@angular/common/http';
 
@@ -17,12 +17,14 @@ export class ApiModule {
         };
     }
 
-    constructor( @Optional() @SkipSelf() parentModule: ApiModule,
-                 @Optional() http: HttpClient) {
-        if (parentModule) {
+    private parentModule: ApiModule = inject(ApiModule, { optional: true, skipSelf: true });
+    private http: HttpClient = inject(HttpClient, { optional: true });
+
+    constructor() {
+        if (this.parentModule) {
             throw new Error('ApiModule is already loaded. Import in your base AppModule only.');
         }
-        if (!http) {
+        if (!this.http) {
             throw new Error('You need to import the HttpClientModule in your AppModule! \n' +
             'See also https://github.com/angular/angular/issues/20575');
         }

--- a/samples/client/petstore/typescript-angular-v18-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v18-provided-in-root/builds/default/api/pet.service.ts
@@ -9,7 +9,7 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
+import { inject, Injectable }                      from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
          HttpResponse, HttpEvent, HttpContext 
         }       from '@angular/common/http';
@@ -33,8 +33,13 @@ import { BaseService } from '../api.base.service';
 })
 export class PetService extends BaseService {
 
-    constructor(protected httpClient: HttpClient, @Optional() @Inject(BASE_PATH) basePath: string|string[], @Optional() configuration?: Configuration) {
-        super(basePath, configuration);
+    protected httpClient: HttpClient = inject(HttpClient);
+
+    constructor() {
+        super(
+          inject(BASE_PATH, { optional: true }) ?? undefined,
+          inject(Configuration, { optional: true }) ?? undefined
+        );
     }
 
     /**

--- a/samples/client/petstore/typescript-angular-v18-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v18-provided-in-root/builds/default/api/store.service.ts
@@ -9,7 +9,7 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
+import { inject, Injectable }                      from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
          HttpResponse, HttpEvent, HttpContext 
         }       from '@angular/common/http';
@@ -31,8 +31,13 @@ import { BaseService } from '../api.base.service';
 })
 export class StoreService extends BaseService {
 
-    constructor(protected httpClient: HttpClient, @Optional() @Inject(BASE_PATH) basePath: string|string[], @Optional() configuration?: Configuration) {
-        super(basePath, configuration);
+    protected httpClient: HttpClient = inject(HttpClient);
+
+    constructor() {
+        super(
+          inject(BASE_PATH, { optional: true }) ?? undefined,
+          inject(Configuration, { optional: true }) ?? undefined
+        );
     }
 
     /**

--- a/samples/client/petstore/typescript-angular-v18-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v18-provided-in-root/builds/default/api/user.service.ts
@@ -9,7 +9,7 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
+import { inject, Injectable }                      from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
          HttpResponse, HttpEvent, HttpContext 
         }       from '@angular/common/http';
@@ -31,8 +31,13 @@ import { BaseService } from '../api.base.service';
 })
 export class UserService extends BaseService {
 
-    constructor(protected httpClient: HttpClient, @Optional() @Inject(BASE_PATH) basePath: string|string[], @Optional() configuration?: Configuration) {
-        super(basePath, configuration);
+    protected httpClient: HttpClient = inject(HttpClient);
+
+    constructor() {
+        super(
+          inject(BASE_PATH, { optional: true }) ?? undefined,
+          inject(Configuration, { optional: true }) ?? undefined
+        );
     }
 
     /**

--- a/samples/client/petstore/typescript-angular-v19-provided-in-root/builds/default/api.module.ts
+++ b/samples/client/petstore/typescript-angular-v19-provided-in-root/builds/default/api.module.ts
@@ -1,4 +1,4 @@
-import { NgModule, ModuleWithProviders, SkipSelf, Optional } from '@angular/core';
+import { NgModule, ModuleWithProviders, inject } from '@angular/core';
 import { Configuration } from './configuration';
 import { HttpClient } from '@angular/common/http';
 
@@ -17,12 +17,14 @@ export class ApiModule {
         };
     }
 
-    constructor( @Optional() @SkipSelf() parentModule: ApiModule,
-                 @Optional() http: HttpClient) {
-        if (parentModule) {
+    private parentModule: ApiModule = inject(ApiModule, { optional: true, skipSelf: true });
+    private http: HttpClient = inject(HttpClient, { optional: true });
+
+    constructor() {
+        if (this.parentModule) {
             throw new Error('ApiModule is already loaded. Import in your base AppModule only.');
         }
-        if (!http) {
+        if (!this.http) {
             throw new Error('You need to import the HttpClientModule in your AppModule! \n' +
             'See also https://github.com/angular/angular/issues/20575');
         }

--- a/samples/client/petstore/typescript-angular-v19-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v19-provided-in-root/builds/default/api/pet.service.ts
@@ -9,7 +9,7 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
+import { inject, Injectable }                      from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
          HttpResponse, HttpEvent, HttpContext 
         }       from '@angular/common/http';
@@ -33,8 +33,13 @@ import { BaseService } from '../api.base.service';
 })
 export class PetService extends BaseService {
 
-    constructor(protected httpClient: HttpClient, @Optional() @Inject(BASE_PATH) basePath: string|string[], @Optional() configuration?: Configuration) {
-        super(basePath, configuration);
+    protected httpClient: HttpClient = inject(HttpClient);
+
+    constructor() {
+        super(
+          inject(BASE_PATH, { optional: true }) ?? undefined,
+          inject(Configuration, { optional: true }) ?? undefined
+        );
     }
 
     /**

--- a/samples/client/petstore/typescript-angular-v19-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v19-provided-in-root/builds/default/api/store.service.ts
@@ -9,7 +9,7 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
+import { inject, Injectable }                      from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
          HttpResponse, HttpEvent, HttpContext 
         }       from '@angular/common/http';
@@ -31,8 +31,13 @@ import { BaseService } from '../api.base.service';
 })
 export class StoreService extends BaseService {
 
-    constructor(protected httpClient: HttpClient, @Optional() @Inject(BASE_PATH) basePath: string|string[], @Optional() configuration?: Configuration) {
-        super(basePath, configuration);
+    protected httpClient: HttpClient = inject(HttpClient);
+
+    constructor() {
+        super(
+          inject(BASE_PATH, { optional: true }) ?? undefined,
+          inject(Configuration, { optional: true }) ?? undefined
+        );
     }
 
     /**

--- a/samples/client/petstore/typescript-angular-v19-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v19-provided-in-root/builds/default/api/user.service.ts
@@ -9,7 +9,7 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
+import { inject, Injectable }                      from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
          HttpResponse, HttpEvent, HttpContext 
         }       from '@angular/common/http';
@@ -31,8 +31,13 @@ import { BaseService } from '../api.base.service';
 })
 export class UserService extends BaseService {
 
-    constructor(protected httpClient: HttpClient, @Optional() @Inject(BASE_PATH) basePath: string|string[], @Optional() configuration?: Configuration) {
-        super(basePath, configuration);
+    protected httpClient: HttpClient = inject(HttpClient);
+
+    constructor() {
+        super(
+          inject(BASE_PATH, { optional: true }) ?? undefined,
+          inject(Configuration, { optional: true }) ?? undefined
+        );
     }
 
     /**

--- a/samples/client/petstore/typescript-angular-v19-with-angular-dependency-params/builds/default/api.module.ts
+++ b/samples/client/petstore/typescript-angular-v19-with-angular-dependency-params/builds/default/api.module.ts
@@ -1,4 +1,4 @@
-import { NgModule, ModuleWithProviders, SkipSelf, Optional } from '@angular/core';
+import { NgModule, ModuleWithProviders, inject } from '@angular/core';
 import { Configuration } from './configuration';
 import { HttpClient } from '@angular/common/http';
 
@@ -17,12 +17,14 @@ export class ApiModule {
         };
     }
 
-    constructor( @Optional() @SkipSelf() parentModule: ApiModule,
-                 @Optional() http: HttpClient) {
-        if (parentModule) {
+    private parentModule: ApiModule = inject(ApiModule, { optional: true, skipSelf: true });
+    private http: HttpClient = inject(HttpClient, { optional: true });
+
+    constructor() {
+        if (this.parentModule) {
             throw new Error('ApiModule is already loaded. Import in your base AppModule only.');
         }
-        if (!http) {
+        if (!this.http) {
             throw new Error('You need to import the HttpClientModule in your AppModule! \n' +
             'See also https://github.com/angular/angular/issues/20575');
         }

--- a/samples/client/petstore/typescript-angular-v19-with-angular-dependency-params/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v19-with-angular-dependency-params/builds/default/api/pet.service.ts
@@ -9,7 +9,7 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
+import { inject, Injectable }                      from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
          HttpResponse, HttpEvent, HttpContext 
         }       from '@angular/common/http';
@@ -33,8 +33,13 @@ import { BaseService } from '../api.base.service';
 })
 export class PetService extends BaseService {
 
-    constructor(protected httpClient: HttpClient, @Optional() @Inject(BASE_PATH) basePath: string|string[], @Optional() configuration?: Configuration) {
-        super(basePath, configuration);
+    protected httpClient: HttpClient = inject(HttpClient);
+
+    constructor() {
+        super(
+          inject(BASE_PATH, { optional: true }) ?? undefined,
+          inject(Configuration, { optional: true }) ?? undefined
+        );
     }
 
     /**

--- a/samples/client/petstore/typescript-angular-v19-with-angular-dependency-params/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v19-with-angular-dependency-params/builds/default/api/store.service.ts
@@ -9,7 +9,7 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
+import { inject, Injectable }                      from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
          HttpResponse, HttpEvent, HttpContext 
         }       from '@angular/common/http';
@@ -31,8 +31,13 @@ import { BaseService } from '../api.base.service';
 })
 export class StoreService extends BaseService {
 
-    constructor(protected httpClient: HttpClient, @Optional() @Inject(BASE_PATH) basePath: string|string[], @Optional() configuration?: Configuration) {
-        super(basePath, configuration);
+    protected httpClient: HttpClient = inject(HttpClient);
+
+    constructor() {
+        super(
+          inject(BASE_PATH, { optional: true }) ?? undefined,
+          inject(Configuration, { optional: true }) ?? undefined
+        );
     }
 
     /**

--- a/samples/client/petstore/typescript-angular-v19-with-angular-dependency-params/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v19-with-angular-dependency-params/builds/default/api/user.service.ts
@@ -9,7 +9,7 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
+import { inject, Injectable }                      from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
          HttpResponse, HttpEvent, HttpContext 
         }       from '@angular/common/http';
@@ -31,8 +31,13 @@ import { BaseService } from '../api.base.service';
 })
 export class UserService extends BaseService {
 
-    constructor(protected httpClient: HttpClient, @Optional() @Inject(BASE_PATH) basePath: string|string[], @Optional() configuration?: Configuration) {
-        super(basePath, configuration);
+    protected httpClient: HttpClient = inject(HttpClient);
+
+    constructor() {
+        super(
+          inject(BASE_PATH, { optional: true }) ?? undefined,
+          inject(Configuration, { optional: true }) ?? undefined
+        );
     }
 
     /**

--- a/samples/client/petstore/typescript-angular-v19/builds/default/api.module.ts
+++ b/samples/client/petstore/typescript-angular-v19/builds/default/api.module.ts
@@ -1,4 +1,4 @@
-import { NgModule, ModuleWithProviders, SkipSelf, Optional } from '@angular/core';
+import { NgModule, ModuleWithProviders, inject } from '@angular/core';
 import { Configuration } from './configuration';
 import { HttpClient } from '@angular/common/http';
 
@@ -17,12 +17,14 @@ export class ApiModule {
         };
     }
 
-    constructor( @Optional() @SkipSelf() parentModule: ApiModule,
-                 @Optional() http: HttpClient) {
-        if (parentModule) {
+    private parentModule: ApiModule = inject(ApiModule, { optional: true, skipSelf: true });
+    private http: HttpClient = inject(HttpClient, { optional: true });
+
+    constructor() {
+        if (this.parentModule) {
             throw new Error('ApiModule is already loaded. Import in your base AppModule only.');
         }
-        if (!http) {
+        if (!this.http) {
             throw new Error('You need to import the HttpClientModule in your AppModule! \n' +
             'See also https://github.com/angular/angular/issues/20575');
         }

--- a/samples/client/petstore/typescript-angular-v19/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v19/builds/default/api/pet.service.ts
@@ -9,7 +9,7 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
+import { inject, Injectable }                      from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
          HttpResponse, HttpEvent, HttpContext 
         }       from '@angular/common/http';
@@ -33,8 +33,13 @@ import { BaseService } from '../api.base.service';
 })
 export class PetService extends BaseService {
 
-    constructor(protected httpClient: HttpClient, @Optional() @Inject(BASE_PATH) basePath: string|string[], @Optional() configuration?: Configuration) {
-        super(basePath, configuration);
+    protected httpClient: HttpClient = inject(HttpClient);
+
+    constructor() {
+        super(
+          inject(BASE_PATH, { optional: true }) ?? undefined,
+          inject(Configuration, { optional: true }) ?? undefined
+        );
     }
 
     /**

--- a/samples/client/petstore/typescript-angular-v19/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v19/builds/default/api/store.service.ts
@@ -9,7 +9,7 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
+import { inject, Injectable }                      from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
          HttpResponse, HttpEvent, HttpContext 
         }       from '@angular/common/http';
@@ -31,8 +31,13 @@ import { BaseService } from '../api.base.service';
 })
 export class StoreService extends BaseService {
 
-    constructor(protected httpClient: HttpClient, @Optional() @Inject(BASE_PATH) basePath: string|string[], @Optional() configuration?: Configuration) {
-        super(basePath, configuration);
+    protected httpClient: HttpClient = inject(HttpClient);
+
+    constructor() {
+        super(
+          inject(BASE_PATH, { optional: true }) ?? undefined,
+          inject(Configuration, { optional: true }) ?? undefined
+        );
     }
 
     /**

--- a/samples/client/petstore/typescript-angular-v19/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v19/builds/default/api/user.service.ts
@@ -9,7 +9,7 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
+import { inject, Injectable }                      from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
          HttpResponse, HttpEvent, HttpContext 
         }       from '@angular/common/http';
@@ -31,8 +31,13 @@ import { BaseService } from '../api.base.service';
 })
 export class UserService extends BaseService {
 
-    constructor(protected httpClient: HttpClient, @Optional() @Inject(BASE_PATH) basePath: string|string[], @Optional() configuration?: Configuration) {
-        super(basePath, configuration);
+    protected httpClient: HttpClient = inject(HttpClient);
+
+    constructor() {
+        super(
+          inject(BASE_PATH, { optional: true }) ?? undefined,
+          inject(Configuration, { optional: true }) ?? undefined
+        );
     }
 
     /**

--- a/samples/client/petstore/typescript-angular-v20-provided-in-root/builds/default/api.module.ts
+++ b/samples/client/petstore/typescript-angular-v20-provided-in-root/builds/default/api.module.ts
@@ -1,4 +1,4 @@
-import { NgModule, ModuleWithProviders, SkipSelf, Optional } from '@angular/core';
+import { NgModule, ModuleWithProviders, inject } from '@angular/core';
 import { Configuration } from './configuration';
 import { HttpClient } from '@angular/common/http';
 
@@ -17,12 +17,14 @@ export class ApiModule {
         };
     }
 
-    constructor( @Optional() @SkipSelf() parentModule: ApiModule,
-                 @Optional() http: HttpClient) {
-        if (parentModule) {
+    private parentModule: ApiModule = inject(ApiModule, { optional: true, skipSelf: true });
+    private http: HttpClient = inject(HttpClient, { optional: true });
+
+    constructor() {
+        if (this.parentModule) {
             throw new Error('ApiModule is already loaded. Import in your base AppModule only.');
         }
-        if (!http) {
+        if (!this.http) {
             throw new Error('You need to import the HttpClientModule in your AppModule! \n' +
             'See also https://github.com/angular/angular/issues/20575');
         }

--- a/samples/client/petstore/typescript-angular-v20-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v20-provided-in-root/builds/default/api/pet.service.ts
@@ -9,7 +9,7 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
+import { inject, Injectable }                      from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
          HttpResponse, HttpEvent, HttpContext 
         }       from '@angular/common/http';
@@ -33,8 +33,13 @@ import { BaseService } from '../api.base.service';
 })
 export class PetService extends BaseService {
 
-    constructor(protected httpClient: HttpClient, @Optional() @Inject(BASE_PATH) basePath: string|string[], @Optional() configuration?: Configuration) {
-        super(basePath, configuration);
+    protected httpClient: HttpClient = inject(HttpClient);
+
+    constructor() {
+        super(
+          inject(BASE_PATH, { optional: true }) ?? undefined,
+          inject(Configuration, { optional: true }) ?? undefined
+        );
     }
 
     /**

--- a/samples/client/petstore/typescript-angular-v20-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v20-provided-in-root/builds/default/api/store.service.ts
@@ -9,7 +9,7 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
+import { inject, Injectable }                      from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
          HttpResponse, HttpEvent, HttpContext 
         }       from '@angular/common/http';
@@ -31,8 +31,13 @@ import { BaseService } from '../api.base.service';
 })
 export class StoreService extends BaseService {
 
-    constructor(protected httpClient: HttpClient, @Optional() @Inject(BASE_PATH) basePath: string|string[], @Optional() configuration?: Configuration) {
-        super(basePath, configuration);
+    protected httpClient: HttpClient = inject(HttpClient);
+
+    constructor() {
+        super(
+          inject(BASE_PATH, { optional: true }) ?? undefined,
+          inject(Configuration, { optional: true }) ?? undefined
+        );
     }
 
     /**

--- a/samples/client/petstore/typescript-angular-v20-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v20-provided-in-root/builds/default/api/user.service.ts
@@ -9,7 +9,7 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
+import { inject, Injectable }                      from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
          HttpResponse, HttpEvent, HttpContext 
         }       from '@angular/common/http';
@@ -31,8 +31,13 @@ import { BaseService } from '../api.base.service';
 })
 export class UserService extends BaseService {
 
-    constructor(protected httpClient: HttpClient, @Optional() @Inject(BASE_PATH) basePath: string|string[], @Optional() configuration?: Configuration) {
-        super(basePath, configuration);
+    protected httpClient: HttpClient = inject(HttpClient);
+
+    constructor() {
+        super(
+          inject(BASE_PATH, { optional: true }) ?? undefined,
+          inject(Configuration, { optional: true }) ?? undefined
+        );
     }
 
     /**

--- a/samples/client/petstore/typescript-angular-v20/builds/default/api.module.ts
+++ b/samples/client/petstore/typescript-angular-v20/builds/default/api.module.ts
@@ -1,4 +1,4 @@
-import { NgModule, ModuleWithProviders, SkipSelf, Optional } from '@angular/core';
+import { NgModule, ModuleWithProviders, inject } from '@angular/core';
 import { Configuration } from './configuration';
 import { HttpClient } from '@angular/common/http';
 
@@ -17,12 +17,14 @@ export class ApiModule {
         };
     }
 
-    constructor( @Optional() @SkipSelf() parentModule: ApiModule,
-                 @Optional() http: HttpClient) {
-        if (parentModule) {
+    private parentModule: ApiModule = inject(ApiModule, { optional: true, skipSelf: true });
+    private http: HttpClient = inject(HttpClient, { optional: true });
+
+    constructor() {
+        if (this.parentModule) {
             throw new Error('ApiModule is already loaded. Import in your base AppModule only.');
         }
-        if (!http) {
+        if (!this.http) {
             throw new Error('You need to import the HttpClientModule in your AppModule! \n' +
             'See also https://github.com/angular/angular/issues/20575');
         }

--- a/samples/client/petstore/typescript-angular-v20/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v20/builds/default/api/pet.service.ts
@@ -9,7 +9,7 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
+import { inject, Injectable }                      from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
          HttpResponse, HttpEvent, HttpContext 
         }       from '@angular/common/http';
@@ -33,8 +33,13 @@ import { BaseService } from '../api.base.service';
 })
 export class PetService extends BaseService {
 
-    constructor(protected httpClient: HttpClient, @Optional() @Inject(BASE_PATH) basePath: string|string[], @Optional() configuration?: Configuration) {
-        super(basePath, configuration);
+    protected httpClient: HttpClient = inject(HttpClient);
+
+    constructor() {
+        super(
+          inject(BASE_PATH, { optional: true }) ?? undefined,
+          inject(Configuration, { optional: true }) ?? undefined
+        );
     }
 
     /**

--- a/samples/client/petstore/typescript-angular-v20/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v20/builds/default/api/store.service.ts
@@ -9,7 +9,7 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
+import { inject, Injectable }                      from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
          HttpResponse, HttpEvent, HttpContext 
         }       from '@angular/common/http';
@@ -31,8 +31,13 @@ import { BaseService } from '../api.base.service';
 })
 export class StoreService extends BaseService {
 
-    constructor(protected httpClient: HttpClient, @Optional() @Inject(BASE_PATH) basePath: string|string[], @Optional() configuration?: Configuration) {
-        super(basePath, configuration);
+    protected httpClient: HttpClient = inject(HttpClient);
+
+    constructor() {
+        super(
+          inject(BASE_PATH, { optional: true }) ?? undefined,
+          inject(Configuration, { optional: true }) ?? undefined
+        );
     }
 
     /**

--- a/samples/client/petstore/typescript-angular-v20/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v20/builds/default/api/user.service.ts
@@ -9,7 +9,7 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
+import { inject, Injectable }                      from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
          HttpResponse, HttpEvent, HttpContext 
         }       from '@angular/common/http';
@@ -31,8 +31,13 @@ import { BaseService } from '../api.base.service';
 })
 export class UserService extends BaseService {
 
-    constructor(protected httpClient: HttpClient, @Optional() @Inject(BASE_PATH) basePath: string|string[], @Optional() configuration?: Configuration) {
-        super(basePath, configuration);
+    protected httpClient: HttpClient = inject(HttpClient);
+
+    constructor() {
+        super(
+          inject(BASE_PATH, { optional: true }) ?? undefined,
+          inject(Configuration, { optional: true }) ?? undefined
+        );
     }
 
     /**

--- a/samples/client/petstore/typescript-angular-v21-provided-in-root/builds/default/api.module.ts
+++ b/samples/client/petstore/typescript-angular-v21-provided-in-root/builds/default/api.module.ts
@@ -1,4 +1,4 @@
-import { NgModule, ModuleWithProviders, SkipSelf, Optional } from '@angular/core';
+import { NgModule, ModuleWithProviders, inject } from '@angular/core';
 import { Configuration } from './configuration';
 import { HttpClient } from '@angular/common/http';
 
@@ -17,12 +17,14 @@ export class ApiModule {
         };
     }
 
-    constructor( @Optional() @SkipSelf() parentModule: ApiModule,
-                 @Optional() http: HttpClient) {
-        if (parentModule) {
+    private parentModule: ApiModule = inject(ApiModule, { optional: true, skipSelf: true });
+    private http: HttpClient = inject(HttpClient, { optional: true });
+
+    constructor() {
+        if (this.parentModule) {
             throw new Error('ApiModule is already loaded. Import in your base AppModule only.');
         }
-        if (!http) {
+        if (!this.http) {
             throw new Error('You need to import the HttpClientModule in your AppModule! \n' +
             'See also https://github.com/angular/angular/issues/20575');
         }

--- a/samples/client/petstore/typescript-angular-v21-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v21-provided-in-root/builds/default/api/pet.service.ts
@@ -9,7 +9,7 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
+import { inject, Injectable }                      from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
          HttpResponse, HttpEvent, HttpContext 
         }       from '@angular/common/http';
@@ -33,8 +33,13 @@ import { BaseService } from '../api.base.service';
 })
 export class PetService extends BaseService {
 
-    constructor(protected httpClient: HttpClient, @Optional() @Inject(BASE_PATH) basePath: string|string[], @Optional() configuration?: Configuration) {
-        super(basePath, configuration);
+    protected httpClient: HttpClient = inject(HttpClient);
+
+    constructor() {
+        super(
+          inject(BASE_PATH, { optional: true }) ?? undefined,
+          inject(Configuration, { optional: true }) ?? undefined
+        );
     }
 
     /**

--- a/samples/client/petstore/typescript-angular-v21-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v21-provided-in-root/builds/default/api/store.service.ts
@@ -9,7 +9,7 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
+import { inject, Injectable }                      from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
          HttpResponse, HttpEvent, HttpContext 
         }       from '@angular/common/http';
@@ -31,8 +31,13 @@ import { BaseService } from '../api.base.service';
 })
 export class StoreService extends BaseService {
 
-    constructor(protected httpClient: HttpClient, @Optional() @Inject(BASE_PATH) basePath: string|string[], @Optional() configuration?: Configuration) {
-        super(basePath, configuration);
+    protected httpClient: HttpClient = inject(HttpClient);
+
+    constructor() {
+        super(
+          inject(BASE_PATH, { optional: true }) ?? undefined,
+          inject(Configuration, { optional: true }) ?? undefined
+        );
     }
 
     /**

--- a/samples/client/petstore/typescript-angular-v21-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v21-provided-in-root/builds/default/api/user.service.ts
@@ -9,7 +9,7 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
+import { inject, Injectable }                      from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
          HttpResponse, HttpEvent, HttpContext 
         }       from '@angular/common/http';
@@ -31,8 +31,13 @@ import { BaseService } from '../api.base.service';
 })
 export class UserService extends BaseService {
 
-    constructor(protected httpClient: HttpClient, @Optional() @Inject(BASE_PATH) basePath: string|string[], @Optional() configuration?: Configuration) {
-        super(basePath, configuration);
+    protected httpClient: HttpClient = inject(HttpClient);
+
+    constructor() {
+        super(
+          inject(BASE_PATH, { optional: true }) ?? undefined,
+          inject(Configuration, { optional: true }) ?? undefined
+        );
     }
 
     /**

--- a/samples/client/petstore/typescript-angular-v21/builds/default/api.module.ts
+++ b/samples/client/petstore/typescript-angular-v21/builds/default/api.module.ts
@@ -1,4 +1,4 @@
-import { NgModule, ModuleWithProviders, SkipSelf, Optional } from '@angular/core';
+import { NgModule, ModuleWithProviders, inject } from '@angular/core';
 import { Configuration } from './configuration';
 import { HttpClient } from '@angular/common/http';
 
@@ -17,12 +17,14 @@ export class ApiModule {
         };
     }
 
-    constructor( @Optional() @SkipSelf() parentModule: ApiModule,
-                 @Optional() http: HttpClient) {
-        if (parentModule) {
+    private parentModule: ApiModule = inject(ApiModule, { optional: true, skipSelf: true });
+    private http: HttpClient = inject(HttpClient, { optional: true });
+
+    constructor() {
+        if (this.parentModule) {
             throw new Error('ApiModule is already loaded. Import in your base AppModule only.');
         }
-        if (!http) {
+        if (!this.http) {
             throw new Error('You need to import the HttpClientModule in your AppModule! \n' +
             'See also https://github.com/angular/angular/issues/20575');
         }

--- a/samples/client/petstore/typescript-angular-v21/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v21/builds/default/api/pet.service.ts
@@ -9,7 +9,7 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
+import { inject, Injectable }                      from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
          HttpResponse, HttpEvent, HttpContext 
         }       from '@angular/common/http';
@@ -33,8 +33,13 @@ import { BaseService } from '../api.base.service';
 })
 export class PetService extends BaseService {
 
-    constructor(protected httpClient: HttpClient, @Optional() @Inject(BASE_PATH) basePath: string|string[], @Optional() configuration?: Configuration) {
-        super(basePath, configuration);
+    protected httpClient: HttpClient = inject(HttpClient);
+
+    constructor() {
+        super(
+          inject(BASE_PATH, { optional: true }) ?? undefined,
+          inject(Configuration, { optional: true }) ?? undefined
+        );
     }
 
     /**

--- a/samples/client/petstore/typescript-angular-v21/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v21/builds/default/api/store.service.ts
@@ -9,7 +9,7 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
+import { inject, Injectable }                      from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
          HttpResponse, HttpEvent, HttpContext 
         }       from '@angular/common/http';
@@ -31,8 +31,13 @@ import { BaseService } from '../api.base.service';
 })
 export class StoreService extends BaseService {
 
-    constructor(protected httpClient: HttpClient, @Optional() @Inject(BASE_PATH) basePath: string|string[], @Optional() configuration?: Configuration) {
-        super(basePath, configuration);
+    protected httpClient: HttpClient = inject(HttpClient);
+
+    constructor() {
+        super(
+          inject(BASE_PATH, { optional: true }) ?? undefined,
+          inject(Configuration, { optional: true }) ?? undefined
+        );
     }
 
     /**

--- a/samples/client/petstore/typescript-angular-v21/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v21/builds/default/api/user.service.ts
@@ -9,7 +9,7 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
+import { inject, Injectable }                      from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
          HttpResponse, HttpEvent, HttpContext 
         }       from '@angular/common/http';
@@ -31,8 +31,13 @@ import { BaseService } from '../api.base.service';
 })
 export class UserService extends BaseService {
 
-    constructor(protected httpClient: HttpClient, @Optional() @Inject(BASE_PATH) basePath: string|string[], @Optional() configuration?: Configuration) {
-        super(basePath, configuration);
+    protected httpClient: HttpClient = inject(HttpClient);
+
+    constructor() {
+        super(
+          inject(BASE_PATH, { optional: true }) ?? undefined,
+          inject(Configuration, { optional: true }) ?? undefined
+        );
     }
 
     /**

--- a/samples/client/petstore/typescript-angular-v22-provided-in-root/builds/default/api.module.ts
+++ b/samples/client/petstore/typescript-angular-v22-provided-in-root/builds/default/api.module.ts
@@ -1,4 +1,4 @@
-import { NgModule, ModuleWithProviders, SkipSelf, Optional } from '@angular/core';
+import { NgModule, ModuleWithProviders, inject } from '@angular/core';
 import { Configuration } from './configuration';
 import { HttpClient } from '@angular/common/http';
 
@@ -17,12 +17,14 @@ export class ApiModule {
         };
     }
 
-    constructor( @Optional() @SkipSelf() parentModule: ApiModule,
-                 @Optional() http: HttpClient) {
-        if (parentModule) {
+    private parentModule: ApiModule = inject(ApiModule, { optional: true, skipSelf: true });
+    private http: HttpClient = inject(HttpClient, { optional: true });
+
+    constructor() {
+        if (this.parentModule) {
             throw new Error('ApiModule is already loaded. Import in your base AppModule only.');
         }
-        if (!http) {
+        if (!this.http) {
             throw new Error('You need to import the HttpClientModule in your AppModule! \n' +
             'See also https://github.com/angular/angular/issues/20575');
         }

--- a/samples/client/petstore/typescript-angular-v22-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v22-provided-in-root/builds/default/api/pet.service.ts
@@ -9,7 +9,7 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
+import { inject, Injectable }                      from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
          HttpResponse, HttpEvent, HttpContext 
         }       from '@angular/common/http';
@@ -33,8 +33,13 @@ import { BaseService } from '../api.base.service';
 })
 export class PetService extends BaseService {
 
-    constructor(protected httpClient: HttpClient, @Optional() @Inject(BASE_PATH) basePath: string|string[], @Optional() configuration?: Configuration) {
-        super(basePath, configuration);
+    protected httpClient: HttpClient = inject(HttpClient);
+
+    constructor() {
+        super(
+          inject(BASE_PATH, { optional: true }) ?? undefined,
+          inject(Configuration, { optional: true }) ?? undefined
+        );
     }
 
     /**

--- a/samples/client/petstore/typescript-angular-v22-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v22-provided-in-root/builds/default/api/store.service.ts
@@ -9,7 +9,7 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
+import { inject, Injectable }                      from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
          HttpResponse, HttpEvent, HttpContext 
         }       from '@angular/common/http';
@@ -31,8 +31,13 @@ import { BaseService } from '../api.base.service';
 })
 export class StoreService extends BaseService {
 
-    constructor(protected httpClient: HttpClient, @Optional() @Inject(BASE_PATH) basePath: string|string[], @Optional() configuration?: Configuration) {
-        super(basePath, configuration);
+    protected httpClient: HttpClient = inject(HttpClient);
+
+    constructor() {
+        super(
+          inject(BASE_PATH, { optional: true }) ?? undefined,
+          inject(Configuration, { optional: true }) ?? undefined
+        );
     }
 
     /**

--- a/samples/client/petstore/typescript-angular-v22-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v22-provided-in-root/builds/default/api/user.service.ts
@@ -9,7 +9,7 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
+import { inject, Injectable }                      from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
          HttpResponse, HttpEvent, HttpContext 
         }       from '@angular/common/http';
@@ -31,8 +31,13 @@ import { BaseService } from '../api.base.service';
 })
 export class UserService extends BaseService {
 
-    constructor(protected httpClient: HttpClient, @Optional() @Inject(BASE_PATH) basePath: string|string[], @Optional() configuration?: Configuration) {
-        super(basePath, configuration);
+    protected httpClient: HttpClient = inject(HttpClient);
+
+    constructor() {
+        super(
+          inject(BASE_PATH, { optional: true }) ?? undefined,
+          inject(Configuration, { optional: true }) ?? undefined
+        );
     }
 
     /**

--- a/samples/client/petstore/typescript-angular-v22/builds/default/api.module.ts
+++ b/samples/client/petstore/typescript-angular-v22/builds/default/api.module.ts
@@ -1,4 +1,4 @@
-import { NgModule, ModuleWithProviders, SkipSelf, Optional } from '@angular/core';
+import { NgModule, ModuleWithProviders, inject } from '@angular/core';
 import { Configuration } from './configuration';
 import { HttpClient } from '@angular/common/http';
 
@@ -17,12 +17,14 @@ export class ApiModule {
         };
     }
 
-    constructor( @Optional() @SkipSelf() parentModule: ApiModule,
-                 @Optional() http: HttpClient) {
-        if (parentModule) {
+    private parentModule: ApiModule = inject(ApiModule, { optional: true, skipSelf: true });
+    private http: HttpClient = inject(HttpClient, { optional: true });
+
+    constructor() {
+        if (this.parentModule) {
             throw new Error('ApiModule is already loaded. Import in your base AppModule only.');
         }
-        if (!http) {
+        if (!this.http) {
             throw new Error('You need to import the HttpClientModule in your AppModule! \n' +
             'See also https://github.com/angular/angular/issues/20575');
         }

--- a/samples/client/petstore/typescript-angular-v22/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v22/builds/default/api/pet.service.ts
@@ -9,7 +9,7 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
+import { inject, Injectable }                      from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
          HttpResponse, HttpEvent, HttpContext 
         }       from '@angular/common/http';
@@ -33,8 +33,13 @@ import { BaseService } from '../api.base.service';
 })
 export class PetService extends BaseService {
 
-    constructor(protected httpClient: HttpClient, @Optional() @Inject(BASE_PATH) basePath: string|string[], @Optional() configuration?: Configuration) {
-        super(basePath, configuration);
+    protected httpClient: HttpClient = inject(HttpClient);
+
+    constructor() {
+        super(
+          inject(BASE_PATH, { optional: true }) ?? undefined,
+          inject(Configuration, { optional: true }) ?? undefined
+        );
     }
 
     /**

--- a/samples/client/petstore/typescript-angular-v22/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v22/builds/default/api/store.service.ts
@@ -9,7 +9,7 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
+import { inject, Injectable }                      from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
          HttpResponse, HttpEvent, HttpContext 
         }       from '@angular/common/http';
@@ -31,8 +31,13 @@ import { BaseService } from '../api.base.service';
 })
 export class StoreService extends BaseService {
 
-    constructor(protected httpClient: HttpClient, @Optional() @Inject(BASE_PATH) basePath: string|string[], @Optional() configuration?: Configuration) {
-        super(basePath, configuration);
+    protected httpClient: HttpClient = inject(HttpClient);
+
+    constructor() {
+        super(
+          inject(BASE_PATH, { optional: true }) ?? undefined,
+          inject(Configuration, { optional: true }) ?? undefined
+        );
     }
 
     /**

--- a/samples/client/petstore/typescript-angular-v22/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v22/builds/default/api/user.service.ts
@@ -9,7 +9,7 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
+import { inject, Injectable }                      from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
          HttpResponse, HttpEvent, HttpContext 
         }       from '@angular/common/http';
@@ -31,8 +31,13 @@ import { BaseService } from '../api.base.service';
 })
 export class UserService extends BaseService {
 
-    constructor(protected httpClient: HttpClient, @Optional() @Inject(BASE_PATH) basePath: string|string[], @Optional() configuration?: Configuration) {
-        super(basePath, configuration);
+    protected httpClient: HttpClient = inject(HttpClient);
+
+    constructor() {
+        super(
+          inject(BASE_PATH, { optional: true }) ?? undefined,
+          inject(Configuration, { optional: true }) ?? undefined
+        );
     }
 
     /**


### PR DESCRIPTION
Remove legacy @Inject() / @Optional() constructor decorators
Adopt functional inject() API for cleaner dependency injection (https://angular.dev/api/core/inject)

**Required update to support "experimentalDecorators": false in new projects**

Angular encourages migrating from legacy decorators to the modern inject() function (https://angular.dev/reference/migrations/inject-function).

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and 

executed cmd:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh bin/configs/typescript-angular* || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 

- [X] **Typesctipt** - technical committee
@TiFu  @taxpon  @sebastianhaas  @kenisteward  @Vrolijkx  @macjohnny  @topce  @akehir  @petejohansonxo  @amakhrov  @davidgamero  @mkusaka  @joscha  @KannaKim 



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces legacy `@Inject()` and `@Optional()` constructor decorators with Angular's functional `inject()` in the TypeScript Angular generator templates and regenerated samples. This makes generated code compatible with projects that disable `experimentalDecorators`, matching Angular's modern DI style.

**Details**
- Updates `api.module.mustache` and `api.service.mustache` to inject `HttpClient`, `BASE_PATH`, and `Configuration` via `inject()` with optional flags, typing optional results as `| null`.
- Regenerates all sample outputs across Angular v18–v22 and other configurations.

<sup>Written for commit 27f15f2a83f4937f3f5abe5aab31bb67c7971677. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24891?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



