### PR TITLE
fix(go): preserve json tags for properties with oneOf

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
@@ -787,13 +787,9 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
             }
 
             List<CodegenProperty> codegenProperties = new ArrayList<>();
-            if (model.getComposedSchemas() == null || (model.getComposedSchemas() != null && model.getComposedSchemas().getAllOf() != null)) {
-                // If the model is an allOf or does not have any composed schemas, then we can use the model's properties.
+            if (model.vars != null && !model.vars.isEmpty()) {
                 codegenProperties.addAll(model.vars);
             } else {
-                // If the model is no model, but is a
-                // anyOf or oneOf, add all first level options
-                // from anyOf or oneOf.
                 codegenProperties.addAll(inheritedProperties);
             }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/GoClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/GoClientCodegenTest.java
@@ -562,4 +562,34 @@ public class GoClientCodegenTest {
                 "validator.Validate",
                 "gopkg.in/validator.v2");
     }
+
+    @Test(description = "schema with both properties and oneOf must emit json tags on properties (#24916)")
+    public void testOneOfWithPropertiesEmitsJsonTags() throws IOException {
+        File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("go")
+                .setInputSpec("src/test/resources/3_0/go/oneof-with-properties.yaml")
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> files = generator.opts(configurator.toClientOptInput()).generate();
+        files.forEach(File::deleteOnExit);
+
+        Path modelFile = Paths.get(output + "/model_thing.go");
+        TestUtils.assertFileExists(modelFile);
+
+        // Properties must have json tags even though oneOf is present
+        TestUtils.assertFileContains(modelFile,
+                "Kind string `json:\"kind\"`");
+        TestUtils.assertFileContains(modelFile,
+                "FirstValue []float32 `json:\"first_value,omitempty\"`");
+        TestUtils.assertFileContains(modelFile,
+                "SecondValue []float32 `json:\"second_value,omitempty\"`");
+
+        // Must not be rendered as a oneOf union struct
+        TestUtils.assertFileNotContains(modelFile,
+                "GetActualInstance");
+    }
 }

--- a/modules/openapi-generator/src/test/resources/3_0/go/oneof-with-properties.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/go/oneof-with-properties.yaml
@@ -1,0 +1,43 @@
+openapi: 3.0.3
+info:
+  title: oneOf with properties regression test
+  version: 1.0.0
+paths:
+  /thing:
+    get:
+      operationId: getThing
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Thing'
+components:
+  schemas:
+    Thing:
+      type: object
+      required:
+        - kind
+      properties:
+        kind:
+          type: string
+        first_value:
+          type: array
+          items:
+            type: number
+        second_value:
+          type: array
+          items:
+            type: number
+      oneOf:
+        - required:
+            - first_value
+          not:
+            required:
+              - second_value
+        - required:
+            - second_value
+          not:
+            required:
+              - first_value


### PR DESCRIPTION
## Description

Fixes #24916.

The Go generator could omit `json` struct tags when a schema contained both
normal properties and a schema-level `oneOf`/`anyOf`.

The issue occurs because model property processing could select inherited
properties from composed schemas instead of the model's own properties.
For validation-only `oneOf` constraints, those inherited properties can be
empty, causing generated fields to lose their JSON tags.

This change ensures that existing model properties retain their generated
JSON tags even when schema-level composition is present, while preserving
the behavior of pure `oneOf` models.

## Tests

- Added a regression fixture for an object containing properties and
  schema-level `oneOf`
- Added regression coverage to verify JSON tags are generated
- Verified the model is not incorrectly generated as a oneOf union
- Existing Go generator tests pass