### PR TITLE
[swift][swift6] fix: recursive schemas generate structs of infinite size

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/Swift5ClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/Swift5ClientCodegen.java
@@ -746,6 +746,7 @@ public class Swift5ClientCodegen extends DefaultCodegen implements CodegenConfig
     @Override
     public Map<String, ModelsMap> postProcessAllModels(Map<String, ModelsMap> objs) {
         objs = super.postProcessAllModels(objs);
+        markModelClassRendering(objs);
         if (additionalModelObjectAttributes.isEmpty()
                 && additionalModelEnumAttributes.isEmpty()
                 && additionalModelImports.isEmpty()) {
@@ -764,6 +765,73 @@ public class Swift5ClientCodegen extends DefaultCodegen implements CodegenConfig
             }
         }
         return objs;
+    }
+
+
+    /**
+     * A struct that stores itself inline - through any chain of model-typed properties,
+     * Optional included - has infinite size and does not compile ("value type cannot have a
+     * stored property that recursively contains it"). Containers store their elements on the
+     * heap and break the recursion, so only bare model-to-model properties form the edges.
+     * Every model on such a reference cycle is generated as a final class instead: heap
+     * allocation provides the indirection the struct cannot have, and the wire format is
+     * unchanged. See https://github.com/OpenAPITools/openapi-generator/issues/15240.
+     *
+     * @param objs the models
+     */
+    private void markModelClassRendering(Map<String, ModelsMap> objs) {
+        Map<String, CodegenModel> modelsByClassname = new HashMap<>();
+        for (ModelsMap modelsMap : objs.values()) {
+            for (ModelMap modelMap : modelsMap.getModels()) {
+                CodegenModel cm = modelMap.getModel();
+                modelsByClassname.put(cm.classname, cm);
+            }
+        }
+
+        Map<String, Set<String>> inlineRefs = new HashMap<>();
+        for (CodegenModel cm : modelsByClassname.values()) {
+            Set<String> refs = new LinkedHashSet<>();
+            collectInlineModelRefs(cm.allVars, modelsByClassname, refs);
+            if (cm.getComposedSchemas() != null) {
+                collectInlineModelRefs(cm.getComposedSchemas().getOneOf(), modelsByClassname, refs);
+                collectInlineModelRefs(cm.getComposedSchemas().getAnyOf(), modelsByClassname, refs);
+                collectInlineModelRefs(cm.getComposedSchemas().getAllOf(), modelsByClassname, refs);
+            }
+            inlineRefs.put(cm.classname, refs);
+        }
+
+        for (CodegenModel cm : modelsByClassname.values()) {
+            boolean recursive = !useClasses && isOnInlineReferenceCycle(cm.classname, inlineRefs);
+            if (useClasses || recursive) {
+                cm.vendorExtensions.put("x-swift-use-class", true);
+            }
+        }
+    }
+
+    private void collectInlineModelRefs(List<CodegenProperty> vars, Map<String, CodegenModel> modelsByClassname, Set<String> refs) {
+        if (vars == null) {
+            return;
+        }
+        for (CodegenProperty var : vars) {
+            if (!var.isContainer && var.complexType != null && modelsByClassname.containsKey(var.complexType)) {
+                refs.add(var.complexType);
+            }
+        }
+    }
+
+    private boolean isOnInlineReferenceCycle(String classname, Map<String, Set<String>> inlineRefs) {
+        Deque<String> toVisit = new ArrayDeque<>(inlineRefs.getOrDefault(classname, Collections.emptySet()));
+        Set<String> visited = new HashSet<>();
+        while (!toVisit.isEmpty()) {
+            String current = toVisit.pop();
+            if (classname.equals(current)) {
+                return true;
+            }
+            if (visited.add(current)) {
+                toVisit.addAll(inlineRefs.getOrDefault(current, Collections.emptySet()));
+            }
+        }
+        return false;
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/Swift5ClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/Swift5ClientCodegen.java
@@ -793,9 +793,10 @@ public class Swift5ClientCodegen extends DefaultCodegen implements CodegenConfig
             Set<String> refs = new LinkedHashSet<>();
             collectInlineModelRefs(cm.allVars, modelsByClassname, refs);
             if (cm.getComposedSchemas() != null) {
+                // oneOf/anyOf render as enums with inline associated values, so they carry the
+                // recursion; allOf is flattened into allVars and is deliberately not an edge
                 collectInlineModelRefs(cm.getComposedSchemas().getOneOf(), modelsByClassname, refs);
                 collectInlineModelRefs(cm.getComposedSchemas().getAnyOf(), modelsByClassname, refs);
-                collectInlineModelRefs(cm.getComposedSchemas().getAllOf(), modelsByClassname, refs);
             }
             inlineRefs.put(cm.classname, refs);
         }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/Swift6ClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/Swift6ClientCodegen.java
@@ -794,6 +794,7 @@ public class Swift6ClientCodegen extends DefaultCodegen implements CodegenConfig
     @Override
     public Map<String, ModelsMap> postProcessAllModels(Map<String, ModelsMap> objs) {
         objs = super.postProcessAllModels(objs);
+        markModelClassRendering(objs);
         if (additionalModelObjectAttributes.isEmpty()
                 && additionalModelEnumAttributes.isEmpty()
                 && additionalModelImports.isEmpty()) {
@@ -812,6 +813,79 @@ public class Swift6ClientCodegen extends DefaultCodegen implements CodegenConfig
             }
         }
         return objs;
+    }
+
+
+    /**
+     * A struct that stores itself inline - through any chain of model-typed properties,
+     * Optional included - has infinite size and does not compile ("value type cannot have a
+     * stored property that recursively contains it"). Containers store their elements on the
+     * heap and break the recursion, so only bare model-to-model properties form the edges.
+     * Every model on such a reference cycle is generated as a final class instead: heap
+     * allocation provides the indirection the struct cannot have, and the wire format is
+     * unchanged. See https://github.com/OpenAPITools/openapi-generator/issues/15240.
+     *
+     * @param objs the models
+     */
+    private void markModelClassRendering(Map<String, ModelsMap> objs) {
+        Map<String, CodegenModel> modelsByClassname = new HashMap<>();
+        for (ModelsMap modelsMap : objs.values()) {
+            for (ModelMap modelMap : modelsMap.getModels()) {
+                CodegenModel cm = modelMap.getModel();
+                modelsByClassname.put(cm.classname, cm);
+            }
+        }
+
+        Map<String, Set<String>> inlineRefs = new HashMap<>();
+        for (CodegenModel cm : modelsByClassname.values()) {
+            Set<String> refs = new LinkedHashSet<>();
+            collectInlineModelRefs(cm.allVars, modelsByClassname, refs);
+            if (cm.getComposedSchemas() != null) {
+                collectInlineModelRefs(cm.getComposedSchemas().getOneOf(), modelsByClassname, refs);
+                collectInlineModelRefs(cm.getComposedSchemas().getAnyOf(), modelsByClassname, refs);
+                collectInlineModelRefs(cm.getComposedSchemas().getAllOf(), modelsByClassname, refs);
+            }
+            inlineRefs.put(cm.classname, refs);
+        }
+
+        for (CodegenModel cm : modelsByClassname.values()) {
+            boolean recursive = !useClasses && isOnInlineReferenceCycle(cm.classname, inlineRefs);
+            if (useClasses || recursive) {
+                cm.vendorExtensions.put("x-swift-use-class", true);
+            }
+            if ((useClasses && readonlyProperties) || recursive) {
+                // a struct embedding one of these classes is still declared Sendable, so the
+                // class must conform; a recursion-breaking class is treated as unchecked the
+                // way readonlyProperties classes already are
+                cm.vendorExtensions.put("x-swift-unchecked-sendable", true);
+            }
+        }
+    }
+
+    private void collectInlineModelRefs(List<CodegenProperty> vars, Map<String, CodegenModel> modelsByClassname, Set<String> refs) {
+        if (vars == null) {
+            return;
+        }
+        for (CodegenProperty var : vars) {
+            if (!var.isContainer && var.complexType != null && modelsByClassname.containsKey(var.complexType)) {
+                refs.add(var.complexType);
+            }
+        }
+    }
+
+    private boolean isOnInlineReferenceCycle(String classname, Map<String, Set<String>> inlineRefs) {
+        Deque<String> toVisit = new ArrayDeque<>(inlineRefs.getOrDefault(classname, Collections.emptySet()));
+        Set<String> visited = new HashSet<>();
+        while (!toVisit.isEmpty()) {
+            String current = toVisit.pop();
+            if (classname.equals(current)) {
+                return true;
+            }
+            if (visited.add(current)) {
+                toVisit.addAll(inlineRefs.getOrDefault(current, Collections.emptySet()));
+            }
+        }
+        return false;
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/Swift6ClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/Swift6ClientCodegen.java
@@ -841,9 +841,10 @@ public class Swift6ClientCodegen extends DefaultCodegen implements CodegenConfig
             Set<String> refs = new LinkedHashSet<>();
             collectInlineModelRefs(cm.allVars, modelsByClassname, refs);
             if (cm.getComposedSchemas() != null) {
+                // oneOf/anyOf render as enums with inline associated values, so they carry the
+                // recursion; allOf is flattened into allVars and is deliberately not an edge
                 collectInlineModelRefs(cm.getComposedSchemas().getOneOf(), modelsByClassname, refs);
                 collectInlineModelRefs(cm.getComposedSchemas().getAnyOf(), modelsByClassname, refs);
-                collectInlineModelRefs(cm.getComposedSchemas().getAllOf(), modelsByClassname, refs);
             }
             inlineRefs.put(cm.classname, refs);
         }

--- a/modules/openapi-generator/src/main/resources/swift5/modelObject.mustache
+++ b/modules/openapi-generator/src/main/resources/swift5/modelObject.mustache
@@ -1,5 +1,5 @@
 {{#additionalModelObjectAttributes}}{{{.}}}
-{{/additionalModelObjectAttributes}}{{^objcCompatible}}{{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} {{#useClasses}}final class{{/useClasses}}{{^useClasses}}struct{{/useClasses}} {{{classname}}}: {{#useVapor}}Content{{/useVapor}}{{^useVapor}}Codable{{#useJsonEncodable}}, JSONEncodable{{/useJsonEncodable}}{{/useVapor}}{{#vendorExtensions.x-swift-hashable}}, Hashable{{/vendorExtensions.x-swift-hashable}} {
+{{/additionalModelObjectAttributes}}{{^objcCompatible}}{{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} {{#vendorExtensions.x-swift-use-class}}final class{{/vendorExtensions.x-swift-use-class}}{{^vendorExtensions.x-swift-use-class}}struct{{/vendorExtensions.x-swift-use-class}} {{{classname}}}: {{#useVapor}}Content{{/useVapor}}{{^useVapor}}Codable{{#useJsonEncodable}}, JSONEncodable{{/useJsonEncodable}}{{/useVapor}}{{#vendorExtensions.x-swift-hashable}}, Hashable{{/vendorExtensions.x-swift-hashable}} {
 {{/objcCompatible}}{{#objcCompatible}}@objcMembers {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} class {{classname}}: NSObject, Codable{{#useJsonEncodable}}, JSONEncodable{{/useJsonEncodable}} {
 {{/objcCompatible}}
 
@@ -121,7 +121,7 @@
         {{/allVars}}
         let additionalPropertiesContainer = try decoder.container(keyedBy: String.self)
         additionalProperties = try additionalPropertiesContainer.decodeMap({{{additionalPropertiesType}}}.self, excludedKeys: nonAdditionalPropertyKeys)
-    }{{/additionalPropertiesType}}{{/generateModelAdditionalProperties}}{{^objcCompatible}}{{#useClasses}}{{#vendorExtensions.x-swift-hashable}}
+    }{{/additionalPropertiesType}}{{/generateModelAdditionalProperties}}{{^objcCompatible}}{{#vendorExtensions.x-swift-use-class}}{{#vendorExtensions.x-swift-hashable}}
 
     {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} static func == (lhs: {{classname}}, rhs: {{classname}}) -> Bool {
         {{#allVars}}
@@ -135,5 +135,5 @@
         hasher.combine({{{name}}}{{^vendorExtensions.x-null-encodable}}{{^required}}?{{/required}}{{/vendorExtensions.x-null-encodable}}.hashValue)
         {{/allVars}}
         {{#generateModelAdditionalProperties}}{{#additionalPropertiesType}}hasher.combine(additionalProperties.hashValue){{/additionalPropertiesType}}{{/generateModelAdditionalProperties}}
-    }{{/vendorExtensions.x-swift-hashable}}{{/useClasses}}{{/objcCompatible}}
+    }{{/vendorExtensions.x-swift-hashable}}{{/vendorExtensions.x-swift-use-class}}{{/objcCompatible}}
 }

--- a/modules/openapi-generator/src/main/resources/swift6/modelObject.mustache
+++ b/modules/openapi-generator/src/main/resources/swift6/modelObject.mustache
@@ -1,5 +1,5 @@
 {{#additionalModelObjectAttributes}}{{{.}}}
-{{/additionalModelObjectAttributes}}{{^objcCompatible}}{{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} {{#useClasses}}final class{{/useClasses}}{{^useClasses}}struct{{/useClasses}} {{{classname}}}: {{^useClasses}}Sendable, {{/useClasses}}{{#useClasses}}{{#readonlyProperties}}@unchecked Sendable, {{/readonlyProperties}}{{/useClasses}}{{#useVapor}}Content{{/useVapor}}{{^useVapor}}Codable{{/useVapor}}{{#vendorExtensions.x-swift-hashable}}, Hashable{{/vendorExtensions.x-swift-hashable}} {
+{{/additionalModelObjectAttributes}}{{^objcCompatible}}{{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} {{#vendorExtensions.x-swift-use-class}}final class{{/vendorExtensions.x-swift-use-class}}{{^vendorExtensions.x-swift-use-class}}struct{{/vendorExtensions.x-swift-use-class}} {{{classname}}}: {{^vendorExtensions.x-swift-use-class}}Sendable, {{/vendorExtensions.x-swift-use-class}}{{#vendorExtensions.x-swift-unchecked-sendable}}@unchecked Sendable, {{/vendorExtensions.x-swift-unchecked-sendable}}{{#useVapor}}Content{{/useVapor}}{{^useVapor}}Codable{{/useVapor}}{{#vendorExtensions.x-swift-hashable}}, Hashable{{/vendorExtensions.x-swift-hashable}} {
 {{/objcCompatible}}{{#objcCompatible}}@objcMembers {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} final class {{classname}}: NSObject, Codable, @unchecked Sendable {
 {{/objcCompatible}}
 
@@ -121,7 +121,7 @@
         {{/allVars}}
         let additionalPropertiesContainer = try decoder.container(keyedBy: String.self)
         additionalProperties = try additionalPropertiesContainer.decodeMap({{{additionalPropertiesType}}}.self, excludedKeys: nonAdditionalPropertyKeys)
-    }{{/additionalPropertiesType}}{{/generateModelAdditionalProperties}}{{^objcCompatible}}{{#useClasses}}{{#vendorExtensions.x-swift-hashable}}
+    }{{/additionalPropertiesType}}{{/generateModelAdditionalProperties}}{{^objcCompatible}}{{#vendorExtensions.x-swift-use-class}}{{#vendorExtensions.x-swift-hashable}}
 
     {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} static func == (lhs: {{classname}}, rhs: {{classname}}) -> Bool {
         {{#allVars}}
@@ -135,5 +135,5 @@
         hasher.combine({{{name}}}{{^vendorExtensions.x-null-encodable}}{{^required}}?{{/required}}{{/vendorExtensions.x-null-encodable}}.hashValue)
         {{/allVars}}
         {{#generateModelAdditionalProperties}}{{#additionalPropertiesType}}hasher.combine(additionalProperties.hashValue){{/additionalPropertiesType}}{{/generateModelAdditionalProperties}}
-    }{{/vendorExtensions.x-swift-hashable}}{{/useClasses}}{{/objcCompatible}}
+    }{{/vendorExtensions.x-swift-hashable}}{{/vendorExtensions.x-swift-use-class}}{{/objcCompatible}}
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/swift5/Swift5ClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/swift5/Swift5ClientCodegenTest.java
@@ -266,6 +266,28 @@ public class Swift5ClientCodegenTest {
         Assert.assertEquals(podAuthors, openAPIDevs);
     }
 
+    @Test(description = "models on an inline reference cycle become classes, everything else stays a struct")
+    public void testRecursiveModelsBecomeClasses() throws IOException {
+        Path target = Files.createTempDirectory("test");
+        target.toFile().deleteOnExit();
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("swift5")
+                .setInputSpec("src/test/resources/3_0/swift/recursive-models.yaml")
+                .setOutputDir(target.toAbsolutePath().toString());
+        new DefaultGenerator().opts(configurator.toClientOptInput()).generate();
+
+        Path models = target.resolve("OpenAPIClient/Classes/OpenAPIs/Models");
+        // a struct that stores itself inline has infinite size and does not compile (#15240):
+        // the self-referencing model and both halves of the mutual cycle become final classes
+        TestUtils.assertFileContains(models.resolve("ContactInfo.swift"), "public final class ContactInfo:");
+        TestUtils.assertFileContains(models.resolve("NodeA.swift"), "public final class NodeA:");
+        TestUtils.assertFileContains(models.resolve("NodeB.swift"), "public final class NodeB:");
+        // embedding a cyclic class costs nothing, and containers already give heap
+        // indirection - these stay structs
+        TestUtils.assertFileContains(models.resolve("DomainInfo.swift"), "public struct DomainInfo:");
+        TestUtils.assertFileContains(models.resolve("Category.swift"), "public struct Category:");
+    }
+
     @Test(description = "Bug example code generation", enabled = true)
     public void crashSwift5ExampleCodeGenerationStackOverflowTest() throws IOException {
         //final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/bugs/Swift5CodeGenerationStackOverflow#2966.yaml");

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/swift6/Swift6ClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/swift6/Swift6ClientCodegenTest.java
@@ -52,6 +52,28 @@ public class Swift6ClientCodegenTest {
         Assert.assertEquals(swiftCodegen.toRegularExpression("/[a-z]/i"), "/[a-z]/i");
     }
 
+    @Test(description = "models on an inline reference cycle become classes, everything else stays a struct")
+    public void testRecursiveModelsBecomeClasses() throws IOException {
+        Path target = Files.createTempDirectory("test");
+        target.toFile().deleteOnExit();
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("swift6")
+                .setInputSpec("src/test/resources/3_0/swift/recursive-models.yaml")
+                .setOutputDir(target.toAbsolutePath().toString());
+        new DefaultGenerator().opts(configurator.toClientOptInput()).generate();
+
+        Path models = target.resolve("Sources/OpenAPIClient/Models");
+        // a struct that stores itself inline has infinite size and does not compile (#15240):
+        // the self-referencing model and both halves of the mutual cycle become final classes
+        TestUtils.assertFileContains(models.resolve("ContactInfo.swift"), "public final class ContactInfo: @unchecked Sendable,");
+        TestUtils.assertFileContains(models.resolve("NodeA.swift"), "public final class NodeA: @unchecked Sendable,");
+        TestUtils.assertFileContains(models.resolve("NodeB.swift"), "public final class NodeB: @unchecked Sendable,");
+        // embedding a cyclic class costs nothing, and containers already give heap
+        // indirection - these stay structs
+        TestUtils.assertFileContains(models.resolve("DomainInfo.swift"), "public struct DomainInfo: Sendable,");
+        TestUtils.assertFileContains(models.resolve("Category.swift"), "public struct Category: Sendable,");
+    }
+
     @Test(enabled = true)
     public void testCapitalizedReservedWord() throws Exception {
         Assert.assertEquals(swiftCodegen.toEnumVarName("AS", null), "_as");

--- a/modules/openapi-generator/src/test/resources/3_0/swift/recursive-models.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/swift/recursive-models.yaml
@@ -1,0 +1,50 @@
+openapi: 3.0.3
+info:
+  title: recursive models
+  version: 1.0.0
+paths:
+  /contacts:
+    get:
+      operationId: getContact
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DomainInfo'
+components:
+  schemas:
+    ContactInfo:
+      type: object
+      properties:
+        name:
+          type: string
+        internationalizedPostalInfo:
+          $ref: '#/components/schemas/ContactInfo'
+    DomainInfo:
+      type: object
+      properties:
+        domainName:
+          type: string
+        registrant:
+          $ref: '#/components/schemas/ContactInfo'
+    NodeA:
+      type: object
+      properties:
+        b:
+          $ref: '#/components/schemas/NodeB'
+    NodeB:
+      type: object
+      properties:
+        a:
+          $ref: '#/components/schemas/NodeA'
+    Category:
+      type: object
+      properties:
+        name:
+          type: string
+        children:
+          type: array
+          items:
+            $ref: '#/components/schemas/Category'


### PR DESCRIPTION
A self- or mutually-referencing schema generates a struct that stores itself inline —
through any chain of model-typed properties, `Optional` included — which has infinite size
and does not compile:

```
Models/ContactInfo.swift: error: value type 'ContactInfo' cannot have a stored property
that recursively contains it
Models/DomainInfo.swift: error: value type 'DomainInfo' has infinite size
```

Every struct that embeds the recursive one is infinite in turn (56 such errors against the
production registry API spec this was found on). The generators emit structs
unconditionally, so the only escape has been `useClasses=true`, which turns *every* model
into a class. This is #15240, open since swift5.

### The fix

`postProcessAllModels` builds the inline-reference graph — a property whose type is a bare
model reference is an edge; containers store their elements on the heap and break the
recursion, so arrays and dictionaries are not — and every model on a cycle is rendered as
a `final class` instead of a struct. Heap allocation provides the indirection the struct
cannot have; the wire format (Codable) is unchanged; every acyclic model stays a struct.
Applies to swift5 and swift6 both.

Two details:

- The struct/class choice in `modelObject.mustache` moves from the global `useClasses`
  flag to a per-model `x-swift-use-class` vendor extension that carries the global value —
  so `useClasses=true` behavior is untouched, and the four `useClasses` sample configs
  (urlsession + vapor, swift5 and swift6) regenerate **byte-identical**.
- In swift6, generated structs are `Sendable`, so a struct embedding a recursion-breaking
  class needs that class to conform: it is declared `@unchecked Sendable`, the way
  `useClasses` + `readonlyProperties` classes already are.

### Tests

`Swift5ClientCodegenTest`/`Swift6ClientCodegenTest#testRecursiveModelsBecomeClasses`
generate the new `3_0/swift/recursive-models.yaml` fixture (a self-reference, a mutual
cycle, a struct embedding the cyclic model, and an array-indirect self-reference) and
assert: the three cyclic models are `final class` (swift6: `@unchecked Sendable`), the
other two stay structs (swift6: `Sendable`). Fails without the change.

Verified end to end: clients generated from the fixture fail on master with exactly the
errors above and `swift build` clean with this change, swift5 and swift6 both.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Built the project and updated samples
      (`./bin/generate-samples.sh ./bin/configs/swift5-*.yaml ./bin/configs/swift6-*.yaml`):
      zero diffs — no sample spec has an inline reference cycle, and the `useClasses`
      samples are unchanged.
- [x] Technical committee: @jgavris @ehyche @Edubits @jaz-ah @4brunu @dydus0x14

---

Generated with Claude Code

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Swift codegen emitting structs of infinite size for self- or mutually-referencing schemas, which don't compile (#15240). Models on a reference cycle now render as `final class` instead; acyclic models stay structs and the wire format is unchanged.

**Details**
- Only bare model-to-model properties and oneOf/anyOf refs count as edges; containers and allOf break the recursion.
- The per-model class flag carries the global `useClasses` value, so existing `useClasses` samples regenerate byte-identical.
- Swift6 recursion-breaking classes are `@unchecked Sendable`, so the `Sendable` structs embedding them still conform.

<sup>Written for commit bb5244e02bcfbefe4aa5f605a0486ad20fca0868. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24898?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

