### PR TITLE
feat(rust-client): Add support for unsigned integer and more signed integer formats

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustClientCodegen.java
@@ -696,10 +696,22 @@ public class RustClientCodegen extends AbstractRustCodegen implements CodegenCon
                 }
             } else {
                 switch (p.getFormat()) {
+                    case "int8":
+                        return unsigned ? "u8" : "i8";
+                    case "int16":
+                        return unsigned ? "u16" : "i16";
                     case "int32":
                         return unsigned ? "u32" : "i32";
                     case "int64":
                         return unsigned ? "u64" : "i64";
+                    case "uint8":
+                        return "u8";
+                    case "uint16":
+                        return "u16";
+                    case "uint32":
+                        return "u32";
+                    case "uint64":
+                        return "u64";
                 }
             }
         }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/rust/RustClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/rust/RustClientCodegenTest.java
@@ -102,11 +102,29 @@ public class RustClientCodegenTest {
         s.setMinimum(BigDecimal.valueOf(0));
         s.setMaximum(BigDecimal.valueOf(1));
 
+        s.setFormat("int8");
+        Assert.assertEquals(codegen.getSchemaType(s), "i8");
+
+        s.setFormat("int16");
+        Assert.assertEquals(codegen.getSchemaType(s), "i16");
+
         s.setFormat("int32");
         Assert.assertEquals(codegen.getSchemaType(s), "i32");
 
         s.setFormat("int64");
         Assert.assertEquals(codegen.getSchemaType(s), "i64");
+
+        s.setFormat("uint8");
+        Assert.assertEquals(codegen.getSchemaType(s), "u8");
+
+        s.setFormat("uint16");
+        Assert.assertEquals(codegen.getSchemaType(s), "u16");
+
+        s.setFormat("uint32");
+        Assert.assertEquals(codegen.getSchemaType(s), "u32");
+
+        s.setFormat("uint64");
+        Assert.assertEquals(codegen.getSchemaType(s), "u64");
 
         // Clear format - should use default of i32
         s.setFormat(null);
@@ -180,6 +198,14 @@ public class RustClientCodegenTest {
 
         s.setMaximum(BigDecimal.valueOf(Long.MAX_VALUE));
         Assert.assertEquals(codegen.getSchemaType(s), "u32");
+
+        // Should respect hardcoded 8-bits, but prefer unsigned
+        s.setFormat("int8");
+        Assert.assertEquals(codegen.getSchemaType(s), "u8");
+
+        // Should respect hardcoded 16-bits, but prefer unsigned
+        s.setFormat("int16");
+        Assert.assertEquals(codegen.getSchemaType(s), "u16");
 
         // Should respect hardcoded 32-bits, but prefer unsigned
         s.setFormat("int32");


### PR DESCRIPTION
see OAI/OpenAPI-Specification#4564

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

fixes #22031

@frol (2017/07) @farcaller (2017/08) @richardwhiuk (2019/07) @paladinzh (2020/05) @jacob-pro (2022/10) @dsteeley (2025/07)

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for additional integer formats in the Rust client generator, mapping `int8`, `int16`, `uint8`, `uint16`, `uint32`, and `uint64` to the corresponding Rust types. Previously only `int32` and `int64` were handled, so other formats fell through to the default. This fixes #22031.

<sup>Written for commit 08933e05e65afc33fdbb894bb8060f510e2c32c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24921?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

