### PR TITLE
[Java] Fix XmlEnumValue generation for URI enums

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -7194,6 +7194,7 @@ public class DefaultCodegen implements CodegenConfig {
             final String finalEnumName = toEnumVarName(enumName, dataType);
 
             enumVar.enumVar(finalEnumName, toEnumValue(String.valueOf(value), dataType), isDataTypeString(dataType));
+            enumVar.setEnumRawValue(value);
             // TODO: add isNumeric
             enumVars.add(enumVar);
         }
@@ -7227,6 +7228,7 @@ public class DefaultCodegen implements CodegenConfig {
                 String.valueOf(11184809);
 
         enumVar.enumVar(toEnumVarName(enumName, dataType), toEnumValue(enumValue, dataType), isDataTypeString(dataType));
+        enumVar.setEnumRawValue(enumValue);
         // TODO: add isNumeric
         enumVars.add(enumVar);
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -7170,13 +7170,38 @@ public class DefaultCodegen implements CodegenConfig {
         return enumDefaultValue;
     }
 
+    /**
+     * Builds enum metadata using the original OpenAPI values for both generation and raw metadata.
+     *
+     * @param values original enum values from the OpenAPI schema; null entries are skipped
+     * @param dataType target data type of the enum
+     * @return enum entries containing generated names, formatted values, and original raw values
+     */
     protected List<EnumVarMap> buildEnumVars(List<Object> values, String dataType) {
+        return buildEnumVars(values, dataType, values);
+    }
+
+    /**
+     * Builds enum metadata using separate values for generation and raw metadata.
+     *
+     * @param values values used to generate enum names and formatted values; null entries are skipped
+     * @param dataType target data type of the enum
+     * @param rawValues original OpenAPI values, in the same order and with the same number of
+     *                  entries as values; each emitted entry retains its corresponding raw value and type
+     * @return enum entries containing generated names, formatted values, and original raw values
+     * @throws IllegalArgumentException if the lists have different sizes
+     */
+    protected List<EnumVarMap> buildEnumVars(List<Object> values, String dataType, List<Object> rawValues) {
+        if (values.size() != rawValues.size()) {
+            throw new IllegalArgumentException("values and rawValues must have the same number of entries");
+        }
         List<EnumVarMap> enumVars = new ArrayList<>();
         int truncateIdx = isRemoveEnumValuePrefix()
                 ? findCommonPrefixOfVars(values).length()
                 : 0;
 
-        for (Object value : values) {
+        for (int i = 0; i < values.size(); i++) {
+            Object value = values.get(i);
             if (value == null) {
                 // raw null values in enums are unions for nullable
                 // attributes, not actual enum values, so we remove them here
@@ -7194,7 +7219,7 @@ public class DefaultCodegen implements CodegenConfig {
             final String finalEnumName = toEnumVarName(enumName, dataType);
 
             enumVar.enumVar(finalEnumName, toEnumValue(String.valueOf(value), dataType), isDataTypeString(dataType));
-            enumVar.setEnumRawValue(value);
+            enumVar.setEnumRawValue(rawValues.get(i));
             // TODO: add isNumeric
             enumVars.add(enumVar);
         }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -2895,7 +2895,10 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
                 writer.write(dataType);
             }
         };
+        Mustache.Lambda javaStringLiteralLambda = (fragment, writer) ->
+                writer.write(toEnumValue(fragment.execute(), "String"));
         return super.addMustacheLambdas()
+                .put("javaStringLiteral", javaStringLiteralLambda)
                 .put("jSpecifyDatatype", jSpecifyDatatypeLambda)
                 .put("jSpecifyNullable", jSpecifyNullableLambda);
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AvroSchemaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AvroSchemaCodegen.java
@@ -252,14 +252,16 @@ public class AvroSchemaCodegen extends DefaultCodegen implements CodegenConfig {
     }
 
     @Override
-    protected List<EnumVarMap> buildEnumVars(List<Object> values, String dataType) {
-        List<Object> sanitizedValues = values.stream()
-                .filter(x -> x != null)
+    protected List<EnumVarMap> buildEnumVars(List<Object> rawValues, String dataType) {
+        List<Object> originalValues = rawValues.stream()
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+        List<Object> sanitizedValues = originalValues.stream()
                 .map(Object::toString)
                 .map(this::sanitizeEnumValue)
                 .collect(Collectors.toList());
         removeEnumValueCollisions(sanitizedValues);
-        return super.buildEnumVars(sanitizedValues, dataType);
+        return super.buildEnumVars(sanitizedValues, dataType, originalValues);
     }
 
     /**

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/model/EnumVarMap.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/model/EnumVarMap.java
@@ -12,8 +12,10 @@ public class EnumVarMap extends HashMap<String, Object> {
     public static final String ENUM_VARS = "enumVars";
     // The name of the enum, for example NAME("value") in Java
     public static final String ENUM_NAME = "name";
-    // The on-the-line value, i.e., the one present in the "values"
+    // The language-specific value emitted by a template
     public static final String ENUM_VALUE = "value";
+    // The original, unformatted value from the OpenAPI specification
+    public static final String ENUM_RAW_VALUE = "rawValue";
     // If the enum is typed as a string
     public static final String ENUM_IS_STRING = "isString";
     // The description that should be attached to an entry in "enumVars"
@@ -51,6 +53,14 @@ public class EnumVarMap extends HashMap<String, Object> {
 
     public Object getEnumValue() {
         return get(ENUM_VALUE);
+    }
+
+    public void setEnumRawValue(Object rawValue) {
+        put(ENUM_RAW_VALUE, rawValue);
+    }
+
+    public Object getEnumRawValue() {
+        return get(ENUM_RAW_VALUE);
     }
 
     public void isString(boolean isString) {

--- a/modules/openapi-generator/src/main/resources/Groovy/modelEnum.mustache
+++ b/modules/openapi-generator/src/main/resources/Groovy/modelEnum.mustache
@@ -9,7 +9,7 @@ enum {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEn
         */
     {{/enumDescription}}
     {{#withXml}}
-    @XmlEnumValue({{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}}{{{value}}}{{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}})
+    @XmlEnumValue({{#lambda.javaStringLiteral}}{{{rawValue}}}{{/lambda.javaStringLiteral}})
     {{/withXml}}
     {{{name}}}({{{value}}}){{^-last}},
     {{/-last}}{{/enumVars}}{{/allowableValues}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/microprofile/enumClass.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/microprofile/enumClass.mustache
@@ -12,7 +12,7 @@
 
     {{#allowableValues}}
     {{#withXml}}
-    {{#enumVars}}@XmlEnumValue({{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}}{{{value}}}{{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}}) {{name}}({{dataType}}.valueOf({{{value}}})){{^-last}}, {{/-last}}{{#-last}};{{/-last}}{{/enumVars}}
+    {{#enumVars}}@XmlEnumValue({{#lambda.javaStringLiteral}}{{{rawValue}}}{{/lambda.javaStringLiteral}}) {{name}}({{^isUri}}{{dataType}}.valueOf({{/isUri}}{{{value}}}{{^isUri}}){{/isUri}}){{^-last}}, {{/-last}}{{#-last}};{{/-last}}{{/enumVars}}
     {{/withXml}}
     {{^withXml}}
     {{#enumVars}}{{name}}({{^isUri}}{{dataType}}.valueOf({{/isUri}}{{{value}}}{{^isUri}}){{/isUri}}){{^-last}}, {{/-last}}{{#-last}};{{/-last}}{{/enumVars}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/modelEnum.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/modelEnum.mustache
@@ -34,7 +34,7 @@ import java.net.URI;
    */
      {{/enumDescription}}
   {{#withXml}}
-  @XmlEnumValue({{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}}{{{value}}}{{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}})
+  @XmlEnumValue({{#lambda.javaStringLiteral}}{{{rawValue}}}{{/lambda.javaStringLiteral}})
   {{/withXml}}
   {{{name}}}({{{value}}}){{^-last}},
   {{/-last}}{{#-last}};{{/-last}}{{/enumVars}}{{/allowableValues}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/modelEnum.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/modelEnum.mustache
@@ -23,7 +23,7 @@ import com.google.gson.stream.JsonWriter;
    */
      {{/enumDescription}}
   {{#withXml}}
-  @XmlEnumValue({{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}}{{{value}}}{{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}})
+  @XmlEnumValue({{#lambda.javaStringLiteral}}{{{rawValue}}}{{/lambda.javaStringLiteral}})
   {{/withXml}}
   {{{name}}}({{{value}}}){{^-last}},
   {{/-last}}{{#-last}};{{/-last}}{{/enumVars}}{{/allowableValues}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/modelInnerEnum.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/modelInnerEnum.mustache
@@ -15,7 +15,7 @@
      */
     {{/enumDescription}}
     {{#withXml}}
-    @XmlEnumValue({{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}}{{{value}}}{{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}})
+    @XmlEnumValue({{#lambda.javaStringLiteral}}{{{rawValue}}}{{/lambda.javaStringLiteral}})
     {{/withXml}}
     {{{name}}}({{{value}}}){{^-last}},
     {{/-last}}{{#-last}};{{/-last}}

--- a/modules/openapi-generator/src/main/resources/Java/modelEnum.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/modelEnum.mustache
@@ -34,7 +34,7 @@ import java.net.URI;
    */
      {{/enumDescription}}
   {{#withXml}}
-  @XmlEnumValue({{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}}{{{value}}}{{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}})
+  @XmlEnumValue({{#lambda.javaStringLiteral}}{{{rawValue}}}{{/lambda.javaStringLiteral}})
   {{/withXml}}
   {{{name}}}({{{value}}}){{^-last}},
   {{/-last}}{{#-last}};{{/-last}}{{/enumVars}}{{/allowableValues}}

--- a/modules/openapi-generator/src/main/resources/Java/modelInnerEnum.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/modelInnerEnum.mustache
@@ -21,7 +21,7 @@
      */
     {{/enumDescription}}
     {{#withXml}}
-    @XmlEnumValue({{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}}{{{value}}}{{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}})
+    @XmlEnumValue({{#lambda.javaStringLiteral}}{{{rawValue}}}{{/lambda.javaStringLiteral}})
     {{/withXml}}
     {{{name}}}({{^isUri}}{{dataType}}.valueOf({{/isUri}}{{{value}}}{{^isUri}}){{/isUri}}){{^-last}},
     {{/-last}}{{#-last}};{{/-last}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-cdi/enumClass.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-cdi/enumClass.mustache
@@ -5,7 +5,7 @@
 {{>additionalEnumTypeAnnotations}}public enum {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} {
 
     {{#allowableValues}}
-    {{#enumVars}}{{#withXml}}@XmlEnumValue({{^isString}}"{{/isString}}{{{value}}}{{^isString}}"{{/isString}}) {{/withXml}}@JsonProperty({{^isString}}"{{/isString}}{{{value}}}{{^isString}}"{{/isString}}) {{name}}({{dataType}}.valueOf({{{value}}})){{^-last}}, {{/-last}}{{#-last}};{{/-last}}{{/enumVars}}
+    {{#enumVars}}{{#withXml}}@XmlEnumValue({{#lambda.javaStringLiteral}}{{{rawValue}}}{{/lambda.javaStringLiteral}}) {{/withXml}}@JsonProperty({{^isString}}"{{/isString}}{{{value}}}{{^isString}}"{{/isString}}) {{name}}({{dataType}}.valueOf({{{value}}})){{^-last}}, {{/-last}}{{#-last}};{{/-last}}{{/enumVars}}
     {{/allowableValues}}
 
 

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-ext/enumClass.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-ext/enumClass.mustache
@@ -5,7 +5,7 @@
 {{>additionalEnumTypeAnnotations}}public enum {{datatypeWithEnum}} {
 
     {{#allowableValues}}
-    {{#enumVars}}{{#withXml}}@XmlEnumValue({{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}}{{{value}}}{{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}}) {{/withXml}}@JsonProperty({{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}}{{{value}}}{{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}}) {{name}}({{dataType}}.valueOf({{{value}}})){{^-last}},
+    {{#enumVars}}{{#withXml}}@XmlEnumValue({{#lambda.javaStringLiteral}}{{{rawValue}}}{{/lambda.javaStringLiteral}}) {{/withXml}}@JsonProperty({{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}}{{{value}}}{{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}}) {{name}}({{dataType}}.valueOf({{{value}}})){{^-last}},
     {{/-last}}{{#-last}};{{/-last}}{{/enumVars}}
     {{/allowableValues}}
 

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/enumClass.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/enumClass.mustache
@@ -5,7 +5,7 @@
 {{>additionalEnumTypeAnnotations}}public enum {{datatypeWithEnum}} {
 
     {{#allowableValues}}
-{{#enumVars}}{{#withXml}}@XmlEnumValue({{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}}{{{value}}}{{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}}) {{/withXml}}{{name}}({{dataType}}.valueOf({{{value}}})){{^-last}}, {{/-last}}{{#-last}};{{/-last}}{{/enumVars}}
+{{#enumVars}}{{#withXml}}@XmlEnumValue({{#lambda.javaStringLiteral}}{{{rawValue}}}{{/lambda.javaStringLiteral}}) {{/withXml}}{{name}}({{dataType}}.valueOf({{{value}}})){{^-last}}, {{/-last}}{{#-last}};{{/-last}}{{/enumVars}}
     {{/allowableValues}}
 
 

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/enumClass.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/enumClass.mustache
@@ -5,7 +5,7 @@
 {{>additionalEnumTypeAnnotations}}public enum {{datatypeWithEnum}} {
 
     {{#allowableValues}}
-{{#enumVars}}{{#withXml}}@XmlEnumValue({{#lambda.javaStringLiteral}}{{{rawValue}}}{{/lambda.javaStringLiteral}}) {{/withXml}}{{name}}({{dataType}}.valueOf({{{value}}})){{^-last}}, {{/-last}}{{#-last}};{{/-last}}{{/enumVars}}
+{{#enumVars}}{{#withXml}}@XmlEnumValue({{#lambda.javaStringLiteral}}{{{rawValue}}}{{/lambda.javaStringLiteral}}) {{/withXml}}{{name}}({{^isUri}}{{dataType}}.valueOf({{/isUri}}{{{value}}}{{^isUri}}){{/isUri}}){{^-last}}, {{/-last}}{{#-last}};{{/-last}}{{/enumVars}}
     {{/allowableValues}}
 
 

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/enumClass.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/enumClass.mustache
@@ -5,7 +5,7 @@
 {{>additionalEnumTypeAnnotations}}public enum {{datatypeWithEnum}} {
 
     {{#allowableValues}}
-    {{#enumVars}}{{#withXml}}@XmlEnumValue({{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}}{{{value}}}{{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}}){{/withXml}}{{name}}({{dataType}}.valueOf({{{value}}})){{^-last}}, {{/-last}}{{#-last}};{{/-last}}{{/enumVars}}
+    {{#enumVars}}{{#withXml}}@XmlEnumValue({{#lambda.javaStringLiteral}}{{{rawValue}}}{{/lambda.javaStringLiteral}}){{/withXml}}{{name}}({{dataType}}.valueOf({{{value}}})){{^-last}}, {{/-last}}{{#-last}};{{/-last}}{{/enumVars}}
     {{/allowableValues}}
 
 

--- a/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/mp/modelInnerEnum.mustache
+++ b/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/mp/modelInnerEnum.mustache
@@ -21,7 +21,7 @@
      */
     {{/enumDescription}}
     {{#withXml}}
-    @XmlEnumValue({{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}}{{{value}}}{{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}})
+    @XmlEnumValue({{#lambda.javaStringLiteral}}{{{rawValue}}}{{/lambda.javaStringLiteral}})
     {{/withXml}}
     {{{name}}}({{{value}}}){{^-last}},
     {{/-last}}{{#-last}};{{/-last}}

--- a/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/se/modelInnerEnum.mustache
+++ b/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/se/modelInnerEnum.mustache
@@ -21,7 +21,7 @@
      */
     {{/enumDescription}}
     {{#withXml}}
-    @XmlEnumValue({{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}}{{{value}}}{{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}})
+    @XmlEnumValue({{#lambda.javaStringLiteral}}{{{rawValue}}}{{/lambda.javaStringLiteral}})
     {{/withXml}}
     {{{name}}}({{{value}}}){{^-last}},
     {{/-last}}{{#-last}};{{/-last}}

--- a/modules/openapi-generator/src/main/resources/java-helidon/server/libraries/mp/modelEnum.mustache
+++ b/modules/openapi-generator/src/main/resources/java-helidon/server/libraries/mp/modelEnum.mustache
@@ -21,7 +21,7 @@
      */
     {{/enumDescription}}
     {{#withXml}}
-    @XmlEnumValue({{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}}{{{value}}}{{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}})
+    @XmlEnumValue({{#lambda.javaStringLiteral}}{{{rawValue}}}{{/lambda.javaStringLiteral}})
     {{/withXml}}
     {{{name}}}({{{value}}}){{^-last}},
     {{/-last}}{{#-last}};{{/-last}}

--- a/modules/openapi-generator/src/main/resources/java-micronaut/common/model/modelEnum.mustache
+++ b/modules/openapi-generator/src/main/resources/java-micronaut/common/model/modelEnum.mustache
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
      */
             {{/enumDescription}}
             {{#withXml}}
-    @XmlEnumValue({{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}}{{{value}}}{{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}})
+    @XmlEnumValue({{#lambda.javaStringLiteral}}{{{rawValue}}}{{/lambda.javaStringLiteral}})
             {{/withXml}}
     {{{name}}}({{{value}}}){{^-last}},{{/-last}}{{#-last}};{{/-last}}
         {{/enumVars}}

--- a/modules/openapi-generator/src/main/resources/java-micronaut/common/model/modelInnerEnum.mustache
+++ b/modules/openapi-generator/src/main/resources/java-micronaut/common/model/modelInnerEnum.mustache
@@ -17,7 +17,7 @@
          */
             {{/enumDescription}}
             {{#withXml}}
-        @XmlEnumValue({{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}}{{{value}}}{{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}})
+        @XmlEnumValue({{#lambda.javaStringLiteral}}{{{rawValue}}}{{/lambda.javaStringLiteral}})
             {{/withXml}}
         {{{name}}}({{{value}}}){{^-last}},{{/-last}}{{#-last}};{{/-last}}
         {{/enumVars}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -898,6 +898,7 @@ public class DefaultCodegenTest {
         Assertions.assertNotNull(testedEnumVar);
         assertEquals("_1", testedEnumVar.getOrDefault("name", ""));
         assertEquals("\"1\"", testedEnumVar.getOrDefault("value", ""));
+        assertEquals(1, testedEnumVar.getOrDefault("rawValue", ""));
         assertEquals(false, testedEnumVar.getOrDefault("isString", ""));
     }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -41,6 +41,7 @@ import org.junit.jupiter.api.Assertions;
 import org.openapitools.codegen.config.CodegenConfigurator;
 import org.openapitools.codegen.config.GlobalSettings;
 import org.openapitools.codegen.languages.SpringCodegen;
+import org.openapitools.codegen.model.EnumVarMap;
 import org.openapitools.codegen.model.ModelMap;
 import org.openapitools.codegen.model.ModelsMap;
 import org.openapitools.codegen.templating.mustache.*;
@@ -70,6 +71,23 @@ public class DefaultCodegenTest {
     private static final String APP_XML = "application/xml";
     private static final String APP_TEXT = "application/text";
     private static final Logger testLogger = (Logger) LoggerFactory.getLogger(ModelUtils.class);
+
+    @Test
+    public void testBuildEnumVarsPreservesRawValueAlignmentAcrossNulls() {
+        DefaultCodegen codegen = new DefaultCodegen();
+        List<EnumVarMap> enumVars = codegen.buildEnumVars(
+                Arrays.asList("first", null, "_42"), "string", Arrays.asList("original", null, 42));
+
+        Assert.assertEquals(enumVars.size(), 2);
+        Assert.assertEquals(enumVars.get(0).getEnumRawValue(), "original");
+        Assert.assertEquals(enumVars.get(1).getEnumRawValue(), Integer.valueOf(42));
+        Assert.assertEquals(enumVars.get(1).getEnumValue(), "\"_42\"");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testBuildEnumVarsRejectsMismatchedRawValues() {
+        new DefaultCodegen().buildEnumVars(Collections.singletonList("value"), "string", Collections.emptyList());
+    }
 
     @Test
     public void testDeeplyNestedAdditionalPropertiesImports() {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -2829,6 +2829,58 @@ public class JavaClientCodegenTest {
         testHandleURIEnum(JavaClientCodegen.MICROPROFILE, expectedInnerEnumLines, expectedEnumLines);
     }
 
+    @Test
+    public void testHandleURIEnumWithXml() {
+        for (String library : List.of(
+                JavaClientCodegen.OKHTTP_GSON,
+                JavaClientCodegen.RESTTEMPLATE,
+                JavaClientCodegen.NATIVE)) {
+            final Path output = newTempFolder();
+            final CodegenConfigurator configurator = new CodegenConfigurator()
+                    .setGeneratorName(JAVA_GENERATOR)
+                    .setLibrary(library)
+                    .addAdditionalProperty(CodegenConstants.WITH_XML, true)
+                    .setInputSpec("src/test/resources/3_0/enum-and-inner-enum-uri.yaml")
+                    .setOutputDir(output.toString().replace("\\", "/"));
+
+            Map<String, File> files = new DefaultGenerator().opts(configurator.toClientOptInput()).generate()
+                    .stream().collect(Collectors.toMap(File::getName, Function.identity()));
+
+            File modelFile = files.get("Metadata.java");
+            Assertions.assertNotNull(modelFile);
+            JavaFileAssert.assertThat(modelFile).fileContains(
+                    "@XmlEnumValue(\"https://example.com/v1/metadata.json\")",
+                    "V1_METADATA_JSON(URI.create(\"https://example.com/v1/metadata.json\"))");
+
+            File innerEnumFile = files.get("V1SchemasGetDefaultResponse.java");
+            Assertions.assertNotNull(innerEnumFile);
+            JavaFileAssert.assertThat(innerEnumFile).fileContains(
+                    "@XmlEnumValue(\"https://example.com/v1/schema.json\")",
+                    "V1_SCHEMA_JSON(URI.create(\"https://example.com/v1/schema.json\"))");
+        }
+    }
+
+    @Test
+    public void testXmlEnumEscapesRawValueAsJavaStringLiteral() {
+        StringSchema enumSchema = new StringSchema();
+        enumSchema.setEnum(List.of("say \"hello\" \\ path"));
+        OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("EscapedEnum", enumSchema);
+
+        final Path output = newTempFolder();
+        JavaClientCodegen codegen = new JavaClientCodegen();
+        codegen.setOutputDir(output.toString());
+        codegen.additionalProperties().put(CodegenConstants.WITH_XML, true);
+
+        Map<String, File> files = new DefaultGenerator()
+                .opts(new ClientOptInput().openAPI(openAPI).config(codegen))
+                .generate().stream().collect(Collectors.toMap(File::getName, Function.identity()));
+
+        File modelFile = files.get("EscapedEnum.java");
+        Assertions.assertNotNull(modelFile);
+        JavaFileAssert.assertThat(modelFile).fileContains(
+                "@XmlEnumValue(\"say \\\"hello\\\" \\\\ path\")");
+    }
+
     private void testHandleURIEnum(String library, String[] expectedInnerEnumLines, String[] expectedEnumLines) {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/languages/AvroSchemaCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/languages/AvroSchemaCodegenTest.java
@@ -1,0 +1,41 @@
+package org.openapitools.codegen.languages;
+
+import org.openapitools.codegen.model.EnumVarMap;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class AvroSchemaCodegenTest {
+    @Test
+    public void preservesRawValuesWhenSanitizingEnumSymbols() {
+        AvroSchemaCodegen codegen = new AvroSchemaCodegen();
+        List<Object> values = Arrays.asList("a-b", null, "a_b", 42);
+
+        List<EnumVarMap> enumVars = codegen.buildEnumVars(values, "string");
+
+        Assert.assertEquals(enumVars.size(), 3);
+        Assert.assertEquals(enumVars.get(0).getEnumValue(), "\"a_b\"");
+        Assert.assertEquals(enumVars.get(1).getEnumValue(), "\"a_b2\"");
+        Assert.assertEquals(enumVars.get(2).getEnumValue(), "\"_42\"");
+        Assert.assertEquals(enumVars.get(0).getEnumRawValue(), "a-b");
+        Assert.assertEquals(enumVars.get(1).getEnumRawValue(), "a_b");
+        Assert.assertEquals(enumVars.get(2).getEnumRawValue(), Integer.valueOf(42));
+        Assert.assertEquals(values, Arrays.asList("a-b", null, "a_b", 42));
+    }
+
+    @Test
+    public void preservesSyntheticUnknownDefaultEntry() {
+        AvroSchemaCodegen codegen = new AvroSchemaCodegen();
+        codegen.setEnumUnknownDefaultCase(true);
+
+        EnumVarMap fallback = codegen.buildEnumVars(Collections.emptyList(), "string").get(0);
+        List<EnumVarMap> enumVars = codegen.buildEnumVars(Arrays.asList(null, "in-progress"), "string");
+
+        Assert.assertEquals(enumVars.size(), 2);
+        Assert.assertEquals(enumVars.get(0).getEnumRawValue(), "in-progress");
+        Assert.assertEquals(enumVars.get(1), fallback);
+    }
+}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/PhpModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/PhpModelTest.java
@@ -312,10 +312,12 @@ public class PhpModelTest {
         Assert.assertEquals(prope.allowableValues.get("values"), Arrays.asList("fish", "crab"));
 
         HashMap<String, Object> fish = new HashMap<String, Object>();
+        fish.put("rawValue", "fish");
         fish.put("name", "FISH");
         fish.put("value", "\'fish\'");
         fish.put("isString", true);
         HashMap<String, Object> crab = new HashMap<String, Object>();
+        crab.put("rawValue", "crab");
         crab.put("name", "CRAB");
         crab.put("value", "\'crab\'");
         crab.put("isString", true);
@@ -348,10 +350,12 @@ public class PhpModelTest {
         Assert.assertEquals(prope.allowableValues.get("values"), Arrays.asList(1, -1));
 
         HashMap<String, Object> one = new HashMap<String, Object>();
+        one.put("rawValue", 1);
         one.put("name", "NUMBER_1");
         one.put("value", "1");
         one.put("isString", false);
         HashMap<String, Object> minusOne = new HashMap<String, Object>();
+        minusOne.put("rawValue", -1);
         minusOne.put("name", "MINUS_1");
         minusOne.put("value", "-1");
         minusOne.put("isString", false);

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchModelTest.java
@@ -381,10 +381,12 @@ public class TypeScriptFetchModelTest {
         Assert.assertEquals(prope.allowableValues.get("values"), Arrays.asList("fish", "crab"));
 
         HashMap<String, Object> fish = new HashMap<String, Object>();
+        fish.put("rawValue", "fish");
         fish.put("name", "Fish");
         fish.put("value", "'fish'");
         fish.put("isString", false);
         HashMap<String, Object> crab = new HashMap<String, Object>();
+        crab.put("rawValue", "crab");
         crab.put("name", "Crab");
         crab.put("value", "'crab'");
         crab.put("isString", false);
@@ -421,10 +423,12 @@ public class TypeScriptFetchModelTest {
         Assert.assertEquals(prope.allowableValues.get("values"), Arrays.asList(1, -1));
 
         HashMap<String, Object> one = new HashMap<String, Object>();
+        one.put("rawValue", 1);
         one.put("name", "NUMBER_1");
         one.put("value", "1");
         one.put("isString", false);
         HashMap<String, Object> minusOne = new HashMap<String, Object>();
+        minusOne.put("rawValue", -1);
         minusOne.put("name", "NUMBER_MINUS_1");
         minusOne.put("value", "-1");
         minusOne.put("isString", false);


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
### Description 
Fixes #24236.

When the Java generator is used with `withXml=true`, URI enum values are currently rendered as Java expressions inside `@XmlEnumValue`:

```java
@XmlEnumValue(URI.create("https://example.com"))
```
Since `@XmlEnumValue` expects a string, the generated model does not compile.

This change preserves the original OpenAPI enum value as `rawValue` in `EnumVarMap`, alongside the existing language-specific value. Java templates pass `rawValue` through a reusable `javaStringLiteral` lambda when generating `@XmlEnumValue`. This produces:
```java
@XmlEnumValue("https://example.com")
HTTPS_EXAMPLE_COM(URI.create("https://example.com"))
```
The Java-specific expression remains available for the enum constructor, while the XML annotation receives a properly quoted and escaped string literal. 

The same XML annotation handling is applied to Groovy, JAX-RS CXF/CDI/CXF-ext/spec, Helidon, and Micronaut enum templates. Injected unknown-default enum entries also receive rawValue, keeping their metadata consistent with regular enum entries.

Existing PHP and TypeScript Fetch tests were updated to include `rawValue` in their expected `enum` metadata. All 34 tests in those two classes pass. The 285 selected JAX-RS, Helidon, Micronaut, and CXF tests also passed.

Tests were added to verify:
- URI enums generate valid XML annotations.
- URI enum constructors continue using URI.create(...).
- Top-level and inner enums are handled.
- Generic, OkHttp/Gson, and native template paths are covered.
- Quotes and backslashes in raw enum values are escaped as valid Java string literals.
- DefaultCodegen preserves the original typed enum value in rawValue.


<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10) @martin-mfg (2023/08) @KannaKim (2026/07)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #24236. With `withXml=true`, the Java generator rendered URI enum values as Java expressions in `@XmlEnumValue` (e.g., `@XmlEnumValue(URI.create("https://example.com"))`), which doesn't compile because the annotation expects a string. Now the raw OpenAPI value is emitted as a quoted, escaped string literal, while the constructor keeps the Java expression.

**Bug Fixes**
- Preserves the original OpenAPI value as `rawValue` in `EnumVarMap` and emits it via a new `javaStringLiteral` lambda, escaping quotes and backslashes.
- Updates top-level and inner enum templates across Java, JavaJaxRS, Groovy, Helidon, and Micronaut generators, and keeps Avro symbol sanitization aligned with raw values.
- Adds tests for URI enums, inner enums, string escaping, and Avro raw-value preservation.

<sup>Written for commit a53e93e8c3636d2ff8829cf914f134613ea1a56c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24919?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



