### PR TITLE
feat(rust-client): Export Client for easier use

### DIFF
--- a/modules/openapi-generator/src/main/resources/rust/reqwest-trait/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/rust/reqwest-trait/configuration.mustache
@@ -11,6 +11,7 @@ use std::sync::Arc;
 use google_cloud_token::TokenSource;
 use async_trait::async_trait;
 {{/supportTokenSource}}
+pub use {{#supportMiddleware}}reqwest_middleware::ClientWithMiddleware{{/supportMiddleware}}{{^supportMiddleware}}reqwest::Client{{/supportMiddleware}};
 
 #[derive(Debug, Clone)]
 pub struct Configuration {

--- a/modules/openapi-generator/src/main/resources/rust/reqwest/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/rust/reqwest/configuration.mustache
@@ -11,6 +11,7 @@ use std::sync::Arc;
 use google_cloud_token::TokenSource;
 use async_trait::async_trait;
 {{/supportTokenSource}}
+pub use {{#supportMiddleware}}reqwest_middleware::ClientWithMiddleware{{/supportMiddleware}}{{^supportMiddleware}}reqwest{{^supportAsync}}::blocking{{/supportAsync}}::Client{{/supportMiddleware}};
 
 #[derive(Debug, Clone)]
 pub struct Configuration {

--- a/samples/client/others/rust/reqwest-regression-16119/src/apis/configuration.rs
+++ b/samples/client/others/rust/reqwest-regression-16119/src/apis/configuration.rs
@@ -9,6 +9,7 @@
  */
 
 
+pub use reqwest::blocking::Client;
 
 #[derive(Debug, Clone)]
 pub struct Configuration {

--- a/samples/client/others/rust/reqwest/api-with-ref-param/src/apis/configuration.rs
+++ b/samples/client/others/rust/reqwest/api-with-ref-param/src/apis/configuration.rs
@@ -9,6 +9,7 @@
  */
 
 
+pub use reqwest::Client;
 
 #[derive(Debug, Clone)]
 pub struct Configuration {

--- a/samples/client/others/rust/reqwest/composed-oneof/src/apis/configuration.rs
+++ b/samples/client/others/rust/reqwest/composed-oneof/src/apis/configuration.rs
@@ -9,6 +9,7 @@
  */
 
 
+pub use reqwest::blocking::Client;
 
 #[derive(Debug, Clone)]
 pub struct Configuration {

--- a/samples/client/others/rust/reqwest/emptyObject/src/apis/configuration.rs
+++ b/samples/client/others/rust/reqwest/emptyObject/src/apis/configuration.rs
@@ -9,6 +9,7 @@
  */
 
 
+pub use reqwest::blocking::Client;
 
 #[derive(Debug, Clone)]
 pub struct Configuration {

--- a/samples/client/others/rust/reqwest/enum-query-params/src/apis/configuration.rs
+++ b/samples/client/others/rust/reqwest/enum-query-params/src/apis/configuration.rs
@@ -9,6 +9,7 @@
  */
 
 
+pub use reqwest::Client;
 
 #[derive(Debug, Clone)]
 pub struct Configuration {

--- a/samples/client/others/rust/reqwest/multipart-async/src/apis/configuration.rs
+++ b/samples/client/others/rust/reqwest/multipart-async/src/apis/configuration.rs
@@ -9,6 +9,7 @@
  */
 
 
+pub use reqwest::Client;
 
 #[derive(Debug, Clone)]
 pub struct Configuration {

--- a/samples/client/others/rust/reqwest/nullable-enum-query-params/src/apis/configuration.rs
+++ b/samples/client/others/rust/reqwest/nullable-enum-query-params/src/apis/configuration.rs
@@ -9,6 +9,7 @@
  */
 
 
+pub use reqwest::Client;
 
 #[derive(Debug, Clone)]
 pub struct Configuration {

--- a/samples/client/others/rust/reqwest/oneOf-array-map/src/apis/configuration.rs
+++ b/samples/client/others/rust/reqwest/oneOf-array-map/src/apis/configuration.rs
@@ -9,6 +9,7 @@
  */
 
 
+pub use reqwest::blocking::Client;
 
 #[derive(Debug, Clone)]
 pub struct Configuration {

--- a/samples/client/others/rust/reqwest/oneOf-reuseRef/src/apis/configuration.rs
+++ b/samples/client/others/rust/reqwest/oneOf-reuseRef/src/apis/configuration.rs
@@ -9,6 +9,7 @@
  */
 
 
+pub use reqwest::blocking::Client;
 
 #[derive(Debug, Clone)]
 pub struct Configuration {

--- a/samples/client/others/rust/reqwest/oneOf/src/apis/configuration.rs
+++ b/samples/client/others/rust/reqwest/oneOf/src/apis/configuration.rs
@@ -9,6 +9,7 @@
  */
 
 
+pub use reqwest::blocking::Client;
 
 #[derive(Debug, Clone)]
 pub struct Configuration {

--- a/samples/client/petstore/rust/reqwest-trait/petstore/src/apis/configuration.rs
+++ b/samples/client/petstore/rust/reqwest-trait/petstore/src/apis/configuration.rs
@@ -9,6 +9,7 @@
  */
 
 
+pub use reqwest::Client;
 
 #[derive(Debug, Clone)]
 pub struct Configuration {

--- a/samples/client/petstore/rust/reqwest/name-mapping/src/apis/configuration.rs
+++ b/samples/client/petstore/rust/reqwest/name-mapping/src/apis/configuration.rs
@@ -9,6 +9,7 @@
  */
 
 
+pub use reqwest::blocking::Client;
 
 #[derive(Debug, Clone)]
 pub struct Configuration {

--- a/samples/client/petstore/rust/reqwest/petstore-async-middleware/src/apis/configuration.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async-middleware/src/apis/configuration.rs
@@ -9,6 +9,7 @@
  */
 
 
+pub use reqwest_middleware::ClientWithMiddleware;
 
 #[derive(Debug, Clone)]
 pub struct Configuration {

--- a/samples/client/petstore/rust/reqwest/petstore-async-tokensource/src/apis/configuration.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async-tokensource/src/apis/configuration.rs
@@ -12,6 +12,7 @@
 use std::sync::Arc;
 use google_cloud_token::TokenSource;
 use async_trait::async_trait;
+pub use reqwest::Client;
 
 #[derive(Debug, Clone)]
 pub struct Configuration {

--- a/samples/client/petstore/rust/reqwest/petstore-async/src/apis/configuration.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async/src/apis/configuration.rs
@@ -9,6 +9,7 @@
  */
 
 
+pub use reqwest::Client;
 
 #[derive(Debug, Clone)]
 pub struct Configuration {

--- a/samples/client/petstore/rust/reqwest/petstore-avoid-box/src/apis/configuration.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-avoid-box/src/apis/configuration.rs
@@ -9,6 +9,7 @@
  */
 
 
+pub use reqwest::Client;
 
 #[derive(Debug, Clone)]
 pub struct Configuration {

--- a/samples/client/petstore/rust/reqwest/petstore-awsv4signature/src/apis/configuration.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-awsv4signature/src/apis/configuration.rs
@@ -13,6 +13,7 @@ use std::time::SystemTime;
 use aws_sigv4::http_request::{sign, SigningSettings, SigningParams, SignableRequest};
 use http;
 use secrecy::{SecretString, ExposeSecret};
+pub use reqwest::blocking::Client;
 
 #[derive(Debug, Clone)]
 pub struct Configuration {

--- a/samples/client/petstore/rust/reqwest/petstore-model-name-prefix/src/apis/configuration.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-model-name-prefix/src/apis/configuration.rs
@@ -9,6 +9,7 @@
  */
 
 
+pub use reqwest::blocking::Client;
 
 #[derive(Debug, Clone)]
 pub struct Configuration {

--- a/samples/client/petstore/rust/reqwest/petstore-no-chrono/src/apis/configuration.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-no-chrono/src/apis/configuration.rs
@@ -9,6 +9,7 @@
  */
 
 
+pub use reqwest::blocking::Client;
 
 #[derive(Debug, Clone)]
 pub struct Configuration {

--- a/samples/client/petstore/rust/reqwest/petstore-serde-path-to-error/src/apis/configuration.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-serde-path-to-error/src/apis/configuration.rs
@@ -9,6 +9,7 @@
  */
 
 
+pub use reqwest::Client;
 
 #[derive(Debug, Clone)]
 pub struct Configuration {

--- a/samples/client/petstore/rust/reqwest/petstore/src/apis/configuration.rs
+++ b/samples/client/petstore/rust/reqwest/petstore/src/apis/configuration.rs
@@ -9,6 +9,7 @@
  */
 
 
+pub use reqwest::blocking::Client;
 
 #[derive(Debug, Clone)]
 pub struct Configuration {

--- a/samples/client/petstore/rust/reqwest/test-duplicates/src/apis/configuration.rs
+++ b/samples/client/petstore/rust/reqwest/test-duplicates/src/apis/configuration.rs
@@ -9,6 +9,7 @@
  */
 
 
+pub use reqwest::blocking::Client;
 
 #[derive(Debug, Clone)]
 pub struct Configuration {


### PR DESCRIPTION
This makes it easier to create clients in projects that use the generated project. It also prevents version conflicts. For example, it is possible to simply create the client with the exported `petstore::apis::configuration::Client`.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

@frol (2017/07) @farcaller (2017/08) @richardwhiuk (2019/07) @paladinzh (2020/05) @jacob-pro (2022/10) @dsteeley (2025/07)

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exports the HTTP client type from generated Rust clients' `configuration` module. Previously, downstream projects had to depend on `reqwest` directly to instantiate a client; now they can use the re-exported `apis::configuration::Client` (or `ClientWithMiddleware` when middleware is enabled) to avoid version conflicts.

<sup>Written for commit 44d54f8002b34a273a45537914f176c1168f5e06. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24922?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

