### PR TITLE
fix(java): fix oneOf interface ignoring useJakartaEe for @Generated a…

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -603,6 +603,7 @@ public class DefaultCodegen implements CodegenConfig {
                 objsValue.put("classname", cm.classname);
                 objsValue.putAll(additionalProperties);
                 objs.put(cm.name, objsValue);
+                objsValue.put("javaxPackage", additionalProperties.getOrDefault("javaxPackage", "javax"));
             }
 
             // Gather data from all the models that contain oneOf into OneOfImplementorAdditionalData classes


### PR DESCRIPTION
Fixes an issue where the generated oneOf interface in Java generators ignores the useJakartaEe=true configuration and hardcodes javax.annotation.Generated instead of using the dynamic javaxPackage.

Root cause: The synthetic oneOf interface model map created in DefaultCodegen.java was missing the javaxPackage context property.

Fix: Injected javaxPackage into the oneOf model map entries (objsValue.put("javaxPackage", ...)) so templates properly receive jakarta when useJakartaEe=true is enabled.

Fixes #24889

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
/cc @wing328 @cbornet @jmini

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Java generator ignoring `useJakartaEe=true` for the oneOf interface's `@Generated` annotation. It previously hardcoded `javax.annotation.Generated`; now it follows the configured `javaxPackage` and emits `jakarta.annotation.Generated` when enabled. Fixes #24889.

<sup>Written for commit efda85f9aede40d23857e4fb8ef3e52ec8c9f526. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24893?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

