### PR TITLE
[kotlin-client] fix collection delimiter

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/infrastructure/ApiAbstractions.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/infrastructure/ApiAbstractions.kt.mustache
@@ -5,8 +5,8 @@ package {{packageName}}.infrastructure
 {{#nonPublicApi}}internal {{/nonPublicApi}}{{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}fun collectionDelimiter(collectionFormat: String): String = when(collectionFormat) {
     "csv" -> ","
     "tsv" -> "\t"
-    "pipe" -> "|"
-    "space" -> " "
+    "pipes" -> "|"
+    "ssv" -> " "
     else -> ""
 }
 

--- a/samples/client/echo_api/kotlin-jvm-okhttp/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
+++ b/samples/client/echo_api/kotlin-jvm-okhttp/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
@@ -5,8 +5,8 @@ typealias MultiValueMap = MutableMap<String,List<String>>
 fun collectionDelimiter(collectionFormat: String): String = when(collectionFormat) {
     "csv" -> ","
     "tsv" -> "\t"
-    "pipe" -> "|"
-    "space" -> " "
+    "pipes" -> "|"
+    "ssv" -> " "
     else -> ""
 }
 

--- a/samples/client/echo_api/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
+++ b/samples/client/echo_api/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
@@ -5,8 +5,8 @@ typealias MultiValueMap = MutableMap<String,List<String>>
 fun collectionDelimiter(collectionFormat: String): String = when(collectionFormat) {
     "csv" -> ","
     "tsv" -> "\t"
-    "pipe" -> "|"
-    "space" -> " "
+    "pipes" -> "|"
+    "ssv" -> " "
     else -> ""
 }
 

--- a/samples/client/echo_api/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
+++ b/samples/client/echo_api/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
@@ -5,8 +5,8 @@ typealias MultiValueMap = MutableMap<String,List<String>>
 fun collectionDelimiter(collectionFormat: String): String = when(collectionFormat) {
     "csv" -> ","
     "tsv" -> "\t"
-    "pipe" -> "|"
-    "space" -> " "
+    "pipes" -> "|"
+    "ssv" -> " "
     else -> ""
 }
 

--- a/samples/client/others/kotlin-integer-enum/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
+++ b/samples/client/others/kotlin-integer-enum/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
@@ -5,8 +5,8 @@ typealias MultiValueMap = MutableMap<String,List<String>>
 fun collectionDelimiter(collectionFormat: String): String = when(collectionFormat) {
     "csv" -> ","
     "tsv" -> "\t"
-    "pipe" -> "|"
-    "space" -> " "
+    "pipes" -> "|"
+    "ssv" -> " "
     else -> ""
 }
 

--- a/samples/client/others/kotlin-jvm-okhttp-non-ascii-headers/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
+++ b/samples/client/others/kotlin-jvm-okhttp-non-ascii-headers/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
@@ -5,8 +5,8 @@ typealias MultiValueMap = MutableMap<String,List<String>>
 fun collectionDelimiter(collectionFormat: String): String = when(collectionFormat) {
     "csv" -> ","
     "tsv" -> "\t"
-    "pipe" -> "|"
-    "space" -> " "
+    "pipes" -> "|"
+    "ssv" -> " "
     else -> ""
 }
 

--- a/samples/client/others/kotlin-jvm-okhttp-parameter-tests/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
+++ b/samples/client/others/kotlin-jvm-okhttp-parameter-tests/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
@@ -5,8 +5,8 @@ typealias MultiValueMap = MutableMap<String,List<String>>
 fun collectionDelimiter(collectionFormat: String): String = when(collectionFormat) {
     "csv" -> ","
     "tsv" -> "\t"
-    "pipe" -> "|"
-    "space" -> " "
+    "pipes" -> "|"
+    "ssv" -> " "
     else -> ""
 }
 

--- a/samples/client/others/kotlin-jvm-okhttp-path-comments/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
+++ b/samples/client/others/kotlin-jvm-okhttp-path-comments/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
@@ -5,8 +5,8 @@ typealias MultiValueMap = MutableMap<String,List<String>>
 fun collectionDelimiter(collectionFormat: String): String = when(collectionFormat) {
     "csv" -> ","
     "tsv" -> "\t"
-    "pipe" -> "|"
-    "space" -> " "
+    "pipes" -> "|"
+    "ssv" -> " "
     else -> ""
 }
 

--- a/samples/client/others/kotlin-jvm-spring-3-restclient-nullable-return/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
+++ b/samples/client/others/kotlin-jvm-spring-3-restclient-nullable-return/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
@@ -5,8 +5,8 @@ typealias MultiValueMap = MutableMap<String,List<String>>
 fun collectionDelimiter(collectionFormat: String): String = when(collectionFormat) {
     "csv" -> ","
     "tsv" -> "\t"
-    "pipe" -> "|"
-    "space" -> " "
+    "pipes" -> "|"
+    "ssv" -> " "
     else -> ""
 }
 

--- a/samples/client/petstore/kotlin-allOf-discriminator-kotlinx-serialization/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
+++ b/samples/client/petstore/kotlin-allOf-discriminator-kotlinx-serialization/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
@@ -5,8 +5,8 @@ typealias MultiValueMap = MutableMap<String,List<String>>
 fun collectionDelimiter(collectionFormat: String): String = when(collectionFormat) {
     "csv" -> ","
     "tsv" -> "\t"
-    "pipe" -> "|"
-    "space" -> " "
+    "pipes" -> "|"
+    "ssv" -> " "
     else -> ""
 }
 

--- a/samples/client/petstore/kotlin-allOf-discriminator/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
+++ b/samples/client/petstore/kotlin-allOf-discriminator/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
@@ -5,8 +5,8 @@ typealias MultiValueMap = MutableMap<String,List<String>>
 fun collectionDelimiter(collectionFormat: String): String = when(collectionFormat) {
     "csv" -> ","
     "tsv" -> "\t"
-    "pipe" -> "|"
-    "space" -> " "
+    "pipes" -> "|"
+    "ssv" -> " "
     else -> ""
 }
 

--- a/samples/client/petstore/kotlin-allOf-special-discriminator-kotlinx-serialization/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
+++ b/samples/client/petstore/kotlin-allOf-special-discriminator-kotlinx-serialization/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
@@ -5,8 +5,8 @@ typealias MultiValueMap = MutableMap<String,List<String>>
 fun collectionDelimiter(collectionFormat: String): String = when(collectionFormat) {
     "csv" -> ","
     "tsv" -> "\t"
-    "pipe" -> "|"
-    "space" -> " "
+    "pipes" -> "|"
+    "ssv" -> " "
     else -> ""
 }
 

--- a/samples/client/petstore/kotlin-array-integer-enum/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
+++ b/samples/client/petstore/kotlin-array-integer-enum/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
@@ -5,8 +5,8 @@ typealias MultiValueMap = MutableMap<String,List<String>>
 fun collectionDelimiter(collectionFormat: String): String = when(collectionFormat) {
     "csv" -> ","
     "tsv" -> "\t"
-    "pipe" -> "|"
-    "space" -> " "
+    "pipes" -> "|"
+    "ssv" -> " "
     else -> ""
 }
 

--- a/samples/client/petstore/kotlin-array-nullable-items-multiplatform/src/commonMain/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
+++ b/samples/client/petstore/kotlin-array-nullable-items-multiplatform/src/commonMain/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
@@ -5,8 +5,8 @@ typealias MultiValueMap = MutableMap<String,List<String>>
 fun collectionDelimiter(collectionFormat: String): String = when(collectionFormat) {
     "csv" -> ","
     "tsv" -> "\t"
-    "pipe" -> "|"
-    "space" -> " "
+    "pipes" -> "|"
+    "ssv" -> " "
     else -> ""
 }
 

--- a/samples/client/petstore/kotlin-array-nullable-items/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
+++ b/samples/client/petstore/kotlin-array-nullable-items/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
@@ -5,8 +5,8 @@ typealias MultiValueMap = MutableMap<String,List<String>>
 fun collectionDelimiter(collectionFormat: String): String = when(collectionFormat) {
     "csv" -> ","
     "tsv" -> "\t"
-    "pipe" -> "|"
-    "space" -> " "
+    "pipes" -> "|"
+    "ssv" -> " "
     else -> ""
 }
 

--- a/samples/client/petstore/kotlin-array-simple-string-jvm-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
+++ b/samples/client/petstore/kotlin-array-simple-string-jvm-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
@@ -5,8 +5,8 @@ typealias MultiValueMap = MutableMap<String,List<String>>
 fun collectionDelimiter(collectionFormat: String): String = when(collectionFormat) {
     "csv" -> ","
     "tsv" -> "\t"
-    "pipe" -> "|"
-    "space" -> " "
+    "pipes" -> "|"
+    "ssv" -> " "
     else -> ""
 }
 

--- a/samples/client/petstore/kotlin-array-simple-string-multiplatform/src/commonMain/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
+++ b/samples/client/petstore/kotlin-array-simple-string-multiplatform/src/commonMain/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
@@ -5,8 +5,8 @@ typealias MultiValueMap = MutableMap<String,List<String>>
 fun collectionDelimiter(collectionFormat: String): String = when(collectionFormat) {
     "csv" -> ","
     "tsv" -> "\t"
-    "pipe" -> "|"
-    "space" -> " "
+    "pipes" -> "|"
+    "ssv" -> " "
     else -> ""
 }
 

--- a/samples/client/petstore/kotlin-bigdecimal-default-multiplatform/src/commonMain/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
+++ b/samples/client/petstore/kotlin-bigdecimal-default-multiplatform/src/commonMain/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
@@ -5,8 +5,8 @@ typealias MultiValueMap = MutableMap<String,List<String>>
 fun collectionDelimiter(collectionFormat: String): String = when(collectionFormat) {
     "csv" -> ","
     "tsv" -> "\t"
-    "pipe" -> "|"
-    "space" -> " "
+    "pipes" -> "|"
+    "ssv" -> " "
     else -> ""
 }
 

--- a/samples/client/petstore/kotlin-bigdecimal-default-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
+++ b/samples/client/petstore/kotlin-bigdecimal-default-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
@@ -5,8 +5,8 @@ typealias MultiValueMap = MutableMap<String,List<String>>
 fun collectionDelimiter(collectionFormat: String): String = when(collectionFormat) {
     "csv" -> ","
     "tsv" -> "\t"
-    "pipe" -> "|"
-    "space" -> " "
+    "pipes" -> "|"
+    "ssv" -> " "
     else -> ""
 }
 

--- a/samples/client/petstore/kotlin-default-values-jvm-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
+++ b/samples/client/petstore/kotlin-default-values-jvm-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
@@ -5,8 +5,8 @@ typealias MultiValueMap = MutableMap<String,List<String>>
 fun collectionDelimiter(collectionFormat: String): String = when(collectionFormat) {
     "csv" -> ","
     "tsv" -> "\t"
-    "pipe" -> "|"
-    "space" -> " "
+    "pipes" -> "|"
+    "ssv" -> " "
     else -> ""
 }
 

--- a/samples/client/petstore/kotlin-default-values-multiplatform/src/commonMain/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
+++ b/samples/client/petstore/kotlin-default-values-multiplatform/src/commonMain/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
@@ -5,8 +5,8 @@ typealias MultiValueMap = MutableMap<String,List<String>>
 fun collectionDelimiter(collectionFormat: String): String = when(collectionFormat) {
     "csv" -> ","
     "tsv" -> "\t"
-    "pipe" -> "|"
-    "space" -> " "
+    "pipes" -> "|"
+    "ssv" -> " "
     else -> ""
 }
 

--- a/samples/client/petstore/kotlin-enum-default-value/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
+++ b/samples/client/petstore/kotlin-enum-default-value/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
@@ -5,8 +5,8 @@ typealias MultiValueMap = MutableMap<String,List<String>>
 fun collectionDelimiter(collectionFormat: String): String = when(collectionFormat) {
     "csv" -> ","
     "tsv" -> "\t"
-    "pipe" -> "|"
-    "space" -> " "
+    "pipes" -> "|"
+    "ssv" -> " "
     else -> ""
 }
 

--- a/samples/client/petstore/kotlin-enum-integers-multiplatform/src/commonMain/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
+++ b/samples/client/petstore/kotlin-enum-integers-multiplatform/src/commonMain/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
@@ -5,8 +5,8 @@ typealias MultiValueMap = MutableMap<String,List<String>>
 fun collectionDelimiter(collectionFormat: String): String = when(collectionFormat) {
     "csv" -> ","
     "tsv" -> "\t"
-    "pipe" -> "|"
-    "space" -> " "
+    "pipes" -> "|"
+    "ssv" -> " "
     else -> ""
 }
 

--- a/samples/client/petstore/kotlin-explicit/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
+++ b/samples/client/petstore/kotlin-explicit/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
@@ -5,8 +5,8 @@ public typealias MultiValueMap = MutableMap<String,List<String>>
 public fun collectionDelimiter(collectionFormat: String): String = when(collectionFormat) {
     "csv" -> ","
     "tsv" -> "\t"
-    "pipe" -> "|"
-    "space" -> " "
+    "pipes" -> "|"
+    "ssv" -> " "
     else -> ""
 }
 

--- a/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
+++ b/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
@@ -5,8 +5,8 @@ typealias MultiValueMap = MutableMap<String,List<String>>
 fun collectionDelimiter(collectionFormat: String): String = when(collectionFormat) {
     "csv" -> ","
     "tsv" -> "\t"
-    "pipe" -> "|"
-    "space" -> " "
+    "pipes" -> "|"
+    "ssv" -> " "
     else -> ""
 }
 

--- a/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
+++ b/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
@@ -5,8 +5,8 @@ typealias MultiValueMap = MutableMap<String,List<String>>
 fun collectionDelimiter(collectionFormat: String): String = when(collectionFormat) {
     "csv" -> ","
     "tsv" -> "\t"
-    "pipe" -> "|"
-    "space" -> " "
+    "pipes" -> "|"
+    "ssv" -> " "
     else -> ""
 }
 

--- a/samples/client/petstore/kotlin-jackson3/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
+++ b/samples/client/petstore/kotlin-jackson3/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
@@ -5,8 +5,8 @@ typealias MultiValueMap = MutableMap<String,List<String>>
 fun collectionDelimiter(collectionFormat: String): String = when(collectionFormat) {
     "csv" -> ","
     "tsv" -> "\t"
-    "pipe" -> "|"
-    "space" -> " "
+    "pipes" -> "|"
+    "ssv" -> " "
     else -> ""
 }
 

--- a/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
+++ b/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
@@ -5,8 +5,8 @@ typealias MultiValueMap = MutableMap<String,List<String>>
 fun collectionDelimiter(collectionFormat: String): String = when(collectionFormat) {
     "csv" -> ","
     "tsv" -> "\t"
-    "pipe" -> "|"
-    "space" -> " "
+    "pipes" -> "|"
+    "ssv" -> " "
     else -> ""
 }
 

--- a/samples/client/petstore/kotlin-jvm-ktor-gson/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
+++ b/samples/client/petstore/kotlin-jvm-ktor-gson/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
@@ -5,8 +5,8 @@ typealias MultiValueMap = MutableMap<String,List<String>>
 fun collectionDelimiter(collectionFormat: String): String = when(collectionFormat) {
     "csv" -> ","
     "tsv" -> "\t"
-    "pipe" -> "|"
-    "space" -> " "
+    "pipes" -> "|"
+    "ssv" -> " "
     else -> ""
 }
 

--- a/samples/client/petstore/kotlin-jvm-ktor-jackson/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
+++ b/samples/client/petstore/kotlin-jvm-ktor-jackson/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
@@ -5,8 +5,8 @@ typealias MultiValueMap = MutableMap<String,List<String>>
 fun collectionDelimiter(collectionFormat: String): String = when(collectionFormat) {
     "csv" -> ","
     "tsv" -> "\t"
-    "pipe" -> "|"
-    "space" -> " "
+    "pipes" -> "|"
+    "ssv" -> " "
     else -> ""
 }
 

--- a/samples/client/petstore/kotlin-jvm-ktor-kotlinx_serialization/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
+++ b/samples/client/petstore/kotlin-jvm-ktor-kotlinx_serialization/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
@@ -5,8 +5,8 @@ typealias MultiValueMap = MutableMap<String,List<String>>
 fun collectionDelimiter(collectionFormat: String): String = when(collectionFormat) {
     "csv" -> ","
     "tsv" -> "\t"
-    "pipe" -> "|"
-    "space" -> " "
+    "pipes" -> "|"
+    "ssv" -> " "
     else -> ""
 }
 

--- a/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
+++ b/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
@@ -5,8 +5,8 @@ typealias MultiValueMap = MutableMap<String,List<String>>
 fun collectionDelimiter(collectionFormat: String): String = when(collectionFormat) {
     "csv" -> ","
     "tsv" -> "\t"
-    "pipe" -> "|"
-    "space" -> " "
+    "pipes" -> "|"
+    "ssv" -> " "
     else -> ""
 }
 

--- a/samples/client/petstore/kotlin-jvm-spring-2-webclient/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-2-webclient/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
@@ -5,8 +5,8 @@ typealias MultiValueMap = MutableMap<String,List<String>>
 fun collectionDelimiter(collectionFormat: String): String = when(collectionFormat) {
     "csv" -> ","
     "tsv" -> "\t"
-    "pipe" -> "|"
-    "space" -> " "
+    "pipes" -> "|"
+    "ssv" -> " "
     else -> ""
 }
 

--- a/samples/client/petstore/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
@@ -5,8 +5,8 @@ typealias MultiValueMap = MutableMap<String,List<String>>
 fun collectionDelimiter(collectionFormat: String): String = when(collectionFormat) {
     "csv" -> ","
     "tsv" -> "\t"
-    "pipe" -> "|"
-    "space" -> " "
+    "pipes" -> "|"
+    "ssv" -> " "
     else -> ""
 }
 

--- a/samples/client/petstore/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
@@ -5,8 +5,8 @@ typealias MultiValueMap = MutableMap<String,List<String>>
 fun collectionDelimiter(collectionFormat: String): String = when(collectionFormat) {
     "csv" -> ","
     "tsv" -> "\t"
-    "pipe" -> "|"
-    "space" -> " "
+    "pipes" -> "|"
+    "ssv" -> " "
     else -> ""
 }
 

--- a/samples/client/petstore/kotlin-jvm-spring-4-restclient-jackson3/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-4-restclient-jackson3/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
@@ -5,8 +5,8 @@ typealias MultiValueMap = MutableMap<String,List<String>>
 fun collectionDelimiter(collectionFormat: String): String = when(collectionFormat) {
     "csv" -> ","
     "tsv" -> "\t"
-    "pipe" -> "|"
-    "space" -> " "
+    "pipes" -> "|"
+    "ssv" -> " "
     else -> ""
 }
 

--- a/samples/client/petstore/kotlin-jvm-vertx-gson/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
+++ b/samples/client/petstore/kotlin-jvm-vertx-gson/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
@@ -5,8 +5,8 @@ typealias MultiValueMap = MutableMap<String,List<String>>
 fun collectionDelimiter(collectionFormat: String): String = when(collectionFormat) {
     "csv" -> ","
     "tsv" -> "\t"
-    "pipe" -> "|"
-    "space" -> " "
+    "pipes" -> "|"
+    "ssv" -> " "
     else -> ""
 }
 

--- a/samples/client/petstore/kotlin-jvm-vertx-jackson-coroutines/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
+++ b/samples/client/petstore/kotlin-jvm-vertx-jackson-coroutines/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
@@ -5,8 +5,8 @@ typealias MultiValueMap = MutableMap<String,List<String>>
 fun collectionDelimiter(collectionFormat: String): String = when(collectionFormat) {
     "csv" -> ","
     "tsv" -> "\t"
-    "pipe" -> "|"
-    "space" -> " "
+    "pipes" -> "|"
+    "ssv" -> " "
     else -> ""
 }
 

--- a/samples/client/petstore/kotlin-jvm-vertx-jackson/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
+++ b/samples/client/petstore/kotlin-jvm-vertx-jackson/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
@@ -5,8 +5,8 @@ typealias MultiValueMap = MutableMap<String,List<String>>
 fun collectionDelimiter(collectionFormat: String): String = when(collectionFormat) {
     "csv" -> ","
     "tsv" -> "\t"
-    "pipe" -> "|"
-    "space" -> " "
+    "pipes" -> "|"
+    "ssv" -> " "
     else -> ""
 }
 

--- a/samples/client/petstore/kotlin-jvm-vertx-moshi/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
+++ b/samples/client/petstore/kotlin-jvm-vertx-moshi/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
@@ -5,8 +5,8 @@ typealias MultiValueMap = MutableMap<String,List<String>>
 fun collectionDelimiter(collectionFormat: String): String = when(collectionFormat) {
     "csv" -> ","
     "tsv" -> "\t"
-    "pipe" -> "|"
-    "space" -> " "
+    "pipes" -> "|"
+    "ssv" -> " "
     else -> ""
 }
 

--- a/samples/client/petstore/kotlin-kotlinx-datetime/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
+++ b/samples/client/petstore/kotlin-kotlinx-datetime/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
@@ -5,8 +5,8 @@ typealias MultiValueMap = MutableMap<String,List<String>>
 fun collectionDelimiter(collectionFormat: String): String = when(collectionFormat) {
     "csv" -> ","
     "tsv" -> "\t"
-    "pipe" -> "|"
-    "space" -> " "
+    "pipes" -> "|"
+    "ssv" -> " "
     else -> ""
 }
 

--- a/samples/client/petstore/kotlin-modelMutable/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
+++ b/samples/client/petstore/kotlin-modelMutable/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
@@ -5,8 +5,8 @@ typealias MultiValueMap = MutableMap<String,List<String>>
 fun collectionDelimiter(collectionFormat: String): String = when(collectionFormat) {
     "csv" -> ","
     "tsv" -> "\t"
-    "pipe" -> "|"
-    "space" -> " "
+    "pipes" -> "|"
+    "ssv" -> " "
     else -> ""
 }
 

--- a/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
+++ b/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
@@ -5,8 +5,8 @@ typealias MultiValueMap = MutableMap<String,List<String>>
 fun collectionDelimiter(collectionFormat: String): String = when(collectionFormat) {
     "csv" -> ","
     "tsv" -> "\t"
-    "pipe" -> "|"
-    "space" -> " "
+    "pipes" -> "|"
+    "ssv" -> " "
     else -> ""
 }
 

--- a/samples/client/petstore/kotlin-multiplatform-allOf-discriminator/src/commonMain/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
+++ b/samples/client/petstore/kotlin-multiplatform-allOf-discriminator/src/commonMain/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
@@ -5,8 +5,8 @@ typealias MultiValueMap = MutableMap<String,List<String>>
 fun collectionDelimiter(collectionFormat: String): String = when(collectionFormat) {
     "csv" -> ","
     "tsv" -> "\t"
-    "pipe" -> "|"
-    "space" -> " "
+    "pipes" -> "|"
+    "ssv" -> " "
     else -> ""
 }
 

--- a/samples/client/petstore/kotlin-multiplatform-allOf-special-discriminator/src/commonMain/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
+++ b/samples/client/petstore/kotlin-multiplatform-allOf-special-discriminator/src/commonMain/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
@@ -5,8 +5,8 @@ typealias MultiValueMap = MutableMap<String,List<String>>
 fun collectionDelimiter(collectionFormat: String): String = when(collectionFormat) {
     "csv" -> ","
     "tsv" -> "\t"
-    "pipe" -> "|"
-    "space" -> " "
+    "pipes" -> "|"
+    "ssv" -> " "
     else -> ""
 }
 

--- a/samples/client/petstore/kotlin-multiplatform-kotlinx-datetime/src/commonMain/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
+++ b/samples/client/petstore/kotlin-multiplatform-kotlinx-datetime/src/commonMain/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
@@ -5,8 +5,8 @@ typealias MultiValueMap = MutableMap<String,List<String>>
 fun collectionDelimiter(collectionFormat: String): String = when(collectionFormat) {
     "csv" -> ","
     "tsv" -> "\t"
-    "pipe" -> "|"
-    "space" -> " "
+    "pipes" -> "|"
+    "ssv" -> " "
     else -> ""
 }
 

--- a/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
+++ b/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
@@ -5,8 +5,8 @@ typealias MultiValueMap = MutableMap<String,List<String>>
 fun collectionDelimiter(collectionFormat: String): String = when(collectionFormat) {
     "csv" -> ","
     "tsv" -> "\t"
-    "pipe" -> "|"
-    "space" -> " "
+    "pipes" -> "|"
+    "ssv" -> " "
     else -> ""
 }
 

--- a/samples/client/petstore/kotlin-name-parameter-mappings/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
+++ b/samples/client/petstore/kotlin-name-parameter-mappings/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
@@ -5,8 +5,8 @@ typealias MultiValueMap = MutableMap<String,List<String>>
 fun collectionDelimiter(collectionFormat: String): String = when(collectionFormat) {
     "csv" -> ","
     "tsv" -> "\t"
-    "pipe" -> "|"
-    "space" -> " "
+    "pipes" -> "|"
+    "ssv" -> " "
     else -> ""
 }
 

--- a/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
+++ b/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
@@ -5,8 +5,8 @@ internal typealias MultiValueMap = MutableMap<String,List<String>>
 internal fun collectionDelimiter(collectionFormat: String): String = when(collectionFormat) {
     "csv" -> ","
     "tsv" -> "\t"
-    "pipe" -> "|"
-    "space" -> " "
+    "pipes" -> "|"
+    "ssv" -> " "
     else -> ""
 }
 

--- a/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
+++ b/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
@@ -5,8 +5,8 @@ typealias MultiValueMap = MutableMap<String,List<String>>
 fun collectionDelimiter(collectionFormat: String): String = when(collectionFormat) {
     "csv" -> ","
     "tsv" -> "\t"
-    "pipe" -> "|"
-    "space" -> " "
+    "pipes" -> "|"
+    "ssv" -> " "
     else -> ""
 }
 

--- a/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
+++ b/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
@@ -5,8 +5,8 @@ typealias MultiValueMap = MutableMap<String,List<String>>
 fun collectionDelimiter(collectionFormat: String): String = when(collectionFormat) {
     "csv" -> ","
     "tsv" -> "\t"
-    "pipe" -> "|"
-    "space" -> " "
+    "pipes" -> "|"
+    "ssv" -> " "
     else -> ""
 }
 

--- a/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
+++ b/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
@@ -5,8 +5,8 @@ typealias MultiValueMap = MutableMap<String,List<String>>
 fun collectionDelimiter(collectionFormat: String): String = when(collectionFormat) {
     "csv" -> ","
     "tsv" -> "\t"
-    "pipe" -> "|"
-    "space" -> " "
+    "pipes" -> "|"
+    "ssv" -> " "
     else -> ""
 }
 

--- a/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
+++ b/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
@@ -5,8 +5,8 @@ typealias MultiValueMap = MutableMap<String,List<String>>
 fun collectionDelimiter(collectionFormat: String): String = when(collectionFormat) {
     "csv" -> ","
     "tsv" -> "\t"
-    "pipe" -> "|"
-    "space" -> " "
+    "pipes" -> "|"
+    "ssv" -> " "
     else -> ""
 }
 

--- a/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
@@ -5,8 +5,8 @@ typealias MultiValueMap = MutableMap<String,List<String>>
 fun collectionDelimiter(collectionFormat: String): String = when(collectionFormat) {
     "csv" -> ","
     "tsv" -> "\t"
-    "pipe" -> "|"
-    "space" -> " "
+    "pipes" -> "|"
+    "ssv" -> " "
     else -> ""
 }
 


### PR DESCRIPTION
The collection delimiter was mismatched. [`DefaultCodegen.getCollectionFormat()`](https://github.com/OpenAPITools/openapi-generator/blob/master/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java#L7713) returns `pipes`, but the Kotlin template used `pipe`.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@karismann @Zomzog @andrewemery @4brunu @yutaka0m @stefankoppier @e5l 