### PR TITLE
[spring] fix schema named "Schema" colliding with the swagger2 annotation

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java
@@ -115,6 +115,15 @@ public class SpringCodegen extends AbstractJavaCodegen
     public static final String USE_SEALED = "useSealed";
     public static final String OPTIONAL_ACCEPT_NULLABLE = "optionalAcceptNullable";
     public static final String USE_SPRING_BUILT_IN_VALIDATION = "useSpringBuiltInValidation";
+
+    /** Default importMapping value registered by {@link AbstractJavaCodegen} for the swagger2 annotation. */
+    private static final String SWAGGER2_ANNOTATION_SCHEMA_IMPORT = "io.swagger.v3.oas.annotations.media.Schema";
+
+    /** Simple or fully-qualified name to use at swagger2 {@code @Schema} annotation usage sites. */
+    private static final String SCHEMA_ANNOTATION = "swagger2SchemaAnnotation";
+
+    /** Whether templates should emit the single-type import for the swagger2 {@code @Schema} annotation. */
+    private static final String IMPORT_SCHEMA_ANNOTATION = "importSwagger2SchemaAnnotation";
     public static final String SPRING_API_VERSION = "springApiVersion";
     public static final String USE_JACKSON_3 = "useJackson3";
     public static final String JACKSON2_PACKAGE = "com.fasterxml.jackson";
@@ -937,9 +946,43 @@ public class SpringCodegen extends AbstractJavaCodegen
 
     }
 
+    /**
+     * Whether any schema in the document produces the given generated model name.
+     * Compared against {@link #toModelName(String)} so modelNamePrefix/modelNameSuffix are honoured.
+     */
+    private boolean hasModelNamed(OpenAPI openAPI, String modelName) {
+        if (openAPI == null || openAPI.getComponents() == null || openAPI.getComponents().getSchemas() == null) {
+            return false;
+        }
+        return openAPI.getComponents().getSchemas().keySet().stream()
+                .anyMatch(schemaName -> modelName.equals(toModelName(schemaName)));
+    }
+
     @Override
     public void preprocessOpenAPI(OpenAPI openAPI) {
         super.preprocessOpenAPI(openAPI);
+
+        // A schema named "Schema" collides with io.swagger.v3.oas.annotations.media.Schema. Two
+        // problems follow:
+        //   1. AbstractJavaCodegen registers "Schema" -> the annotation FQN in importMapping, and
+        //      importMapping is consulted before toModelImport(), so the model import is silently
+        //      replaced by the annotation import. The bare "Schema" type in api signatures then
+        //      resolves to the annotation instead of the model.
+        //   2. Emitting the model import alongside the annotation import the templates add is a
+        //      compile error: two single-type imports for the same simple name (JLS 7.5.1). In the
+        //      model file the declared class shadows the import for the same reason.
+        // Let the model keep the simple name and fully qualify the annotation at its usage sites
+        // instead of importing it. An explicit --import-mappings entry for "Schema" carries a
+        // different value and is deliberately left untouched.
+        additionalProperties.put(SCHEMA_ANNOTATION, "Schema");
+        additionalProperties.put(IMPORT_SCHEMA_ANNOTATION, true);
+        if (hasModelNamed(openAPI, "Schema")) {
+            if (SWAGGER2_ANNOTATION_SCHEMA_IMPORT.equals(importMapping.get("Schema"))) {
+                importMapping.remove("Schema");
+            }
+            additionalProperties.put(SCHEMA_ANNOTATION, SWAGGER2_ANNOTATION_SCHEMA_IMPORT);
+            additionalProperties.put(IMPORT_SCHEMA_ANNOTATION, false);
+        }
 
         if (SPRING_BOOT.equals(library) && ModelUtils.containsEnums(this.openAPI)) {
             supportingFiles.add(new SupportingFile("converter.mustache",

--- a/modules/openapi-generator/src/main/resources/JavaSpring/api.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/api.mustache
@@ -14,7 +14,9 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
+{{#importSwagger2SchemaAnnotation}}
 import io.swagger.v3.oas.annotations.media.Schema;
+{{/importSwagger2SchemaAnnotation}}
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -187,7 +189,7 @@ public interface {{classname}} {
             {{#responses}}
             @ApiResponse(responseCode = {{#isDefault}}"default"{{/isDefault}}{{^isDefault}}"{{{code}}}"{{/isDefault}}, description = "{{{message}}}"{{#baseType}}, content = {
                 {{#produces}}
-                @Content(mediaType = "{{{mediaType}}}", {{#isArray}}array = @ArraySchema({{/isArray}}schema = @Schema(implementation = {{{baseType}}}.class){{#isArray}}){{/isArray}}{{^isJson}}){{^-last}},{{/-last}}{{/isJson}}{{#isJson}}{{^examples.0}}){{^-last}},{{/-last}}{{/examples.0}}{{#examples.0}}, examples = {
+                @Content(mediaType = "{{{mediaType}}}", {{#isArray}}array = @ArraySchema({{/isArray}}schema = @{{swagger2SchemaAnnotation}}(implementation = {{{baseType}}}.class){{#isArray}}){{/isArray}}{{^isJson}}){{^-last}},{{/-last}}{{/isJson}}{{#isJson}}{{^examples.0}}){{^-last}},{{/-last}}{{/examples.0}}{{#examples.0}}, examples = {
                 {{#examples}}
                     @ExampleObject(
                         name = "{{{exampleName}}}",

--- a/modules/openapi-generator/src/main/resources/JavaSpring/apiController.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/apiController.mustache
@@ -8,7 +8,9 @@ package {{package}};
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
+{{#importSwagger2SchemaAnnotation}}
 import io.swagger.v3.oas.annotations.media.Schema;
+{{/importSwagger2SchemaAnnotation}}
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;

--- a/modules/openapi-generator/src/main/resources/JavaSpring/lombokAnnotation.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/lombokAnnotation.mustache
@@ -21,7 +21,7 @@
     {{/required}}
   {{/useBeanValidation}}
   {{#swagger2AnnotationLibrary}}
-  @Schema(name = "{{{baseName}}}"{{#isReadOnly}}, accessMode = Schema.AccessMode.READ_ONLY{{/isReadOnly}}{{#example}}, example = "{{{.}}}"{{/example}}{{#description}}, description = "{{{.}}}"{{/description}}{{#deprecated}}, deprecated = true{{/deprecated}}, requiredMode = {{#required}}Schema.RequiredMode.REQUIRED{{/required}}{{^required}}Schema.RequiredMode.NOT_REQUIRED{{/required}})
+  @{{swagger2SchemaAnnotation}}(name = "{{{baseName}}}"{{#isReadOnly}}, accessMode = {{swagger2SchemaAnnotation}}.AccessMode.READ_ONLY{{/isReadOnly}}{{#example}}, example = "{{{.}}}"{{/example}}{{#description}}, description = "{{{.}}}"{{/description}}{{#deprecated}}, deprecated = true{{/deprecated}}, requiredMode = {{#required}}{{swagger2SchemaAnnotation}}.RequiredMode.REQUIRED{{/required}}{{^required}}{{swagger2SchemaAnnotation}}.RequiredMode.NOT_REQUIRED{{/required}})
   {{/swagger2AnnotationLibrary}}
 {{#jackson}}{{>jackson_annotations}}{{/jackson}}
 {{/lombok.Data}}

--- a/modules/openapi-generator/src/main/resources/JavaSpring/model.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/model.mustache
@@ -29,7 +29,9 @@ import {{jacksonPackage}}.dataformat.xml.annotation.JacksonXmlElementWrapper;
 {{/withXml}}
 {{/jackson}}
 {{#swagger2AnnotationLibrary}}
+{{#importSwagger2SchemaAnnotation}}
 import io.swagger.v3.oas.annotations.media.Schema;
+{{/importSwagger2SchemaAnnotation}}
 {{/swagger2AnnotationLibrary}}
 
 {{#withXml}}

--- a/modules/openapi-generator/src/main/resources/JavaSpring/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/pojo.mustache
@@ -12,7 +12,7 @@
 @ApiModel(description = "{{{description}}}")
 {{/swagger1AnnotationLibrary}}
 {{#swagger2AnnotationLibrary}}
-@Schema({{#name}}name = "{{name}}", {{/name}}description = "{{{description}}}"{{#deprecated}}, deprecated = true{{/deprecated}})
+@{{swagger2SchemaAnnotation}}({{#name}}name = "{{name}}", {{/name}}description = "{{{description}}}"{{#deprecated}}, deprecated = true{{/deprecated}})
 {{/swagger2AnnotationLibrary}}
 {{/description}}
 {{#discriminator}}
@@ -231,7 +231,7 @@ public {{>sealed}}class {{classname}}{{#parent}} extends {{{parent}}}{{/parent}}
   {{#lambda.trim}}{{>notNull}}{{/lambda.trim}}
   {{/useBeanValidation}}
   {{#swagger2AnnotationLibrary}}
-  @Schema(name = "{{{baseName}}}"{{#isReadOnly}}, accessMode = Schema.AccessMode.READ_ONLY{{/isReadOnly}}{{#example}}, example = "{{{.}}}"{{/example}}{{#description}}, description = "{{{.}}}"{{/description}}{{#deprecated}}, deprecated = true{{/deprecated}}, requiredMode = {{#required}}Schema.RequiredMode.REQUIRED{{/required}}{{^required}}Schema.RequiredMode.NOT_REQUIRED{{/required}}{{#isNullable}}, nullable = true{{/isNullable}})
+  @{{swagger2SchemaAnnotation}}(name = "{{{baseName}}}"{{#isReadOnly}}, accessMode = {{swagger2SchemaAnnotation}}.AccessMode.READ_ONLY{{/isReadOnly}}{{#example}}, example = "{{{.}}}"{{/example}}{{#description}}, description = "{{{.}}}"{{/description}}{{#deprecated}}, deprecated = true{{/deprecated}}, requiredMode = {{#required}}{{swagger2SchemaAnnotation}}.RequiredMode.REQUIRED{{/required}}{{^required}}{{swagger2SchemaAnnotation}}.RequiredMode.NOT_REQUIRED{{/required}}{{#isNullable}}, nullable = true{{/isNullable}})
   {{/swagger2AnnotationLibrary}}
   {{#swagger1AnnotationLibrary}}
   @ApiModelProperty({{#example}}example = "{{{.}}}", {{/example}}{{#required}}required = {{required}}, {{/required}}{{#isReadOnly}}readOnly = {{{isReadOnly}}}, {{/isReadOnly}}value = "{{{description}}}")

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
@@ -2287,6 +2287,56 @@ public class SpringCodegenTest {
     }
 
     @Test
+    public void schemaNamedSchemaDoesNotCollideWithSwagger2Annotation_issue16584() throws IOException {
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+        String outputPath = output.getAbsolutePath().replace('\\', '/');
+
+        OpenAPI openAPI = new OpenAPIParser()
+                .readLocation("src/test/resources/bugs/issue_16584.yaml", null, new ParseOptions()).getOpenAPI();
+
+        SpringCodegen codegen = new SpringCodegen();
+        codegen.setOutputDir(output.getAbsolutePath());
+        codegen.additionalProperties().put(INTERFACE_ONLY, "true");
+
+        ClientOptInput input = new ClientOptInput();
+        input.openAPI(openAPI);
+        input.config(codegen);
+
+        DefaultGenerator generator = new DefaultGenerator();
+        generator.setGenerateMetadata(false);
+        generator.opts(input).generate();
+
+        // The api must reference the generated model, not the swagger annotation. Importing both
+        // would be a compile error: two single-type imports for the same simple name.
+        JavaFileAssert.assertThat(Paths.get(outputPath + "/src/main/java/org/openapitools/api/SchemasApi.java"))
+                .hasImports("org.openapitools.model.Schema")
+                .hasNoImports("io.swagger.v3.oas.annotations.media.Schema")
+                .fileContains("ResponseEntity<Schema> getSchema")
+                .fileContains("@io.swagger.v3.oas.annotations.media.Schema(implementation = Schema.class)");
+
+        // In the model the declared class shadows the annotation, so the annotation is qualified.
+        JavaFileAssert.assertThat(Paths.get(outputPath + "/src/main/java/org/openapitools/model/Schema.java"))
+                .hasNoImports("io.swagger.v3.oas.annotations.media.Schema")
+                .fileContains("@io.swagger.v3.oas.annotations.media.Schema(name = \"id\"");
+    }
+
+    @Test
+    public void schemaNamedSchemaKeepsExplicitImportMapping_issue16584() {
+        final SpringCodegen codegen = new SpringCodegen();
+        codegen.processOpts();
+        // DefaultGenerator applies --import-mappings after processOpts(), so mirror that order.
+        codegen.importMapping().put("Schema", "com.example.custom.Schema");
+
+        OpenAPI openAPI = new OpenAPIParser()
+                .readLocation("src/test/resources/bugs/issue_16584.yaml", null, new ParseOptions()).getOpenAPI();
+        codegen.preprocessOpenAPI(openAPI);
+
+        // A user-supplied --import-mappings entry must survive the collision workaround.
+        Assert.assertEquals(codegen.importMapping().get("Schema"), "com.example.custom.Schema");
+    }
+
+    @Test
     public void testImportMappings() {
         final SpringCodegen codegen = new SpringCodegen();
         codegen.additionalProperties().put("useSpringBoot3", false);
@@ -6764,9 +6814,12 @@ public class SpringCodegenTest {
         File apiFile = files.get("Schema.java");
         assertNotNull(apiFile);
 
-        JavaFileAssert.assertThat(apiFile).fileContains(
-            "import io.swagger.v3.oas.annotations.media.Schema;"
-        );
+        // The spec names a schema "Schema". A single-type import of the annotation cannot coexist
+        // with the model class of the same name declared in this compilation unit (JLS 7.5.1), so
+        // the annotation is emitted fully qualified instead of imported. See issue #16584.
+        JavaFileAssert.assertThat(apiFile)
+            .fileDoesNotContain("import io.swagger.v3.oas.annotations.media.Schema;")
+            .fileContains("@io.swagger.v3.oas.annotations.media.Schema(");
     }
 
     @Test

--- a/modules/openapi-generator/src/test/resources/bugs/issue_16584.yaml
+++ b/modules/openapi-generator/src/test/resources/bugs/issue_16584.yaml
@@ -1,0 +1,35 @@
+openapi: 3.0.3
+info:
+  title: Schema name collision
+  description: A schema named "Schema" collides with io.swagger.v3.oas.annotations.media.Schema.
+  version: 1.0.0
+paths:
+  /schemas/{id}:
+    get:
+      operationId: getSchema
+      tags:
+        - schemas
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Schema found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Schema'
+components:
+  schemas:
+    Schema:
+      type: object
+      title: Schema
+      properties:
+        id:
+          type: string
+          readOnly: true
+        name:
+          type: string


### PR DESCRIPTION
## Fixes #16584

A schema named `Schema` generates a model that the generated code cannot reference.

`AbstractJavaCodegen` registers:

```java
importMapping.put("Schema", "io.swagger.v3.oas.annotations.media.Schema");
```

and `DefaultGenerator` consults `importMapping` **before** `toModelImport()` (`getAllImportsMappings`, and the model path around `DefaultGenerator:1794`). The model import is therefore silently replaced by the annotation import, and the bare `Schema` type in api signatures binds to the annotation instead of the model:

```java
import org.openapitools.model.BadRequest;
import org.openapitools.model.Error;
import io.swagger.v3.oas.annotations.media.Schema;   // <- substituted for the model import

default ResponseEntity<Schema> getSchema(...)                       // the annotation, not the model
@Content(schema = @Schema(implementation = Schema.class))           // self-referential
```

Emitting the model import instead does not fix it on its own: it then clashes with the annotation import the templates add, and in the model file with the declared class of the same name. Two single-type imports for the same simple name, and an import conflicting with a type declared in the same compilation unit, are both compile errors (JLS 7.5.1).

### Change

- `SpringCodegen.preprocessOpenAPI` detects a model named `Schema` and drops the default `importMapping` entry so the model keeps the simple name. An explicit `--import-mappings` entry pointing at a **different** class is left untouched (covered by a test).
- The swagger2 annotation is then emitted fully qualified at its usage sites instead of imported, via two new template variables (`swagger2SchemaAnnotation`, `importSwagger2SchemaAnnotation`). This is confined to `JavaSpring` templates: `api`, `apiController`, `model`, `pojo`, `lombokAnnotation`.

The collision detection compares against `toModelName(...)`, so `modelNamePrefix`/`modelNameSuffix` are honoured, and it runs after `InlineModelResolver.flatten` so inline-promoted models are covered.

### Verification

Using the spec from the issue:

| | result |
|---|---|
| `master` | `BUILD FAILURE` — 15 compile errors, e.g. `org.openapitools.model.Schema is already defined in this compilation unit` |
| this branch | `BUILD SUCCESS` |

Verified for both `interfaceOnly=true` and the api controller variant.

- `SpringCodegenTest`: 339/339 pass.
- Regenerating all 71 `spring*` and `java-camel*` sample configs produces **no diff** — the qualification only applies when the collision is actually present, so existing output is byte-identical.

### Note on the modified test

`annotationLibraryDoesNotCauseImportConflictsInSpringWithAnnotationLibrary` asserted that the model file contains `import io.swagger.v3.oas.annotations.media.Schema;`. Its spec (`issue21991.yaml`) names a schema `Schema`, so that assertion pins output that does not compile (the 15 errors above). It now asserts the fully-qualified form instead. Its sibling `annotationLibraryDoesNotCauseImportConflictsInSpring` (the `annotationLibrary=none` path fixed by #21992 / #22045) passes unchanged.

This completes the half that #21991 explicitly deferred — quoting that reporter:

> This could also be presented as a different issue - "imports conflict with the model names", which would require significantly more effort to investigate and properly fix (figuring out which imports exactly might be conflicting and using fully-qualified class names all over the templates).

#21992 and #22045 fixed only the `annotationLibrary=none` path; the default `swagger2` path, where the collision is unavoidable, is this issue.

### Scope

Deliberately limited to the `spring` generator and the `Schema` key. `AbstractJavaCodegen` puts `File`, `Date`, `Map`, `List`, `Set` and `UUID` in the same map, so a model named `File` currently resolves to `java.io.File` — the same class of bug, but changing it means real behaviour changes and sample churn. Happy to widen this to `AbstractJavaCodegen` and the other Java generators (`JavaClientCodegen` and `JavaJerseyServerCodegen` call `model.imports.add("Schema")` and would need matching template work) if you'd prefer that in one pass.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Spring generator so a schema named `Schema` generates code that compiles, instead of a model that cannot be referenced.

Bug Fixes
- Previously the model import was silently replaced by the `io.swagger.v3.oas.annotations.media.Schema` annotation import, so API signatures referenced the annotation instead of the model, and emitting both imports caused compile errors.
- The model now keeps the simple name `Schema`, and the swagger2 annotation is fully qualified at its usage sites in the Spring templates.
- An explicit `--import-mappings` entry for `Schema` pointing to a different class is left untouched.
- Existing output is unchanged when the collision is absent; regenerating all `spring` and `java-camel` samples produced no diff.

<sup>Written for commit 8dfaa1f3eb19c2e3f36c0487ee3cca6be120e2bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24901?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

