### PR TITLE
[rust] fix: map-typed query parameters do not compile (.to_string() on a HashMap)

### DIFF
--- a/modules/openapi-generator/src/main/resources/rust/reqwest-trait/api.mustache
+++ b/modules/openapi-generator/src/main/resources/rust/reqwest-trait/api.mustache
@@ -188,7 +188,12 @@ impl {{classname}} for {{classname}}Client {
         {{/isArray}}
         {{^isArray}}
         {{^isNullable}}
+        {{#isMap}}
+        local_var_req_builder = local_var_req_builder.query(&[("{{{baseName}}}", &serde_json::to_string(&{{{paramName}}})?)]);
+        {{/isMap}}
+        {{^isMap}}
         local_var_req_builder = local_var_req_builder.query(&[("{{{baseName}}}", &{{{paramName}}}.to_string())]);
+        {{/isMap}}
         {{/isNullable}}
         {{#isNullable}}
         {{#isDeepObject}}
@@ -228,9 +233,16 @@ impl {{classname}} for {{classname}}Client {
         {{/isModel}}
         {{^isObject}}
         {{^isModel}}
+        {{#isMap}}
+        if let Some(ref param_value) = {{{paramName}}} {
+            local_var_req_builder = local_var_req_builder.query(&[("{{{baseName}}}", &serde_json::to_string(param_value)?)]);
+        };
+        {{/isMap}}
+        {{^isMap}}
         if let Some(ref param_value) = {{{paramName}}} {
             local_var_req_builder = local_var_req_builder.query(&[("{{{baseName}}}", &param_value.to_string())]);
         };
+        {{/isMap}}
         {{/isModel}}
         {{/isObject}}
         {{/isDeepObject}}
@@ -273,7 +285,12 @@ impl {{classname}} for {{classname}}Client {
             {{/isModel}}
             {{^isObject}}
             {{^isModel}}
+            {{#isMap}}
+            local_var_req_builder = local_var_req_builder.query(&[("{{{baseName}}}", &serde_json::to_string(param_value)?)]);
+            {{/isMap}}
+            {{^isMap}}
             local_var_req_builder = local_var_req_builder.query(&[("{{{baseName}}}", &param_value.to_string())]);
+            {{/isMap}}
             {{/isModel}}
             {{/isObject}}
             {{/isDeepObject}}

--- a/modules/openapi-generator/src/main/resources/rust/reqwest/api.mustache
+++ b/modules/openapi-generator/src/main/resources/rust/reqwest/api.mustache
@@ -166,7 +166,12 @@ pub {{#supportAsync}}async {{/supportAsync}}fn {{{operationId}}}(configuration: 
     {{/isArray}}
     {{^isArray}}
     {{^isNullable}}
+    {{#isMap}}
+    req_builder = req_builder.query(&[("{{{baseName}}}", &serde_json::to_string(&{{{vendorExtensions.x-rust-param-identifier}}})?)]);
+    {{/isMap}}
+    {{^isMap}}
     req_builder = req_builder.query(&[("{{{baseName}}}", &{{{vendorExtensions.x-rust-param-identifier}}}.to_string())]);
+    {{/isMap}}
     {{/isNullable}}
     {{#isNullable}}
     {{#isDeepObject}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/rust/RustClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/rust/RustClientCodegenTest.java
@@ -294,6 +294,32 @@ public class RustClientCodegenTest {
     }
 
     @Test
+    public void testMapQueryParamsSerializeAsJson() throws IOException {
+        // HashMap implements neither Display nor ToString, so the .to_string() the templates
+        // emitted for a map-typed query parameter did not compile (E0599) - for a required map
+        // in both libraries, and for optional/nullable maps in reqwest-trait too
+        for (String library : new String[] {"reqwest", "reqwest-trait"}) {
+            Path target = Files.createTempDirectory("test");
+            target.toFile().deleteOnExit();
+            final CodegenConfigurator configurator = new CodegenConfigurator()
+                    .setGeneratorName("rust")
+                    .setLibrary(library)
+                    .setInputSpec("src/test/resources/3_0/rust/map-query-params.yaml")
+                    .setSkipOverwrite(false)
+                    .setOutputDir(target.toAbsolutePath().toString().replace("\\", "/"));
+            new DefaultGenerator().opts(configurator.toClientOptInput()).generate();
+            Path outputPath = Path.of(target.toString(), "/src/apis/default_api.rs");
+            TestUtils.assertFileExists(outputPath);
+            // the required and the optional map both serialize as one json-encoded parameter,
+            // like the other libraries' non-primitive parameters
+            TestUtils.assertFileContains(outputPath, "serde_json::to_string(&");
+            TestUtils.assertFileContains(outputPath, "(\"counts\", &serde_json::to_string(param_value)?)");
+            TestUtils.assertFileNotContains(outputPath, "labels.to_string()");
+            TestUtils.assertFileNotContains(outputPath, "param_value.to_string()");
+        }
+    }
+
+    @Test
     public void testArrayWithObjectEnumValues() throws IOException {
         Path target = Files.createTempDirectory("test");
         target.toFile().deleteOnExit();

--- a/modules/openapi-generator/src/test/resources/3_0/rust/map-query-params.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/rust/map-query-params.yaml
@@ -1,0 +1,25 @@
+openapi: 3.0.3
+info:
+  title: map query params
+  version: 1.0.0
+paths:
+  /items:
+    get:
+      operationId: listItems
+      parameters:
+        - name: labels
+          in: query
+          required: true
+          schema:
+            type: object
+            additionalProperties:
+              type: string
+        - name: counts
+          in: query
+          schema:
+            type: object
+            additionalProperties:
+              type: integer
+      responses:
+        '200':
+          description: ok


### PR DESCRIPTION
A map-typed query parameter (`type: object` with typed `additionalProperties`, generated as
`HashMap<String, T>`) falls through to the scalar query path in several template branches,
which call `.to_string()` on it. `HashMap` implements neither `Display` nor `ToString`, so
the generated crate does not compile:

```
error[E0599]: `HashMap<std::string::String, std::string::String>` doesn't implement `std::fmt::Display`
error[E0599]: the method `to_string` exists for reference `&HashMap<std::string::String, i32>`,
              but its trait bounds were not satisfied
```

The holes, from a spec with one required and one optional map parameter:

| branch | reqwest | reqwest-trait |
| --- | --- | --- |
| required, non-nullable | `.to_string()` — broken | `.to_string()` — broken |
| required, nullable, non-deepObject | non-primitive path, JSON-encoded — ok | `.to_string()` fallthrough — broken |
| optional, non-deepObject | non-primitive path, JSON-encoded — ok | `.to_string()` fallthrough — broken |
| deepObject + explode | handled (`parse_deep_object` / per-entry) | handled |

This was noted as a pre-existing, out-of-scope breakage in #24866's PR body; this is the
follow-up. Found generating a client from a production registry API whose listing filters
are map-typed.

### The fix

Add an `{{#isMap}}` split at each hole, serializing the map as one json-encoded parameter
with `serde_json::to_string` — exactly how reqwest's optional branch already handles
non-primitive parameters, so the optional-vs-required and reqwest-vs-reqwest-trait wire
behaviors now agree. No behavior change for any parameter that compiled before: a required
free-form map (`HashMap<String, serde_json::Value>`) moves from a broken `.to_string()` to
the same JSON text, and `serde_json::Value`'s `Display` was that JSON already.

### Tests

`RustClientCodegenTest#testMapQueryParamsSerializeAsJson` generates the new
`3_0/rust/map-query-params.yaml` fixture with both libraries and asserts the json-encoded
form with no `.to_string()` left on either parameter. Fails without the template changes
(verified by stashing only the templates).

Verified by `cargo build` of clients generated from the fixture: both libraries compile
clean with the fix and fail with E0599 without it.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Built the project and updated samples (`./bin/generate-samples.sh ./bin/configs/rust-*`):
      zero diffs across all 39 rust configs - no sample spec has a plain map-typed query
      parameter, which is how the breakage stayed unnoticed.
- [x] Technical committee (Rust): @frol @farcaller @richardwhiuk @paladinzh @jacob-pro @dsteeley

---

Generated with Claude Code


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Rust client codegen for map-typed query parameters, which previously emitted `.to_string()` on a `HashMap` (which doesn't implement `Display` or `ToString`), causing compilation errors in both `reqwest` and `reqwest-trait` libraries for required non-nullable maps, and optional/nullable maps in `reqwest-trait`. Now these serialize as a single JSON-encoded query parameter via `serde_json::to_string`, matching how non-primitive parameters are already handled. No behavior change for parameters that compiled before.

<sup>Written for commit 58b99b653aeefc7eb513aa9cd8c6f22cdcc8bfdd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24896?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

