### PR TITLE
[Rust] Use named lifetimes for UUID params in reqwest-trait (fix mockall build)

### DIFF
--- a/modules/openapi-generator/src/main/resources/rust/reqwest-trait/api.mustache
+++ b/modules/openapi-generator/src/main/resources/rust/reqwest-trait/api.mustache
@@ -47,7 +47,7 @@ pub trait {{{classname}}}: Send + Sync {
     ### &str and Vec<&str>
     }}{{#isString}}{{#isArray}}Vec<{{/isArray}}{{^isUuid}}&'{{#lambda.lifetimeName}}{{{paramName}}}{{/lambda.lifetimeName}} str{{/isUuid}}{{#isArray}}>{{/isArray}}{{/isString}}{{!
     ### UUIDs
-    }}{{#isUuid}}{{#isArray}}Vec<{{/isArray}}&str{{#isArray}}>{{/isArray}}{{/isUuid}}{{!
+    }}{{#isUuid}}{{#isArray}}Vec<{{/isArray}}&'{{#lambda.lifetimeName}}{{{paramName}}}{{/lambda.lifetimeName}} str{{#isArray}}>{{/isArray}}{{/isUuid}}{{!
     ### Models and primative types
     }}{{^isString}}{{^isUuid}}{{^isPrimitiveType}}{{^isContainer}}models::{{/isContainer}}{{/isPrimitiveType}}{{{dataType}}}{{/isUuid}}{{/isString}}{{!
     ### Option End
@@ -155,7 +155,7 @@ impl {{classname}} for {{classname}}Client {
     ### &str and Vec<&str>
     }}{{#isString}}{{#isArray}}Vec<{{/isArray}}{{^isUuid}}&'{{#lambda.lifetimeName}}{{{paramName}}}{{/lambda.lifetimeName}} str{{/isUuid}}{{#isArray}}>{{/isArray}}{{/isString}}{{!
     ### UUIDs
-    }}{{#isUuid}}{{#isArray}}Vec<{{/isArray}}&str{{#isArray}}>{{/isArray}}{{/isUuid}}{{!
+    }}{{#isUuid}}{{#isArray}}Vec<{{/isArray}}&'{{#lambda.lifetimeName}}{{{paramName}}}{{/lambda.lifetimeName}} str{{#isArray}}>{{/isArray}}{{/isUuid}}{{!
     ### Models and primative types
     }}{{^isString}}{{^isUuid}}{{^isPrimitiveType}}{{^isContainer}}models::{{/isContainer}}{{/isPrimitiveType}}{{{dataType}}}{{/isUuid}}{{/isString}}{{!
     ### Option End

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/rust/RustClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/rust/RustClientCodegenTest.java
@@ -311,4 +311,24 @@ public class RustClientCodegenTest {
         TestUtils.assertFileExists(outputPath);
         TestUtils.assertFileContains(outputPath, enumSpec);
     }
+
+    @Test
+    public void testReqwestTraitUuidParamsUseNamedLifetimes() throws IOException {
+        Path target = Files.createTempDirectory("test");
+        target.toFile().deleteOnExit();
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("rust")
+                .setLibrary("reqwest-trait")
+                .addAdditionalProperty("mockall", true)
+                .setInputSpec("src/test/resources/3_0/rust/reqwest-trait-uuid-params.yaml")
+                .setSkipOverwrite(false)
+                .setOutputDir(target.toAbsolutePath().toString().replace("\\", "/"));
+        new DefaultGenerator().opts(configurator.toClientOptInput()).generate();
+        Path outputPath = Path.of(target.toString(), "/src/apis/widget_api.rs");
+        TestUtils.assertFileExists(outputPath);
+        // mockall's #[automock] cannot elide the lifetime of a reference nested in Option<..>
+        TestUtils.assertFileContains(outputPath,
+                "async fn list_widget_items<'id, 'run_id>(&self, id: &'id str, run_id: Option<&'run_id str>)");
+        TestUtils.assertFileNotContains(outputPath, "Option<&str>");
+    }
 }

--- a/modules/openapi-generator/src/test/resources/3_0/rust/reqwest-trait-uuid-params.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/rust/reqwest-trait-uuid-params.yaml
@@ -1,0 +1,31 @@
+openapi: 3.0.3
+info:
+  title: UUID parameters with the reqwest-trait library
+  description: >-
+    Regression test for #24912. UUID parameters must use the named lifetime
+    declared on the trait method (e.g. Option<&'run_id str>), otherwise
+    mockall's #[automock] fails to compile.
+  version: 1.0.0
+paths:
+  /widgets/{id}/items:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    get:
+      operationId: listWidgetItems
+      tags:
+        - widget
+      parameters:
+        - name: run_id
+          in: query
+          required: false
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "204":
+          description: No content


### PR DESCRIPTION
Fixes the Rust `reqwest-trait` client failing to compile with `mockall=true` when an operation has an optional (or required-nullable) UUID parameter.

Closes #24912

### Root cause

`rust/reqwest-trait/api.mustache` declares a lifetime per parameter on every trait method (`fn list_widget_items<'id, 'run_id>(...)`) and string parameters use it (`&'status str`). The UUID branch was left with a bare `&str`, so the issue's spec generated:

```rust
async fn list_widget_items<'id, 'run_id>(&self, id: &str, run_id: Option<&str>) -> ...
```

`#[automock]` can handle an elided reference at the top level of an argument (`id: &str` compiles), but not one nested inside another type. So `Option<&str>` fails with `E0106: missing lifetime specifier` / `E0637`. Plain string params never hit this because they already use the named lifetime.

### Change

In both the trait declaration and the `impl`, the UUID branch now renders `&'<param> str`, the same as the string branch:

```rust
async fn list_widget_items<'id, 'run_id>(&self, id: &'id str, run_id: Option<&'run_id str>) -> ...
```

Only the `reqwest-trait` template changes. The plain `reqwest` template doesn't declare named lifetimes or use mockall, so it isn't affected. UUID arrays render as `Vec<uuid::Uuid>` and are unchanged.

### Testing

- New `RustClientCodegenTest#testReqwestTraitUuidParamsUseNamedLifetimes` with a regression spec at `src/test/resources/3_0/rust/reqwest-trait-uuid-params.yaml` (taken from the issue). It fails on the old template and passes with the fix:
  ```
  ./mvnw -B -pl modules/openapi-generator -am test -Dtest='RustClientCodegenTest' -Dsurefire.failIfNoSpecifiedTests=false
  ```
- Generated the client from the issue's spec with the reporter's exact options (`library=reqwest-trait,mockall=true,supportMiddleware=true,reqwestDefaultFeatures=rustls`), then ran `cargo build --features mockall`. Before the fix it failed with the E0106/E0637 errors from the issue. After the fix it builds, and plain `cargo build` still builds too.
- Also generated a wider spec (required-nullable UUID query param, optional UUID header param, UUID array query param) and ran a `cargo test --features mockall` that sets expectations on and calls the generated `MockWidgetApi` methods. It passes.
- `./bin/generate-samples.sh bin/configs/rust-reqwest-trait-petstore.yaml`: no changes to `samples/`, because the shared Rust petstore spec has no UUID operation parameters.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ```
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files.
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master.
  These must match the expectations made by your contribution.
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`.
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.

  Built with `./mvnw -pl modules/openapi-generator-cli -am package -DskipTests` and regenerated the only affected config, `bin/configs/rust-reqwest-trait-petstore.yaml` (no diff). No generator options changed, so the docs export is unaffected.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc Rust technical committee: @frol @farcaller @richardwhiuk @paladinzh @jacob-pro @dsteeley


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Rust `reqwest-trait` client failing to compile with `mockall=true` when an operation has an optional (or required-nullable) UUID parameter. UUID parameters now render with the same named lifetime as string parameters (`&'<param> str`), so `Option<&str>` no longer causes E0106/E0637. Closes #24912.

- Adds a regression test and OpenAPI spec covering an optional UUID query parameter.

<sup>Written for commit d0265e18af16e59697e5acbf58e335b48ff018ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24930?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

