### PR TITLE
[kotlin] fix: enumUnknownDefaultCase's moshi fallback adapters break nullable enum fields

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/jvm-common/infrastructure/SerializerHelper.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/jvm-common/infrastructure/SerializerHelper.kt.mustache
@@ -19,7 +19,7 @@ import com.squareup.moshi.adapters.EnumJsonAdapter
 {{#enumVars}}
 {{#-last}}
             .add({{modelPackage}}.{{classname}}::class.java, EnumJsonAdapter.create({{modelPackage}}.{{classname}}::class.java)
-                .withUnknownFallback({{modelPackage}}.{{classname}}.{{&name}}))
+                .withUnknownFallback({{modelPackage}}.{{classname}}.{{&name}}).nullSafe())
 {{/-last}}
 {{/enumVars}}
 {{/allowableValues}}
@@ -33,7 +33,7 @@ import com.squareup.moshi.adapters.EnumJsonAdapter
 {{#enumVars}}
 {{#-last}}
             .add({{modelPackage}}.{{classname}}.{{{nameInPascalCase}}}::class.java, EnumJsonAdapter.create({{modelPackage}}.{{classname}}.{{{nameInPascalCase}}}::class.java)
-                .withUnknownFallback({{modelPackage}}.{{classname}}.{{{nameInPascalCase}}}.{{&name}}))
+                .withUnknownFallback({{modelPackage}}.{{classname}}.{{{nameInPascalCase}}}.{{&name}}).nullSafe())
 {{/-last}}
 {{/enumVars}}
 {{/allowableValues}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinClientCodegenModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinClientCodegenModelTest.java
@@ -989,6 +989,35 @@ public class KotlinClientCodegenModelTest {
   }
 
   @Test
+  public void testMoshiEnumUnknownDefaultCaseAdaptersAreNullSafe() throws IOException {
+      File output = Files.createTempDirectory("test").toFile();
+      output.deleteOnExit();
+
+      final CodegenConfigurator configurator = new CodegenConfigurator()
+              .setGeneratorName(KOTLIN_GENERATOR)
+              .setLibrary("jvm-okhttp4")
+              .setAdditionalProperties(new HashMap<>() {{
+                put(CodegenConstants.SERIALIZATION_LIBRARY, "moshi");
+                put(CodegenConstants.ENUM_UNKNOWN_DEFAULT_CASE, "true");
+              }})
+              .setInputSpec("src/test/resources/3_0/enum.yaml")
+              .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+      final ClientOptInput clientOptInput = configurator.toClientOptInput();
+      DefaultGenerator generator = new DefaultGenerator();
+
+      generator.opts(clientOptInput).generate();
+
+      final Path helperKt = Paths.get(output + "/src/main/kotlin/org/openapitools/client/infrastructure/SerializerHelper.kt");
+
+      // EnumJsonAdapter is not null-safe: registered bare, any model with a nullable enum
+      // property throws "value was null! Wrap in .nullSafe() to write nullable values" on
+      // a null value - reading and writing alike - so the flag broke every optional enum field
+      TestUtils.assertFileContains(helperKt, ".nullSafe())");
+      TestUtils.assertFileNotContains(helperKt, "unknown_default_open_api))");
+  }
+
+  @Test
   public void testJacksonEnumsWithUnknownDefaultCase() throws IOException {
       File output = Files.createTempDirectory("test").toFile();
       output.deleteOnExit();

--- a/samples/client/petstore/kotlin-enum-default-value/src/main/kotlin/org/openapitools/client/infrastructure/SerializerHelper.kt
+++ b/samples/client/petstore/kotlin-enum-default-value/src/main/kotlin/org/openapitools/client/infrastructure/SerializerHelper.kt
@@ -7,14 +7,14 @@ object SerializerHelper {
     fun addEnumUnknownDefaultCase(moshiBuilder: Moshi.Builder): Moshi.Builder {
         return moshiBuilder
             .add(org.openapitools.client.models.ComplexEnum::class.java, EnumJsonAdapter.create(org.openapitools.client.models.ComplexEnum::class.java)
-                .withUnknownFallback(org.openapitools.client.models.ComplexEnum.unknown_default_open_api))
+                .withUnknownFallback(org.openapitools.client.models.ComplexEnum.unknown_default_open_api).nullSafe())
             .add(org.openapitools.client.models.ModelWithEnumPropertyHavingDefault.PropertyName::class.java, EnumJsonAdapter.create(org.openapitools.client.models.ModelWithEnumPropertyHavingDefault.PropertyName::class.java)
-                .withUnknownFallback(org.openapitools.client.models.ModelWithEnumPropertyHavingDefault.PropertyName.unknown_default_open_api))
+                .withUnknownFallback(org.openapitools.client.models.ModelWithEnumPropertyHavingDefault.PropertyName.unknown_default_open_api).nullSafe())
             .add(org.openapitools.client.models.PropertyOfDay.DaysOfWeek::class.java, EnumJsonAdapter.create(org.openapitools.client.models.PropertyOfDay.DaysOfWeek::class.java)
-                .withUnknownFallback(org.openapitools.client.models.PropertyOfDay.DaysOfWeek.unknown_default_open_api))
+                .withUnknownFallback(org.openapitools.client.models.PropertyOfDay.DaysOfWeek.unknown_default_open_api).nullSafe())
             .add(org.openapitools.client.models.PropertyOfDay.MonthOfYear::class.java, EnumJsonAdapter.create(org.openapitools.client.models.PropertyOfDay.MonthOfYear::class.java)
-                .withUnknownFallback(org.openapitools.client.models.PropertyOfDay.MonthOfYear.unknown_default_open_api))
+                .withUnknownFallback(org.openapitools.client.models.PropertyOfDay.MonthOfYear.unknown_default_open_api).nullSafe())
             .add(org.openapitools.client.models.PropertyOfDay.HolidayTypes::class.java, EnumJsonAdapter.create(org.openapitools.client.models.PropertyOfDay.HolidayTypes::class.java)
-                .withUnknownFallback(org.openapitools.client.models.PropertyOfDay.HolidayTypes.unknown_default_open_api))
+                .withUnknownFallback(org.openapitools.client.models.PropertyOfDay.HolidayTypes.unknown_default_open_api).nullSafe())
     }
 }


### PR DESCRIPTION
`enumUnknownDefaultCase=true` does what it promises for unknown wire values in the moshi
kotlin client: every enum gains an `unknown_default_open_api` member and
`SerializerHelper.addEnumUnknownDefaultCase` registers a
`com.squareup.moshi.adapters.EnumJsonAdapter` with `withUnknownFallback` per enum. But
`EnumJsonAdapter` is **not null-safe**, and the helper registers it bare — so any model with
a *nullable* enum property now throws on a null value, reading and writing alike:

```
java.lang.NullPointerException: value was null! Wrap in .nullSafe() to write nullable values.
```

Concretely: serializing an update command whose optional enum field is unset, or
deserializing a response whose optional enum field is null. Found while running a generated
kotlin client (jvm-okhttp, moshi) against a production registry API on v7.15.0: enabling the
flag made unknown enum values tolerated and simultaneously broke every request/response with
an absent optional enum field. Without the flag, moshi's built-in enum handling is null-safe
and the same payloads round-trip fine — the flag is a strict regression for nullable enum
fields.

### The fix

Append `.nullSafe()` to each registered adapter in
`jvm-common/infrastructure/SerializerHelper.kt.mustache`, in both the top-level-enum and
inline-enum branches. `withUnknownFallback` returns `EnumJsonAdapter`, `.nullSafe()` wraps it
as a `JsonAdapter` — which is what `Moshi.Builder.add(Type, JsonAdapter)` takes — so the
change is two template lines.

> Sibling of #24878 (php) and #24879 (ruby): the same flag, half-implemented in a different
> way per language. No shared `main/` code.

### Tests

`KotlinClientCodegenModelTest#testMoshiEnumUnknownDefaultCaseAdaptersAreNullSafe` generates
from the existing `3_0/enum.yaml` fixture with the flag on and asserts every registered
adapter is wrapped. Fails without the template change (verified by stashing only the
template).

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Built the project and updated samples (`./bin/generate-samples.sh ./bin/configs/kotlin*.yaml`).
      One sample changes: `kotlin-enum-default-value`, the only moshi config with the flag on —
      its five adapters (top-level and inline enums both) gain `.nullSafe()`.
- [x] Technical committee: @jimschubert @dr4ke616 @karismann @Zomzog @andrewemery @4brunu @yutaka0m @stefankoppier

---

Generated with Claude Code


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enabling `enumUnknownDefaultCase` in the Moshi Kotlin client no longer breaks nullable enum fields. Previously, the fallback `EnumJsonAdapter` was registered bare, so any null enum value threw a `NullPointerException` on read and write; the adapters are now wrapped with `.nullSafe()` in both the top-level and inline enum branches.

**Tests**
- Adds a generator test asserting every registered enum fallback adapter is null-safe.
- Updates the `kotlin-enum-default-value` sample to reflect the new `.nullSafe()` calls.

<sup>Written for commit 0cb5a0d7a1c963fe436d35b2fd232de506635a10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24894?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

