### PR TITLE
[Java] Fix #24875: Add missing import for direct enum property reference in parameters

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -5711,6 +5711,9 @@ public class DefaultCodegen implements CodegenConfig {
         if (codegenProperty.isEnum) {
             codegenParameter.datatypeWithEnum = codegenProperty.datatypeWithEnum;
             codegenParameter.enumName = codegenProperty.enumName;
+            if(codegenParameter.dataType != null && !codegenParameter.dataType.contains("&") && !codegenParameter.dataType.contains("<")) {
+                imports.add(codegenParameter.dataType);
+            }
             if (codegenProperty.defaultValue != null) {
                 codegenParameter.enumDefaultValue = codegenProperty.defaultValue.replace(codegenProperty.enumName + ".", "");
             }
@@ -5721,6 +5724,9 @@ public class DefaultCodegen implements CodegenConfig {
             codegenParameter.enumName = codegenProperty.enumName;
             codegenParameter.items = codegenProperty.items;
             codegenParameter.mostInnerItems = codegenProperty.mostInnerItems;
+            if(codegenParameter.items.dataType != null && !codegenParameter.items.dataType.contains("&") && !codegenParameter.items.dataType.contains("<")) {
+                imports.add(codegenParameter.items.dataType);
+            }
         }
 
         codegenParameter.collectionFormat = collectionFormat;

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -31,6 +31,7 @@ import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.PathItem;
 import io.swagger.v3.oas.models.headers.Header;
 import io.swagger.v3.oas.models.media.*;
+import io.swagger.v3.oas.models.parameters.Parameter;
 import io.swagger.v3.oas.models.parameters.QueryParameter;
 import io.swagger.v3.oas.models.parameters.RequestBody;
 import io.swagger.v3.oas.models.responses.ApiResponse;
@@ -57,6 +58,7 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.util.stream.Collectors;
 
+import static com.fasterxml.jackson.databind.util.ClassUtil.name;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.junit.jupiter.api.Assertions.*;
@@ -5426,5 +5428,24 @@ public class DefaultCodegenTest {
         DefaultCodegen off = new DefaultCodegen();
         off.processOpts();
         assertThat(off.splitOperationsByContentType).isFalse();
+    }
+
+    @Test
+    public void testFromParameterEnumImports() {
+        OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_1/issue24875-enum-parameter-import.yaml");
+        DefaultCodegen codegen = new DefaultCodegen();
+        codegen.setOpenAPI(openAPI);
+
+        Operation operation = openAPI.getPaths().get("/archives").getGet();
+        Parameter parameter = operation.getParameters().get(0);
+
+        Set<String> imports = new HashSet<>();
+        codegen.fromParameter(parameter, imports);
+
+        // Assert enum type is present in imports
+        Assert.assertTrue(
+                imports.contains("State"),
+                "Expected enum 'State' to be present in imports but got: " + imports
+        );
     }
 }

--- a/modules/openapi-generator/src/test/resources/3_1/issue24875-enum-parameter-import.yaml
+++ b/modules/openapi-generator/src/test/resources/3_1/issue24875-enum-parameter-import.yaml
@@ -1,0 +1,26 @@
+openapi: 3.1.0
+info:
+  title: Enum parameter import
+  version: 1.0.0
+paths:
+  /archives:
+    get:
+      operationId: listArchives
+      parameters:
+        - name: state
+          in: query
+          required: false
+          schema:
+            $ref: "#/components/schemas/Archive/properties/state"
+      responses:
+        "200":
+          description: Success
+components:
+  schemas:
+    Archive:
+      type: object
+      properties:
+        state:
+          type: string
+          enum:
+            - ACTIVE


### PR DESCRIPTION
### PR Title
[Java] Fix #24875: Add missing import for direct enum property reference in parameters

### Description of the change
Fixes #24875

When a query parameter references a direct enum property via
`$ref: "#/components/schemas/Component/properties/field"`, the required
import statement was missing from the generated API class, causing
compilation failures.

This fix updates `DefaultCodegen#fromParameter` to add the resolved enum
type to the operation's import set, with a guard against composed/generic
types (containing `&` or `<`) that are not valid single-type imports.

### PR Checklist
- [x] Read the contribution guidelines.
- [x] Pull Request title conforms to conventions.
- [x] Ran `mvn clean install` to ensure all unit tests pass.
- [x] Added unit test in `DefaultCodegenTest.java` verifying enum imports
      are included when a parameter directly references an enum property.
- [ ] Generated updated samples using `./bin/generate-samples.sh`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes generated code missing enum imports when a query parameter directly references an enum property via `$ref` (issue #24875). Previously the generated API class failed to compile because the resolved enum type wasn't imported; now `fromParameter` adds it to the operation's imports, skipping composed/generic type strings containing `&` or `<`.

Side effect: regenerated JavaScript samples now include `import [String] from '../model/[String]'` lines, which are invalid JavaScript imports and may break the `javascript-apollo`, `javascript-es6`, and `javascript-promise-es6` generators.

<sup>Written for commit 3ba2cb1311abfc2b7524390f78108f9efda28fe7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24918?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

