### PR TITLE
[java] fix: okhttp-gson additionalProperties field makes every allOf child undeserializable

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/additional_properties.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/additional_properties.mustache
@@ -5,10 +5,11 @@
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private {{^hasChildren}}transient {{/hasChildren}}Map<String, Object> additionalProperties;
 

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/additional_properties.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/additional_properties.mustache
@@ -4,11 +4,13 @@
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
-  private transient Map<String, Object> additionalProperties;
+  private {{^hasChildren}}transient {{/hasChildren}}Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/additional_properties.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/additional_properties.mustache
@@ -3,8 +3,12 @@
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -2044,14 +2044,19 @@ public class JavaClientCodegenTest {
         // gson's reflective adapter refuses a class with two JSON fields of one name; without
         // `transient` an allOf child declares additionalProperties itself and inherits it too,
         // making it undeserializable ("declares multiple JSON fields named
-        // 'additionalProperties'"). The bag is read and written by the model's own
-        // TypeAdapterFactory, never by gson reflection, so hiding the field changes nothing else.
+        // 'additionalProperties'"). The child's bag is read and written by its own
+        // TypeAdapterFactory, so hiding the field from reflection changes nothing else.
         assertThat(output.resolve("src/main/java/xyz/abcdef/model/Child.java"))
                 .content()
                 .contains("public class Child extends Person {")
                 .contains("private transient Map<String, Object> additionalProperties;");
+        // a parent with children gets no TypeAdapterFactory of its own ({{^hasChildren}} in
+        // pojo.mustache), so its field stays visible to reflection - the child's transient
+        // declaration shadows it, and no duplicate JSON field arises
         assertThat(output.resolve("src/main/java/xyz/abcdef/model/Person.java"))
-                .content().contains("private transient Map<String, Object> additionalProperties;");
+                .content().contains("private Map<String, Object> additionalProperties;");
+        assertThat(output.resolve("src/main/java/xyz/abcdef/model/Person.java"))
+                .content().doesNotContain("private transient Map<String, Object> additionalProperties;");
     }
 
     @Test

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -2025,6 +2025,36 @@ public class JavaClientCodegenTest {
     }
 
     @Test
+    public void testAdditionalPropertiesFieldIsTransientForGson() {
+        final Path output = newTempFolder();
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName(JAVA_GENERATOR)
+                // use default `okhttp-gson`
+                .addAdditionalProperty(CodegenConstants.API_PACKAGE, "xyz.abcdef.api")
+                .addAdditionalProperty(CodegenConstants.MODEL_PACKAGE, "xyz.abcdef.model")
+                .addAdditionalProperty(CodegenConstants.INVOKER_PACKAGE, "xyz.abcdef.invoker")
+                .addAdditionalProperty("disallowAdditionalPropertiesIfNotPresent", "false")
+                .setInputSpec("src/test/resources/3_0/allOf_extension_parent.yaml")
+                .setOutputDir(output.toString().replace("\\", "/"));
+
+        DefaultGenerator generator = new DefaultGenerator();
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODELS, "true");
+        generator.opts(configurator.toClientOptInput()).generate();
+
+        // gson's reflective adapter refuses a class with two JSON fields of one name; without
+        // `transient` an allOf child declares additionalProperties itself and inherits it too,
+        // making it undeserializable ("declares multiple JSON fields named
+        // 'additionalProperties'"). The bag is read and written by the model's own
+        // TypeAdapterFactory, never by gson reflection, so hiding the field changes nothing else.
+        assertThat(output.resolve("src/main/java/xyz/abcdef/model/Child.java"))
+                .content()
+                .contains("public class Child extends Person {")
+                .contains("private transient Map<String, Object> additionalProperties;");
+        assertThat(output.resolve("src/main/java/xyz/abcdef/model/Person.java"))
+                .content().contains("private transient Map<String, Object> additionalProperties;");
+    }
+
+    @Test
     public void allOfWithSeveralRefsAndRefAsParentInAllOfNormalizationIsTrue() {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/AllOfSimpleModel.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/AllOfSimpleModel.java
@@ -93,10 +93,11 @@ public class AllOfSimpleModel {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/AllOfSimpleModel.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/AllOfSimpleModel.java
@@ -91,8 +91,12 @@ public class AllOfSimpleModel {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/AllOfSimpleModel.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/AllOfSimpleModel.java
@@ -92,9 +92,11 @@ public class AllOfSimpleModel {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/Animal.java
@@ -106,8 +106,12 @@ public class Animal {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/Animal.java
@@ -107,11 +107,13 @@ public class Animal {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
-  private transient Map<String, Object> additionalProperties;
+  private Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/Animal.java
@@ -108,10 +108,11 @@ public class Animal {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/AnyTypeTest.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/AnyTypeTest.java
@@ -150,10 +150,11 @@ public class AnyTypeTest {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/AnyTypeTest.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/AnyTypeTest.java
@@ -149,9 +149,11 @@ public class AnyTypeTest {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/AnyTypeTest.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/AnyTypeTest.java
@@ -148,8 +148,12 @@ public class AnyTypeTest {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/ArrayOfSameRef.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/ArrayOfSameRef.java
@@ -158,10 +158,11 @@ public class ArrayOfSameRef {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/ArrayOfSameRef.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/ArrayOfSameRef.java
@@ -156,8 +156,12 @@ public class ArrayOfSameRef {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/ArrayOfSameRef.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/ArrayOfSameRef.java
@@ -157,9 +157,11 @@ public class ArrayOfSameRef {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/Cat.java
@@ -85,10 +85,11 @@ public class Cat extends Animal {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/Cat.java
@@ -84,9 +84,11 @@ public class Cat extends Animal {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/Cat.java
@@ -83,8 +83,12 @@ public class Cat extends Animal {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/Category.java
@@ -107,10 +107,11 @@ public class Category {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/Category.java
@@ -105,8 +105,12 @@ public class Category {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/Category.java
@@ -106,9 +106,11 @@ public class Category {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/CircularReference1.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/CircularReference1.java
@@ -82,8 +82,12 @@ public class CircularReference1 {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/CircularReference1.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/CircularReference1.java
@@ -83,9 +83,11 @@ public class CircularReference1 {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/CircularReference1.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/CircularReference1.java
@@ -84,10 +84,11 @@ public class CircularReference1 {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/CircularReference2.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/CircularReference2.java
@@ -83,9 +83,11 @@ public class CircularReference2 {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/CircularReference2.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/CircularReference2.java
@@ -82,8 +82,12 @@ public class CircularReference2 {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/CircularReference2.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/CircularReference2.java
@@ -84,10 +84,11 @@ public class CircularReference2 {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/CircularReference3.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/CircularReference3.java
@@ -84,10 +84,11 @@ public class CircularReference3 {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/CircularReference3.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/CircularReference3.java
@@ -83,9 +83,11 @@ public class CircularReference3 {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/CircularReference3.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/CircularReference3.java
@@ -82,8 +82,12 @@ public class CircularReference3 {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/Dog.java
@@ -84,9 +84,11 @@ public class Dog extends Animal {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/Dog.java
@@ -83,8 +83,12 @@ public class Dog extends Animal {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/Dog.java
@@ -85,10 +85,11 @@ public class Dog extends Animal {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/FakeWebhooksSourcesDeletedPostRequest.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/FakeWebhooksSourcesDeletedPostRequest.java
@@ -131,8 +131,12 @@ public class FakeWebhooksSourcesDeletedPostRequest {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/FakeWebhooksSourcesDeletedPostRequest.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/FakeWebhooksSourcesDeletedPostRequest.java
@@ -133,10 +133,11 @@ public class FakeWebhooksSourcesDeletedPostRequest {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/FakeWebhooksSourcesDeletedPostRequest.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/FakeWebhooksSourcesDeletedPostRequest.java
@@ -132,9 +132,11 @@ public class FakeWebhooksSourcesDeletedPostRequest {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/FakeWebhooksSourcesDeletedPostRequestEvent.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/FakeWebhooksSourcesDeletedPostRequestEvent.java
@@ -81,8 +81,12 @@ public class FakeWebhooksSourcesDeletedPostRequestEvent {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/FakeWebhooksSourcesDeletedPostRequestEvent.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/FakeWebhooksSourcesDeletedPostRequestEvent.java
@@ -83,10 +83,11 @@ public class FakeWebhooksSourcesDeletedPostRequestEvent {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/FakeWebhooksSourcesDeletedPostRequestEvent.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/FakeWebhooksSourcesDeletedPostRequestEvent.java
@@ -82,9 +82,11 @@ public class FakeWebhooksSourcesDeletedPostRequestEvent {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -131,10 +131,11 @@ public class ModelApiResponse {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -129,8 +129,12 @@ public class ModelApiResponse {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -130,9 +130,11 @@ public class ModelApiResponse {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/Order.java
@@ -258,10 +258,11 @@ public class Order {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/Order.java
@@ -257,9 +257,11 @@ public class Order {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/Order.java
@@ -256,8 +256,12 @@ public class Order {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/Pet.java
@@ -282,10 +282,11 @@ public class Pet {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/Pet.java
@@ -281,9 +281,11 @@ public class Pet {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/Pet.java
@@ -280,8 +280,12 @@ public class Pet {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/PetWithTypesObjectNullAndRef.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/PetWithTypesObjectNullAndRef.java
@@ -108,9 +108,11 @@ public class PetWithTypesObjectNullAndRef {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/PetWithTypesObjectNullAndRef.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/PetWithTypesObjectNullAndRef.java
@@ -107,8 +107,12 @@ public class PetWithTypesObjectNullAndRef {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/PetWithTypesObjectNullAndRef.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/PetWithTypesObjectNullAndRef.java
@@ -109,10 +109,11 @@ public class PetWithTypesObjectNullAndRef {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/SelfReferenceAdditionalProperties.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/SelfReferenceAdditionalProperties.java
@@ -83,10 +83,11 @@ public class SelfReferenceAdditionalProperties {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/SelfReferenceAdditionalProperties.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/SelfReferenceAdditionalProperties.java
@@ -82,9 +82,11 @@ public class SelfReferenceAdditionalProperties {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/SelfReferenceAdditionalProperties.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/SelfReferenceAdditionalProperties.java
@@ -81,8 +81,12 @@ public class SelfReferenceAdditionalProperties {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/SimpleModelWithArrayProperty.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/SimpleModelWithArrayProperty.java
@@ -93,10 +93,11 @@ public class SimpleModelWithArrayProperty {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/SimpleModelWithArrayProperty.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/SimpleModelWithArrayProperty.java
@@ -92,9 +92,11 @@ public class SimpleModelWithArrayProperty {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/SimpleModelWithArrayProperty.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/SimpleModelWithArrayProperty.java
@@ -91,8 +91,12 @@ public class SimpleModelWithArrayProperty {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/Tag.java
@@ -107,10 +107,11 @@ public class Tag {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/Tag.java
@@ -106,9 +106,11 @@ public class Tag {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/Tag.java
@@ -105,8 +105,12 @@ public class Tag {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/User.java
@@ -251,10 +251,11 @@ public class User {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/User.java
@@ -249,8 +249,12 @@ public class User {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/User.java
@@ -250,9 +250,11 @@ public class User {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-awsv4signature/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/okhttp-gson-awsv4signature/src/main/java/org/openapitools/client/model/Category.java
@@ -107,10 +107,11 @@ public class Category {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-awsv4signature/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/okhttp-gson-awsv4signature/src/main/java/org/openapitools/client/model/Category.java
@@ -105,8 +105,12 @@ public class Category {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson-awsv4signature/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/okhttp-gson-awsv4signature/src/main/java/org/openapitools/client/model/Category.java
@@ -106,9 +106,11 @@ public class Category {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-awsv4signature/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/okhttp-gson-awsv4signature/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -131,10 +131,11 @@ public class ModelApiResponse {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-awsv4signature/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/okhttp-gson-awsv4signature/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -129,8 +129,12 @@ public class ModelApiResponse {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson-awsv4signature/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/okhttp-gson-awsv4signature/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -130,9 +130,11 @@ public class ModelApiResponse {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-awsv4signature/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/okhttp-gson-awsv4signature/src/main/java/org/openapitools/client/model/Order.java
@@ -258,10 +258,11 @@ public class Order {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-awsv4signature/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/okhttp-gson-awsv4signature/src/main/java/org/openapitools/client/model/Order.java
@@ -257,9 +257,11 @@ public class Order {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-awsv4signature/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/okhttp-gson-awsv4signature/src/main/java/org/openapitools/client/model/Order.java
@@ -256,8 +256,12 @@ public class Order {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson-awsv4signature/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/okhttp-gson-awsv4signature/src/main/java/org/openapitools/client/model/Pet.java
@@ -282,10 +282,11 @@ public class Pet {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-awsv4signature/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/okhttp-gson-awsv4signature/src/main/java/org/openapitools/client/model/Pet.java
@@ -281,9 +281,11 @@ public class Pet {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-awsv4signature/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/okhttp-gson-awsv4signature/src/main/java/org/openapitools/client/model/Pet.java
@@ -280,8 +280,12 @@ public class Pet {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson-awsv4signature/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/okhttp-gson-awsv4signature/src/main/java/org/openapitools/client/model/Tag.java
@@ -107,10 +107,11 @@ public class Tag {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-awsv4signature/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/okhttp-gson-awsv4signature/src/main/java/org/openapitools/client/model/Tag.java
@@ -106,9 +106,11 @@ public class Tag {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-awsv4signature/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/okhttp-gson-awsv4signature/src/main/java/org/openapitools/client/model/Tag.java
@@ -105,8 +105,12 @@ public class Tag {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson-awsv4signature/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/okhttp-gson-awsv4signature/src/main/java/org/openapitools/client/model/User.java
@@ -251,10 +251,11 @@ public class User {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-awsv4signature/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/okhttp-gson-awsv4signature/src/main/java/org/openapitools/client/model/User.java
@@ -249,8 +249,12 @@ public class User {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson-awsv4signature/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/okhttp-gson-awsv4signature/src/main/java/org/openapitools/client/model/User.java
@@ -250,9 +250,11 @@ public class User {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -81,8 +81,12 @@ public class AdditionalPropertiesAnyType {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -82,9 +82,11 @@ public class AdditionalPropertiesAnyType {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -83,10 +83,11 @@ public class AdditionalPropertiesAnyType {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -83,9 +83,11 @@ public class AdditionalPropertiesArray {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -84,10 +84,11 @@ public class AdditionalPropertiesArray {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -82,8 +82,12 @@ public class AdditionalPropertiesArray {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -82,9 +82,11 @@ public class AdditionalPropertiesBoolean {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -81,8 +81,12 @@ public class AdditionalPropertiesBoolean {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -83,10 +83,11 @@ public class AdditionalPropertiesBoolean {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -83,10 +83,11 @@ public class AdditionalPropertiesInteger {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -82,9 +82,11 @@ public class AdditionalPropertiesInteger {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -81,8 +81,12 @@ public class AdditionalPropertiesInteger {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -82,8 +82,12 @@ public class AdditionalPropertiesNumber {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -84,10 +84,11 @@ public class AdditionalPropertiesNumber {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -83,9 +83,11 @@ public class AdditionalPropertiesNumber {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -82,8 +82,12 @@ public class AdditionalPropertiesObject {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -83,9 +83,11 @@ public class AdditionalPropertiesObject {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -84,10 +84,11 @@ public class AdditionalPropertiesObject {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -82,9 +82,11 @@ public class AdditionalPropertiesString {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -81,8 +81,12 @@ public class AdditionalPropertiesString {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -83,10 +83,11 @@ public class AdditionalPropertiesString {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-group-parameter/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/okhttp-gson-group-parameter/src/main/java/org/openapitools/client/model/Category.java
@@ -107,10 +107,11 @@ public class Category {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-group-parameter/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/okhttp-gson-group-parameter/src/main/java/org/openapitools/client/model/Category.java
@@ -105,8 +105,12 @@ public class Category {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson-group-parameter/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/okhttp-gson-group-parameter/src/main/java/org/openapitools/client/model/Category.java
@@ -106,9 +106,11 @@ public class Category {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-group-parameter/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/okhttp-gson-group-parameter/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -131,10 +131,11 @@ public class ModelApiResponse {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-group-parameter/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/okhttp-gson-group-parameter/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -129,8 +129,12 @@ public class ModelApiResponse {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson-group-parameter/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/okhttp-gson-group-parameter/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -130,9 +130,11 @@ public class ModelApiResponse {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-group-parameter/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/okhttp-gson-group-parameter/src/main/java/org/openapitools/client/model/Order.java
@@ -258,10 +258,11 @@ public class Order {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-group-parameter/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/okhttp-gson-group-parameter/src/main/java/org/openapitools/client/model/Order.java
@@ -257,9 +257,11 @@ public class Order {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-group-parameter/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/okhttp-gson-group-parameter/src/main/java/org/openapitools/client/model/Order.java
@@ -256,8 +256,12 @@ public class Order {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson-group-parameter/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/okhttp-gson-group-parameter/src/main/java/org/openapitools/client/model/Pet.java
@@ -282,10 +282,11 @@ public class Pet {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-group-parameter/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/okhttp-gson-group-parameter/src/main/java/org/openapitools/client/model/Pet.java
@@ -281,9 +281,11 @@ public class Pet {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-group-parameter/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/okhttp-gson-group-parameter/src/main/java/org/openapitools/client/model/Pet.java
@@ -280,8 +280,12 @@ public class Pet {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson-group-parameter/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/okhttp-gson-group-parameter/src/main/java/org/openapitools/client/model/Tag.java
@@ -107,10 +107,11 @@ public class Tag {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-group-parameter/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/okhttp-gson-group-parameter/src/main/java/org/openapitools/client/model/Tag.java
@@ -106,9 +106,11 @@ public class Tag {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-group-parameter/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/okhttp-gson-group-parameter/src/main/java/org/openapitools/client/model/Tag.java
@@ -105,8 +105,12 @@ public class Tag {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson-group-parameter/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/okhttp-gson-group-parameter/src/main/java/org/openapitools/client/model/User.java
@@ -251,10 +251,11 @@ public class User {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-group-parameter/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/okhttp-gson-group-parameter/src/main/java/org/openapitools/client/model/User.java
@@ -249,8 +249,12 @@ public class User {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson-group-parameter/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/okhttp-gson-group-parameter/src/main/java/org/openapitools/client/model/User.java
@@ -250,9 +250,11 @@ public class User {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-nullable-required/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/okhttp-gson-nullable-required/src/main/java/org/openapitools/client/model/Category.java
@@ -107,10 +107,11 @@ public class Category {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-nullable-required/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/okhttp-gson-nullable-required/src/main/java/org/openapitools/client/model/Category.java
@@ -105,8 +105,12 @@ public class Category {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson-nullable-required/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/okhttp-gson-nullable-required/src/main/java/org/openapitools/client/model/Category.java
@@ -106,9 +106,11 @@ public class Category {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-nullable-required/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/okhttp-gson-nullable-required/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -131,10 +131,11 @@ public class ModelApiResponse {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-nullable-required/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/okhttp-gson-nullable-required/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -129,8 +129,12 @@ public class ModelApiResponse {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson-nullable-required/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/okhttp-gson-nullable-required/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -130,9 +130,11 @@ public class ModelApiResponse {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-nullable-required/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/okhttp-gson-nullable-required/src/main/java/org/openapitools/client/model/Order.java
@@ -258,10 +258,11 @@ public class Order {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-nullable-required/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/okhttp-gson-nullable-required/src/main/java/org/openapitools/client/model/Order.java
@@ -257,9 +257,11 @@ public class Order {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-nullable-required/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/okhttp-gson-nullable-required/src/main/java/org/openapitools/client/model/Order.java
@@ -256,8 +256,12 @@ public class Order {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson-nullable-required/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/okhttp-gson-nullable-required/src/main/java/org/openapitools/client/model/Pet.java
@@ -282,10 +282,11 @@ public class Pet {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-nullable-required/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/okhttp-gson-nullable-required/src/main/java/org/openapitools/client/model/Pet.java
@@ -281,9 +281,11 @@ public class Pet {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-nullable-required/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/okhttp-gson-nullable-required/src/main/java/org/openapitools/client/model/Pet.java
@@ -280,8 +280,12 @@ public class Pet {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson-nullable-required/src/main/java/org/openapitools/client/model/PetWithRequiredNullableCases1.java
+++ b/samples/client/petstore/java/okhttp-gson-nullable-required/src/main/java/org/openapitools/client/model/PetWithRequiredNullableCases1.java
@@ -283,10 +283,11 @@ public class PetWithRequiredNullableCases1 {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-nullable-required/src/main/java/org/openapitools/client/model/PetWithRequiredNullableCases1.java
+++ b/samples/client/petstore/java/okhttp-gson-nullable-required/src/main/java/org/openapitools/client/model/PetWithRequiredNullableCases1.java
@@ -281,8 +281,12 @@ public class PetWithRequiredNullableCases1 {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson-nullable-required/src/main/java/org/openapitools/client/model/PetWithRequiredNullableCases1.java
+++ b/samples/client/petstore/java/okhttp-gson-nullable-required/src/main/java/org/openapitools/client/model/PetWithRequiredNullableCases1.java
@@ -282,9 +282,11 @@ public class PetWithRequiredNullableCases1 {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-nullable-required/src/main/java/org/openapitools/client/model/PetWithRequiredNullableCases2.java
+++ b/samples/client/petstore/java/okhttp-gson-nullable-required/src/main/java/org/openapitools/client/model/PetWithRequiredNullableCases2.java
@@ -281,9 +281,11 @@ public class PetWithRequiredNullableCases2 {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-nullable-required/src/main/java/org/openapitools/client/model/PetWithRequiredNullableCases2.java
+++ b/samples/client/petstore/java/okhttp-gson-nullable-required/src/main/java/org/openapitools/client/model/PetWithRequiredNullableCases2.java
@@ -282,10 +282,11 @@ public class PetWithRequiredNullableCases2 {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-nullable-required/src/main/java/org/openapitools/client/model/PetWithRequiredNullableCases2.java
+++ b/samples/client/petstore/java/okhttp-gson-nullable-required/src/main/java/org/openapitools/client/model/PetWithRequiredNullableCases2.java
@@ -280,8 +280,12 @@ public class PetWithRequiredNullableCases2 {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson-nullable-required/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/okhttp-gson-nullable-required/src/main/java/org/openapitools/client/model/Tag.java
@@ -107,10 +107,11 @@ public class Tag {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-nullable-required/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/okhttp-gson-nullable-required/src/main/java/org/openapitools/client/model/Tag.java
@@ -106,9 +106,11 @@ public class Tag {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-nullable-required/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/okhttp-gson-nullable-required/src/main/java/org/openapitools/client/model/Tag.java
@@ -105,8 +105,12 @@ public class Tag {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson-nullable-required/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/okhttp-gson-nullable-required/src/main/java/org/openapitools/client/model/User.java
@@ -251,10 +251,11 @@ public class User {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-nullable-required/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/okhttp-gson-nullable-required/src/main/java/org/openapitools/client/model/User.java
@@ -249,8 +249,12 @@ public class User {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson-nullable-required/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/okhttp-gson-nullable-required/src/main/java/org/openapitools/client/model/User.java
@@ -250,9 +250,11 @@ public class User {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -84,9 +84,11 @@ public class AdditionalPropertiesAnyType implements Parcelable {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -83,8 +83,12 @@ public class AdditionalPropertiesAnyType implements Parcelable {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -85,10 +85,11 @@ public class AdditionalPropertiesAnyType implements Parcelable {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -86,10 +86,11 @@ public class AdditionalPropertiesArray implements Parcelable {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -84,8 +84,12 @@ public class AdditionalPropertiesArray implements Parcelable {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -85,9 +85,11 @@ public class AdditionalPropertiesArray implements Parcelable {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -85,10 +85,11 @@ public class AdditionalPropertiesBoolean implements Parcelable {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -83,8 +83,12 @@ public class AdditionalPropertiesBoolean implements Parcelable {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -84,9 +84,11 @@ public class AdditionalPropertiesBoolean implements Parcelable {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -83,8 +83,12 @@ public class AdditionalPropertiesInteger implements Parcelable {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -84,9 +84,11 @@ public class AdditionalPropertiesInteger implements Parcelable {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -85,10 +85,11 @@ public class AdditionalPropertiesInteger implements Parcelable {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -86,10 +86,11 @@ public class AdditionalPropertiesNumber implements Parcelable {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -84,8 +84,12 @@ public class AdditionalPropertiesNumber implements Parcelable {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -85,9 +85,11 @@ public class AdditionalPropertiesNumber implements Parcelable {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -85,9 +85,11 @@ public class AdditionalPropertiesObject implements Parcelable {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -84,8 +84,12 @@ public class AdditionalPropertiesObject implements Parcelable {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -86,10 +86,11 @@ public class AdditionalPropertiesObject implements Parcelable {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -84,9 +84,11 @@ public class AdditionalPropertiesString implements Parcelable {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -85,10 +85,11 @@ public class AdditionalPropertiesString implements Parcelable {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -83,8 +83,12 @@ public class AdditionalPropertiesString implements Parcelable {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson-swagger1/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/okhttp-gson-swagger1/src/main/java/org/openapitools/client/model/Category.java
@@ -112,10 +112,11 @@ public class Category {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-swagger1/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/okhttp-gson-swagger1/src/main/java/org/openapitools/client/model/Category.java
@@ -110,8 +110,12 @@ public class Category {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson-swagger1/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/okhttp-gson-swagger1/src/main/java/org/openapitools/client/model/Category.java
@@ -111,9 +111,11 @@ public class Category {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-swagger1/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/okhttp-gson-swagger1/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -136,9 +136,11 @@ public class ModelApiResponse {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-swagger1/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/okhttp-gson-swagger1/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -135,8 +135,12 @@ public class ModelApiResponse {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson-swagger1/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/okhttp-gson-swagger1/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -137,10 +137,11 @@ public class ModelApiResponse {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-swagger1/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/okhttp-gson-swagger1/src/main/java/org/openapitools/client/model/Order.java
@@ -265,8 +265,12 @@ public class Order {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson-swagger1/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/okhttp-gson-swagger1/src/main/java/org/openapitools/client/model/Order.java
@@ -267,10 +267,11 @@ public class Order {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-swagger1/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/okhttp-gson-swagger1/src/main/java/org/openapitools/client/model/Order.java
@@ -266,9 +266,11 @@ public class Order {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-swagger1/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/okhttp-gson-swagger1/src/main/java/org/openapitools/client/model/Pet.java
@@ -291,10 +291,11 @@ public class Pet {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-swagger1/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/okhttp-gson-swagger1/src/main/java/org/openapitools/client/model/Pet.java
@@ -290,9 +290,11 @@ public class Pet {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-swagger1/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/okhttp-gson-swagger1/src/main/java/org/openapitools/client/model/Pet.java
@@ -289,8 +289,12 @@ public class Pet {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson-swagger1/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/okhttp-gson-swagger1/src/main/java/org/openapitools/client/model/Tag.java
@@ -110,8 +110,12 @@ public class Tag {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson-swagger1/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/okhttp-gson-swagger1/src/main/java/org/openapitools/client/model/Tag.java
@@ -111,9 +111,11 @@ public class Tag {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-swagger1/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/okhttp-gson-swagger1/src/main/java/org/openapitools/client/model/Tag.java
@@ -112,10 +112,11 @@ public class Tag {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-swagger1/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/okhttp-gson-swagger1/src/main/java/org/openapitools/client/model/User.java
@@ -261,9 +261,11 @@ public class User {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-swagger1/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/okhttp-gson-swagger1/src/main/java/org/openapitools/client/model/User.java
@@ -262,10 +262,11 @@ public class User {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-swagger1/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/okhttp-gson-swagger1/src/main/java/org/openapitools/client/model/User.java
@@ -260,8 +260,12 @@ public class User {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson-swagger2/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/okhttp-gson-swagger2/src/main/java/org/openapitools/client/model/Category.java
@@ -110,9 +110,11 @@ public class Category {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-swagger2/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/okhttp-gson-swagger2/src/main/java/org/openapitools/client/model/Category.java
@@ -109,8 +109,12 @@ public class Category {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson-swagger2/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/okhttp-gson-swagger2/src/main/java/org/openapitools/client/model/Category.java
@@ -111,10 +111,11 @@ public class Category {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-swagger2/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/okhttp-gson-swagger2/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -136,10 +136,11 @@ public class ModelApiResponse {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-swagger2/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/okhttp-gson-swagger2/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -135,9 +135,11 @@ public class ModelApiResponse {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-swagger2/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/okhttp-gson-swagger2/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -134,8 +134,12 @@ public class ModelApiResponse {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson-swagger2/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/okhttp-gson-swagger2/src/main/java/org/openapitools/client/model/Order.java
@@ -265,9 +265,11 @@ public class Order {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-swagger2/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/okhttp-gson-swagger2/src/main/java/org/openapitools/client/model/Order.java
@@ -264,8 +264,12 @@ public class Order {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson-swagger2/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/okhttp-gson-swagger2/src/main/java/org/openapitools/client/model/Order.java
@@ -266,10 +266,11 @@ public class Order {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-swagger2/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/okhttp-gson-swagger2/src/main/java/org/openapitools/client/model/Pet.java
@@ -288,8 +288,12 @@ public class Pet {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson-swagger2/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/okhttp-gson-swagger2/src/main/java/org/openapitools/client/model/Pet.java
@@ -289,9 +289,11 @@ public class Pet {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-swagger2/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/okhttp-gson-swagger2/src/main/java/org/openapitools/client/model/Pet.java
@@ -290,10 +290,11 @@ public class Pet {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-swagger2/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/okhttp-gson-swagger2/src/main/java/org/openapitools/client/model/Tag.java
@@ -109,8 +109,12 @@ public class Tag {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson-swagger2/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/okhttp-gson-swagger2/src/main/java/org/openapitools/client/model/Tag.java
@@ -111,10 +111,11 @@ public class Tag {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-swagger2/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/okhttp-gson-swagger2/src/main/java/org/openapitools/client/model/Tag.java
@@ -110,9 +110,11 @@ public class Tag {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-swagger2/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/okhttp-gson-swagger2/src/main/java/org/openapitools/client/model/User.java
@@ -261,10 +261,11 @@ public class User {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson-swagger2/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/okhttp-gson-swagger2/src/main/java/org/openapitools/client/model/User.java
@@ -259,8 +259,12 @@ public class User {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson-swagger2/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/okhttp-gson-swagger2/src/main/java/org/openapitools/client/model/User.java
@@ -260,9 +260,11 @@ public class User {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -285,9 +285,11 @@ public class AdditionalPropertiesClass {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -286,10 +286,11 @@ public class AdditionalPropertiesClass {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -284,8 +284,12 @@ public class AdditionalPropertiesClass {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AllOfModelArrayAnyOf.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AllOfModelArrayAnyOf.java
@@ -156,9 +156,11 @@ public class AllOfModelArrayAnyOf {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AllOfModelArrayAnyOf.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AllOfModelArrayAnyOf.java
@@ -155,8 +155,12 @@ public class AllOfModelArrayAnyOf {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AllOfModelArrayAnyOf.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AllOfModelArrayAnyOf.java
@@ -157,10 +157,11 @@ public class AllOfModelArrayAnyOf {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AllOfModelArrayAnyOfAllOfAttributes.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AllOfModelArrayAnyOfAllOfAttributes.java
@@ -83,9 +83,11 @@ public class AllOfModelArrayAnyOfAllOfAttributes {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AllOfModelArrayAnyOfAllOfAttributes.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AllOfModelArrayAnyOfAllOfAttributes.java
@@ -82,8 +82,12 @@ public class AllOfModelArrayAnyOfAllOfAttributes {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AllOfModelArrayAnyOfAllOfAttributes.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AllOfModelArrayAnyOfAllOfAttributes.java
@@ -84,10 +84,11 @@ public class AllOfModelArrayAnyOfAllOfAttributes {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AllOfModelArrayAnyOfAllOfLinkListColumn1.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AllOfModelArrayAnyOfAllOfLinkListColumn1.java
@@ -94,10 +94,11 @@ public class AllOfModelArrayAnyOfAllOfLinkListColumn1 {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AllOfModelArrayAnyOfAllOfLinkListColumn1.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AllOfModelArrayAnyOfAllOfLinkListColumn1.java
@@ -93,9 +93,11 @@ public class AllOfModelArrayAnyOfAllOfLinkListColumn1 {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AllOfModelArrayAnyOfAllOfLinkListColumn1.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AllOfModelArrayAnyOfAllOfLinkListColumn1.java
@@ -92,8 +92,12 @@ public class AllOfModelArrayAnyOfAllOfLinkListColumn1 {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AllOfRefToDouble.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AllOfRefToDouble.java
@@ -81,8 +81,12 @@ public class AllOfRefToDouble {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AllOfRefToDouble.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AllOfRefToDouble.java
@@ -83,10 +83,11 @@ public class AllOfRefToDouble {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AllOfRefToDouble.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AllOfRefToDouble.java
@@ -82,9 +82,11 @@ public class AllOfRefToDouble {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AllOfRefToFloat.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AllOfRefToFloat.java
@@ -83,10 +83,11 @@ public class AllOfRefToFloat {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AllOfRefToFloat.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AllOfRefToFloat.java
@@ -82,9 +82,11 @@ public class AllOfRefToFloat {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AllOfRefToFloat.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AllOfRefToFloat.java
@@ -81,8 +81,12 @@ public class AllOfRefToFloat {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AllOfRefToLong.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AllOfRefToLong.java
@@ -81,8 +81,12 @@ public class AllOfRefToLong {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AllOfRefToLong.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AllOfRefToLong.java
@@ -82,9 +82,11 @@ public class AllOfRefToLong {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AllOfRefToLong.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AllOfRefToLong.java
@@ -83,10 +83,11 @@ public class AllOfRefToLong {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Animal.java
@@ -106,8 +106,12 @@ public class Animal {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Animal.java
@@ -107,11 +107,13 @@ public class Animal {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
-  private transient Map<String, Object> additionalProperties;
+  private Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Animal.java
@@ -108,10 +108,11 @@ public class Animal {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Apple.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Apple.java
@@ -106,9 +106,11 @@ public class Apple {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Apple.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Apple.java
@@ -107,10 +107,11 @@ public class Apple {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Apple.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Apple.java
@@ -105,8 +105,12 @@ public class Apple {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ArrayDefault.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ArrayDefault.java
@@ -123,8 +123,12 @@ public class ArrayDefault {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ArrayDefault.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ArrayDefault.java
@@ -124,9 +124,11 @@ public class ArrayDefault {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ArrayDefault.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ArrayDefault.java
@@ -125,10 +125,11 @@ public class ArrayDefault {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -93,9 +93,11 @@ public class ArrayOfArrayOfNumberOnly {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -92,8 +92,12 @@ public class ArrayOfArrayOfNumberOnly {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -94,10 +94,11 @@ public class ArrayOfArrayOfNumberOnly {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ArrayOfInlineAllOf.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ArrayOfInlineAllOf.java
@@ -142,10 +142,11 @@ public class ArrayOfInlineAllOf {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ArrayOfInlineAllOf.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ArrayOfInlineAllOf.java
@@ -141,9 +141,11 @@ public class ArrayOfInlineAllOf {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ArrayOfInlineAllOf.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ArrayOfInlineAllOf.java
@@ -140,8 +140,12 @@ public class ArrayOfInlineAllOf {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ArrayOfInlineAllOfArrayAllofDogPropertyInner.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ArrayOfInlineAllOfArrayAllofDogPropertyInner.java
@@ -106,9 +106,11 @@ public class ArrayOfInlineAllOfArrayAllofDogPropertyInner {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ArrayOfInlineAllOfArrayAllofDogPropertyInner.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ArrayOfInlineAllOfArrayAllofDogPropertyInner.java
@@ -107,10 +107,11 @@ public class ArrayOfInlineAllOfArrayAllofDogPropertyInner {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ArrayOfInlineAllOfArrayAllofDogPropertyInner.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ArrayOfInlineAllOfArrayAllofDogPropertyInner.java
@@ -105,8 +105,12 @@ public class ArrayOfInlineAllOfArrayAllofDogPropertyInner {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -94,10 +94,11 @@ public class ArrayOfNumberOnly {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -93,9 +93,11 @@ public class ArrayOfNumberOnly {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -92,8 +92,12 @@ public class ArrayOfNumberOnly {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -156,8 +156,12 @@ public class ArrayTest {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -157,9 +157,11 @@ public class ArrayTest {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -158,10 +158,11 @@ public class ArrayTest {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Banana.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Banana.java
@@ -84,10 +84,11 @@ public class Banana {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Banana.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Banana.java
@@ -83,9 +83,11 @@ public class Banana {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Banana.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Banana.java
@@ -82,8 +82,12 @@ public class Banana {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/BasquePig.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/BasquePig.java
@@ -81,8 +81,12 @@ public class BasquePig {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/BasquePig.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/BasquePig.java
@@ -82,9 +82,11 @@ public class BasquePig {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/BasquePig.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/BasquePig.java
@@ -83,10 +83,11 @@ public class BasquePig {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -201,8 +201,12 @@ public class Capitalization {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -203,10 +203,11 @@ public class Capitalization {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -202,9 +202,11 @@ public class Capitalization {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Cat.java
@@ -85,9 +85,11 @@ public class Cat extends Animal {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Cat.java
@@ -84,8 +84,12 @@ public class Cat extends Animal {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Cat.java
@@ -86,10 +86,11 @@ public class Cat extends Animal {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Category.java
@@ -107,10 +107,11 @@ public class Category {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Category.java
@@ -105,8 +105,12 @@ public class Category {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Category.java
@@ -106,9 +106,11 @@ public class Category {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -81,8 +81,12 @@ public class ClassModel {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -82,9 +82,11 @@ public class ClassModel {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -83,10 +83,11 @@ public class ClassModel {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Client.java
@@ -83,10 +83,11 @@ public class Client {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Client.java
@@ -81,8 +81,12 @@ public class Client {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Client.java
@@ -82,9 +82,11 @@ public class Client {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ComplexQuadrilateral.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ComplexQuadrilateral.java
@@ -105,8 +105,12 @@ public class ComplexQuadrilateral {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ComplexQuadrilateral.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ComplexQuadrilateral.java
@@ -106,9 +106,11 @@ public class ComplexQuadrilateral {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ComplexQuadrilateral.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ComplexQuadrilateral.java
@@ -107,10 +107,11 @@ public class ComplexQuadrilateral {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/DanishPig.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/DanishPig.java
@@ -83,10 +83,11 @@ public class DanishPig {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/DanishPig.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/DanishPig.java
@@ -82,9 +82,11 @@ public class DanishPig {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/DanishPig.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/DanishPig.java
@@ -81,8 +81,12 @@ public class DanishPig {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/DeprecatedObject.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/DeprecatedObject.java
@@ -84,9 +84,11 @@ public class DeprecatedObject {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/DeprecatedObject.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/DeprecatedObject.java
@@ -85,10 +85,11 @@ public class DeprecatedObject {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/DeprecatedObject.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/DeprecatedObject.java
@@ -83,8 +83,12 @@ public class DeprecatedObject {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Dog.java
@@ -84,9 +84,11 @@ public class Dog extends Animal {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Dog.java
@@ -83,8 +83,12 @@ public class Dog extends Animal {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Dog.java
@@ -85,10 +85,11 @@ public class Dog extends Animal {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Drawing.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Drawing.java
@@ -170,10 +170,11 @@ public class Drawing {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Drawing.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Drawing.java
@@ -169,9 +169,11 @@ public class Drawing {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Drawing.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Drawing.java
@@ -168,8 +168,12 @@ public class Drawing {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -220,9 +220,11 @@ public class EnumArrays {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -219,8 +219,12 @@ public class EnumArrays {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -221,10 +221,11 @@ public class EnumArrays {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/EnumStringDiscriminator.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/EnumStringDiscriminator.java
@@ -136,10 +136,11 @@ public class EnumStringDiscriminator {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/EnumStringDiscriminator.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/EnumStringDiscriminator.java
@@ -135,9 +135,11 @@ public class EnumStringDiscriminator {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/EnumStringDiscriminator.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/EnumStringDiscriminator.java
@@ -134,8 +134,12 @@ public class EnumStringDiscriminator {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -547,8 +547,12 @@ public class EnumTest {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -548,9 +548,11 @@ public class EnumTest {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -549,10 +549,11 @@ public class EnumTest {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/EquilateralTriangle.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/EquilateralTriangle.java
@@ -107,10 +107,11 @@ public class EquilateralTriangle {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/EquilateralTriangle.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/EquilateralTriangle.java
@@ -105,8 +105,12 @@ public class EquilateralTriangle {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/EquilateralTriangle.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/EquilateralTriangle.java
@@ -106,9 +106,11 @@ public class EquilateralTriangle {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -118,10 +118,11 @@ public class FileSchemaTestClass {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -117,9 +117,11 @@ public class FileSchemaTestClass {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -116,8 +116,12 @@ public class FileSchemaTestClass {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Foo.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Foo.java
@@ -83,10 +83,11 @@ public class Foo {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Foo.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Foo.java
@@ -81,8 +81,12 @@ public class Foo {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Foo.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Foo.java
@@ -82,9 +82,11 @@ public class Foo {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/FooGetDefaultResponse.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/FooGetDefaultResponse.java
@@ -83,9 +83,11 @@ public class FooGetDefaultResponse {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/FooGetDefaultResponse.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/FooGetDefaultResponse.java
@@ -82,8 +82,12 @@ public class FooGetDefaultResponse {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/FooGetDefaultResponse.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/FooGetDefaultResponse.java
@@ -84,10 +84,11 @@ public class FooGetDefaultResponse {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -481,9 +481,11 @@ public class FormatTest {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -480,8 +480,12 @@ public class FormatTest {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -482,10 +482,11 @@ public class FormatTest {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/FreeFormObjectTestClass.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/FreeFormObjectTestClass.java
@@ -107,9 +107,11 @@ public class FreeFormObjectTestClass {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/FreeFormObjectTestClass.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/FreeFormObjectTestClass.java
@@ -108,10 +108,11 @@ public class FreeFormObjectTestClass {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/FreeFormObjectTestClass.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/FreeFormObjectTestClass.java
@@ -106,8 +106,12 @@ public class FreeFormObjectTestClass {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/GrandparentAnimal.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/GrandparentAnimal.java
@@ -83,11 +83,13 @@ public class GrandparentAnimal {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
-  private transient Map<String, Object> additionalProperties;
+  private Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/GrandparentAnimal.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/GrandparentAnimal.java
@@ -82,8 +82,12 @@ public class GrandparentAnimal {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/GrandparentAnimal.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/GrandparentAnimal.java
@@ -84,10 +84,11 @@ public class GrandparentAnimal {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -99,9 +99,11 @@ public class HasOnlyReadOnly {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -100,10 +100,11 @@ public class HasOnlyReadOnly {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -98,8 +98,12 @@ public class HasOnlyReadOnly {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/HealthCheckResult.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/HealthCheckResult.java
@@ -83,9 +83,11 @@ public class HealthCheckResult {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/HealthCheckResult.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/HealthCheckResult.java
@@ -82,8 +82,12 @@ public class HealthCheckResult {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/HealthCheckResult.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/HealthCheckResult.java
@@ -84,10 +84,11 @@ public class HealthCheckResult {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/MapTest.java
@@ -240,9 +240,11 @@ public class MapTest {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/MapTest.java
@@ -239,8 +239,12 @@ public class MapTest {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/MapTest.java
@@ -241,10 +241,11 @@ public class MapTest {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -144,10 +144,11 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -142,8 +142,12 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -143,9 +143,11 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -105,8 +105,12 @@ public class Model200Response {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -107,10 +107,11 @@ public class Model200Response {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -106,9 +106,11 @@ public class Model200Response {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -131,10 +131,11 @@ public class ModelApiResponse {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -129,8 +129,12 @@ public class ModelApiResponse {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -130,9 +130,11 @@ public class ModelApiResponse {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ModelFile.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ModelFile.java
@@ -81,8 +81,12 @@ public class ModelFile {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ModelFile.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ModelFile.java
@@ -82,9 +82,11 @@ public class ModelFile {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ModelFile.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ModelFile.java
@@ -83,10 +83,11 @@ public class ModelFile {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ModelList.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ModelList.java
@@ -82,9 +82,11 @@ public class ModelList {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ModelList.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ModelList.java
@@ -83,10 +83,11 @@ public class ModelList {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ModelList.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ModelList.java
@@ -81,8 +81,12 @@ public class ModelList {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -82,9 +82,11 @@ public class ModelReturn {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -81,8 +81,12 @@ public class ModelReturn {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -83,10 +83,11 @@ public class ModelReturn {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ModelWithOneOfAnyOfProperties.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ModelWithOneOfAnyOfProperties.java
@@ -108,9 +108,11 @@ public class ModelWithOneOfAnyOfProperties {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ModelWithOneOfAnyOfProperties.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ModelWithOneOfAnyOfProperties.java
@@ -107,8 +107,12 @@ public class ModelWithOneOfAnyOfProperties {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ModelWithOneOfAnyOfProperties.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ModelWithOneOfAnyOfProperties.java
@@ -109,10 +109,11 @@ public class ModelWithOneOfAnyOfProperties {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Name.java
@@ -146,8 +146,12 @@ public class Name {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Name.java
@@ -148,10 +148,11 @@ public class Name {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Name.java
@@ -147,9 +147,11 @@ public class Name {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/NestedArrayWithDefaultValues.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/NestedArrayWithDefaultValues.java
@@ -93,10 +93,11 @@ public class NestedArrayWithDefaultValues {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/NestedArrayWithDefaultValues.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/NestedArrayWithDefaultValues.java
@@ -92,9 +92,11 @@ public class NestedArrayWithDefaultValues {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/NestedArrayWithDefaultValues.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/NestedArrayWithDefaultValues.java
@@ -91,8 +91,12 @@ public class NestedArrayWithDefaultValues {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/NewPet.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/NewPet.java
@@ -348,9 +348,11 @@ public class NewPet {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/NewPet.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/NewPet.java
@@ -347,8 +347,12 @@ public class NewPet {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/NewPet.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/NewPet.java
@@ -349,10 +349,11 @@ public class NewPet {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/NewPetCategoryInlineAllof.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/NewPetCategoryInlineAllof.java
@@ -132,10 +132,11 @@ public class NewPetCategoryInlineAllof {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/NewPetCategoryInlineAllof.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/NewPetCategoryInlineAllof.java
@@ -130,8 +130,12 @@ public class NewPetCategoryInlineAllof {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/NewPetCategoryInlineAllof.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/NewPetCategoryInlineAllof.java
@@ -131,9 +131,11 @@ public class NewPetCategoryInlineAllof {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/NewPetCategoryInlineAllofAllOfCategoryTag.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/NewPetCategoryInlineAllofAllOfCategoryTag.java
@@ -106,9 +106,11 @@ public class NewPetCategoryInlineAllofAllOfCategoryTag {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/NewPetCategoryInlineAllofAllOfCategoryTag.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/NewPetCategoryInlineAllofAllOfCategoryTag.java
@@ -107,10 +107,11 @@ public class NewPetCategoryInlineAllofAllOfCategoryTag {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/NewPetCategoryInlineAllofAllOfCategoryTag.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/NewPetCategoryInlineAllofAllOfCategoryTag.java
@@ -105,8 +105,12 @@ public class NewPetCategoryInlineAllofAllOfCategoryTag {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/NullableClass.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/NullableClass.java
@@ -403,10 +403,11 @@ public class NullableClass {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/NullableClass.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/NullableClass.java
@@ -401,8 +401,12 @@ public class NullableClass {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/NullableClass.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/NullableClass.java
@@ -402,9 +402,11 @@ public class NullableClass {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/NullableFieldsValue.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/NullableFieldsValue.java
@@ -107,10 +107,11 @@ public class NullableFieldsValue {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/NullableFieldsValue.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/NullableFieldsValue.java
@@ -106,9 +106,11 @@ public class NullableFieldsValue {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/NullableFieldsValue.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/NullableFieldsValue.java
@@ -105,8 +105,12 @@ public class NullableFieldsValue {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -82,8 +82,12 @@ public class NumberOnly {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -84,10 +84,11 @@ public class NumberOnly {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -83,9 +83,11 @@ public class NumberOnly {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ObjectWithDeprecatedFields.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ObjectWithDeprecatedFields.java
@@ -182,10 +182,11 @@ public class ObjectWithDeprecatedFields {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ObjectWithDeprecatedFields.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ObjectWithDeprecatedFields.java
@@ -180,8 +180,12 @@ public class ObjectWithDeprecatedFields {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ObjectWithDeprecatedFields.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ObjectWithDeprecatedFields.java
@@ -181,9 +181,11 @@ public class ObjectWithDeprecatedFields {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Order.java
@@ -258,10 +258,11 @@ public class Order {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Order.java
@@ -257,9 +257,11 @@ public class Order {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Order.java
@@ -256,8 +256,12 @@ public class Order {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -130,8 +130,12 @@ public class OuterComposite {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -132,10 +132,11 @@ public class OuterComposite {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -131,9 +131,11 @@ public class OuterComposite {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ParentPet.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ParentPet.java
@@ -59,8 +59,12 @@ public class ParentPet extends GrandparentAnimal {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ParentPet.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ParentPet.java
@@ -61,10 +61,11 @@ public class ParentPet extends GrandparentAnimal {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ParentPet.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ParentPet.java
@@ -60,9 +60,11 @@ public class ParentPet extends GrandparentAnimal {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Pet.java
@@ -277,10 +277,11 @@ public class Pet {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Pet.java
@@ -276,9 +276,11 @@ public class Pet {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Pet.java
@@ -275,8 +275,12 @@ public class Pet {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/PetComposition.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/PetComposition.java
@@ -275,8 +275,12 @@ public class PetComposition {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/PetComposition.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/PetComposition.java
@@ -276,9 +276,11 @@ public class PetComposition {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/PetComposition.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/PetComposition.java
@@ -277,10 +277,11 @@ public class PetComposition {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/PetRef.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/PetRef.java
@@ -276,9 +276,11 @@ public class PetRef {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/PetRef.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/PetRef.java
@@ -277,10 +277,11 @@ public class PetRef {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/PetRef.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/PetRef.java
@@ -275,8 +275,12 @@ public class PetRef {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/PetUsingAllOf.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/PetUsingAllOf.java
@@ -276,9 +276,11 @@ public class PetUsingAllOf {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/PetUsingAllOf.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/PetUsingAllOf.java
@@ -277,10 +277,11 @@ public class PetUsingAllOf {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/PetUsingAllOf.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/PetUsingAllOf.java
@@ -275,8 +275,12 @@ public class PetUsingAllOf {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/PetWithRequiredTags.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/PetWithRequiredTags.java
@@ -277,10 +277,11 @@ public class PetWithRequiredTags {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/PetWithRequiredTags.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/PetWithRequiredTags.java
@@ -275,8 +275,12 @@ public class PetWithRequiredTags {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/PetWithRequiredTags.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/PetWithRequiredTags.java
@@ -276,9 +276,11 @@ public class PetWithRequiredTags {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/PropertyNameCollision.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/PropertyNameCollision.java
@@ -131,10 +131,11 @@ public class PropertyNameCollision {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/PropertyNameCollision.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/PropertyNameCollision.java
@@ -129,8 +129,12 @@ public class PropertyNameCollision {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/PropertyNameCollision.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/PropertyNameCollision.java
@@ -130,9 +130,11 @@ public class PropertyNameCollision {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/QuadrilateralInterface.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/QuadrilateralInterface.java
@@ -82,9 +82,11 @@ public class QuadrilateralInterface {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/QuadrilateralInterface.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/QuadrilateralInterface.java
@@ -83,10 +83,11 @@ public class QuadrilateralInterface {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/QuadrilateralInterface.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/QuadrilateralInterface.java
@@ -81,8 +81,12 @@ public class QuadrilateralInterface {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -104,8 +104,12 @@ public class ReadOnlyFirst {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -106,10 +106,11 @@ public class ReadOnlyFirst {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -105,9 +105,11 @@ public class ReadOnlyFirst {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/RequiredNullableBody.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/RequiredNullableBody.java
@@ -500,9 +500,11 @@ public class RequiredNullableBody {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/RequiredNullableBody.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/RequiredNullableBody.java
@@ -499,8 +499,12 @@ public class RequiredNullableBody {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/RequiredNullableBody.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/RequiredNullableBody.java
@@ -501,10 +501,11 @@ public class RequiredNullableBody {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ScaleneTriangle.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ScaleneTriangle.java
@@ -105,8 +105,12 @@ public class ScaleneTriangle {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ScaleneTriangle.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ScaleneTriangle.java
@@ -107,10 +107,11 @@ public class ScaleneTriangle {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ScaleneTriangle.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ScaleneTriangle.java
@@ -106,9 +106,11 @@ public class ScaleneTriangle {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ShapeInterface.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ShapeInterface.java
@@ -81,8 +81,12 @@ public class ShapeInterface {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ShapeInterface.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ShapeInterface.java
@@ -83,10 +83,11 @@ public class ShapeInterface {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ShapeInterface.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ShapeInterface.java
@@ -82,9 +82,11 @@ public class ShapeInterface {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/SimpleQuadrilateral.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/SimpleQuadrilateral.java
@@ -107,10 +107,11 @@ public class SimpleQuadrilateral {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/SimpleQuadrilateral.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/SimpleQuadrilateral.java
@@ -106,9 +106,11 @@ public class SimpleQuadrilateral {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/SimpleQuadrilateral.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/SimpleQuadrilateral.java
@@ -105,8 +105,12 @@ public class SimpleQuadrilateral {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -106,9 +106,11 @@ public class SpecialModelName {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -105,8 +105,12 @@ public class SpecialModelName {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -107,10 +107,11 @@ public class SpecialModelName {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Tag.java
@@ -107,10 +107,11 @@ public class Tag {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Tag.java
@@ -106,9 +106,11 @@ public class Tag {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Tag.java
@@ -105,8 +105,12 @@ public class Tag {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/TestInlineFreeformAdditionalPropertiesRequest.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/TestInlineFreeformAdditionalPropertiesRequest.java
@@ -83,10 +83,11 @@ public class TestInlineFreeformAdditionalPropertiesRequest {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/TestInlineFreeformAdditionalPropertiesRequest.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/TestInlineFreeformAdditionalPropertiesRequest.java
@@ -82,9 +82,11 @@ public class TestInlineFreeformAdditionalPropertiesRequest {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/TestInlineFreeformAdditionalPropertiesRequest.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/TestInlineFreeformAdditionalPropertiesRequest.java
@@ -81,8 +81,12 @@ public class TestInlineFreeformAdditionalPropertiesRequest {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/TriangleInterface.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/TriangleInterface.java
@@ -82,9 +82,11 @@ public class TriangleInterface {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/TriangleInterface.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/TriangleInterface.java
@@ -83,10 +83,11 @@ public class TriangleInterface {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/TriangleInterface.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/TriangleInterface.java
@@ -81,8 +81,12 @@ public class TriangleInterface {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/User.java
@@ -347,9 +347,11 @@ public class User {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/User.java
@@ -346,8 +346,12 @@ public class User {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/User.java
@@ -348,10 +348,11 @@ public class User {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Variable.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Variable.java
@@ -108,10 +108,11 @@ public class Variable {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Variable.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Variable.java
@@ -107,9 +107,11 @@ public class Variable {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Variable.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Variable.java
@@ -106,8 +106,12 @@ public class Variable {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Whale.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Whale.java
@@ -131,10 +131,11 @@ public class Whale {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Whale.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Whale.java
@@ -130,9 +130,11 @@ public class Whale {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Whale.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Whale.java
@@ -129,8 +129,12 @@ public class Whale {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Zebra.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Zebra.java
@@ -159,8 +159,12 @@ public class Zebra {
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
+   *
+   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
+   * it from gson's reflection keeps an allOf child (which also inherits the field from its
+   * parent) from declaring two JSON fields of one name.
    */
-  private Map<String, Object> additionalProperties;
+  private transient Map<String, Object> additionalProperties;
 
   /**
    * Set the additional (undeclared) property with the specified name and value.

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Zebra.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Zebra.java
@@ -160,9 +160,11 @@ public class Zebra {
    * This is a holder for any undeclared properties as specified with
    * the 'additionalProperties' keyword in the OAS document.
    *
-   * Transient: the bag is read and written by this model's TypeAdapterFactory, and hiding
-   * it from gson's reflection keeps an allOf child (which also inherits the field from its
-   * parent) from declaring two JSON fields of one name.
+   * Transient (on models without children): the bag is read and written by this model's
+   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
+   * also inherits the field from its parent) from declaring two JSON fields of one name.
+   * A parent with children has no factory of its own and keeps the field visible, which
+   * the child's transient declaration shadows.
    */
   private transient Map<String, Object> additionalProperties;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Zebra.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Zebra.java
@@ -161,10 +161,11 @@ public class Zebra {
    * the 'additionalProperties' keyword in the OAS document.
    *
    * Transient (on models without children): the bag is read and written by this model's
-   * TypeAdapterFactory, and hiding it from gson's reflection keeps an allOf child (which
-   * also inherits the field from its parent) from declaring two JSON fields of one name.
-   * A parent with children has no factory of its own and keeps the field visible, which
-   * the child's transient declaration shadows.
+   * TypeAdapterFactory, so gson's reflection does not need to see it. Gson collects the
+   * declared fields of every class in the hierarchy and rejects two bound to one JSON
+   * name, which is what an allOf child - declaring the field itself and inheriting it -
+   * used to hit. A parent with children has no factory of its own, so it keeps the field
+   * bound for reflection; the child excludes only its own copy, leaving exactly one.
    */
   private transient Map<String, Object> additionalProperties;
 


### PR DESCRIPTION
With `disallowAdditionalPropertiesIfNotPresent=false`, `additional_properties.mustache`
declares a private field in every okhttp-gson model:

```java
private Map<String, Object> additionalProperties;
```

An allOf child (`Child extends Person`) therefore declares the field twice: once itself,
once inherited. Gson refuses the class as soon as any code asks for its adapter,
*before* the model's own `CustomTypeAdapterFactory` can run:

```
java.lang.IllegalArgumentException: Class Child declares multiple JSON fields named
'additionalProperties'; conflict is caused by fields Child#additionalProperties and
Person#additionalProperties
```

The conflict surfaces on `gson.fromJson(element, Child.class)` and equally on
serialization, because the custom adapter's `getDelegateAdapter` chains to the reflective
factory, which walks both fields. **Every allOf child model is undeserializable under the flag.**
Clients largely get away with it because allOf hierarchies typically live in error bodies,
which are rarely deserialized into their models. I found it while running a generated client
whose discriminated error responses *are* deserialized, against a production registry API
on v7.15.0.

### The fix

Declare the bag once per inheritance hierarchy, on the topmost ancestor that has one, and let
every descendant inherit it:

- `JavaClientCodegen.postProcessAllModels` (okhttp-gson only) tags each model whose
  `parentModel` chain carries the bag with `x-inherits-additional-properties`.
- For those models, `additional_properties.mustache` declares neither the field nor its
  getters. It only overrides `putAdditionalProperty` to keep the covariant return type.
  `pojo.mustache` leaves the bag to `super.equals` / `super.hashCode` / `super.toString`.
- On the declaring model the field is `transient` when the model has no children. Its
  `CustomTypeAdapterFactory` reads and writes the bag explicitly around the reflective
  delegate, so reflection does not need to see it. A parent with children gets no factory
  (`{{^hasChildren}}` in `pojo.mustache`), so its field stays bound for reflection exactly as
  before.

Gson therefore sees exactly one `additionalProperties` field at any depth. A three-level chain
(`Root <- Middle <- Leaf`) is covered too, where marking only the leaf's copy `transient`
still left Root's and Middle's bound together.

One consequence needs handling. On a descendant the bag is inherited from a class that has
children, so the field is not `transient` and gson's reflective delegate binds it. An
undeclared property literally named `additionalProperties` therefore lands in the bag twice:
the delegate puts it there under its own name, and the descendant's adapter then collects it
again from the raw JSON, flattening its entries into the bag. Writing back emitted those
entries as top-level properties. The adapter now clears the delegate-bound bag right after
`fromJsonTree`, before the loop that collects the undeclared keys; the loop re-reads every
one of them from the raw JSON, so nothing is lost and the literal key round-trips as a
single entry.

Verified end to end: I generated and compiled a three-level client, and `JSON.getGson()`
deserializes and round-trips Root, Middle and Leaf. The leaf's undeclared properties land in
the inherited bag and serialize back out, and `equals`/`hashCode` still distinguish different
bags.

### Tests

`JavaClientCodegenTest#testAdditionalPropertiesFieldIsDeclaredOncePerHierarchyForGson`
(`3_0/allOf_extension_parent.yaml`, `Child extends Person`) and
`#testAdditionalPropertiesFieldIsDeclaredOnceAcrossMultiLevelAllOfForGson`
(new `3_0/java/okhttp-gson-additional-properties-allof-chain.yaml`, `Root <- Middle <- Leaf`)
assert that only the root declares the field, that descendants override
`putAdditionalProperty`, and that a descendant's adapter clears the inherited bag before
collecting the undeclared keys. Both fail without the change.

`JSONTest#testLiteralAdditionalPropertiesKeyRoundTripsOnAllOfChild` in the `okhttp-gson`
petstore sample covers the literal key at runtime: `{"className":"Dog","breed":"b",
"additionalProperties":{"x":1},"extra":"e"}` deserializes to the bag
`{additionalProperties={x=1.0}, extra=e}` and writes back with no top-level `x`.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Built the project and updated samples (`./bin/generate-samples.sh` for every okhttp-gson config).
      Flat models change only in the field's javadoc (and `transient`). allOf children such
      as `Cat`/`Dog` drop their own field and getters in favour of the inherited ones.
- [x] Technical committee: @bbdouglas @sreeshas @jfiala @lukoyanov @cbornet @jeff9finger @karismann @Zomzog @lwlee2608 @martin-mfg

---

Generated with Claude Code

