### PR TITLE
ci: scope sample and test execution

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,11 @@
 version: 2.1
+parameters:
+  full_run:
+    type: boolean
+    default: false
+  selection_mode:
+    type: string
+    default: shadow
 commands: # a reusable command with parameters
   command_build_and_test:
     parameters:
@@ -6,13 +13,47 @@ commands: # a reusable command with parameters
         default: "0"
         type: string
     steps:
+      # Pin the event revision: a PR head ref may have advanced since scheduling.
+      - run:
+          name: Checkout source over HTTPS with retry
+          command: |
+            if [ -n "${CIRCLE_PULL_REQUEST:-}" ]; then
+              ref="refs/pull/${CIRCLE_PULL_REQUEST##*/}/head"
+            elif [[ "${CIRCLE_BRANCH:-}" =~ ^pull/[0-9]+$ ]]; then
+              ref="refs/${CIRCLE_BRANCH}/head"
+            else
+              ref="$CIRCLE_SHA1"
+            fi
+            [[ "$CIRCLE_SHA1" =~ ^[0-9a-fA-F]{40}$ ]] || exit 1
+            git init .
+            git remote add origin https://github.com/OpenAPITools/openapi-generator.git
+            for i in $(seq 1 5); do
+              if git fetch --no-tags --depth=1 origin "$CIRCLE_SHA1" ||
+                 git fetch --no-tags --depth=1 origin "$ref"; then
+                if [ "$(git rev-parse FETCH_HEAD)" = "$CIRCLE_SHA1" ] &&
+                   git checkout --detach "$CIRCLE_SHA1"; then
+                  exit 0
+                fi
+              fi
+              sleep 5
+            done
+            echo "Unable to check out the exact CircleCI event revision" >&2
+            exit 1
+      - run:
+          name: Select relevant CircleCI scope before setup
+          environment:
+            CIRCLE_NODE_INDEX: "<<parameters.nodeNo>>"
+            CI_FORCE_FULL: "<<pipeline.parameters.full_run>>"
+            CI_SELECTION_MODE: "<<pipeline.parameters.selection_mode>>"
+          command: bash CI/circle_select.sh
       # Restore the dependency cache
       - restore_cache:
           keys:
-            # Default branch if not
-            - source-v2-{{ .Branch }}-{{ .Revision }}
-            - source-v2-{{ .Branch }}-
-            - source-v2-
+            # Do not restore legacy source-v2 caches containing .git over the
+            # already verified checkout. Future caches must be dependency-only.
+            - dependencies-v3-{{ .Branch }}-{{ .Revision }}
+            - dependencies-v3-{{ .Branch }}-
+            - dependencies-v3-
       # Machine Setup
       #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
       - run:
@@ -24,26 +65,6 @@ commands: # a reusable command with parameters
             libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 \
             libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates \
             fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget libgbm1
-      # Avoid intermittent SSH checkout failures from CircleCI workers.
-      - run:
-          name: Checkout source over HTTPS with retry
-          command: |
-            if [ -n "${CIRCLE_PULL_REQUEST:-}" ]; then
-              ref="refs/pull/${CIRCLE_PULL_REQUEST##*/}/head"
-            elif [[ "${CIRCLE_BRANCH:-}" =~ ^pull/[0-9]+$ ]]; then
-              ref="refs/${CIRCLE_BRANCH}/head"
-            else
-              ref="$CIRCLE_SHA1"
-            fi
-            git init .
-            git remote add origin https://github.com/OpenAPITools/openapi-generator.git
-            for i in $(seq 1 5); do
-              if git fetch --depth=1 origin "$ref" && git checkout --detach FETCH_HEAD; then
-                exit 0
-              fi
-              sleep 5
-            done
-            exit 1
       # Prepare for artifact and test results  collection equivalent to how it was done on 1.0.
       # In many cases you can simplify this from what is generated here.
       # 'See docs on artifact collection here https://circleci.com/docs/2.0/artifacts/'

--- a/.github/.test/ci-scopes.js
+++ b/.github/.test/ci-scopes.js
@@ -1,0 +1,140 @@
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const {execFileSync} = require('child_process');
+const yaml = require('./js-yaml.js');
+
+const root = path.resolve(__dirname, '..', '..');
+const manifest = JSON.parse(fs.readFileSync(path.join(root, 'CI', 'change-scopes.json'), 'utf8'));
+assert.strictEqual(manifest.version, 1, 'Unsupported CI scope manifest version');
+assert(manifest.suites && typeof manifest.suites === 'object', 'Missing CI suites');
+
+function matches(file, pattern) {
+    pattern = pattern.replace(/\/+$/, '');
+    if (!/[?*]/.test(pattern)) return file === pattern || file.startsWith(`${pattern}/`);
+    const expression = pattern.split(/(\*\*|\*|\?)/).map(part => {
+        if (part === '**') return '.*';
+        if (part === '*') return '[^/]*';
+        if (part === '?') return '[^/]';
+        return part.replace(/[\\^$+.()|[\]{}]/g, '\\$&');
+    }).join('');
+    return new RegExp(`^${expression}$`).test(file) ||
+        (pattern.endsWith('/**') && file === pattern.slice(0, -3));
+}
+
+function sampleRoots(suite) {
+    return [...new Set([
+        ...(suite.matrix?.sample || []),
+        ...(suite.matrix?.include || []).filter(row => row.sample).map(row => row.sample)
+    ])].map(dir => dir.replace(/\/+$/, ''));
+}
+
+const tracked = execFileSync('git', ['ls-files', '-z', '--', 'samples'], {
+    cwd: root, encoding: 'utf8', maxBuffer: 32 * 1024 * 1024
+}).split('\0').filter(Boolean);
+const trackedSet = new Set(tracked);
+const typescriptRoots = tracked.filter(file => file.endsWith('/tsconfig.json'))
+    .map(file => path.posix.dirname(file))
+    .filter(dir => trackedSet.has(`${dir}/.openapi-generator-ignore`) && trackedSet.has(`${dir}/package.json`));
+const owned = Object.entries(manifest.suites).filter(([id]) => id.startsWith('samples-') ||
+    id.startsWith('gradle-test.') || id.startsWith('circle.'));
+
+function owners(dir) {
+    return owned.filter(([, suite]) => {
+        const roots = sampleRoots(suite);
+        if (suite.discovery === 'typescript') roots.push(...typescriptRoots);
+        return roots.some(candidate => matches(dir, candidate)) ||
+            (suite.paths || []).some(pattern => matches(dir, pattern));
+    }).map(([id]) => id);
+}
+
+// Config outputs and tracked generator markers reveal newly added samples even
+// when no workflow path filter or matrix has been updated.
+const candidates = new Set(tracked.filter(file => file.endsWith('/.openapi-generator-ignore'))
+    .map(file => path.posix.dirname(file)));
+const buildFiles = new Set(['pom.xml', 'package.json', 'pyproject.toml', 'Cargo.toml',
+    'pubspec.yaml', 'go.mod', 'mix.exs', 'build.gradle', 'build.gradle.kts', 'Project.toml']);
+for (const file of tracked) {
+    const name = path.posix.basename(file);
+    const directory = path.posix.dirname(file);
+    if (directory !== 'samples' && (buildFiles.has(name) || name.endsWith('.csproj'))) candidates.add(directory);
+}
+for (const file of fs.readdirSync(path.join(root, 'bin', 'configs')).filter(file => file.endsWith('.yaml'))) {
+    const text = fs.readFileSync(path.join(root, 'bin', 'configs', file), 'utf8');
+    const output = text.match(/^outputDir:\s*(.+)$/m);
+    if (output) {
+        const dir = yaml.safeLoad(output[1]);
+        if (typeof dir === 'string' && dir.startsWith('samples/')) candidates.add(dir.replace(/\/+$/, ''));
+    }
+}
+const unowned = [...candidates].filter(dir => owners(dir).length === 0).sort();
+if (process.argv.includes('--list-unowned')) {
+    process.stdout.write(JSON.stringify(unowned, null, 2) + '\n');
+    process.exit(0);
+}
+
+const exclusions = new Map((manifest.exclusions || []).map(entry => {
+    assert(typeof entry.path === 'string' && entry.path.startsWith('samples/') &&
+        !/[?*]/.test(entry.path), 'Exclusions must name exact sample roots');
+    assert(typeof entry.reason === 'string' && entry.reason.trim(), `Missing exclusion reason: ${entry.path}`);
+    return [entry.path, entry.reason];
+}));
+for (const dir of unowned) {
+    assert(exclusions.has(dir), `Unowned sample ${dir}: register a CI suite or document an explicit exclusion`);
+}
+
+const workflowDir = path.join(root, '.github', 'workflows');
+const workflows = new Map();
+for (const file of fs.readdirSync(workflowDir).filter(file => /\.ya?ml$/.test(file))) {
+    workflows.set(`.github/workflows/${file}`, yaml.safeLoad(fs.readFileSync(path.join(workflowDir, file), 'utf8')));
+}
+for (const [id, suite] of Object.entries(manifest.suites)) {
+    for (const dir of sampleRoots(suite)) {
+        assert(!dir.includes('..') && !path.posix.isAbsolute(dir), `Invalid sample root in ${id}: ${dir}`);
+        assert(fs.statSync(path.join(root, ...dir.split('/'))).isDirectory(), `Missing sample target ${id}: ${dir}`);
+        const packageFile = path.join(root, ...dir.split('/'), 'package.json');
+        if (fs.existsSync(packageFile)) {
+            const pkg = JSON.parse(fs.readFileSync(packageFile, 'utf8'));
+            for (const reference of Object.values({...pkg.dependencies, ...pkg.devDependencies})) {
+                if (typeof reference !== 'string' || !reference.startsWith('file:')) continue;
+                const dependency = path.posix.normalize(path.posix.join(dir, reference.slice(5)));
+                if (matches(dependency, dir)) continue;
+                assert([...(suite.paths || []), ...(suite.shared_paths || [])].some(p => matches(dependency, p)),
+                    `${id}: declare external local dependency ${dependency} as a shared input`);
+            }
+        }
+    }
+    if (!suite.workflow) continue;
+    if (suite.workflow === '.circleci/config.yml') continue;
+    const workflow = workflows.get(suite.workflow);
+    assert(workflow, `Missing workflow for ${id}: ${suite.workflow}`);
+    const calls = Object.values(workflow.jobs).flatMap(job => job.steps || [])
+        .filter(step => step.uses === './.github/actions/compute-matrix' && step.with?.suite === id);
+    assert.strictEqual(calls.length, 1, `Suite ${id} must have exactly one workflow selector`);
+}
+let sampleJobs = 0;
+for (const [filename, workflow] of workflows) {
+    if (!/\/samples-[^/]+\.ya?ml$/.test(filename) && !filename.endsWith('/gradle-test.yaml')) continue;
+    assert(workflow.on.workflow_dispatch !== undefined, `${filename}: missing full-run dispatch`);
+    assert(!workflow.on.pull_request?.paths, `${filename}: PR path filters can hide relevant changes`);
+    assert(!workflow.on.push?.paths, `${filename}: safety pushes must run full scope`);
+    assert.deepStrictEqual(workflow.on.push.branches, ['master', '[5-9]+.[0-9]+.x'],
+        `${filename}: unexpected safety branches`);
+    for (const [jobId, job] of Object.entries(workflow.jobs)) {
+        if (jobId === 'setup') continue;
+        sampleJobs++;
+        const id = `${path.posix.basename(filename).replace(/\.ya?ml$/, '')}.${jobId}`;
+        const suite = manifest.suites[id];
+        assert(suite, `Missing scope for ${filename}/${jobId}`);
+        assert.strictEqual(job.needs, 'setup', `${id}: selection must precede runner allocation`);
+        assert(job.if?.includes("_changed == 'true'"), `${id}: missing explicit empty-selection guard`);
+        if (suite.matrix) {
+            assert.strictEqual(typeof job.strategy.matrix, 'string', `${id}: duplicate static matrix`);
+            assert(job.strategy.matrix.includes('fromJSON(needs.setup.outputs.'), `${id}: disconnected matrix`);
+        }
+    }
+}
+console.log(`CI scope coverage: ${sampleJobs} sample jobs, ${Object.keys(manifest.suites).length} suites, ` +
+    `${candidates.size} sample roots (${unowned.length} documented exclusions).`);

--- a/.github/actions/compute-matrix/action.yaml
+++ b/.github/actions/compute-matrix/action.yaml
@@ -1,0 +1,49 @@
+name: Select changed CI scope
+description: Compute a conservative PR matrix using the shared ownership policy.
+inputs:
+  suite:
+    description: Suite ID in CI/change-scopes.json
+    required: true
+  mode:
+    description: enforce filters matrices; shadow preserves historical workflow gating and executes full matrices
+    default: shadow
+  force-full:
+    description: Execute the original complete matrix
+    default: 'false'
+outputs:
+  matrix:
+    description: JSON matrix object
+    value: ${{ steps.select.outputs.matrix }}
+  samples:
+    description: JSON array of selected sample paths
+    value: ${{ steps.select.outputs.samples }}
+  has_changes:
+    description: Whether the suite should execute
+    value: ${{ steps.select.outputs.has_changes }}
+  run_all:
+    description: Whether execution uses the full suite
+    value: ${{ steps.select.outputs.run_all }}
+  reasons:
+    description: JSON array of decision reasons
+    value: ${{ steps.select.outputs.reasons }}
+  proposed_selection:
+    description: Proposed filtered decision in shadow mode
+    value: ${{ steps.select.outputs.proposed_selection }}
+runs:
+  using: composite
+  steps:
+    - id: select
+      shell: bash
+      env:
+        CI_SUITE: ${{ inputs.suite }}
+        CI_SELECTION_MODE: ${{ inputs.mode }}
+        CI_ACTION_FORCE_FULL: ${{ inputs.force-full }}
+      run: |
+        args=()
+        if [[ "$CI_ACTION_FORCE_FULL" == "true" ]]; then
+          args+=(--force-full)
+        elif [[ "$CI_ACTION_FORCE_FULL" != "false" ]]; then
+          echo "force-full must be true or false" >&2
+          exit 2
+        fi
+        python3 CI/select_changes.py --provider github --suite "$CI_SUITE" --mode "$CI_SELECTION_MODE" "${args[@]}"

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -3,26 +3,33 @@ name: Docker tests
 on:
   workflow_dispatch:
   push:
-    paths:
-      - Dockerfile
-      - run-in-docker.sh
-      - pom.xml
-      - modules/openapi-generator-online/pom.xml
-      - modules/openapi-generator-online/Dockerfile
-      - modules/openapi-generator-cli/pom.xml
-      - modules/openapi-generator-cli/Dockerfile
+    branches:
+      - master
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - Dockerfile
-      - run-in-docker.sh
-      - pom.xml
-      - modules/openapi-generator-online/pom.xml
-      - modules/openapi-generator-online/Dockerfile
-      - modules/openapi-generator-cli/pom.xml
-      - modules/openapi-generator-cli/Dockerfile
+
 jobs:
+  setup:
+    name: Select changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - uses: ./.github/actions/compute-matrix
+        id: build
+        with:
+          suite: docker.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
     name: 'Build: Docker'
+    needs: setup
+    if: needs.setup.outputs.build_changed == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Check out code

--- a/.github/workflows/gradle-plugin-tests.yaml
+++ b/.github/workflows/gradle-plugin-tests.yaml
@@ -1,16 +1,35 @@
 name: Gradle plugin tests
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - modules/openapi-generator-gradle-plugin/**
+    branches:
+      - master
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - modules/openapi-generator-gradle-plugin/**
 
 jobs:
+  setup:
+    name: Select changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      test_changed: ${{ steps.test.outputs.has_changes }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - uses: ./.github/actions/compute-matrix
+        id: test
+        with:
+          suite: gradle-plugin-tests.test
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   test:
     name: Gradle plugin tests
+    needs: setup
+    if: needs.setup.outputs.test_changed == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/gradle-test.yaml
+++ b/.github/workflows/gradle-test.yaml
@@ -1,36 +1,43 @@
 name: Gradle tests (Java samples)
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - 'samples/client/petstore/java/**'
-      - 'samples/openapi3/client/petstore/java/**'
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - 'samples/client/petstore/java/**'
-      - 'samples/openapi3/client/petstore/java/**'
+
 env:
   GRADLE_VERSION: 8.7
 
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: gradle-test.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Gradle tests
     runs-on: ubuntu-latest
     container: gradle:jdk11
     strategy:
       fail-fast: true
-      matrix:
-        sample:
-          - samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8
-          - samples/openapi3/client/petstore/java/jersey2-java8-special-characters
-          - samples/openapi3/client/petstore/java/jersey2-java8
-          - samples/client/petstore/java/jersey2-java8-localdatetime
-          - samples/client/petstore/java/jersey2-java8
-          - samples/client/petstore/java/okhttp-gson
-          - samples/client/petstore/java/okhttp-gson-group-parameter
-          - samples/client/petstore/java/webclient-swagger2
-          - samples/client/petstore/java/native
-          - samples/client/petstore/java/native-jakarta
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-java@v6.0.0

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -1,6 +1,7 @@
 name: Linux tests
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - master
@@ -11,8 +12,33 @@ on:
       - '[5-9]+.[0-9]+.x'
 
 jobs:
+  setup:
+    name: Select changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      verify_changed: ${{ steps.verify.outputs.has_changes }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - uses: ./.github/actions/compute-matrix
+        id: build
+        with:
+          suite: linux.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+      - uses: ./.github/actions/compute-matrix
+        id: verify
+        with:
+          suite: linux.verify
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
     name: 'Build: JDK ${{ matrix.java }} (${{ matrix.os }})'
+    needs: setup
+    if: needs.setup.outputs.build_changed == 'true' || needs.setup.outputs.verify_changed == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -84,7 +110,8 @@ jobs:
 
   verify:
     name: Verify outputs on ${{ matrix.os }}
-    needs: build
+    needs: [setup, build]
+    if: needs.setup.outputs.verify_changed == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -102,13 +129,14 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: artifact
+          path: modules/openapi-generator-cli/target
       - name: Run Ensures Script
         shell: bash
         run: |
           git config --global core.fileMode false
           git config --global core.safecrlf false
           git config --global core.autocrlf true
-          ./mvnw clean package -Dmaven.test.skip=true -Dmaven.javadoc.skip=true
+          test -s modules/openapi-generator-cli/target/openapi-generator-cli.jar
           # test with java (jersey2) client generation only as ensure-up-to-date script is run in another job instead
           ./bin/generate-samples.sh ./bin/configs/java-jersey2-8.yaml
           # test debugSupportingFiles

--- a/.github/workflows/maven-plugin-tests-jdk17.yaml
+++ b/.github/workflows/maven-plugin-tests-jdk17.yaml
@@ -1,16 +1,35 @@
 name: Maven plugin tests (JDK17)
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - modules/openapi-generator-maven-plugin/**
+    branches:
+      - master
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - modules/openapi-generator-maven-plugin/**
 
 jobs:
+  setup:
+    name: Select changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      test_changed: ${{ steps.test.outputs.has_changes }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - uses: ./.github/actions/compute-matrix
+        id: test
+        with:
+          suite: maven-plugin-tests-jdk17.test
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   test:
     name: Maven plugin tests
+    needs: setup
+    if: needs.setup.outputs.test_changed == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/maven-plugin-tests.yaml
+++ b/.github/workflows/maven-plugin-tests.yaml
@@ -1,16 +1,35 @@
 name: Maven plugin tests
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - modules/openapi-generator-maven-plugin/**
+    branches:
+      - master
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - modules/openapi-generator-maven-plugin/**
 
 jobs:
+  setup:
+    name: Select changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      test_changed: ${{ steps.test.outputs.has_changes }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - uses: ./.github/actions/compute-matrix
+        id: test
+        with:
+          suite: maven-plugin-tests.test
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   test:
     name: Maven plugin tests
+    needs: setup
+    if: needs.setup.outputs.test_changed == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/mill-plugin-tests.yaml
+++ b/.github/workflows/mill-plugin-tests.yaml
@@ -1,16 +1,35 @@
 name: Mill plugin tests
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - modules/openapi-generator-mill-plugin/**
+    branches:
+      - master
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - modules/openapi-generator-mill-plugin/**
 
 jobs:
+  setup:
+    name: Select changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      test_changed: ${{ steps.test.outputs.has_changes }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - uses: ./.github/actions/compute-matrix
+        id: test
+        with:
+          suite: mill-plugin-tests.test
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   test:
     name: Mill plugin tests
+    needs: setup
+    if: needs.setup.outputs.test_changed == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/misc-test.yaml
+++ b/.github/workflows/misc-test.yaml
@@ -16,6 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+      - name: Check CI scope coverage
+        run: node .github/.test/ci-scopes.js
+      - name: Test CI change selection
+        run: python3 -m unittest discover -s CI/tests -p 'test_*.py'
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '2.6'

--- a/.github/workflows/openapi-generator-test-results.yaml
+++ b/.github/workflows/openapi-generator-test-results.yaml
@@ -8,8 +8,54 @@ on:
 
 # separate workflow required due to https://github.com/dorny/test-reporter#recommended-setup-for-public-repositories
 jobs:
-  report:
+  inspect:
+    name: Inspect unit test outcome
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+    outputs:
+      publish: ${{ steps.outcome.outputs.publish }}
+    steps:
+      - uses: actions/github-script@v8
+        id: outcome
+        with:
+          script: |
+            const run = context.payload.workflow_run;
+            const parameters = { ...context.repo, run_id: run.id, per_page: 100 };
+            const jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun,
+              { ...parameters, filter: 'latest' });
+            const tests = jobs.filter(job => job.name === 'Unit tests');
+            if (tests.length !== 1) {
+              throw new Error(`Expected one Unit tests job in run ${run.id}, found ${tests.length}`);
+            }
+            const test = tests[0];
+            if (test.conclusion === 'skipped') {
+              const setup = jobs.find(job => job.name === 'Select changes');
+              if (!setup || setup.conclusion !== 'success' || run.conclusion === 'cancelled') {
+                throw new Error('Unit tests did not run because selection failed or the run was cancelled');
+              }
+              core.setOutput('publish', 'false');
+              await core.summary.addHeading('Unit tests not run')
+                .addRaw('The upstream change selector intentionally skipped unit tests.').write();
+              return;
+            }
+            if (!['success', 'failure'].includes(test.conclusion)) {
+              throw new Error(`Unit tests did not complete: ${test.conclusion}`);
+            }
+            const artifacts = await github.paginate(github.rest.actions.listWorkflowRunArtifacts, parameters);
+            if (!artifacts.some(artifact => artifact.name === 'surefire-test-results' && !artifact.expired)) {
+              throw new Error('Executed unit tests have no available surefire-test-results artifact');
+            }
+            core.setOutput('publish', 'true');
+
+  report:
+    needs: inspect
+    if: needs.inspect.outputs.publish == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      checks: write
     steps:
       - uses: dorny/test-reporter@v3
         with:

--- a/.github/workflows/openapi-generator.yaml
+++ b/.github/workflows/openapi-generator.yaml
@@ -1,6 +1,7 @@
 name: OpenAPI Generator
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - master
@@ -11,8 +12,45 @@ on:
       - '[5-9]+.[0-9]+.x'
 
 jobs:
+  setup:
+    name: Select changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      test_changed: ${{ steps.test.outputs.has_changes }}
+      documentation_changed: ${{ steps.documentation.outputs.has_changes }}
+      samples_changed: ${{ steps.samples.outputs.has_changes }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - uses: ./.github/actions/compute-matrix
+        id: build
+        with:
+          suite: openapi-generator.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+      - uses: ./.github/actions/compute-matrix
+        id: test
+        with:
+          suite: openapi-generator.test
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+      - uses: ./.github/actions/compute-matrix
+        id: documentation
+        with:
+          suite: openapi-generator.documentation
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+      - uses: ./.github/actions/compute-matrix
+        id: samples
+        with:
+          suite: openapi-generator.samples
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
     name: Build
+    needs: setup
+    if: needs.setup.outputs.build_changed == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -51,8 +89,8 @@ jobs:
   test:
     name: Unit tests
     runs-on: ubuntu-latest
-    needs:
-      - build
+    needs: setup
+    if: needs.setup.outputs.test_changed == 'true'
     steps:
       - uses: actions/checkout@v7
       - name: Set up JDK 11
@@ -85,12 +123,15 @@ jobs:
         with:
           name: surefire-test-results
           path: '**/surefire-reports/TEST-*.xml'
+          if-no-files-found: error
 
   documentation:
     name: Docs up-to-date
     runs-on: ubuntu-latest
     needs:
+      - setup
       - build
+    if: needs.setup.outputs.documentation_changed == 'true'
     steps:
       - uses: actions/checkout@v7
       - name: Set up JDK 11
@@ -128,7 +169,9 @@ jobs:
   samples:
     name: Samples up-to-date
     needs:
+      - setup
       - build
+    if: needs.setup.outputs.samples_changed == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/samples-aspnet-fastenpoints-server.yaml
+++ b/.github/workflows/samples-aspnet-fastenpoints-server.yaml
@@ -1,29 +1,39 @@
 name: Samples C# .Net 8 FastEndpoints Server
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - samples/server/petstore/aspnet/fastendpoints/**
-      - samples/server/petstore/aspnet/fastendpoints-*/**
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - samples/server/petstore/aspnet/fastendpoints/**
-      - samples/server/petstore/aspnet/fastendpoints-*/**
+
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-aspnet-fastenpoints-server.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build .Net 8 FastEndpoints servers
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          - samples/server/petstore/aspnet/fastendpoints
-          - samples/server/petstore/aspnet/fastendpoints-useApiVersioning
-          - samples/server/petstore/aspnet/fastendpoints-useAuthentication
-          - samples/server/petstore/aspnet/fastendpoints-useProblemDetails
-          - samples/server/petstore/aspnet/fastendpoints-useRecords
-          - samples/server/petstore/aspnet/fastendpoints-useResponseCaching
-          - samples/server/petstore/aspnet/fastendpoints-useValidators
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-dotnet@v6.0.0

--- a/.github/workflows/samples-c-libcurl-client.yaml
+++ b/.github/workflows/samples-c-libcurl-client.yaml
@@ -1,29 +1,39 @@
 name: Samples c libcurl client
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - 'samples/client/petstore/c/**'
-      - 'samples/client/petstore/c-useJsonUnformatted/**'
-      - 'samples/client/others/c/bearerAuth/**'
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - 'samples/client/petstore/c/**'
-      - 'samples/client/petstore/c-useJsonUnformatted/**'
-      - 'samples/client/others/c/bearerAuth/**'
 
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-c-libcurl-client.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build c libcurl client
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          - 'samples/client/petstore/c/'
-          - 'samples/client/petstore/c-useJsonUnformatted/'
-          - 'samples/client/others/c/bearerAuth/'
-
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - name: Prepare

--- a/.github/workflows/samples-clojure.yaml
+++ b/.github/workflows/samples-clojure.yaml
@@ -1,21 +1,39 @@
 name: Samples Clojure Client
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - samples/client/petstore/clojure/**
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - samples/client/petstore/clojure/**
+
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-clojure.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build Clojure Client (JDK11)
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          - samples/client/petstore/clojure/
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     services:
       petstore-api:
         image: swaggerapi/petstore

--- a/.github/workflows/samples-cpp-httplib-server.yaml
+++ b/.github/workflows/samples-cpp-httplib-server.yaml
@@ -1,30 +1,40 @@
 name: Samples cpp httplib server
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - "samples/server/petstore/cpp-httplib-server/**"
-      - ".github/workflows/samples-cpp-httplib-server.yaml"
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - "samples/server/petstore/cpp-httplib-server/**"
-      - ".github/workflows/samples-cpp-httplib-server.yaml"
 
 env:
   GRADLE_VERSION: 6.9
 
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-cpp-httplib-server.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build cpp httplib server
     strategy:
-      matrix:
-        sample:
-          - samples/server/petstore/cpp-httplib-server/petstore
-          - samples/server/petstore/cpp-httplib-server/feature-test
-        os:
-          - ubuntu-latest
-          - macOS-latest
-          - windows-latest
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/samples-cpp-oatpp-client.yaml
+++ b/.github/workflows/samples-cpp-oatpp-client.yaml
@@ -1,27 +1,40 @@
 name: Samples cpp oat++ client
 
 on:
+  workflow_dispatch:
   push:
     branches:
-      - "samples/client/petstore/cpp-oatpp/**"
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - "samples/client/petstore/cpp-oatpp/**"
 
 env:
   GRADLE_VERSION: 6.9
 
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-cpp-oatpp-client.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build cpp oat++ client
     strategy:
-      matrix:
-        sample:
-          - samples/client/petstore/cpp-oatpp
-        os:
-          - ubuntu-latest
-          - macOS-latest
-          - windows-latest
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/samples-cpp-oatpp-server.yaml
+++ b/.github/workflows/samples-cpp-oatpp-server.yaml
@@ -1,27 +1,40 @@
 name: Samples cpp oat++ server
 
 on:
+  workflow_dispatch:
   push:
     branches:
-      - "samples/server/petstore/cpp-oatpp/**"
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - "samples/server/petstore/cpp-oatpp/**"
 
 env:
   GRADLE_VERSION: 6.9
 
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-cpp-oatpp-server.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build cpp oat++ server
     strategy:
-      matrix:
-        sample:
-          - samples/server/petstore/cpp-oatpp
-        os:
-          - ubuntu-latest
-          - macOS-latest
-          - windows-latest
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/samples-cpp-qt-client.yaml
+++ b/.github/workflows/samples-cpp-qt-client.yaml
@@ -1,28 +1,40 @@
 name: Samples cpp qt client
 
 on:
+  workflow_dispatch:
   push:
     branches:
-      - "samples/client/petstore/cpp-qt*/**"
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - "samples/client/petstore/cpp-qt*/**"
 
 env:
   GRADLE_VERSION: 6.9
 
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-cpp-qt-client.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build cpp qt client
     strategy:
-      matrix:
-        sample:
-          - samples/client/petstore/cpp-qt
-          - samples/client/petstore/cpp-qt-addDownloadProgress
-        os:
-          - ubuntu-latest
-          - macOS-latest
-          - windows-latest
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/samples-crystal.yaml
+++ b/.github/workflows/samples-crystal.yaml
@@ -1,22 +1,39 @@
 name: Samples Crystal clients
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - samples/client/petstore/crystal/**
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - samples/client/petstore/crystal/**
+
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-crystal.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build Crystal projects
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          # clients
-          - samples/client/petstore/crystal/
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     services:
       petstore-api:
         image: swaggerapi/petstore

--- a/.github/workflows/samples-dart-build-test.yaml
+++ b/.github/workflows/samples-dart-build-test.yaml
@@ -1,47 +1,37 @@
 name: Samples Dart (build, test)
 
 on:
+  workflow_dispatch:
   push:
     branches:
-    paths:
-      #- samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/**
-      #- samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake_tests/**
-      #- samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/**
-      - samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/**
-      - samples/openapi3/client/petstore/dart-dio/oneof/**
-      - samples/openapi3/client/petstore/dart-dio/anyof/**
-      - samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/**
-      - samples/openapi3/client/petstore/dart-dio/binary_response/**
-      - samples/openapi3/client/petstore/dart-dio/petstore-timemachine/**
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      #- samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/**
-      #- samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake_tests/**
-      #- samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/**
-      - samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/**
-      - samples/openapi3/client/petstore/dart-dio/oneof/**
-      - samples/openapi3/client/petstore/dart-dio/anyof/**
-      - samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/**
-      - samples/openapi3/client/petstore/dart-dio/binary_response/**
-      - samples/openapi3/client/petstore/dart-dio/petstore-timemachine/**
 
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      test_changed: ${{ steps.test.outputs.has_changes }}
+      test_matrix: ${{ steps.test.outputs.matrix }}
+      test_samples: ${{ steps.test.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: test
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-dart-build-test.test
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   test:
+    needs: setup
+    if: ${{ needs.setup.outputs.test_changed == 'true' }}
     runs-on: ${{ matrix.os }}
     strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest]
-        sdk: ["3.9.0"]
-        sample:
-          #- samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/
-          #- samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake_tests/
-          #- samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/
-          - samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/
-          - samples/openapi3/client/petstore/dart-dio/oneof/
-          - samples/openapi3/client/petstore/dart-dio/anyof/
-          - samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/
-          - samples/openapi3/client/petstore/dart-dio/binary_response/
-          - samples/openapi3/client/petstore/dart-dio/petstore-timemachine/
+      matrix: ${{ fromJSON(needs.setup.outputs.test_matrix) }}
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/samples-dart.yaml
+++ b/.github/workflows/samples-dart.yaml
@@ -1,19 +1,37 @@
 name: Samples Dart
 
 on:
+  workflow_dispatch:
   push:
     branches:
-      - master
+      - 'master'
       - '[5-9]+.[0-9]+.x'
   pull_request:
     branches:
-      - master
+      - 'master'
       - '[5-9]+.[0-9]+.x'
-    paths:
-      - 'samples/openapi3/client/petstore/dart*/**'
 
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      tests_dart_changed: ${{ steps.tests_dart.outputs.has_changes }}
+      tests_dart_matrix: ${{ steps.tests_dart.outputs.matrix }}
+      tests_dart_samples: ${{ steps.tests_dart.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: tests_dart
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-dart.tests-dart
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   tests-dart:
+    needs: setup
+    if: ${{ needs.setup.outputs.tests_dart_changed == 'true' }}
     name: Tests Dart
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/samples-dotnet-fx.yaml
+++ b/.github/workflows/samples-dotnet-fx.yaml
@@ -1,37 +1,39 @@
 name: Samples C# .Net Framework Clients
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - samples/client/petstore/csharp/generichost/net4.7/**
-      - samples/client/petstore/csharp/generichost/net4.8/**
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - samples/client/petstore/csharp/generichost/net4.7/**
-      - samples/client/petstore/csharp/generichost/net4.8/**
+
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-dotnet-fx.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build .Net Framework projects
     runs-on: windows-latest
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          - samples/client/petstore/csharp/generichost/net4.7/AllOf
-          - samples/client/petstore/csharp/generichost/net4.7/AnyOf
-          - samples/client/petstore/csharp/generichost/net4.7/AnyOfNoCompare
-          - samples/client/petstore/csharp/generichost/net4.7/FormModels
-          - samples/client/petstore/csharp/generichost/net4.7/OneOf
-          - samples/client/petstore/csharp/generichost/net4.7/Petstore
-          - samples/client/petstore/csharp/generichost/net4.7/UseDateTimeForDate
-
-          - samples/client/petstore/csharp/generichost/net4.8/AllOf
-          - samples/client/petstore/csharp/generichost/net4.8/AnyOf
-          - samples/client/petstore/csharp/generichost/net4.8/AnyOfNoCompare
-          - samples/client/petstore/csharp/generichost/net4.8/FormModels
-          - samples/client/petstore/csharp/generichost/net4.8/OneOf
-          - samples/client/petstore/csharp/generichost/net4.8/Petstore
-          - samples/client/petstore/csharp/generichost/net4.8/UseDateTimeForDate
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - name: Build

--- a/.github/workflows/samples-dotnet-petstore-net10.yml
+++ b/.github/workflows/samples-dotnet-petstore-net10.yml
@@ -1,14 +1,34 @@
 name: Samples C# .Net 10 Client (Petstore)
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - samples/client/petstore/csharp/restsharp/net10/Petstore/**
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - samples/client/petstore/csharp/restsharp/net10/Petstore/**
+
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-dotnet-petstore-net10.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build clients
     runs-on: ubuntu-latest
     services:
@@ -21,9 +41,7 @@ jobs:
           SWAGGER_BASE_PATH: /v2
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          - samples/client/petstore/csharp/restsharp/net10/Petstore/
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-dotnet@v6.0.0

--- a/.github/workflows/samples-dotnet-petstore.yml
+++ b/.github/workflows/samples-dotnet-petstore.yml
@@ -1,14 +1,34 @@
 name: Samples C# .Net Client (Petstore)
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - samples/client/petstore/csharp/restsharp/standard2.0/Petstore/**
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - samples/client/petstore/csharp/restsharp/standard2.0/Petstore/**
+
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-dotnet-petstore.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build clients
     runs-on: ubuntu-latest
     services:
@@ -21,9 +41,7 @@ jobs:
           SWAGGER_BASE_PATH: /v2
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          - samples/client/petstore/csharp/restsharp/standard2.0/Petstore/
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-dotnet@v6.0.0

--- a/.github/workflows/samples-dotnet-standard.yaml
+++ b/.github/workflows/samples-dotnet-standard.yaml
@@ -1,31 +1,39 @@
 name: Samples C# .Net Standard Client
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - samples/client/petstore/csharp/generichost/standard2.0/**
-      - samples/client/petstore/csharp/httpclient/standard2.0/**
-      - samples/client/petstore/csharp/restsharp/standard2.0/**
-      - samples/client/petstore/csharp/unityWebRequest/standard2.0/**
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - samples/client/petstore/csharp/generichost/standard2.0/**
-      - samples/client/petstore/csharp/httpclient/standard2.0/**
-      - samples/client/petstore/csharp/restsharp/standard2.0/**
-      - samples/client/petstore/csharp/unityWebRequest/standard2.0/**
+
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-dotnet-standard.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build .Net Standard projects
     runs-on: windows-latest
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          - samples/client/petstore/csharp/generichost/standard2.0/Petstore/
-          - samples/client/petstore/csharp/httpclient/standard2.0/Petstore/
-          - samples/client/petstore/csharp/restsharp/standard2.0/Petstore/
-          - samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/
-          # - samples/client/petstore/csharp/unityWebRequest/standard2.0/Petstore/
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-dotnet@v6.0.0

--- a/.github/workflows/samples-dotnet10.yaml
+++ b/.github/workflows/samples-dotnet10.yaml
@@ -1,54 +1,39 @@
 name: Samples C# .Net 10 Clients
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - samples/client/petstore/csharp/generichost/latest/**
-      - samples/client/petstore/csharp/generichost/net10/**
-      - samples/client/petstore/csharp/httpclient/net10/**
-      - samples/client/petstore/csharp/restsharp/net10/**
-      - samples/client/petstore/csharp/unityWebRequest/net10/**
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - samples/client/petstore/csharp/generichost/latest/**
-      - samples/client/petstore/csharp/generichost/net10/**
-      - samples/client/petstore/csharp/httpclient/net10/**
-      - samples/client/petstore/csharp/restsharp/net10/**
-      - samples/client/petstore/csharp/unityWebRequest/net10/**
+
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-dotnet10.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build .Net 10 projects
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          - samples/client/petstore/csharp/generichost/latest/AnnotatedEnum
-          - samples/client/petstore/csharp/generichost/latest/ComposedEnum
-          - samples/client/petstore/csharp/generichost/latest/InlineEnumAnyOf
-          - samples/client/petstore/csharp/generichost/latest/Tags
-          - samples/client/petstore/csharp/generichost/latest/HelloWorld
-          - samples/client/petstore/csharp/generichost/latest/NullTypes
-          - samples/client/petstore/csharp/generichost/latest/OneOfList
-          - samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset
-          - samples/client/petstore/csharp/generichost/net10/AllOf
-          - samples/client/petstore/csharp/generichost/net10/AnyOf
-          - samples/client/petstore/csharp/generichost/net10/AnyOfNoCompare
-          - samples/client/petstore/csharp/generichost/net10/FormModels
-          # - samples/client/petstore/csharp/generichost/net10/ManualPetstoreTests
-          # - samples/client/petstore/csharp/generichost/net10/ManualSourceGenerationTests
-          - samples/client/petstore/csharp/generichost/net10/NullReferenceTypes
-          - samples/client/petstore/csharp/generichost/net10/OneOf
-          - samples/client/petstore/csharp/generichost/net10/Petstore
-          - samples/client/petstore/csharp/generichost/net10/SourceGeneration
-          - samples/client/petstore/csharp/generichost/net10/UseDateTimeForDate
-          # restsharp
-          - samples/client/petstore/csharp/restsharp/net10/EnumMappings
-          # httpclient
-          - samples/client/petstore/csharp/httpclient/net10/Petstore
-          - samples/client/petstore/csharp/httpclient/net10/Petstore-nonPublicApi
-          # unity
-          # - samples/client/petstore/csharp/unityWebRequest/net10/Petstore
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-dotnet@v6.0.0

--- a/.github/workflows/samples-dotnet6-server.yaml
+++ b/.github/workflows/samples-dotnet6-server.yaml
@@ -1,28 +1,39 @@
 name: Samples C# .Net 6 Server
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - samples/server/petstore/aspnetcore-6.0/**
-      - samples/server/petstore/aspnetcore-6.0-*/**
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - samples/server/petstore/aspnetcore-6.0/**
-      - samples/server/petstore/aspnetcore-6.0-*/**
+
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-dotnet6-server.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build .Net 6 servers
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          - samples/server/petstore/aspnetcore-6.0
-          - samples/server/petstore/aspnetcore-6.0-NewtonsoftFalse
-          - samples/server/petstore/aspnetcore-6.0-nullableReferenceTypes
-          - samples/server/petstore/aspnetcore-6.0-pocoModels
-          - samples/server/petstore/aspnetcore-6.0-project4Models
-          - samples/server/petstore/aspnetcore-6.0-useSwashBuckle
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-dotnet@v6.0.0

--- a/.github/workflows/samples-dotnet7-client.yml
+++ b/.github/workflows/samples-dotnet7-client.yml
@@ -1,46 +1,39 @@
 name: Samples C# .Net 7 Client
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      # the .NET Core 3.0 runtime is no longer supported as it reached its end-of-life on March 3, 2020
-      #- samples/client/petstore/csharp/httpclient/standard2.0/Petstore/**
-      - samples/client/petstore/csharp/restsharp/net4.7/MultipleFrameworks/**
-      - samples/client/petstore/csharp/restsharp/net4.7/Petstore/**
-      - samples/client/petstore/csharp/restsharp/net4.8/Petstore/**
-      - samples/client/petstore/csharp/restsharp/net8/ParameterMappings/**
-      - samples/client/petstore/csharp/restsharp/net8/EnumMappings/**
-      - samples/client/petstore/csharp/restsharp/net8/Petstore/**
-      - samples/client/petstore/csharp/restsharp/net8/UseDateTimeForDate/**
-      - samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/**
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      #- samples/client/petstore/csharp/httpclient/standard2.0/Petstore/**
-      - samples/client/petstore/csharp/restsharp/net4.7/MultipleFrameworks/**
-      - samples/client/petstore/csharp/restsharp/net4.7/Petstore/**
-      - samples/client/petstore/csharp/restsharp/net4.8/Petstore/**
-      - samples/client/petstore/csharp/restsharp/net8/ParameterMappings/**
-      - samples/client/petstore/csharp/restsharp/net8/EnumMappings/**
-      - samples/client/petstore/csharp/restsharp/net8/Petstore/**
-      - samples/client/petstore/csharp/restsharp/net8/UseDateTimeForDate/**
-      - samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/**
+
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-dotnet7-client.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build clients
     runs-on: windows-latest
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          #- samples/client/petstore/csharp/httpclient/standard2.0/Petstore/
-          - samples/client/petstore/csharp/restsharp/net4.7/MultipleFrameworks/
-          - samples/client/petstore/csharp/restsharp/net4.7/Petstore/
-          - samples/client/petstore/csharp/restsharp/net4.8/Petstore/
-          - samples/client/petstore/csharp/restsharp/net8/ParameterMappings/
-          - samples/client/petstore/csharp/restsharp/net8/EnumMappings/
-          - samples/client/petstore/csharp/restsharp/net8/Petstore/
-          - samples/client/petstore/csharp/restsharp/net8/UseDateTimeForDate/
-          - samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-dotnet@v6.0.0

--- a/.github/workflows/samples-dotnet8-client-echo-api.yaml
+++ b/.github/workflows/samples-dotnet8-client-echo-api.yaml
@@ -1,22 +1,39 @@
 name: Samples C# .Net 8 Client Echo API
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - samples/client/echo_api/csharp/restsharp/net8/**
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - samples/client/echo_api/csharp/restsharp/net8/**
+
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-dotnet8-client-echo-api.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build .Net clients
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          # clients
-          - samples/client/echo_api/csharp/restsharp/net8/EchoApi
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-dotnet@v6.0.0

--- a/.github/workflows/samples-dotnet8-client.yaml
+++ b/.github/workflows/samples-dotnet8-client.yaml
@@ -1,22 +1,39 @@
 name: Samples C# .Net 8 Client
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - samples/client/petstore/csharp/restsharp/net8/**
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - samples/client/petstore/csharp/restsharp/net8/**
+
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-dotnet8-client.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build .Net clients
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          - samples/client/petstore/csharp/restsharp/net8/ParameterMappings/
-          - samples/client/petstore/csharp/restsharp/net8/useVirtualForHooks/
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-dotnet@v6.0.0

--- a/.github/workflows/samples-dotnet8-server.yaml
+++ b/.github/workflows/samples-dotnet8-server.yaml
@@ -1,29 +1,39 @@
 name: Samples C# .Net 8 Server
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - samples/server/petstore/aspnetcore-8.0/**
-      - samples/server/petstore/aspnetcore-8.0-*/**
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - samples/server/petstore/aspnetcore-8.0/**
-      - samples/server/petstore/aspnetcore-8.0-*/**
+
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-dotnet8-server.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build .Net 8 servers
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          - samples/server/petstore/aspnetcore-8.0
-          - samples/server/petstore/aspnetcore-8.0-NewtonsoftFalse
-          - samples/server/petstore/aspnetcore-8.0-nullableReferenceTypes
-          - samples/server/petstore/aspnetcore-8.0-pocoModels
-          - samples/server/petstore/aspnetcore-8.0-project4Models
-          - samples/server/petstore/aspnetcore-8.0-useSwashBuckle
-          - samples/server/petstore/aspnetcore-8.0-use-centralized-package-version-management
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-dotnet@v6.0.0

--- a/.github/workflows/samples-dotnet8.yaml
+++ b/.github/workflows/samples-dotnet8.yaml
@@ -1,37 +1,39 @@
 name: Samples C# .Net 8 Clients
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - samples/client/petstore/csharp/generichost/net8/**
-      - samples/client/petstore/csharp/httpclient/net8/**
-      - samples/client/petstore/csharp/restsharp/net8/**
-      - samples/client/petstore/csharp/unityWebRequest/net8/**
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - samples/client/petstore/csharp/generichost/net8/**
-      - samples/client/petstore/csharp/httpclient/net8/**
-      - samples/client/petstore/csharp/restsharp/net8/**
-      - samples/client/petstore/csharp/unityWebRequest/net8/**
+
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-dotnet8.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build .Net 8 projects
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          - samples/client/petstore/csharp/generichost/net8/AllOf
-          - samples/client/petstore/csharp/generichost/net8/AnyOf
-          - samples/client/petstore/csharp/generichost/net8/AnyOfNoCompare
-          - samples/client/petstore/csharp/generichost/net8/FormModels
-          - samples/client/petstore/csharp/generichost/net8/ManualPetstoreTests
-          - samples/client/petstore/csharp/generichost/net8/ManualSourceGenerationTests
-          - samples/client/petstore/csharp/generichost/net8/NullReferenceTypes
-          - samples/client/petstore/csharp/generichost/net8/OneOf
-          - samples/client/petstore/csharp/generichost/net8/Petstore
-          - samples/client/petstore/csharp/generichost/net8/SourceGeneration
-          - samples/client/petstore/csharp/generichost/net8/UseDateTimeForDate
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-dotnet@v6.0.0

--- a/.github/workflows/samples-dotnet9.yaml
+++ b/.github/workflows/samples-dotnet9.yaml
@@ -1,44 +1,39 @@
 name: Samples C# .Net 9 Clients
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - samples/client/petstore/csharp/generichost/net9/**
-      - samples/client/petstore/csharp/httpclient/net9/**
-      - samples/client/petstore/csharp/restsharp/net9/**
-      - samples/client/petstore/csharp/unityWebRequest/net9/**
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - samples/client/petstore/csharp/generichost/net9/**
-      - samples/client/petstore/csharp/httpclient/net9/**
-      - samples/client/petstore/csharp/restsharp/net9/**
-      - samples/client/petstore/csharp/unityWebRequest/net9/**
+
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-dotnet9.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build .Net 9 projects
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          - samples/client/petstore/csharp/generichost/net9/AllOf
-          - samples/client/petstore/csharp/generichost/net9/AnyOf
-          - samples/client/petstore/csharp/generichost/net9/AnyOfNoCompare
-          - samples/client/petstore/csharp/generichost/net9/FormModels
-          # - samples/client/petstore/csharp/generichost/net9/ManualPetstoreTests
-          # - samples/client/petstore/csharp/generichost/net9/ManualSourceGenerationTests
-          - samples/client/petstore/csharp/generichost/net9/NullReferenceTypes
-          - samples/client/petstore/csharp/generichost/net9/OneOf
-          - samples/client/petstore/csharp/generichost/net9/Petstore
-          - samples/client/petstore/csharp/generichost/net9/SourceGeneration
-          - samples/client/petstore/csharp/generichost/net9/UseDateTimeForDate
-          # restsharp
-          - samples/client/petstore/csharp/restsharp/net9/EnumMappings
-          # httpclient
-          - samples/client/petstore/csharp/httpclient/net9/Petstore
-          - samples/client/petstore/csharp/httpclient/net9/Petstore-nonPublicApi
-          # unity
-          #- samples/client/petstore/csharp/unityWebRequest/net9/Petstore
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-dotnet@v6.0.0

--- a/.github/workflows/samples-elixir.yaml
+++ b/.github/workflows/samples-elixir.yaml
@@ -1,25 +1,38 @@
 name: Samples Elixir
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - samples/client/petstore/elixir/**
-      - samples/client/petstore/elixir-req/**
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - samples/client/petstore/elixir/**
-      - samples/client/petstore/elixir-req/**
+
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-elixir.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     runs-on: ubuntu-latest
     name: OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}}
     strategy:
-      matrix:
-        otp: ['25.3.2', '26.2.5', '27.3.3']
-        elixir: ['1.18.3']
-        sample:
-          - samples/client/petstore/elixir/
-          - samples/client/petstore/elixir-req/
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     services:
       petstore-api:
         image: swaggerapi/petstore

--- a/.github/workflows/samples-elm.yaml
+++ b/.github/workflows/samples-elm.yaml
@@ -1,27 +1,39 @@
 name: Samples Elm
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - .github/workflows/samples-elm.yaml
-      - samples/client/petstore/elm/**
-      - samples/openapi3/client/elm/**
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - .github/workflows/samples-elm.yaml
-      - samples/client/petstore/elm/**
-      - samples/openapi3/client/elm/**
+
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-elm.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build Elm clients
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          # clients
-          - samples/client/petstore/elm
-          - samples/openapi3/client/elm
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - uses: jorelali/setup-elm@v6

--- a/.github/workflows/samples-erlang.yaml
+++ b/.github/workflows/samples-erlang.yaml
@@ -1,30 +1,39 @@
 name: Samples Erlang
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - samples/server/echo_api/erlang-server/**
-      - samples/server/petstore/erlang-server/**
-      - samples/client/petstore/erlang-client/**
-      - samples/client/petstore/erlang-proper/**
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - samples/server/echo_api/erlang-server/**
-      - samples/server/petstore/erlang-server/**
-      - samples/client/petstore/erlang-client/**
-      - samples/client/petstore/erlang-proper/**
+
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-erlang.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build Erlang projects
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          - samples/server/echo_api/erlang-server/
-          - samples/server/petstore/erlang-server/
-          - samples/client/petstore/erlang-client/
-          - samples/client/petstore/erlang-proper/
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - uses: erlef/setup-beam@v1

--- a/.github/workflows/samples-go-client-echo-api.yaml
+++ b/.github/workflows/samples-go-client-echo-api.yaml
@@ -1,20 +1,39 @@
 name: Go Client (Echo API)
 
 on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - samples/client/echo_api/go/**
-      - .github/workflows/samples-go-client-echo-api.yaml
+
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-go-client-echo-api.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Test Go client
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          # clients
-          - samples/client/echo_api/go
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7

--- a/.github/workflows/samples-go-client-petstore.yaml
+++ b/.github/workflows/samples-go-client-petstore.yaml
@@ -1,17 +1,34 @@
 name: Samples Go Clients (Petstore)
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - samples/client/petstore/go/**
-      - samples/openapi3/client/petstore/go/**
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - samples/client/petstore/go/**
-      - samples/openapi3/client/petstore/go/**
 
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-go-client-petstore.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build Go
     runs-on: ubuntu-latest
     services:
@@ -24,10 +41,7 @@ jobs:
           SWAGGER_BASE_PATH: /v2
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          - samples/client/petstore/go/
-          - samples/openapi3/client/petstore/go/
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - name: Add hosts to /etc/hosts

--- a/.github/workflows/samples-go-client.yaml
+++ b/.github/workflows/samples-go-client.yaml
@@ -1,39 +1,39 @@
 name: Samples Go Clients
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - 'samples/openapi3/client/petstore/go/go-petstore-aws-signature/**'
-      - 'samples/openapi3/client/petstore/go-petstore-withXml/**'
-      - samples/openapi3/client/petstore/go-petstore-generateMarshalJSON-false/**
-      - samples/client/others/go/allof_multiple_ref_and_discriminator/**
-      - samples/client/others/go/oneof-anyof-required/**
-      - samples/client/others/go/oneof-discriminator-lookup/**
-      - samples/client/others/go/issue_20079_go_regex_wrongly_translated/**
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - 'samples/openapi3/client/petstore/go/go-petstore-aws-signature/**'
-      - 'samples/openapi3/client/petstore/go-petstore-withXml/**'
-      - samples/openapi3/client/petstore/go-petstore-generateMarshalJSON-false/**
-      - samples/client/others/go/allof_multiple_ref_and_discriminator/**
-      - samples/client/others/go/oneof-anyof-required/**
-      - samples/client/others/go/oneof-discriminator-lookup/**
-      - samples/client/others/go/issue_20079_go_regex_wrongly_translated/**
+
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-go-client.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build Go
     runs-on: windows-latest
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          - 'samples/openapi3/client/petstore/go/go-petstore-aws-signature/'
-          - 'samples/openapi3/client/petstore/go-petstore-withXml/'
-          - samples/openapi3/client/petstore/go-petstore-generateMarshalJSON-false/
-          - samples/client/others/go/allof_multiple_ref_and_discriminator/
-          - samples/client/others/go/oneof-anyof-required/
-          - samples/client/others/go/oneof-discriminator-lookup/
-          - samples/client/others/go/issue_20079_go_regex_wrongly_translated/
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7

--- a/.github/workflows/samples-go-gin.yaml
+++ b/.github/workflows/samples-go-gin.yaml
@@ -1,25 +1,39 @@
 name: Samples Go 
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - 'samples/server/petstore/go-gin-api-server/**'
-      - 'samples/server/petstore/go-gin-api-server-interface-only/**'
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - 'samples/server/petstore/go-gin-api-server/**'
-      - 'samples/server/petstore/go-gin-api-server-interface-only/**'
 
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-go-gin.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build Go 
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          - samples/server/petstore/go-gin-api-server/
-          - samples/server/petstore/go-gin-api-server-interface-only/
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7

--- a/.github/workflows/samples-go.yaml
+++ b/.github/workflows/samples-go.yaml
@@ -1,33 +1,47 @@
 name: Samples Go
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - 'samples/server/petstore/go-echo-server/**'
-      - 'samples/server/petstore/go-api-server/**'
-      - 'samples/server/petstore/go-chi-server/**'
-      - 'samples/server/others/go-server/**'
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - 'samples/server/petstore/go-echo-server/**'
-      - 'samples/server/petstore/go-api-server/**'
-      - 'samples/server/petstore/go-chi-server/**'
-      - 'samples/server/others/go-server/**'
 
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+      verify_changed: ${{ steps.verify.outputs.has_changes }}
+      verify_matrix: ${{ steps.verify.outputs.matrix }}
+      verify_samples: ${{ steps.verify.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-go.build
+          mode: ${{ vars.CI_SELECTION_MODE_PILOT || vars.CI_SELECTION_MODE || 'shadow' }}
+      - id: verify
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-go.verify
+          mode: ${{ vars.CI_SELECTION_MODE_PILOT || vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build Go
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          - samples/server/petstore/go-echo-server/
-          - samples/server/petstore/go-api-server/
-          - samples/server/petstore/go-chi-server/
-          - samples/server/others/go-server/no-body-path-params/
-          - samples/server/others/go-server/optional-body/
-          - samples/server/others/go-server/required-zero-value/
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
@@ -39,15 +53,13 @@ jobs:
         run: go test -mod=mod ./... -v
 
   verify:
+    needs: setup
+    if: ${{ needs.setup.outputs.verify_changed == 'true' }}
     name: Verify generated Go files with Go tests
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          - samples/server/petstore/go-api-server/
-        go-version:
-          - "1.25"
+      matrix: ${{ fromJSON(needs.setup.outputs.verify_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - name: Set up Go

--- a/.github/workflows/samples-groovy.yaml
+++ b/.github/workflows/samples-groovy.yaml
@@ -1,25 +1,42 @@
 name: Samples Groovy
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - 'samples/client/petstore/groovy**'
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - 'samples/client/petstore/groovy**'
 
 env:
   GRADLE_VERSION: 6.9
 
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-groovy.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build Groovy
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          - samples/client/petstore/groovy
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     services:
       petstore-api:
         image: swaggerapi/petstore

--- a/.github/workflows/samples-haskell.yaml
+++ b/.github/workflows/samples-haskell.yaml
@@ -1,31 +1,39 @@
 name: Samples Haskell
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - samples/server/petstore/haskell-yesod/**
-      - samples/server/petstore/haskell-servant/**
-      - samples/server/others/haskell-servant-ping/**
-      - samples/client/petstore/haskell-http-client/**
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - samples/server/petstore/haskell-yesod/**
-      - samples/server/petstore/haskell-servant/**
-      - samples/server/others/haskell-servant-ping/**
-      - samples/client/petstore/haskell-http-client/**
+
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-haskell.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build stack projects
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          # servers
-          - samples/server/petstore/haskell-yesod/
-          - samples/server/petstore/haskell-servant/
-          - samples/server/others/haskell-servant-ping/
-          - samples/client/petstore/haskell-http-client/
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - uses: haskell/actions/setup@v2

--- a/.github/workflows/samples-java-client-echo-api-jdk11.yaml
+++ b/.github/workflows/samples-java-client-echo-api-jdk11.yaml
@@ -1,26 +1,39 @@
 name: Java Client (Echo API) JDK11
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - samples/client/echo_api/java/**
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - samples/client/echo_api/java/**
+
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-java-client-echo-api-jdk11.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build Java Client JDK11
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          # clients
-          - samples/client/echo_api/java/apache-httpclient
-          - samples/client/echo_api/java/native
-          - samples/client/echo_api/java/feign-gson
-          - samples/client/echo_api/java/resttemplate
-          - samples/client/echo_api/java/resteasy
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-java@v6.0.0

--- a/.github/workflows/samples-java-client-echo-api-jdk17.yaml
+++ b/.github/workflows/samples-java-client-echo-api-jdk17.yaml
@@ -1,27 +1,39 @@
 name: Java Client (Echo API) JDK17
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - samples/client/echo_api/java/**
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - samples/client/echo_api/java/**
+
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-java-client-echo-api-jdk17.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build Java Client JDK17
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          # clients
-          - samples/client/echo_api/java/apache-httpclient
-          - samples/client/echo_api/java/native
-          - samples/client/echo_api/java/feign-gson
-          - samples/client/echo_api/java/resttemplate
-          - samples/client/echo_api/java/resteasy
-          - samples/client/echo_api/java/restclient
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-java@v6.0.0

--- a/.github/workflows/samples-java-client-echo-api-jdk8.yaml
+++ b/.github/workflows/samples-java-client-echo-api-jdk8.yaml
@@ -1,33 +1,39 @@
 name: Java Client (Echo API) JDK8
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - samples/client/echo_api/java/apache-httpclient/**
-      - samples/client/echo_api/java/feign-gson/**
-      - samples/client/echo_api/java/okhttp-gson/**
-      - samples/client/echo_api/java/resttemplate/**
-      - samples/client/echo_api/java/resteasy/**
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - samples/client/echo_api/java/apache-httpclient/**
-      - samples/client/echo_api/java/feign-gson/**
-      - samples/client/echo_api/java/okhttp-gson/**
-      - samples/client/echo_api/java/resteasy/**
+
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-java-client-echo-api-jdk8.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build Java Client JDK8
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          # clients
-          - samples/client/echo_api/java/apache-httpclient
-          - samples/client/echo_api/java/feign-gson
-          - samples/client/echo_api/java/okhttp-gson
-          - samples/client/echo_api/java/resttemplate
-          - samples/client/echo_api/java/resteasy
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-java@v6.0.0

--- a/.github/workflows/samples-java-client-jdk11.yaml
+++ b/.github/workflows/samples-java-client-jdk11.yaml
@@ -1,119 +1,39 @@
 name: Samples Java Client JDK11
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - 'samples/client/petstore/java/**'
-      - samples/client/petstore/jaxrs-cxf-client/**
-      - samples/client/petstore/jaxrs-cxf-client-swagger2/**
-      - samples/client/petstore/java-micronaut-client/**
-      - samples/openapi3/client/petstore/java/jersey2-java8-special-characters/**
-      - samples/openapi3/client/petstore/java/jersey2-java8-swagger1/**
-      - samples/openapi3/client/petstore/java/jersey2-java8-swagger2/**
-      - samples/openapi3/client/petstore/java/native**
-      - samples/client/others/java/okhttp-gson-oneOf/**
-      - samples/client/others/java/okhttp-gson-oneOf-array/**
-      - samples/client/others/java/resttemplate-useAbstractionForFiles/**
-      - samples/client/others/java/webclient-useAbstractionForFiles/**
-      - samples/client/petstore/java/webclient-useSingleRequestParameter/**
-      - samples/client/others/java/jersey2-oneOf-duplicates/**
-      - samples/client/others/java/jersey2-oneOf-Mixed/**
-      - samples/client/others/java/okhttp-gson-streaming/**
-      - samples/client/others/java/resteasy/**
-      - samples/client/others/java/apache-httpclient/**
-      - samples/client/others/java/resttemplate-list-schema-validation/**
-      - samples/client/petstore/java/okhttp-gson-3.1-duplicated-operationid/**
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - 'samples/client/petstore/java/**'
-      - samples/client/petstore/jaxrs-cxf-client/**
-      - samples/client/petstore/jaxrs-cxf-client-swagger2/**
-      - samples/client/petstore/java-micronaut-client/**
-      - samples/openapi3/client/petstore/java/jersey2-java8-special-characters/**
-      - samples/openapi3/client/petstore/java/jersey2-java8-swagger1/**
-      - samples/openapi3/client/petstore/java/jersey2-java8-swagger2/**
-      - samples/openapi3/client/petstore/java/native**
-      - samples/client/others/java/okhttp-gson-oneOf/**
-      - samples/client/others/java/okhttp-gson-oneOf-array/**
-      - samples/client/others/java/resttemplate-useAbstractionForFiles/**
-      - samples/client/others/java/webclient-useAbstractionForFiles/**
-      - samples/client/petstore/java/webclient-useSingleRequestParameter/**
-      - samples/client/others/java/jersey2-oneOf-duplicates/**
-      - samples/client/others/java/jersey2-oneOf-Mixed/**
-      - samples/client/others/java/okhttp-gson-streaming/**
-      - samples/client/others/java/resteasy/**
-      - samples/client/others/java/apache-httpclient/**
-      - samples/client/others/java/resttemplate-list-schema-validation/**
-      - samples/client/petstore/java/okhttp-gson-3.1-duplicated-operationid/**
+
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-java-client-jdk11.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build Java Client JDK11
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          # clients
-          - samples/client/petstore/jaxrs-cxf-client-swagger2
-          - samples/client/petstore/jaxrs-cxf-client
-          - samples/client/petstore/java/native
-          - samples/client/petstore/java/native-async
-          - samples/client/petstore/java/native-jakarta
-          - samples/client/petstore/java/native-useGzipFeature
-          - samples/client/petstore/java/retrofit2
-          - samples/client/petstore/java/retrofit2rx2
-          - samples/client/petstore/java/retrofit2rx3
-          - samples/client/petstore/java/retrofit2-play26
-          - samples/client/petstore/java/resttemplate
-          - samples/client/petstore/java/resttemplate-withXml
-          - samples/client/petstore/java/webclient
-          - samples/client/petstore/java/webclient-nullable-arrays
-          - samples/client/petstore/java/webclient-swagger2
-          - samples/client/petstore/java/webclient-useSingleRequestParameter
-          - samples/client/petstore/java/vertx
-          - samples/client/petstore/java/vertx5
-          - samples/client/petstore/java/vertx5-supportVertxFuture
-          - samples/client/petstore/java/vertx-no-nullable
-          - samples/client/petstore/java/vertx-supportVertxFuture
-          - samples/client/petstore/java/jersey2-java8-localdatetime
-          - samples/client/petstore/java/google-api-client
-          - samples/client/petstore/java/rest-assured
-          - samples/client/petstore/java/rest-assured-jackson
-          - samples/client/petstore/java/microprofile-rest-client
-          - samples/client/petstore/java/microprofile-rest-client-mutiny
-          - samples/client/petstore/java/microprofile-rest-client-3.0
-          - samples/client/petstore/java/microprofile-rest-client-3.0-jackson
-          - samples/client/petstore/java/microprofile-rest-client-3.0-jackson-mutiny
-          - samples/client/petstore/java/microprofile-rest-client-3.0-jackson-with-xml
-          - samples/client/petstore/java/microprofile-rest-client-3.0-mutiny
-          - samples/client/petstore/java/microprofile-rest-client-3.0-jspecify
-          - samples/client/petstore/java/microprofile-rest-client-with-useSingleRequestParameter
-          - samples/client/petstore/java/microprofile-oneof-interface
-          - samples/client/petstore/java/apache-httpclient
-          - samples/client/petstore/java/feign
-          - samples/client/petstore/java/feign-hc5
-          - samples/client/petstore/java/feign-no-nullable
-          - samples/client/petstore/java/okhttp-gson-awsv4signature
-          - samples/openapi3/client/petstore/java/jersey2-java8-special-characters
-          - samples/openapi3/client/petstore/java/native
-          - samples/client/petstore/java/okhttp-gson-swagger1/
-          - samples/client/petstore/java/resttemplate-swagger1/
-          - samples/openapi3/client/petstore/java/jersey2-java8-swagger1/
-          - samples/client/petstore/java/okhttp-gson-swagger2/
-          - samples/client/petstore/java/resttemplate-swagger2/
-          - samples/openapi3/client/petstore/java/jersey2-java8-swagger2/
-          - samples/client/others/java/okhttp-gson-oneOf/
-          - samples/client/others/java/okhttp-gson-oneOf-array/
-          - samples/client/echo_api/java/okhttp-gson-user-defined-templates/
-          - samples/client/others/java/resttemplate-useAbstractionForFiles/
-          - samples/client/others/java/webclient-useAbstractionForFiles/
-          - samples/client/others/java/jersey2-oneOf-duplicates/
-          - samples/client/others/java/jersey2-oneOf-Mixed/
-          - samples/client/others/java/resttemplate-list-schema-validation/
-          - samples/client/petstore/java/okhttp-gson-3.1-duplicated-operationid/
-          - samples/client/others/java/okhttp-gson-streaming/
-          - samples/client/petstore/java/resteasy/
-          - samples/client/petstore/java/apache-httpclient/
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-java@v6.0.0

--- a/.github/workflows/samples-java-client-jdk17.yaml
+++ b/.github/workflows/samples-java-client-jdk17.yaml
@@ -1,81 +1,39 @@
 name: Samples Java Client JDK17
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - samples/client/petstore/java/resttemplate-jakarta/**
-      - samples/client/petstore/java/resttemplate-springBoot4-*/**
-      - samples/client/petstore/java/webclient-jakarta/**
-      - samples/client/petstore/java/restclient-*/**
-      - samples/client/petstore/java/native-jackson3/**
-      - samples/client/petstore/java/apache-httpclient-jackson3/**
-      - samples/client/petstore/java/native-jackson3-jspecify/**
-      - samples/client/petstore/java/restclient-springBoot4-jackson3-jspecify/**
-      - samples/client/petstore/java/restclient-springBoot4-jackson3-jspecify-openapiNullable/**
-      - samples/client/others/java/webclient-sealedInterface/**
-      - samples/client/others/java/webclient-sealedInterface_3_1/**
-      - samples/client/petstore/java/webclient-useSingleRequestParameter/**
-      - samples/client/others/java/restclient-enum-in-multipart/**
-      - samples/client/others/java/restclient-sealedInterface/**
-      - samples/client/others/java/restclient-useAbstractionForFiles/**
-      - samples/client/petstore/java/jersey3-oneOf/**
-      - samples/client/petstore/java/jersey3-jackson3/**
-      - samples/client/petstore/java/microprofile-oneof-sealed/**
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - samples/client/petstore/java/resttemplate-jakarta/**
-      - samples/client/petstore/java/resttemplate-springBoot4-*/**
-      - samples/client/petstore/java/webclient-jakarta/**
-      - samples/client/petstore/java/restclient-*/**
-      - samples/client/petstore/java/native-jackson3/**
-      - samples/client/petstore/java/apache-httpclient-jackson3/**
-      - samples/client/petstore/java/native-jackson3-jspecify/**
-      - samples/client/petstore/java/restclient-springBoot4-jackson3-jspecify/**
-      - samples/client/petstore/java/restclient-springBoot4-jackson3-jspecify-openapiNullable/**
-      - samples/client/others/java/webclient-sealedInterface/**
-      - samples/client/others/java/webclient-sealedInterface_3_1/**
-      - samples/client/petstore/java/webclient-useSingleRequestParameter/**
-      - samples/client/others/java/restclient-enum-in-multipart/**
-      - samples/client/others/java/restclient-sealedInterface/**
-      - samples/client/others/java/restclient-useAbstractionForFiles/**
-      - samples/client/petstore/java/jersey3-oneOf/**
-      - samples/client/petstore/java/jersey3-jackson3/**
-      - samples/client/petstore/java/microprofile-oneof-sealed/**
+
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-java-client-jdk17.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build Java Client JDK17
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          # clients
-          - samples/client/petstore/java/resttemplate-jakarta
-          - samples/client/petstore/java/resttemplate-springBoot4-jackson2
-          - samples/client/petstore/java/resttemplate-springBoot4-jackson3
-          - samples/client/petstore/java/webclient-jakarta
-          - samples/client/petstore/java/restclient
-          - samples/client/petstore/java/restclient-nullable-arrays
-          - samples/client/petstore/java/restclient-springBoot4-jackson2
-          - samples/client/petstore/java/restclient-springBoot4-jackson3
-          - samples/client/petstore/java/restclient-springBoot4-jackson3-jspecify
-          - samples/client/petstore/java/restclient-springBoot4-jackson3-jspecify-openapiNullable
-          - samples/client/petstore/java/native-jackson3-jspecify
-          - samples/client/petstore/java/restclient-swagger2
-          - samples/client/petstore/java/restclient-useSingleRequestParameter
-          - samples/client/petstore/java/restclient-useSingleRequestParameter-static
-          - samples/client/petstore/java/native-jackson3
-          - samples/client/petstore/java/apache-httpclient-jackson3
-          - samples/client/others/java/webclient-sealedInterface
-          - samples/client/others/java/webclient-sealedInterface_3_1
-          - samples/client/petstore/java/webclient-springBoot4-jackson3
-          - samples/client/petstore/java/webclient-useSingleRequestParameter
-          - samples/client/others/java/restclient-enum-in-multipart
-          - samples/client/others/java/restclient-sealedInterface
-          - samples/client/others/java/restclient-useAbstractionForFiles
-          - samples/client/petstore/java/jersey3-oneOf
-          - samples/client/petstore/java/jersey3-jackson3
-          - samples/client/petstore/java/microprofile-oneof-sealed
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-java@v6.0.0

--- a/.github/workflows/samples-java-dubbo.yaml
+++ b/.github/workflows/samples-java-dubbo.yaml
@@ -1,23 +1,39 @@
 name: Samples Java Dubbo
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - 'samples/server/petstore/java-dubbo/**'
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - 'samples/server/petstore/java-dubbo/**'
 
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-java-dubbo.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build Java Dubbo
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          # servers
-          - samples/server/petstore/java-dubbo
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-java@v6.0.0

--- a/.github/workflows/samples-java-helidon-v3.yaml
+++ b/.github/workflows/samples-java-helidon-v3.yaml
@@ -1,30 +1,39 @@
 name: Samples Java Helidon v3
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - samples/client/petstore/java-helidon-client/v3/**
-      - samples/server/petstore/java-helidon-server/v3/**
-      - samples/server/others/java-helidon-server/v3/**
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - samples/client/petstore/java-helidon-client/v3/**
-      - samples/server/petstore/java-helidon-server/v3/**
-      - samples/server/others/java-helidon-server/v3/**
+
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-java-helidon-v3.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build Java Helidon 
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          - samples/client/petstore/java-helidon-client/v3/mp
-          - samples/client/petstore/java-helidon-client/v3/se
-          - samples/server/petstore/java-helidon-server/v3/mp
-          - samples/server/petstore/java-helidon-server/v3/se
-          - samples/server/others/java-helidon-server/v3/mp-format-test
-        version: [17]
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-java@v6.0.0

--- a/.github/workflows/samples-java-helidon-v4.yaml
+++ b/.github/workflows/samples-java-helidon-v4.yaml
@@ -1,31 +1,39 @@
 name: Samples Java Helidon v4
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - samples/client/petstore/java-helidon-client/v4/**
-      - samples/server/petstore/java-helidon-server/v4/**
-      - samples/server/others/java-helidon-server/v4/**
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - samples/client/petstore/java-helidon-client/v4/**
-      - samples/server/petstore/java-helidon-server/v4/**
-      - samples/server/others/java-helidon-server/v4/**
+
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-java-helidon-v4.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build Java Helidon 
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          - samples/client/petstore/java-helidon-client/v4/mp
-          - samples/client/petstore/java-helidon-client/v4/se
-          - samples/server/petstore/java-helidon-server/v4/mp
-          - samples/server/petstore/java-helidon-server/v4/se
-          - samples/server/petstore/java-helidon-server/v4/se-uac
-          - samples/server/others/java-helidon-server/v4/mp-format-test
-        version: [21]
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-java@v6.0.0

--- a/.github/workflows/samples-java-petsore-client-jdk11.yaml
+++ b/.github/workflows/samples-java-petsore-client-jdk11.yaml
@@ -2,36 +2,39 @@
 name: Samples Java Petsore Client JDK11
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - samples/client/petstore/java/jersey2-java8/**
-      - samples/openapi3/client/petstore/java/jersey2-java8/**
-      - samples/client/petstore/java/okhttp-gson/**
-      - samples/client/petstore/java/okhttp-gson-3.1/**
-      - samples/client/petstore/java/okhttp-gson-dynamicOperations/**
-      - samples/client/petstore/java-micronaut-client/**
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - samples/client/petstore/java/jersey2-java8/**
-      - samples/openapi3/client/petstore/java/jersey2-java8/**
-      - samples/client/petstore/java/okhttp-gson/**
-      - samples/client/petstore/java/okhttp-gson-3.1/**
-      - samples/client/petstore/java/okhttp-gson-dynamicOperations/**
-      - samples/client/petstore/java-micronaut-client/**
+
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-java-petsore-client-jdk11.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build Java Client JDK11
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          - samples/client/petstore/java/jersey2-java8
-          - samples/openapi3/client/petstore/java/jersey2-java8
-          - samples/client/petstore/java/okhttp-gson
-          - samples/client/petstore/java/okhttp-gson-3.1
-          - samples/client/petstore/java/okhttp-gson-dynamicOperations
-          - samples/client/petstore/java-micronaut-client
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     services:
       petstore-api:
         image: swaggerapi/petstore

--- a/.github/workflows/samples-java-petsore-client-jdk17.yaml
+++ b/.github/workflows/samples-java-petsore-client-jdk17.yaml
@@ -2,21 +2,39 @@
 name: Samples Java Petsore Client JDK17
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - samples/client/petstore/java/jersey3/**
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - samples/client/petstore/java/jersey3/**
+
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-java-petsore-client-jdk17.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build Java Client JDK17
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          - samples/client/petstore/java/jersey3
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     services:
       petstore-api:
         image: swaggerapi/petstore

--- a/.github/workflows/samples-java-play-framework.yaml
+++ b/.github/workflows/samples-java-play-framework.yaml
@@ -1,33 +1,39 @@
 name: Samples Java Play Framework
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - 'samples/server/petstore/java-play-framework**'
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - 'samples/server/petstore/java-play-framework**'
+
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-java-play-framework.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build Java Play Framework
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          # servers
-          - samples/server/petstore/java-play-framework
-          - samples/server/petstore/java-play-framework-api-package-override
-          - samples/server/petstore/java-play-framework-async
-          - samples/server/petstore/java-play-framework-controller-only
-          - samples/server/petstore/java-play-framework-fake-endpoints
-          - samples/server/petstore/java-play-framework-fake-endpoints-with-security
-          - samples/server/petstore/java-play-framework-no-bean-validation
-          - samples/server/petstore/java-play-framework-no-excp-handling
-          - samples/server/petstore/java-play-framework-no-interface
-          - samples/server/petstore/java-play-framework-no-nullable
-          - samples/server/petstore/java-play-framework-no-swagger-ui
-          - samples/server/petstore/java-play-framework-no-wrap-calls
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-java@v6.0.0

--- a/.github/workflows/samples-java-sbt.yaml
+++ b/.github/workflows/samples-java-sbt.yaml
@@ -1,22 +1,39 @@
 name: Samples Java (sbt)
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - 'samples/client/petstore/java/okhttp-gson/**'
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - 'samples/client/petstore/java/okhttp-gson/**'
+
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-java-sbt.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build sbt/Java client, servers
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          # clients
-          - samples/client/petstore/java/okhttp-gson
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-java@v6.0.0

--- a/.github/workflows/samples-java-server-jdk8.yaml
+++ b/.github/workflows/samples-java-server-jdk8.yaml
@@ -1,39 +1,39 @@
 name: Samples Java Server
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - 'samples/server/petstore/java-vertx-web/**'
-      - 'samples/server/petstore/java-vertx-web-interface-only/**'
-      - 'samples/server/petstore/java-inflector/**'
-      - 'samples/server/petstore/java-pkmst/**'
-      # test in circleci instead
-      #- 'samples/server/petstore/java-undertow/**'
-      - 'samples/server/petstore/java-microprofile/**'
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - 'samples/server/petstore/java-vertx-web/**'
-      - 'samples/server/petstore/java-vertx-web-interface-only/**'
-      - 'samples/server/petstore/java-inflector/**'
-      - 'samples/server/petstore/java-inflector/**'
-      - 'samples/server/petstore/java-pkmst/**'
-      #- 'samples/server/petstore/java-undertow/**'
-      - 'samples/server/petstore/java-microprofile/**'
+
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-java-server-jdk8.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build Java Server
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          # servers
-          - samples/server/petstore/java-vertx-web/
-          - samples/server/petstore/java-vertx-web-interface-only/
-          - samples/server/petstore/java-inflector/
-          - samples/server/petstore/java-pkmst/
-          #- samples/server/petstore/java-undertow/
-          - samples/server/petstore/java-microprofile/
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-java@v6.0.0

--- a/.github/workflows/samples-java-wiremock.yaml
+++ b/.github/workflows/samples-java-wiremock.yaml
@@ -1,21 +1,39 @@
 name: Samples Java Wiremock
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - samples/server/petstore/java-wiremock/**
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - samples/server/petstore/java-wiremock/**
+
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-java-wiremock.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build Java Wiremock
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          - samples/server/petstore/java-wiremock
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-java@v6.0.0

--- a/.github/workflows/samples-javascript.yaml
+++ b/.github/workflows/samples-javascript.yaml
@@ -1,30 +1,39 @@
 name: Samples JS clients
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      #- samples/client/petstore/javascript-flowtyped/**
-      - samples/client/petstore/javascript-es6/**
-      - samples/client/petstore/javascript-promise-es6/**
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      #- samples/client/petstore/javascript-flowtyped/**
-      - samples/client/petstore/javascript-es6/**
-      - samples/client/petstore/javascript-promise-es6/**
+
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-javascript.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build projects
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        node:
-          - "18.x"
-          - "20.x"
-        sample:
-          # clients
-          - samples/client/petstore/javascript-es6/
-          - samples/client/petstore/javascript-promise-es6/
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     services:
       petstore-api:
         image: swaggerapi/petstore

--- a/.github/workflows/samples-jaxrs-jdk11.yaml
+++ b/.github/workflows/samples-jaxrs-jdk11.yaml
@@ -1,22 +1,39 @@
 name: Samples JAX-RS (JDK11)
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - samples/server/petstore/jaxrs/jersey3/**
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - samples/server/petstore/jaxrs/jersey3/**
+
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-jaxrs-jdk11.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build JAX-RS
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          # servers
-          - samples/server/petstore/jaxrs/jersey3
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-java@v6.0.0

--- a/.github/workflows/samples-jaxrs.yaml
+++ b/.github/workflows/samples-jaxrs.yaml
@@ -1,43 +1,39 @@
 name: Samples JAX-RS
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - 'samples/server/petstore/jaxrs*/**'
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - 'samples/server/petstore/jaxrs*/**'
+
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-jaxrs.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build JAX-RS
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          # servers
-          - samples/server/petstore/jaxrs/jersey2
-          - samples/server/petstore/jaxrs/jersey2-useTags
-          - samples/server/petstore/jaxrs-jersey
-          - samples/server/petstore/jaxrs-spec
-          - samples/server/petstore/jaxrs-spec-withxml
-          - samples/server/petstore/jaxrs-spec-interface
-          - samples/server/petstore/jaxrs-spec-interface-response
-          - samples/server/petstore/jaxrs-spec-oneof-interface
-          - samples/server/petstore/jaxrs-datelib-j8
-          - samples/server/petstore/jaxrs-resteasy/default
-          - samples/server/petstore/jaxrs-resteasy/eap
-          - samples/server/petstore/jaxrs-resteasy/eap-joda
-          - samples/server/petstore/jaxrs-resteasy/eap-java8
-          - samples/server/petstore/jaxrs-resteasy/joda
-          - samples/server/petstore/jaxrs-cxf
-          - samples/server/petstore/jaxrs-cxf-annotated-base-path
-          - samples/server/petstore/jaxrs-cxf-cdi
-          - samples/server/petstore/jaxrs-cxf-non-spring-app
-          - samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations
-          - samples/server/petstore/jaxrs-spec-swagger-annotations
-          - samples/server/petstore/jaxrs-spec-swagger-v3-annotations-jakarta
-          - samples/server/petstore/jaxrs-spec-swagger-v3-annotations
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-java@v6.0.0

--- a/.github/workflows/samples-jdk17.yaml
+++ b/.github/workflows/samples-jdk17.yaml
@@ -1,83 +1,38 @@
 name: Samples JDK17
 on:
+  workflow_dispatch:
   push:
-    paths:
-      # clients
-      - samples/openapi3/client/petstore/spring-cloud-3/**
-      - samples/client/petstore/java-helidon-client/v3/mp/**
-      - samples/client/petstore/java-helidon-client/v3/se/**
-      - samples/client/petstore/spring-http-interface-reactive/**
-      - samples/client/petstore/spring-http-interface-reactive-bean-validation/**
-      - samples/client/petstore/spring-http-interface-bean-validation/**
-      - samples/client/petstore/spring-http-interface/**
-      - samples/client/petstore/spring-http-interface-reactive-noResponseEntity/**
-      - samples/client/petstore/spring-http-interface-noResponseEntity/**
-      - samples/client/petstore/spring-http-interface-useHttpServiceProxyFactoryInterfacesConfigurator/**
-      - samples/client/petstore/java/webclient-jakarta/**
-      - samples/client/petstore/java/microprofile-rest-client-outer-enum/**
-      # servers
-      - samples/openapi3/server/petstore/springboot-3/**
-      - samples/openapi3/server/petstore/springboot-3-include-http-request-context/**
-      - samples/server/petstore/springboot-x-implements-skip/**
-      - samples/server/petstore/java-camel/**
-      - samples/server/petstore/java-helidon-server/v3/mp/**
-      - samples/server/petstore/java-helidon-server/v3/se/**
-      - samples/server/petstore/jaxrs-spec-sealed/**
-      - samples/server/petstore/jaxrs-spec/quarkus-security/**
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      # clients
-      - samples/openapi3/client/petstore/spring-cloud-3/**
-      - samples/client/petstore/java-helidon-client/v3/mp/**
-      - samples/client/petstore/java-helidon-client/v3/se/**
-      - samples/client/petstore/spring-http-interface-reactive/**
-      - samples/client/petstore/spring-http-interface-reactive-bean-validation/**
-      - samples/client/petstore/spring-http-interface-bean-validation/**
-      - samples/client/petstore/spring-http-interface/**
-      - samples/client/petstore/spring-http-interface-reactive-noResponseEntity/**
-      - samples/client/petstore/spring-http-interface-noResponseEntity/**
-      - samples/client/petstore/spring-http-interface-useHttpServiceProxyFactoryInterfacesConfigurator/**
-      - samples/client/petstore/java/webclient-jakarta/**
-      - samples/client/petstore/java/microprofile-rest-client-outer-enum/**
-      # servers
-      - samples/openapi3/server/petstore/springboot-3/**
-      - samples/openapi3/server/petstore/springboot-3-include-http-request-context/**
-      - samples/server/petstore/springboot-x-implements-skip/**
-      - samples/server/petstore/java-camel/**
-      - samples/server/petstore/java-helidon-server/v3/mp/**
-      - samples/server/petstore/java-helidon-server/v3/se/**
-      - samples/server/petstore/jaxrs-spec-sealed/**
-      - samples/server/petstore/jaxrs-spec/quarkus-security/**
+
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-jdk17.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build with JDK17
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          # clients
-          - samples/openapi3/client/petstore/spring-cloud-3
-          - samples/client/petstore/java-helidon-client/v3/mp/
-          - samples/client/petstore/java-helidon-client/v3/se
-          - samples/client/petstore/spring-http-interface-reactive
-          - samples/client/petstore/spring-http-interface-reactive-bean-validation
-          - samples/client/petstore/spring-http-interface-bean-validation
-          - samples/client/petstore/spring-http-interface
-          - samples/client/petstore/spring-http-interface-reactive-noResponseEntity
-          - samples/client/petstore/spring-http-interface-noResponseEntity
-          - samples/client/petstore/spring-http-interface-useHttpServiceProxyFactoryInterfacesConfigurator
-          - samples/client/petstore/java/webclient-jakarta
-          - samples/client/petstore/java/microprofile-rest-client-outer-enum
-          # servers
-          - samples/openapi3/server/petstore/springboot-3
-          - samples/openapi3/server/petstore/springboot-3-include-http-request-context
-          - samples/server/petstore/springboot-x-implements-skip
-          - samples/server/petstore/java-camel/
-          - samples/server/petstore/java-helidon-server/v3/mp/
-          - samples/server/petstore/java-helidon-server/v3/se
-          - samples/server/petstore/jaxrs-spec-sealed
-          - samples/server/petstore/jaxrs-spec/quarkus-security
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-java@v6.0.0

--- a/.github/workflows/samples-jdk21.yaml
+++ b/.github/workflows/samples-jdk21.yaml
@@ -1,35 +1,38 @@
 name: Samples JDK21
 on:
+  workflow_dispatch:
   push:
-    paths:
-      # clients
-      - samples/client/petstore/java-helidon-client/v4/mp/**
-      - samples/client/petstore/java-helidon-client/v4/se/**
-      # servers
-      - samples/server/petstore/java-helidon-server/v4/mp/**
-      - samples/server/petstore/java-helidon-server/v4/se/**
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      # clients
-      - samples/client/petstore/java-helidon-client/v4/mp/**
-      - samples/client/petstore/java-helidon-client/v4/se/**
-      # servers
-      - samples/server/petstore/java-helidon-server/v4/mp/**
-      - samples/server/petstore/java-helidon-server/v4/se/**
+
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-jdk21.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build with JDK21
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          # clients
-          - samples/client/petstore/java-helidon-client/v4/mp/
-          - samples/client/petstore/java-helidon-client/v4/se/
-          # servers
-          - samples/server/petstore/java-helidon-server/v4/mp/
-          - samples/server/petstore/java-helidon-server/v4/se/
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-java@v6.0.0

--- a/.github/workflows/samples-julia.yaml
+++ b/.github/workflows/samples-julia.yaml
@@ -1,17 +1,34 @@
 name: Samples Julia
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - 'samples/client/petstore/julia/**'
-      - 'samples/server/petstore/julia/**'
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - 'samples/client/petstore/julia/**'
-      - 'samples/server/petstore/julia/**'
 
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      tests_julia_changed: ${{ steps.tests_julia.outputs.has_changes }}
+      tests_julia_matrix: ${{ steps.tests_julia.outputs.matrix }}
+      tests_julia_samples: ${{ steps.tests_julia.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: tests_julia
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-julia.tests-julia
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   tests-julia:
+    needs: setup
+    if: ${{ needs.setup.outputs.tests_julia_changed == 'true' }}
     name: Tests Julia
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/samples-kotlin-client.yaml
+++ b/.github/workflows/samples-kotlin-client.yaml
@@ -1,92 +1,39 @@
 name: Samples Kotlin client
 
 on:
+  workflow_dispatch:
   push:
     branches:
-      - 'samples/client/petstore/kotlin*/**'
-      - 'samples/client/others/kotlin-jvm-okhttp-parameter-tests/**'
-      - samples/client/others/kotlin-integer-enum/**
-      - samples/client/others/kotlin-jvm-spring-3-restclient-nullable-return/**
-      - samples/client/others/kotlin-oneOf-anyOf-kotlinx-serialization*/**
-      - samples/client/others/kotlin-oneOf-discriminator-kotlinx-serialization*/**
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - 'samples/client/petstore/kotlin*/**'
-      - 'samples/client/others/kotlin-jvm-okhttp-parameter-tests/**'
-      - samples/client/others/kotlin-integer-enum/**
-      - samples/client/others/kotlin-jvm-spring-3-restclient-nullable-return/**
-      - samples/client/others/kotlin-oneOf-anyOf-kotlinx-serialization*/**
-      - samples/client/others/kotlin-oneOf-discriminator-kotlinx-serialization*/**
 
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-kotlin-client.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build Kotlin client
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          # client
-          - samples/client/petstore/kotlin
-          - samples/client/petstore/kotlin-explicit
-          - samples/client/petstore/kotlin-gson
-          - samples/client/petstore/kotlin-jackson
-          - samples/client/petstore/kotlin-jackson3
-          - samples/client/petstore/kotlin-model-prefix-type-mappings
-          # needs Android configured
-          #- samples/client/petstore/kotlin-json-request-string
-          - samples/client/petstore/kotlin-jvm-okhttp4-coroutines
-          - samples/client/petstore/kotlin-moshi-codegen
-          - samples/client/petstore/kotlin-multiplatform
-          - samples/client/petstore/kotlin-multiplatform-kotlinx-datetime
-          - samples/client/petstore/kotlin-multiplatform-allOf-discriminator
-          - samples/client/petstore/kotlin-nonpublic
-          - samples/client/petstore/kotlin-nullable
-          - samples/client/petstore/kotlin-retrofit2
-          - samples/client/petstore/kotlin-retrofit2-kotlinx_serialization
-          - samples/client/petstore/kotlin-retrofit2-jackson
-          - samples/client/petstore/kotlin-retrofit2-rx3
-          - samples/client/petstore/kotlin-string
-          - samples/client/petstore/kotlin-threetenbp
-          - samples/client/petstore/kotlin-kotlinx-datetime
-          - samples/client/petstore/kotlin-uppercase-enum
-          - samples/client/petstore/kotlin-array-integer-enum
-          - samples/client/petstore/kotlin-default-values-jvm-okhttp4
-          - samples/client/petstore/kotlin-default-values-jvm-retrofit2
-          - samples/client/petstore/kotlin-default-values-multiplatform
-          - samples/client/petstore/kotlin-enum-integers-multiplatform
-          - samples/client/petstore/kotlin-array-simple-string-jvm-okhttp4
-          - samples/client/petstore/kotlin-array-simple-string-multiplatform
-          - samples/client/petstore/kotlin-array-nullable-items
-          - samples/client/petstore/kotlin-array-nullable-items-multiplatform
-          - samples/client/petstore/kotlin-bigdecimal-default-multiplatform
-          - samples/client/petstore/kotlin-bigdecimal-default-okhttp4
-          - samples/client/petstore/kotlin-jvm-jackson
-          - samples/client/petstore/kotlin-jvm-ktor-jackson
-          - samples/client/petstore/kotlin-jvm-ktor-gson
-          - samples/client/petstore/kotlin-jvm-ktor-kotlinx_serialization
-          - samples/client/petstore/kotlin-jvm-vertx-gson
-          - samples/client/petstore/kotlin-jvm-vertx-jackson
-          - samples/client/petstore/kotlin-jvm-vertx-jackson-coroutines
-          - samples/client/petstore/kotlin-jvm-vertx-moshi
-          - samples/client/petstore/kotlin-jvm-spring-2-webclient
-          - samples/client/petstore/kotlin-jvm-spring-3-webclient
-          - samples/client/echo_api/kotlin-jvm-spring-3-webclient
-          - samples/client/petstore/kotlin-jvm-spring-3-restclient
-          - samples/client/echo_api/kotlin-jvm-spring-3-restclient
-          - samples/client/others/kotlin-jvm-spring-3-restclient-nullable-return
-          - samples/client/petstore/kotlin-jvm-spring-4-restclient-jackson3
-          - samples/client/petstore/kotlin-name-parameter-mappings
-          - samples/client/others/kotlin-jvm-okhttp-parameter-tests
-          - samples/client/others/kotlin-jvm-okhttp-path-comments
-          - samples/client/others/kotlin-integer-enum
-          - samples/client/petstore/kotlin-allOf-discriminator-kotlinx-serialization
-          - samples/client/others/kotlin-oneOf-discriminator-kotlinx-serialization
-          - samples/client/others/kotlin-oneOf-anyOf-kotlinx-serialization
-          - samples/client/others/kotlin-oneOf-anyOf-kotlinx-serialization-nonPublicApi
-          - samples/client/others/kotlin-oneOf-anyOf-kotlinx-serialization-explicitApi
-          - samples/client/petstore/kotlin-allOf-special-discriminator-kotlinx-serialization
-          - samples/client/petstore/kotlin-multiplatform-allOf-special-discriminator
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-java@v6.0.0

--- a/.github/workflows/samples-kotlin-echo-api.yaml
+++ b/.github/workflows/samples-kotlin-echo-api.yaml
@@ -1,26 +1,39 @@
 name: Kotlin Client (Echo API) JDK17
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - samples/client/echo_api/kotlin**
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - samples/client/echo_api/kotlin**
 
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-kotlin-echo-api.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build Kotlin Client JDK17
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          # clients
-          - samples/client/echo_api/kotlin-jvm-spring-3-restclient
-          - samples/client/echo_api/kotlin-model-prefix-type-mappings
-          - samples/client/echo_api/kotlin-jvm-okhttp
-          - samples/client/echo_api/kotlin-jvm-okhttp-multipart-json
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-java@v6.0.0

--- a/.github/workflows/samples-kotlin-server-jdk17.yaml
+++ b/.github/workflows/samples-kotlin-server-jdk17.yaml
@@ -1,84 +1,42 @@
 name: Samples Kotlin server (jdk17)
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - 'samples/server/others/kotlin-server/**'
-      - 'samples/server/others/kotlin-springboot/**'
-      - 'samples/server/petstore/kotlin-springboot-3*/**'
-      - 'samples/server/petstore/kotlin-server/**'
-      - 'samples/server/petstore/kotlin-server-modelMutable/**'
-      - 'samples/server/petstore/kotlin-springboot-*/**'
-      - 'samples/server/petstore/kotlin-server-required-and-nullable-properties/**'
-      - 'samples/server/petstore/kotlin-spring-declarative*/**'
-      - 'samples/server/petstore/kotlin-spring-sealed-interfaces/**'
-      - 'samples/server/petstore/kotlin-springboot-sort-validation/**'
-      - 'samples/server/petstore/kotlin-springboot-paged-model/**'
-      - 'samples/server/petstore/kotlin-server/ktor-delegate-pattern/generated/**'
-      # comment out due to gradle build failure
-      # - samples/server/petstore/kotlin-spring-default/**
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - 'samples/server/others/kotlin-server/**'
-      - 'samples/server/others/kotlin-springboot/**'
-      - 'samples/server/petstore/kotlin-springboot-3*/**'
-      - 'samples/server/petstore/kotlin-server/**'
-      - 'samples/server/petstore/kotlin-server-modelMutable/**'
-      - 'samples/server/petstore/kotlin-springboot-*/**'
-      - 'samples/server/petstore/kotlin-server-required-and-nullable-properties/**'
-      - 'samples/server/petstore/kotlin-spring-declarative*/**'
-      - 'samples/server/petstore/kotlin-spring-sealed-interfaces/**'
-      - 'samples/server/petstore/kotlin-springboot-sort-validation/**'
-      - 'samples/server/petstore/kotlin-springboot-paged-model/**'
-      - 'samples/server/petstore/kotlin-server/ktor-delegate-pattern/generated/**'
-      # comment out due to gradle build failure
-      # - samples/server/petstore/kotlin-spring-default/**
 
 env:
   GRADLE_VERSION: '8.14'
 
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-kotlin-server-jdk17.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build Kotlin server (jdk17)
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          # server
-          - samples/server/others/kotlin-springboot/oneOf-discriminator
-          - samples/server/others/kotlin-springboot/oneOf-discriminator-const
-          - samples/server/others/kotlin-springboot/oneOf-enum-discriminator
-          - samples/server/others/kotlin-server/polymorphism-allof-and-discriminator
-          - samples/server/others/kotlin-server/polymorphism-and-discriminator-disabled-jackson-fix
-          - samples/server/others/kotlin-server/polymorphism-and-discriminator
-          - samples/server/others/kotlin-server/polymorphism
-          - samples/server/petstore/kotlin-server-required-and-nullable-properties
-          - samples/server/petstore/kotlin-springboot-3
-          - samples/server/petstore/kotlin-springboot-3-no-response-entity
-          - samples/server/petstore/kotlin-springboot-additionalproperties
-          - samples/server/petstore/kotlin-springboot-delegate-nodefaults
-          - samples/server/petstore/kotlin-springboot-request-cookie
-          - samples/server/petstore/kotlin-springboot-4
-          - samples/server/petstore/kotlin-server/jaxrs-spec
-          - samples/server/petstore/kotlin-server/jaxrs-spec-mutiny
-          - samples/server/petstore/kotlin-server/javalin
-          - samples/server/petstore/kotlin-server/javalin-6
-          - samples/server/petstore/kotlin-server/ktor
-          - samples/server/petstore/kotlin-server/ktor-delegate-pattern/generated
-          - samples/server/petstore/kotlin-server/ktor2
-          - samples/server/petstore/kotlin-server-modelMutable
-          - samples/server/petstore/kotlin-misk
-          - samples/server/petstore/kotlin-spring-declarative-interface
-          - samples/server/petstore/kotlin-spring-declarative-interface-bean-validation
-          - samples/server/petstore/kotlin-spring-declarative-interface-reactive-coroutines
-          - samples/server/petstore/kotlin-spring-declarative-interface-reactive-reactor-wrapped
-          - samples/server/petstore/kotlin-spring-declarative-interface-wrapped
-          - samples/server/petstore/kotlin-spring-sealed-interfaces
-          - samples/server/petstore/kotlin-springboot-sort-validation
-          - samples/server/petstore/kotlin-springboot-paged-model
-          # comment out due to gradle build failure
-          # - samples/server/petstore/kotlin-spring-default/
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-java@v6.0.0

--- a/.github/workflows/samples-kotlin-server-jdk21.yaml
+++ b/.github/workflows/samples-kotlin-server-jdk21.yaml
@@ -1,42 +1,42 @@
 name: Samples Kotlin server (jdk21)
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - 'samples/server/others/kotlin-server/**'
-      - 'samples/server/others/kotlin-springboot/**'
-      - 'samples/server/petstore/kotlin-server/**'
-      - 'samples/server/petstore/kotlin-server-required-and-nullable-properties/**'
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - 'samples/server/others/kotlin-server/**'
-      - 'samples/server/others/kotlin-springboot/**'
-      - 'samples/server/petstore/kotlin-server/**'
-      - 'samples/server/petstore/kotlin-server-required-and-nullable-properties/**'
 
 env:
   GRADLE_VERSION: '8.14'
 
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-kotlin-server-jdk21.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build Kotlin server (jdk21)
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          - samples/server/others/kotlin-springboot/oneOf-discriminator
-          - samples/server/others/kotlin-springboot/oneOf-discriminator-const
-          - samples/server/others/kotlin-springboot/oneOf-enum-discriminator
-          - samples/server/others/kotlin-server/polymorphism-allof-and-discriminator
-          - samples/server/others/kotlin-server/polymorphism-and-discriminator-disabled-jackson-fix
-          - samples/server/others/kotlin-server/polymorphism-and-discriminator
-          - samples/server/others/kotlin-server/polymorphism
-          - samples/server/petstore/kotlin-server/javalin-6
-          - samples/server/petstore/kotlin-server/ktor
-          - samples/server/petstore/kotlin-server/ktor2
-          - samples/server/petstore/kotlin-server-required-and-nullable-properties
-          - samples/server/petstore/kotlin-misk
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-java@v6.0.0

--- a/.github/workflows/samples-kotlin-server.yaml
+++ b/.github/workflows/samples-kotlin-server.yaml
@@ -1,59 +1,42 @@
 name: Samples Kotlin server (jdk8)
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - samples/server/others/kotlin-server/jaxrs-spec/**
-      - 'samples/server/petstore/kotlin*/**'
-      - 'samples/server/others/kotlin-server/jaxrs-spec-array-response/**'
-      # comment out due to gradle build failure
-      #- samples/server/petstore/kotlin-spring-default/**
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - samples/server/others/kotlin-server/jaxrs-spec/**
-      - 'samples/server/petstore/kotlin*/**'
-      - 'samples/server/others/kotlin-server/jaxrs-spec-array-response/**'
-      # comment out due to gradle build failure
-      # - samples/server/petstore/kotlin-spring-default/**
 
 env:
   GRADLE_VERSION: 7.6.4
 
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-kotlin-server.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build Kotlin server (jdk8)
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          # server
-          - samples/server/petstore/kotlin-springboot
-          - samples/server/petstore/kotlin-springboot-no-response-entity
-          - samples/server/petstore/kotlin-springboot-no-response-entity-delegate
-          - samples/server/petstore/kotlin-springboot-multipart-request-model
-          - samples/server/petstore/kotlin-springboot-bigdecimal-default
-          - samples/server/petstore/kotlin-springboot-delegate
-          - samples/server/petstore/kotlin-springboot-modelMutable
-          - samples/server/petstore/kotlin-springboot-reactive
-          - samples/server/petstore/kotlin-springboot-reactive-without-flow
-          - samples/server/petstore/kotlin-springboot-source-swagger1
-          - samples/server/petstore/kotlin-springboot-source-swagger2
-          - samples/server/petstore/kotlin-springboot-x-kotlin-implements
-          - samples/server/petstore/kotlin-springboot-include-http-request-context-delegate
-          - samples/server/petstore/kotlin-server/ktor2
-          - samples/server/petstore/kotlin-server/jaxrs-spec
-          - samples/server/petstore/kotlin-server/jaxrs-spec-mutiny
-          - samples/server/petstore/kotlin-server/javalin
-          - samples/server/others/kotlin-server/jaxrs-spec
-          - samples/server/others/kotlin-server/jaxrs-spec-array-response
-          - samples/server/petstore/kotlin-spring-cloud
-          - samples/server/petstore/kotlin-misk
-          - samples/server/petstore/kotlin-misk-config
-          # comment out due to gradle build failure
-          #- samples/server/petstore/kotlin-spring-default
-          # no build.gradle file
-          #- samples/server/petstore/kotlin-vertx-modelMutable
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-java@v6.0.0

--- a/.github/workflows/samples-kotlin-wiremock.yaml
+++ b/.github/workflows/samples-kotlin-wiremock.yaml
@@ -1,26 +1,39 @@
 name: Samples Kotlin WireMock
 
 on:
+  workflow_dispatch:
   push:
     branches:
-      - samples/server/petstore/kotlin-wiremock*/**
-      - samples/server/echo_api/kotlin-wiremock/**
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - samples/server/petstore/kotlin-wiremock*/**
-      - samples/server/echo_api/kotlin-wiremock/**
 
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-kotlin-wiremock.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build Kotlin WireMock
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          - samples/server/petstore/kotlin-wiremock
-          - samples/server/petstore/kotlin-wiremock-responses
-          - samples/server/echo_api/kotlin-wiremock
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-java@v6.0.0

--- a/.github/workflows/samples-ocaml.yaml
+++ b/.github/workflows/samples-ocaml.yaml
@@ -1,37 +1,39 @@
 name: Samples OCaml
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - 'samples/client/petstore/ocaml/**'
-      - 'samples/client/petstore/ocaml-fake-petstore/**'
-      - 'samples/client/petstore/ocaml-oneOf-primitive/**'
-      - 'samples/client/petstore/ocaml-additional-properties/**'
-      - 'samples/client/petstore/ocaml-enum-in-composed-schema/**'
-      - 'samples/client/petstore/ocaml-recursion-test/**'
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - 'samples/client/petstore/ocaml/**'
-      - 'samples/client/petstore/ocaml-fake-petstore/**'
-      - 'samples/client/petstore/ocaml-oneOf-primitive/**'
-      - 'samples/client/petstore/ocaml-additional-properties/**'
-      - 'samples/client/petstore/ocaml-enum-in-composed-schema/**'
-      - 'samples/client/petstore/ocaml-recursion-test/**'
 
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-ocaml.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build OCaml
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          - 'samples/client/petstore/ocaml/'
-          - 'samples/client/petstore/ocaml-fake-petstore/'
-          - 'samples/client/petstore/ocaml-oneOf-primitive/'
-          - 'samples/client/petstore/ocaml-additional-properties/'
-          - 'samples/client/petstore/ocaml-enum-in-composed-schema/'
-          - 'samples/client/petstore/ocaml-recursion-test/'
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - name: Set-up OCaml

--- a/.github/workflows/samples-php-client.yaml
+++ b/.github/workflows/samples-php-client.yaml
@@ -1,27 +1,39 @@
 name: Samples PHP clients
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - samples/client/petstore/php/OpenAPIClient-php/**
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - samples/client/petstore/php/OpenAPIClient-php/**
+
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-php-client.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build PHP projects
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        php:
-          - "8.1"
-          - "8.2"
-          - "8.3"
-          - "8.4"
-        sample:
-          # clients
-          - samples/client/petstore/php/OpenAPIClient-php/
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     services:
       petstore-api:
         image: swaggerapi/petstore

--- a/.github/workflows/samples-php-nextgen-phpstan.yaml
+++ b/.github/workflows/samples-php-nextgen-phpstan.yaml
@@ -1,27 +1,39 @@
 name: Samples php-nextgen (phpstan)
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - samples/client/petstore/php-nextgen/OpenAPIClient-php/**
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - samples/client/petstore/php-nextgen/OpenAPIClient-php/**
+
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-php-nextgen-phpstan.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build 
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true
-      matrix:
-        php:
-          - "8.1"
-          - "8.2"
-          - "8.3"
-          - "8.4"
-        sample:
-          # clients
-          - samples/client/petstore/php-nextgen/OpenAPIClient-php/
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - name: Setup PHP with tools

--- a/.github/workflows/samples-php-server-syntax-check.yaml
+++ b/.github/workflows/samples-php-server-syntax-check.yaml
@@ -1,42 +1,39 @@
 name: Samples PHP (Server) Syntax Checker
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - samples/server/petstore/php-symfony/SymfonyBundle-php/**
-      #- samples/server/petstore/php-laravel/**
-      - samples/server/petstore/php-flight/**
-      - samples/server/petstore/php-mezzio-ph-modern/**
-      - samples/server/petstore/php-mezzio-ph/**
-      - samples/server/petstore/php-slim4/**
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - samples/server/petstore/php-symfony/SymfonyBundle-php/**
-      #- samples/server/petstore/php-laravel/**
-      - samples/server/petstore/php-flight/**
-      - samples/server/petstore/php-mezzio-ph-modern/**
-      - samples/server/petstore/php-mezzio-ph/**
-      - samples/server/petstore/php-slim4/**
+
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-php-server-syntax-check.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build PHP projects
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        php:
-          - "8.1"
-          - "8.2"
-          - "8.3"
-          - "8.4"
-        sample:
-          # servers
-          - samples/server/petstore/php-symfony/SymfonyBundle-php/
-          #- samples/server/petstore/php-laravel/
-          - samples/server/petstore/php-flight/
-          - samples/server/petstore/php-mezzio-ph-modern/
-          - samples/server/petstore/php-mezzio-ph/
-          - samples/server/petstore/php-slim4/
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - name: Setup PHP with tools

--- a/.github/workflows/samples-php-servers-phpstan.yaml
+++ b/.github/workflows/samples-php-servers-phpstan.yaml
@@ -1,29 +1,39 @@
 name: Samples php-laravel 8.x
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - samples/server/petstore/php-laravel/**
-      - samples/server/petstore/php-laravel-issue-21334/**
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - samples/server/petstore/php-laravel/**
-      - samples/server/petstore/php-laravel-issue-21334/**
+
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-php-servers-phpstan.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build 
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        php:
-          - "8.3"
-          - "8.4"
-        sample:
-          # servers
-          # comment out due to errors
-          #- samples/server/petstore/php-laravel/
-          - samples/server/petstore/php-laravel-issue-21334/
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - name: Setup PHP with tools

--- a/.github/workflows/samples-php-syntax-check.yaml
+++ b/.github/workflows/samples-php-syntax-check.yaml
@@ -1,30 +1,39 @@
 name: Samples PHP Syntax Checker
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - samples/client/petstore/php/OpenAPIClient-php/**
-      - samples/client/petstore/php-nextgen/OpenAPIClient-php/**
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - samples/client/petstore/php/OpenAPIClient-php/**
-      - samples/client/petstore/php-nextgen/OpenAPIClient-php/**
+
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-php-syntax-check.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build PHP projects
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        php:
-          - "8.1"
-          - "8.2"
-          - "8.3"
-          - "8.4"
-        sample:
-          # clients
-          - samples/client/petstore/php/OpenAPIClient-php/
-          - samples/client/petstore/php-nextgen/OpenAPIClient-php/
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - name: Setup PHP with tools

--- a/.github/workflows/samples-php8.yaml
+++ b/.github/workflows/samples-php8.yaml
@@ -1,30 +1,39 @@
 name: Samples PHP 8.x
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - samples/server/petstore/php-symfony/SymfonyBundle-php/**
-      - samples/server/petstore/php-flight/**
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - samples/server/petstore/php-symfony/SymfonyBundle-php/**
-      - samples/server/petstore/php-flight/**
+
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-php8.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build PHP projects
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        php:
-          - "8.1"
-          - "8.2"
-          - "8.3"
-          - "8.4"
-        sample:
-          # servers
-          - samples/server/petstore/php-symfony/SymfonyBundle-php/
-          - samples/server/petstore/php-flight/
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - name: Setup PHP with tools

--- a/.github/workflows/samples-postman.yaml
+++ b/.github/workflows/samples-postman.yaml
@@ -1,23 +1,39 @@
 name: Samples Postman
 
 on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - samples/schema/postman-collection/python/**
-      - samples/schema/postman-collection/postman.json
-      - .github/workflows/samples-postman.yaml
+
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-postman.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Test Python client
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          # schema
-          - samples/schema/postman-collection
-        python-version:
-          - "3.12"
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7

--- a/.github/workflows/samples-powershell.yaml
+++ b/.github/workflows/samples-powershell.yaml
@@ -1,20 +1,38 @@
 name: Samples PowerShell
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - samples/client/petstore/powershell/**
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - samples/client/petstore/powershell/**
+
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-powershell.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     runs-on: ubuntu-latest
     name: Test Powershell Clients
     strategy:
-      matrix:
-        sample:
-          - samples/client/petstore/powershell/
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     services:
       petstore-api:
         image: swaggerapi/petstore

--- a/.github/workflows/samples-protobuf.yaml
+++ b/.github/workflows/samples-protobuf.yaml
@@ -1,26 +1,38 @@
 name: Samples Protobuf
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - .github/workflows/samples-protobuf.yaml
-      - samples/config/petstore/protobuf-schema/**
-      - samples/config/petstore/protobuf-schema-config/**
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - .github/workflows/samples-protobuf.yaml
-      - samples/config/petstore/protobuf-schema/**
-      - samples/config/petstore/protobuf-schema-config/**
+
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-protobuf.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build Protobuf Client
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          - 'samples/config/petstore/protobuf-schema/'
-          - 'samples/config/petstore/protobuf-schema-config/'
-          - 'samples/config/petstore/protobuf-schema-config-complex/'
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - name: Install Protocol Buffers Compiler

--- a/.github/workflows/samples-python-client-echo-api.yaml
+++ b/.github/workflows/samples-python-client-echo-api.yaml
@@ -1,28 +1,39 @@
 name: Python Client (Echo API)
 
 on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - samples/client/echo_api/python/**
-      - samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/**
-      - .github/workflows/samples-python-client-echo-api.yaml
+
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-python-client-echo-api.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Test Python client
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          # clients
-          - samples/client/echo_api/python
-          - samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent
-        python-version:
-          - "3.10"
-          - "3.11"
-          - "3.12"
-          - "3.13"
-          - "3.14"
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7

--- a/.github/workflows/samples-python-client-legacy-model-dictionaries.yaml
+++ b/.github/workflows/samples-python-client-legacy-model-dictionaries.yaml
@@ -1,24 +1,39 @@
 name: Python Client (Legacy Model Dictionaries)
 
 on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - samples/client/others/python-legacy-model-dictionaries/**
-      - .github/workflows/samples-python-client-legacy-model-dictionaries.yaml
 
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-python-client-legacy-model-dictionaries.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Test Python client
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        python-version:
-          - "3.10"
-          - "3.11"
-          - "3.12"
-          - "3.13"
-          - "3.14"
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7

--- a/.github/workflows/samples-python-fastapi-server.yaml
+++ b/.github/workflows/samples-python-fastapi-server.yaml
@@ -1,22 +1,39 @@
 name: Python FastAPI Server
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - samples/server/petstore/python-fastapi/**
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - samples/server/petstore/python-fastapi/**
+
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-python-fastapi-server.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Test Python FastAPI server
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          # servers
-          - samples/server/petstore/python-fastapi/
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7

--- a/.github/workflows/samples-python-flask-connexion3-server.yaml
+++ b/.github/workflows/samples-python-flask-connexion3-server.yaml
@@ -1,24 +1,39 @@
 name: Python Flask (Connexion 3) Server
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - samples/server/petstore/python-flask-connexion3/**
-      - .github/workflows/samples-python-flask-connexion3-server.yaml
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - samples/server/petstore/python-flask-connexion3/**
-      - .github/workflows/samples-python-flask-connexion3-server.yaml
+
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-python-flask-connexion3-server.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Test Python Flask (Connexion 3) server
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          # servers
-          - samples/server/petstore/python-flask-connexion3/
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7

--- a/.github/workflows/samples-python-petstore.yaml
+++ b/.github/workflows/samples-python-petstore.yaml
@@ -1,17 +1,42 @@
 name: "Python Client: Petstore"
 
 on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - samples/openapi3/client/petstore/python-aiohttp/**
-      - samples/openapi3/client/petstore/python-httpx/**
-      - samples/openapi3/client/petstore/python-httpx-sync/**
-      - samples/openapi3/client/petstore/python/**
-      - samples/openapi3/client/petstore/python-lazyImports/**
-      - .github/workflows/samples-python-petstore.yaml
 
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      validate_pyproject_toml_changed: ${{ steps.validate_pyproject_toml.outputs.has_changes }}
+      validate_pyproject_toml_matrix: ${{ steps.validate_pyproject_toml.outputs.matrix }}
+      validate_pyproject_toml_samples: ${{ steps.validate_pyproject_toml.outputs.samples }}
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: validate_pyproject_toml
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-python-petstore.validate-pyproject-toml
+          mode: ${{ vars.CI_SELECTION_MODE_PILOT || vars.CI_SELECTION_MODE || 'shadow' }}
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-python-petstore.build
+          mode: ${{ vars.CI_SELECTION_MODE_PILOT || vars.CI_SELECTION_MODE || 'shadow' }}
+
   validate-pyproject-toml:
+    needs: setup
+    if: ${{ needs.setup.outputs.validate_pyproject_toml_changed == 'true' }}
     name: Validate pyproject.toml
     runs-on: ubuntu-latest
     steps:
@@ -24,23 +49,13 @@ jobs:
       - name: Validate
         run: validate-pyproject samples/openapi3/client/petstore/python/pyproject.toml
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Test Python client
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        python-version:
-          - "3.10"
-          - "3.11"
-          - "3.12"
-          - "3.13"
-          - "3.14"
-        sample:
-          - samples/openapi3/client/petstore/python-aiohttp
-          - samples/openapi3/client/petstore/python-httpx
-          - samples/openapi3/client/petstore/python-httpx-sync
-          - samples/openapi3/client/petstore/python
-          - samples/openapi3/client/petstore/python-lazyImports
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     services:
       petstore-api:
         image: swaggerapi/petstore

--- a/.github/workflows/samples-python-pydantic-v1-client-echo-api.yaml
+++ b/.github/workflows/samples-python-pydantic-v1-client-echo-api.yaml
@@ -1,27 +1,39 @@
 name: Python Client pydantic v1 (Echo API)
 
 on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - samples/client/echo_api/python-pydantic-v1/**
-      - .github/workflows/samples-python-pydantic-v1-client-echo-api.yaml
 
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-python-pydantic-v1-client-echo-api.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Test Python client
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          # clients
-          - samples/client/echo_api/python-pydantic-v1/
-        python-version:
-          - "3.10"
-          - "3.11"
-          - "3.12"
-          - "3.13"
-          #- "3.14"
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7

--- a/.github/workflows/samples-python-pydantic-v1-petstore.yaml
+++ b/.github/workflows/samples-python-pydantic-v1-petstore.yaml
@@ -1,28 +1,39 @@
 name: "Python Client pydantic v1: Petstore"
 
 on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/**
-      - samples/openapi3/client/petstore/python-pydantic-v1/**
-      - .github/workflows/samples-python-pydantic-v1-petstore.yaml
 
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-python-pydantic-v1-petstore.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Test Python client
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        python-version:
-          - "3.10"
-          - "3.11"
-          - "3.12"
-          - "3.13"
-          - "3.14"
-        sample:
-          - samples/openapi3/client/petstore/python-pydantic-v1-aiohttp
-          - samples/openapi3/client/petstore/python-pydantic-v1
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     services:
       petstore-api:
         image: swaggerapi/petstore

--- a/.github/workflows/samples-python-server.yaml
+++ b/.github/workflows/samples-python-server.yaml
@@ -1,22 +1,39 @@
 name: Python Server
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - samples/server/petstore/python-aiohttp-srclayout/**
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - samples/server/petstore/python-aiohttp-srclayout/**
+
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-python-server.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Test Python server
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          # servers
-          - samples/server/petstore/python-aiohttp-srclayout/
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7

--- a/.github/workflows/samples-r.yaml
+++ b/.github/workflows/samples-r.yaml
@@ -1,28 +1,39 @@
 name: Samples R clients
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - samples/client/petstore/R/**
-      - samples/client/petstore/R-httr2/**
-      - samples/client/petstore/R-httr2-wrapper/**
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - samples/client/petstore/R/**
-      - samples/client/petstore/R-httr2/**
-      - samples/client/petstore/R-httr2-wrapper/**
+
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-r.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build R projects
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          # clients
-          - samples/client/petstore/R/
-          - samples/client/petstore/R-httr2/
-          - samples/client/petstore/R-httr2-wrapper/
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     services:
       petstore-api:
         image: swaggerapi/petstore

--- a/.github/workflows/samples-ruby-nextgen.yaml
+++ b/.github/workflows/samples-ruby-nextgen.yaml
@@ -1,27 +1,39 @@
 name: Samples ruby-nextgen
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - 'samples/client/petstore/ruby-nextgen/**'
-      - 'samples/client/others/ruby-nextgen-qdrant/**'
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - 'samples/client/petstore/ruby-nextgen/**'
-      - 'samples/client/others/ruby-nextgen-qdrant/**'
 
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-ruby-nextgen.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          - samples/client/petstore/ruby-nextgen
-        ruby-version:
-          - '3.0'
-          - '3.3'
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - uses: ruby/setup-ruby@v1

--- a/.github/workflows/samples-ruby.yaml
+++ b/.github/workflows/samples-ruby.yaml
@@ -1,28 +1,39 @@
 name: Samples Ruby 
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - 'samples/client/echo_api/ruby-httpx/**'
-      - 'samples/client/echo_api/ruby-faraday/**'
-      - 'samples/client/echo_api/ruby-typhoeus/**'
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - 'samples/client/echo_api/ruby-httpx/**'
-      - 'samples/client/echo_api/ruby-faraday/**'
-      - 'samples/client/echo_api/ruby-typhoeus/**'
 
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-ruby.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build Ruby
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          - 'samples/client/echo_api/ruby-httpx/'
-          - 'samples/client/echo_api/ruby-faraday/'
-          - 'samples/client/echo_api/ruby-typhoeus/'
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - name: Setup node.js

--- a/.github/workflows/samples-rust-client.yaml
+++ b/.github/workflows/samples-rust-client.yaml
@@ -1,17 +1,34 @@
 name: Samples Rust Clients
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - "samples/client/others/rust/**"
-      - "samples/client/petstore/rust-server/**"
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - "samples/client/others/rust/**"
-      - "samples/client/petstore/rust/**"
 
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-rust-client.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build Rust
     runs-on: ubuntu-latest
     services:
@@ -24,11 +41,7 @@ jobs:
           SWAGGER_BASE_PATH: /v2
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          # these folders contain sub-projects of rust clients, servers
-          - samples/client/others/rust/
-          - samples/client/petstore/rust/
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/samples-rust-server.yaml
+++ b/.github/workflows/samples-rust-server.yaml
@@ -1,29 +1,39 @@
 name: Samples Rust Servers
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - "samples/server/petstore/rust-server/**"
-      - "samples/server/petstore/rust-axum/**"
-      - "samples/server/petstore/rust-salvo/**"
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - "samples/server/petstore/rust-server/**"
-      - "samples/server/petstore/rust-axum/**"
-      - "samples/server/petstore/rust-salvo/**"
 
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-rust-server.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build Rust
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          # these folders contain sub-projects of rust clients, servers
-          - samples/server/petstore/rust-server/
-          - samples/server/petstore/rust-axum/
-          - samples/server/petstore/rust-salvo/
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/samples-scala-client.yaml
+++ b/.github/workflows/samples-scala-client.yaml
@@ -1,46 +1,39 @@
 name: Samples Scala/sbt client
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - samples/client/petstore/scalaz/**
-      - samples/client/petstore/scala-pekko/**
-      - samples/client/petstore/scala-http4s/**
-      - samples/client/petstore/scala-sttp4-jsoniter/**
-      - samples/client/petstore/scala-akka/**
-      - samples/client/petstore/scala-sttp/**
-      - samples/client/petstore/scala-sttp-circe/**
-      - samples/client/petstore/scala-sttp4/**
-      - samples/client/petstore/scala-sttp4-circe/**
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - samples/client/petstore/scalaz/**
-      - samples/client/petstore/scala-pekko/**
-      - samples/client/petstore/scala-http4s/**
-      - samples/client/petstore/scala-sttp4-jsoniter/**
-      - samples/client/petstore/scala-akka/**
-      - samples/client/petstore/scala-sttp/**
-      - samples/client/petstore/scala-sttp-circe/**
-      - samples/client/petstore/scala-sttp4/**
-      - samples/client/petstore/scala-sttp4-circe/**
+
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-scala-client.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build sbt/Scala
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          # clients
-          - samples/client/petstore/scalaz
-          - samples/client/petstore/scala-pekko
-          - samples/client/petstore/scala-http4s
-          - samples/client/petstore/scala-sttp4-jsoniter
-          - samples/client/petstore/scala-akka
-          - samples/client/petstore/scala-sttp
-          - samples/client/petstore/scala-sttp-circe
-          - samples/client/petstore/scala-sttp4
-          - samples/client/petstore/scala-sttp4-circe
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     services:
       petstore-api:
         image: swaggerapi/petstore

--- a/.github/workflows/samples-scala-server.yaml
+++ b/.github/workflows/samples-scala-server.yaml
@@ -1,27 +1,39 @@
 name: Samples Scala/sbt server
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - 'samples/server/petstore/scala**'
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - 'samples/server/petstore/scala**'
+
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-scala-server.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build sbt/Scala
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          # servers
-          - samples/server/petstore/scala-play-server
-          - samples/server/petstore/scala-akka-http-server
-          - samples/server/petstore/scala-pekko-http-server
-          - samples/server/petstore/scalatra
-          - samples/server/petstore/scala-http4s-server
-          - samples/server/petstore/scala-cask
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-java@v6.0.0

--- a/.github/workflows/samples-spring-jdk11.yaml
+++ b/.github/workflows/samples-spring-jdk11.yaml
@@ -1,27 +1,39 @@
 name: Samples Java Spring (JDK11)
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      # servers
-      - samples/server/petstore/springboot-implicitHeaders/**
-      - samples/server/petstore/springboot-implicitHeaders-annotationLibrary/**
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      # servers
-      - samples/server/petstore/springboot-implicitHeaders/**
-      - samples/server/petstore/springboot-implicitHeaders-annotationLibrary/**
+
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-spring-jdk11.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build 
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          # servers
-          - samples/server/petstore/springboot-implicitHeaders
-          - samples/server/petstore/springboot-implicitHeaders-annotationLibrary
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-java@v6.0.0

--- a/.github/workflows/samples-spring-jdk17.yaml
+++ b/.github/workflows/samples-spring-jdk17.yaml
@@ -1,77 +1,39 @@
 name: Samples Java Spring (JDK17)
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - samples/openapi3/client/petstore/spring-cloud-3-with-optional/**
-      - samples/openapi3/client/petstore/spring-cloud-4-with-optional/**
-      - samples/client/petstore/spring-http-interface-springboot-4/**
-      - samples/openapi3/server/petstore/springboot-3/**
-      - samples/openapi3/server/petstore/springboot-4/**
-      - samples/openapi3/server/petstore/springboot-4-jspecify/**
-      - samples/openapi3/server/petstore/springboot-4-jspecify-openapiNullable/**
-      - samples/openapi3/server/petstore/springboot-4-jspecify-useOptional/**
-      - samples/server/petstore/springboot-api-response-examples/**
-      - samples/server/petstore/springboot-lombok-data/**
-      - samples/server/petstore/springboot-lombok-tostring/**
-      - samples/server/petstore/springboot-file-delegate-optional/**
-      - samples/server/petstore/springboot-petstore-with-api-response-examples/**
-      - samples/server/petstore/springboot-sort-validation/**
-      - samples/server/petstore/springboot-paged-model/**
-      - samples/server/others/springboot-pre-authorize/**
-      - samples/openapi3/server/petstore/spring-boot-oneof-sealed/**
-      - samples/openapi3/server/petstore/spring-boot-oneof-interface/**
-      - samples/client/petstore/spring-http-interface-oauth/**
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - samples/openapi3/client/petstore/spring-cloud-3-with-optional/**
-      - samples/openapi3/client/petstore/spring-cloud-4-with-optional/**
-      - samples/client/petstore/spring-http-interface-springboot-4/**
-      - samples/openapi3/server/petstore/springboot-3/**
-      - samples/openapi3/server/petstore/springboot-4/**
-      - samples/openapi3/server/petstore/springboot-4-jspecify/**
-      - samples/openapi3/server/petstore/springboot-4-jspecify-openapiNullable/**
-      - samples/openapi3/server/petstore/springboot-4-jspecify-useOptional/**
-      - samples/server/petstore/springboot-api-response-examples/**
-      - samples/server/petstore/springboot-lombok-data/**
-      - samples/server/petstore/springboot-lombok-tostring/**
-      - samples/server/petstore/springboot-file-delegate-optional/**
-      - samples/server/petstore/springboot-petstore-with-api-response-examples/**
-      - samples/server/petstore/springboot-sort-validation/**
-      - samples/server/petstore/springboot-paged-model/**
-      - samples/server/others/springboot-pre-authorize/**
-      - samples/openapi3/server/petstore/spring-boot-oneof-sealed/**
-      - samples/openapi3/server/petstore/spring-boot-oneof-interface/**
-      - samples/client/petstore/spring-http-interface-oauth/**
+
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-spring-jdk17.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build Java Spring (JDK17)
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          # clients
-          - samples/openapi3/client/petstore/spring-cloud-3-with-optional
-          - samples/openapi3/client/petstore/spring-cloud-4-with-optional
-          - samples/client/petstore/spring-http-interface-springboot-4
-          # servers
-          - samples/openapi3/server/petstore/springboot-3
-          - samples/openapi3/server/petstore/springboot-4
-          - samples/openapi3/server/petstore/springboot-4-jspecify
-          - samples/openapi3/server/petstore/springboot-4-jspecify-openapiNullable
-          - samples/openapi3/server/petstore/springboot-4-jspecify-useOptional
-          - samples/server/petstore/springboot-api-response-examples
-          - samples/server/petstore/springboot-lombok-data
-          - samples/server/petstore/springboot-lombok-tostring
-          - samples/server/petstore/springboot-file-delegate-optional
-          - samples/server/petstore/springboot-petstore-with-api-response-examples
-          - samples/server/petstore/springboot-sort-validation
-          - samples/server/petstore/springboot-paged-model
-          - samples/server/others/springboot-pre-authorize
-          - samples/openapi3/server/petstore/spring-boot-oneof-sealed
-          - samples/openapi3/server/petstore/spring-boot-oneof-interface
-          - samples/client/petstore/spring-http-interface-oauth
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-java@v6.0.0

--- a/.github/workflows/samples-spring.yaml
+++ b/.github/workflows/samples-spring.yaml
@@ -1,67 +1,39 @@
 name: Samples Java Spring
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      # clients
-      - 'samples/client/petstore/spring*/**'
-      # servers
-      - 'samples/server/petstore/spring*/**'
-      - 'samples/openapi3/server/petstore/spring*/**'
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      # clients
-      - 'samples/client/petstore/spring*/**'
-      # servers
-      - 'samples/server/petstore/spring*/**'
-      - 'samples/openapi3/server/petstore/spring*/**'
+
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-spring.build
+          mode: ${{ vars.CI_SELECTION_MODE_PILOT || vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build Java Spring
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          # clients
-          - samples/client/petstore/spring-cloud
-          - samples/client/petstore/spring-cloud-auth
-          - samples/client/petstore/spring-cloud-date-time
-          - samples/client/petstore/spring-cloud-deprecated
-          - samples/client/petstore/spring-cloud-tags
-          - samples/openapi3/client/petstore/spring-cloud
-          - samples/openapi3/client/petstore/spring-cloud-async
-          - samples/openapi3/client/petstore/spring-cloud-date-time
-          - samples/openapi3/client/petstore/spring-cloud-http-basic
-          - samples/openapi3/client/petstore/spring-cloud-spring-pageable
-          - samples/openapi3/client/petstore/spring-stubs
-          - samples/openapi3/client/petstore/spring-stubs-skip-default-interface
-          # servers
-          - samples/openapi3/server/petstore/springboot
-          - samples/openapi3/server/petstore/springboot-implicitHeaders
-          - samples/openapi3/server/petstore/springboot-delegate
-          - samples/openapi3/server/petstore/spring-boot-oneof
-          - samples/server/petstore/spring-boot-nullable-set
-          - samples/server/petstore/spring-boot-defaultInterface-unhandledExcp
-          - samples/server/petstore/springboot
-          - samples/server/petstore/springboot-include-http-request-context
-          - samples/server/petstore/springboot-beanvalidation
-          - samples/server/petstore/springboot-builtin-validation
-          - samples/server/petstore/springboot-delegate
-          - samples/server/petstore/springboot-delegate-no-response-entity
-          - samples/server/petstore/springboot-implicitHeaders
-          - samples/server/petstore/springboot-implicitHeaders-annotationLibrary
-          - samples/server/petstore/springboot-lombok-data
-          - samples/server/petstore/springboot-reactive
-          - samples/server/petstore/springboot-reactive-noResponseEntity
-          - samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8
-          - samples/server/petstore/springboot-spring-pageable-delegatePattern
-          - samples/server/petstore/springboot-spring-pageable-without-j8
-          - samples/server/petstore/springboot-spring-pageable
-          - samples/server/petstore/springboot-spring-provide-args
-          - samples/server/petstore/springboot-useoptional
-          - samples/server/petstore/springboot-virtualan
-          - samples/openapi3/server/petstore/spring-boot-oneof-interface
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-java@v6.0.0

--- a/.github/workflows/samples-swift5.yaml
+++ b/.github/workflows/samples-swift5.yaml
@@ -1,36 +1,37 @@
 name: Samples Swift 5
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - samples/client/petstore/swift5/**
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - samples/client/petstore/swift5/**
 
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-swift5.build
+          mode: ${{ vars.CI_SELECTION_MODE_PILOT || vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     strategy:
       fail-fast: false
-      matrix:
-        os: [macos-latest]
-        sample:
-          - samples/client/petstore/swift5/alamofireLibrary
-          - samples/client/petstore/swift5/asyncAwaitLibrary
-          - samples/client/petstore/swift5/combineLibrary
-          - samples/client/petstore/swift5/default
-          - samples/client/petstore/swift5/objcCompatible
-          - samples/client/petstore/swift5/oneOf
-          - samples/client/petstore/swift5/promisekitLibrary
-          - samples/client/petstore/swift5/resultLibrary
-          - samples/client/petstore/swift5/rxswiftLibrary
-          - samples/client/petstore/swift5/urlsessionLibrary
-          - samples/client/petstore/swift5/validation
-          # NOTE: disabled as vaporLibrary doesnt build when adding this CI config
-          #- samples/client/petstore/swift5/vaporLibrary
-        include:
-        - os: ubuntu-latest
-          sample: samples/client/petstore/swift5/alamofireLibrary
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     name: Build Swift samples
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/samples-terraform.yaml
+++ b/.github/workflows/samples-terraform.yaml
@@ -1,33 +1,39 @@
 name: Samples Terraform
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - 'samples/client/petstore/terraform/**'
-      - 'samples/client/petstore/terraform-addpet/**'
-      - 'samples/client/petstore/terraform-server/**'
-      - 'samples/client/others/terraform/**'
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - 'samples/client/petstore/terraform/**'
-      - 'samples/client/petstore/terraform-addpet/**'
-      - 'samples/client/petstore/terraform-server/**'
-      - 'samples/client/others/terraform/**'
 
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-terraform.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build Terraform Provider
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          - samples/client/petstore/terraform/
-          - samples/client/petstore/terraform-addpet/
-          - samples/client/petstore/terraform-server/
-          - samples/client/others/terraform/allof-discriminator/
-          - samples/client/others/terraform/oneof-anyof-required/
-          - samples/client/others/terraform/oneof-discriminator-lookup/
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7

--- a/.github/workflows/samples-typescript-axios-echo-api.yaml
+++ b/.github/workflows/samples-typescript-axios-echo-api.yaml
@@ -1,24 +1,39 @@
 name: TypeScript Axios Client (Echo API)
 
 on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - samples/client/echo_api/typescript-axios/**
-      - .github/workflows/samples-typescript-axios-echo-api.yaml
+
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-typescript-axios-echo-api.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Test TypeScript Axios client
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          # clients
-          - samples/client/echo_api/typescript-axios/test
-        node-version:
-          - 16
-          - 18
-          - 20
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/samples-typescript-client.yaml
+++ b/.github/workflows/samples-typescript-client.yaml
@@ -1,64 +1,34 @@
 name: Samples TS clients
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - samples/client/others/typescript-angular/**
-      - samples/client/others/typescript-angular-v20/**
-      - samples/client/petstore/typescript-angular-v18-provided-in-root/**
-      - samples/client/petstore/typescript-angular-v19-provided-in-root/**
-      - samples/client/petstore/typescript-angular-v20-provided-in-root/**
-      - samples/client/petstore/typescript-angular-v21-provided-in-root/**
-      - samples/client/petstore/typescript-angular-v22-provided-in-root/**
-      - samples/openapi3/client/petstore/typescript/builds/default/**
-      # comment out due to build failure
-      #- samples/openapi3/client/petstore/typescript/tests/default/**
-      - samples/openapi3/client/petstore/typescript/builds/jquery/**
-      # comment out due to build failure
-      #- samples/openapi3/client/petstore/typescript/tests/jquery/**
-      - samples/openapi3/client/petstore/typescript/builds/object_params/**
-      # comment out due to build failure
-      #- samples/openapi3/client/petstore/typescript/tests/object_params/**
-      #- samples/openapi3/client/petstore/typescript/builds/inversify/**
-      #- samples/openapi3/client/petstore/typescript/tests/inversify/**
-      #- samples/openapi3/client/petstore/typescript/tests/deno/**
-      - samples/openapi3/client/petstore/typescript/builds/browser/**
-      # comment out due to build failure
-      #- samples/openapi3/client/petstore/typescript/tests/browser/**
-      #- samples/openapi3/client/petstore/typescript/builds/nullable-enum/**
-      # comment out due to build failure
-      #- samples/client/petstore/typescript-node/npm/**
-      - samples/client/petstore/typescript-rxjs/builds/with-npm-version/**
-      - samples/client/petstore/typescript-axios/builds/with-npm-version/**
-      # comment out due to build failure
-      #- samples/client/petstore/typescript-axios/tests/default/**
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - samples/client/others/typescript-angular/**
-      - samples/client/others/typescript-angular-v20/**
-      - samples/client/petstore/typescript-angular-v18-provided-in-root/**
-      - samples/client/petstore/typescript-angular-v19-provided-in-root/**
-      - samples/client/petstore/typescript-angular-v20-provided-in-root/**
-      - samples/client/petstore/typescript-angular-v21-provided-in-root/**
-      - samples/client/petstore/typescript-angular-v22-provided-in-root/**
-      - samples/openapi3/client/petstore/typescript/builds/default/**
-      #- samples/openapi3/client/petstore/typescript/tests/default/**
-      - samples/openapi3/client/petstore/typescript/builds/jquery/**
-      #- samples/openapi3/client/petstore/typescript/tests/jquery/**
-      - samples/openapi3/client/petstore/typescript/builds/object_params/**
-      #- samples/openapi3/client/petstore/typescript/tests/object_params/**
-      #- samples/openapi3/client/petstore/typescript/builds/inversify/**
-      #- samples/openapi3/client/petstore/typescript/tests/inversify/**
-      #- samples/openapi3/client/petstore/typescript/tests/deno/**
-      - samples/openapi3/client/petstore/typescript/builds/browser/**
-      #- samples/openapi3/client/petstore/typescript/tests/browser/**
-      #- samples/openapi3/client/petstore/typescript/builds/nullable-enum/**
-      #- samples/client/petstore/typescript-node/npm/**
-      - samples/client/petstore/typescript-rxjs/builds/with-npm-version/**
-      - samples/client/petstore/typescript-axios/builds/with-npm-version/**
-      #- samples/client/petstore/typescript-axios/tests/default/**
+
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-typescript-client.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build projects
     runs-on: ubuntu-latest
     services:
@@ -71,34 +41,7 @@ jobs:
           SWAGGER_BASE_PATH: /v2
     strategy:
       fail-fast: false
-      matrix:
-        node:
-          #- "18.x"
-          - "22.x"
-        sample:
-          - samples/client/others/typescript-angular/
-          - samples/client/others/typescript-angular-v20/
-          - samples/client/petstore/typescript-angular-v18-provided-in-root/
-          - samples/client/petstore/typescript-angular-v19-provided-in-root/
-          - samples/client/petstore/typescript-angular-v20-provided-in-root/
-          - samples/client/petstore/typescript-angular-v21-provided-in-root/
-          - samples/client/petstore/typescript-angular-v22-provided-in-root/
-          - samples/openapi3/client/petstore/typescript/builds/default/
-          #- samples/openapi3/client/petstore/typescript/tests/default/
-          - samples/openapi3/client/petstore/typescript/builds/jquery/
-          #- samples/openapi3/client/petstore/typescript/tests/jquery/
-          - samples/openapi3/client/petstore/typescript/builds/object_params/
-          #- samples/openapi3/client/petstore/typescript/tests/object_params/
-          #- samples/openapi3/client/petstore/typescript/builds/inversify/
-          #- samples/openapi3/client/petstore/typescript/tests/inversify/
-          #- samples/openapi3/client/petstore/typescript/tests/deno/
-          - samples/openapi3/client/petstore/typescript/builds/browser/
-          #- samples/openapi3/client/petstore/typescript/tests/browser/
-          #- samples/openapi3/client/petstore/typescript/builds/nullable-enum/
-          #- samples/client/petstore/typescript-node/npm/
-          - samples/client/petstore/typescript-rxjs/builds/with-npm-version/
-          - samples/client/petstore/typescript-axios/builds/with-npm-version/
-          #- samples/client/petstore/typescript-axios/tests/default/
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - name: Add hosts to /etc/hosts

--- a/.github/workflows/samples-typescript-encode-decode.yaml
+++ b/.github/workflows/samples-typescript-encode-decode.yaml
@@ -1,24 +1,39 @@
 name: TypeScript Client (Encoding / Decoding Test)
 
 on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - samples/client/others/typescript/encode-decode/**
-      - .github/workflows/samples-typescript-encode-decode.yaml
+
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-typescript-encode-decode.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Test TypeScript Encoding / Decoding
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          # clients
-          - samples/client/others/typescript/encode-decode/test
-        node-version:
-          - 20
-          - 22
-          - 24
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/samples-typescript-fetch-client.yaml
+++ b/.github/workflows/samples-typescript-fetch-client.yaml
@@ -1,20 +1,34 @@
 name: Samples TS clients
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - samples/client/petstore/typescript-fetch/builds/default/**
-      - samples/client/petstore/typescript-fetch/builds/es6-target/**
-      - samples/client/petstore/typescript-fetch/builds/with-npm-version/**
-      - samples/client/petstore/typescript-fetch/tests/default/**
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - samples/client/petstore/typescript-fetch/builds/default/**
-      - samples/client/petstore/typescript-fetch/builds/es6-target/**
-      - samples/client/petstore/typescript-fetch/builds/with-npm-version/**
-      - samples/client/petstore/typescript-fetch/tests/default/**
+
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-typescript-fetch-client.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build projects
     runs-on: ubuntu-latest
     services:
@@ -27,15 +41,7 @@ jobs:
           SWAGGER_BASE_PATH: /v2
     strategy:
       fail-fast: false
-      matrix:
-        node:
-          #- "18.x"
-          - "20.x"
-        sample:
-          - samples/client/petstore/typescript-fetch/builds/default/
-          - samples/client/petstore/typescript-fetch/builds/es6-target/
-          - samples/client/petstore/typescript-fetch/builds/with-npm-version/
-          - samples/client/petstore/typescript-fetch/tests/default/
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - name: Add hosts to /etc/hosts

--- a/.github/workflows/samples-typescript-nestjs-server.yaml
+++ b/.github/workflows/samples-typescript-nestjs-server.yaml
@@ -1,24 +1,39 @@
 name: TypeScript NestJS Server
 
 on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - samples/server/petstore/typescript-nestjs-server/**
-      - .github/workflows/samples-typescript-nestjs-server.yaml
-      - .github/workflows/samples-typescript-nestjs-server-parameters.yaml
+
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-typescript-nestjs-server.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Test TypeScript NestJS Server
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          # clients
-          - samples/server/petstore/typescript-nestjs-server
-        node-version:
-          - 20
-          - 22
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/samples-typescript-node-encode-decode.yaml
+++ b/.github/workflows/samples-typescript-node-encode-decode.yaml
@@ -1,24 +1,39 @@
 name: TypeScript Node Client (Encoding / Decoding Test)
 
 on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - samples/client/others/typescript-node/encode-decode/**
-      - .github/workflows/samples-typescript-node-encode-decode.yaml
+
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-typescript-node-encode-decode.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Test TypeScript Node Encoding / Decoding
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          # clients
-          - samples/client/others/typescript-node/encode-decode/test
-        node-version:
-          - 16
-          - 18
-          - 20
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/samples-typescript-server.yaml
+++ b/.github/workflows/samples-typescript-server.yaml
@@ -1,24 +1,39 @@
 name: Samples TS servers
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - samples/server/petstore/typescript-nestjs-server/**
+    branches:
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - samples/server/petstore/typescript-nestjs-server/**
+
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-typescript-server.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Build projects
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        node:
-          - "18.x"
-          - "20.x"
-        sample:
-          - samples/server/petstore/typescript-nestjs-server/
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
       - name: Use Node.js 20.x

--- a/.github/workflows/samples-typescript-typecheck.yaml
+++ b/.github/workflows/samples-typescript-typecheck.yaml
@@ -1,35 +1,39 @@
 name: TypeScript clients type checks
 
 on:
+  workflow_dispatch:
   push:
     branches:
-      - master
-    paths:
-      - samples/client/petstore/typescript*/**
-      - samples/client/others/typescript*/**
-      - samples/client/echo_api/typescript*/**
-      - samples/openapi3/client/petstore*/typescript/**
-      - samples/server/petstore/typescript-nestjs-server/**
-      - bin/ts-typecheck-all.sh
-      - .github/workflows/samples-typescript-typecheck.yaml
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - samples/client/petstore/typescript*/**
-      - samples/client/others/typescript*/**
-      - samples/client/echo_api/typescript*/**
-      - samples/openapi3/client/petstore*/typescript/**
-      - samples/server/petstore/typescript-nestjs-server/**
-      - bin/ts-typecheck-all.sh
-      - .github/workflows/samples-typescript-typecheck.yaml
+
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+      build_matrix: ${{ steps.build.outputs.matrix }}
+      build_samples: ${{ steps.build.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: build
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-typescript-typecheck.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
     name: Typecheck TypeScript samples
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        node-version:
-          - 20
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
     steps:
       - uses: actions/checkout@v7
 
@@ -38,4 +42,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Run type checker
-        run: ./bin/ts-typecheck-all.sh
+        env:
+          SELECTED_SAMPLES: ${{ needs.setup.outputs.build_samples }}
+        run: ./bin/ts-typecheck-all.sh --samples-json "$SELECTED_SAMPLES"

--- a/.github/workflows/samples-zapier.yaml
+++ b/.github/workflows/samples-zapier.yaml
@@ -1,22 +1,39 @@
 name: Samples Zapier
 
 on:
+  workflow_dispatch:
   push:
     branches:
-      - 'samples/client/petstore/zapier/**'
+      - 'master'
+      - '[5-9]+.[0-9]+.x'
   pull_request:
-    paths:
-      - 'samples/client/petstore/zapier/**'
 
 jobs:
+  setup:
+    name: Select affected samples
+    runs-on: ubuntu-latest
+    outputs:
+      validate_changed: ${{ steps.validate.outputs.has_changes }}
+      validate_matrix: ${{ steps.validate.outputs.matrix }}
+      validate_samples: ${{ steps.validate.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - id: validate
+        uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-zapier.validate
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   validate:
+    needs: setup
+    if: ${{ needs.setup.outputs.validate_changed == 'true' }}
     name: Test zapier generation
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        sample:
-          - samples/client/petstore/zapier
+      matrix: ${{ fromJSON(needs.setup.outputs.validate_matrix) }}
     steps:
     - uses: actions/checkout@v7
     - name: Setup node

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -1,6 +1,7 @@
 name: Windows tests
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - master
@@ -11,8 +12,27 @@ on:
       - '[5-9]+.[0-9]+.x'
 
 jobs:
+  setup:
+    name: Select changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      build_changed: ${{ steps.build.outputs.has_changes }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - uses: ./.github/actions/compute-matrix
+        id: build
+        with:
+          suite: windows.build
+          mode: ${{ vars.CI_SELECTION_MODE || 'shadow' }}
+
   build:
     name: Build
+    needs: setup
+    if: needs.setup.outputs.build_changed == 'true'
     runs-on: windows-latest
     strategy:
       matrix:

--- a/CI/change-scopes.json
+++ b/CI/change-scopes.json
@@ -1,0 +1,3506 @@
+{
+  "version": 1,
+  "suites": {
+    "gradle-test.build": {
+      "workflow": ".github/workflows/gradle-test.yaml",
+      "matrix": {
+        "sample": [
+          "samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8",
+          "samples/openapi3/client/petstore/java/jersey2-java8-special-characters",
+          "samples/openapi3/client/petstore/java/jersey2-java8",
+          "samples/client/petstore/java/jersey2-java8-localdatetime",
+          "samples/client/petstore/java/jersey2-java8",
+          "samples/client/petstore/java/okhttp-gson",
+          "samples/client/petstore/java/okhttp-gson-group-parameter",
+          "samples/client/petstore/java/webclient-swagger2",
+          "samples/client/petstore/java/native",
+          "samples/client/petstore/java/native-jakarta"
+        ]
+      },
+      "shadow_paths": [
+        "samples/client/petstore/java/**",
+        "samples/openapi3/client/petstore/java/**"
+      ]
+    },
+    "samples-aspnet-fastenpoints-server.build": {
+      "workflow": ".github/workflows/samples-aspnet-fastenpoints-server.yaml",
+      "matrix": {
+        "sample": [
+          "samples/server/petstore/aspnet/fastendpoints",
+          "samples/server/petstore/aspnet/fastendpoints-useApiVersioning",
+          "samples/server/petstore/aspnet/fastendpoints-useAuthentication",
+          "samples/server/petstore/aspnet/fastendpoints-useProblemDetails",
+          "samples/server/petstore/aspnet/fastendpoints-useRecords",
+          "samples/server/petstore/aspnet/fastendpoints-useResponseCaching",
+          "samples/server/petstore/aspnet/fastendpoints-useValidators"
+        ]
+      },
+      "shadow_paths": [
+        "samples/server/petstore/aspnet/fastendpoints/**",
+        "samples/server/petstore/aspnet/fastendpoints-*/**"
+      ]
+    },
+    "samples-c-libcurl-client.build": {
+      "workflow": ".github/workflows/samples-c-libcurl-client.yaml",
+      "matrix": {
+        "sample": [
+          "samples/client/petstore/c/",
+          "samples/client/petstore/c-useJsonUnformatted/",
+          "samples/client/others/c/bearerAuth/"
+        ]
+      },
+      "shadow_paths": [
+        "samples/client/petstore/c/**",
+        "samples/client/petstore/c-useJsonUnformatted/**",
+        "samples/client/others/c/bearerAuth/**"
+      ]
+    },
+    "samples-clojure.build": {
+      "workflow": ".github/workflows/samples-clojure.yaml",
+      "matrix": {
+        "sample": [
+          "samples/client/petstore/clojure/"
+        ]
+      },
+      "shadow_paths": [
+        "samples/client/petstore/clojure/**"
+      ]
+    },
+    "samples-cpp-httplib-server.build": {
+      "workflow": ".github/workflows/samples-cpp-httplib-server.yaml",
+      "matrix": {
+        "sample": [
+          "samples/server/petstore/cpp-httplib-server/petstore",
+          "samples/server/petstore/cpp-httplib-server/feature-test"
+        ],
+        "os": [
+          "ubuntu-latest",
+          "macOS-latest",
+          "windows-latest"
+        ]
+      },
+      "shadow_paths": [
+        "samples/server/petstore/cpp-httplib-server/**",
+        ".github/workflows/samples-cpp-httplib-server.yaml"
+      ]
+    },
+    "samples-cpp-oatpp-client.build": {
+      "workflow": ".github/workflows/samples-cpp-oatpp-client.yaml",
+      "matrix": {
+        "sample": [
+          "samples/client/petstore/cpp-oatpp"
+        ],
+        "os": [
+          "ubuntu-latest",
+          "macOS-latest",
+          "windows-latest"
+        ]
+      },
+      "shadow_paths": [
+        "samples/client/petstore/cpp-oatpp/**"
+      ]
+    },
+    "samples-cpp-oatpp-server.build": {
+      "workflow": ".github/workflows/samples-cpp-oatpp-server.yaml",
+      "matrix": {
+        "sample": [
+          "samples/server/petstore/cpp-oatpp"
+        ],
+        "os": [
+          "ubuntu-latest",
+          "macOS-latest",
+          "windows-latest"
+        ]
+      },
+      "shadow_paths": [
+        "samples/server/petstore/cpp-oatpp/**"
+      ]
+    },
+    "samples-cpp-qt-client.build": {
+      "workflow": ".github/workflows/samples-cpp-qt-client.yaml",
+      "matrix": {
+        "sample": [
+          "samples/client/petstore/cpp-qt",
+          "samples/client/petstore/cpp-qt-addDownloadProgress"
+        ],
+        "os": [
+          "ubuntu-latest",
+          "macOS-latest",
+          "windows-latest"
+        ]
+      },
+      "shadow_paths": [
+        "samples/client/petstore/cpp-qt*/**"
+      ]
+    },
+    "samples-crystal.build": {
+      "workflow": ".github/workflows/samples-crystal.yaml",
+      "matrix": {
+        "sample": [
+          "samples/client/petstore/crystal/"
+        ]
+      },
+      "shadow_paths": [
+        "samples/client/petstore/crystal/**"
+      ]
+    },
+    "samples-dart-build-test.test": {
+      "workflow": ".github/workflows/samples-dart-build-test.yaml",
+      "matrix": {
+        "os": [
+          "ubuntu-latest",
+          "windows-latest"
+        ],
+        "sdk": [
+          "3.9.0"
+        ],
+        "sample": [
+          "samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/",
+          "samples/openapi3/client/petstore/dart-dio/oneof/",
+          "samples/openapi3/client/petstore/dart-dio/anyof/",
+          "samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/",
+          "samples/openapi3/client/petstore/dart-dio/binary_response/",
+          "samples/openapi3/client/petstore/dart-dio/petstore-timemachine/"
+        ]
+      },
+      "shadow_paths": [
+        "samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/**",
+        "samples/openapi3/client/petstore/dart-dio/oneof/**",
+        "samples/openapi3/client/petstore/dart-dio/anyof/**",
+        "samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/**",
+        "samples/openapi3/client/petstore/dart-dio/binary_response/**",
+        "samples/openapi3/client/petstore/dart-dio/petstore-timemachine/**"
+      ]
+    },
+    "samples-dart.tests-dart": {
+      "workflow": ".github/workflows/samples-dart.yaml",
+      "paths": [
+        "samples/openapi3/client/petstore/dart*/**"
+      ],
+      "shared_paths": [
+        "pom.xml",
+        ".mvn/**",
+        "mvnw",
+        "mvnw.cmd",
+        "CI/settings.xml",
+        "modules/**",
+        ".github/actions/run-samples/**",
+        "samples/pom.xml"
+      ],
+      "shadow_paths": [
+        "samples/openapi3/client/petstore/dart*/**"
+      ]
+    },
+    "samples-dotnet-fx.build": {
+      "workflow": ".github/workflows/samples-dotnet-fx.yaml",
+      "matrix": {
+        "sample": [
+          "samples/client/petstore/csharp/generichost/net4.7/AllOf",
+          "samples/client/petstore/csharp/generichost/net4.7/AnyOf",
+          "samples/client/petstore/csharp/generichost/net4.7/AnyOfNoCompare",
+          "samples/client/petstore/csharp/generichost/net4.7/FormModels",
+          "samples/client/petstore/csharp/generichost/net4.7/OneOf",
+          "samples/client/petstore/csharp/generichost/net4.7/Petstore",
+          "samples/client/petstore/csharp/generichost/net4.7/UseDateTimeForDate",
+          "samples/client/petstore/csharp/generichost/net4.8/AllOf",
+          "samples/client/petstore/csharp/generichost/net4.8/AnyOf",
+          "samples/client/petstore/csharp/generichost/net4.8/AnyOfNoCompare",
+          "samples/client/petstore/csharp/generichost/net4.8/FormModels",
+          "samples/client/petstore/csharp/generichost/net4.8/OneOf",
+          "samples/client/petstore/csharp/generichost/net4.8/Petstore",
+          "samples/client/petstore/csharp/generichost/net4.8/UseDateTimeForDate"
+        ]
+      },
+      "shadow_paths": [
+        "samples/client/petstore/csharp/generichost/net4.7/**",
+        "samples/client/petstore/csharp/generichost/net4.8/**"
+      ]
+    },
+    "samples-dotnet-petstore-net10.build": {
+      "workflow": ".github/workflows/samples-dotnet-petstore-net10.yml",
+      "matrix": {
+        "sample": [
+          "samples/client/petstore/csharp/restsharp/net10/Petstore/"
+        ]
+      },
+      "shadow_paths": [
+        "samples/client/petstore/csharp/restsharp/net10/Petstore/**"
+      ]
+    },
+    "samples-dotnet-petstore.build": {
+      "workflow": ".github/workflows/samples-dotnet-petstore.yml",
+      "matrix": {
+        "sample": [
+          "samples/client/petstore/csharp/restsharp/standard2.0/Petstore/"
+        ]
+      },
+      "shadow_paths": [
+        "samples/client/petstore/csharp/restsharp/standard2.0/Petstore/**"
+      ]
+    },
+    "samples-dotnet-standard.build": {
+      "workflow": ".github/workflows/samples-dotnet-standard.yaml",
+      "matrix": {
+        "sample": [
+          "samples/client/petstore/csharp/generichost/standard2.0/Petstore/",
+          "samples/client/petstore/csharp/httpclient/standard2.0/Petstore/",
+          "samples/client/petstore/csharp/restsharp/standard2.0/Petstore/",
+          "samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/"
+        ]
+      },
+      "shadow_paths": [
+        "samples/client/petstore/csharp/generichost/standard2.0/**",
+        "samples/client/petstore/csharp/httpclient/standard2.0/**",
+        "samples/client/petstore/csharp/restsharp/standard2.0/**",
+        "samples/client/petstore/csharp/unityWebRequest/standard2.0/**"
+      ]
+    },
+    "samples-dotnet10.build": {
+      "workflow": ".github/workflows/samples-dotnet10.yaml",
+      "matrix": {
+        "sample": [
+          "samples/client/petstore/csharp/generichost/latest/AnnotatedEnum",
+          "samples/client/petstore/csharp/generichost/latest/ComposedEnum",
+          "samples/client/petstore/csharp/generichost/latest/InlineEnumAnyOf",
+          "samples/client/petstore/csharp/generichost/latest/Tags",
+          "samples/client/petstore/csharp/generichost/latest/HelloWorld",
+          "samples/client/petstore/csharp/generichost/latest/NullTypes",
+          "samples/client/petstore/csharp/generichost/latest/OneOfList",
+          "samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset",
+          "samples/client/petstore/csharp/generichost/net10/AllOf",
+          "samples/client/petstore/csharp/generichost/net10/AnyOf",
+          "samples/client/petstore/csharp/generichost/net10/AnyOfNoCompare",
+          "samples/client/petstore/csharp/generichost/net10/FormModels",
+          "samples/client/petstore/csharp/generichost/net10/NullReferenceTypes",
+          "samples/client/petstore/csharp/generichost/net10/OneOf",
+          "samples/client/petstore/csharp/generichost/net10/Petstore",
+          "samples/client/petstore/csharp/generichost/net10/SourceGeneration",
+          "samples/client/petstore/csharp/generichost/net10/UseDateTimeForDate",
+          "samples/client/petstore/csharp/restsharp/net10/EnumMappings",
+          "samples/client/petstore/csharp/httpclient/net10/Petstore",
+          "samples/client/petstore/csharp/httpclient/net10/Petstore-nonPublicApi"
+        ]
+      },
+      "shadow_paths": [
+        "samples/client/petstore/csharp/generichost/latest/**",
+        "samples/client/petstore/csharp/generichost/net10/**",
+        "samples/client/petstore/csharp/httpclient/net10/**",
+        "samples/client/petstore/csharp/restsharp/net10/**",
+        "samples/client/petstore/csharp/unityWebRequest/net10/**"
+      ]
+    },
+    "samples-dotnet6-server.build": {
+      "workflow": ".github/workflows/samples-dotnet6-server.yaml",
+      "matrix": {
+        "sample": [
+          "samples/server/petstore/aspnetcore-6.0",
+          "samples/server/petstore/aspnetcore-6.0-NewtonsoftFalse",
+          "samples/server/petstore/aspnetcore-6.0-nullableReferenceTypes",
+          "samples/server/petstore/aspnetcore-6.0-pocoModels",
+          "samples/server/petstore/aspnetcore-6.0-project4Models",
+          "samples/server/petstore/aspnetcore-6.0-useSwashBuckle"
+        ]
+      },
+      "shadow_paths": [
+        "samples/server/petstore/aspnetcore-6.0/**",
+        "samples/server/petstore/aspnetcore-6.0-*/**"
+      ]
+    },
+    "samples-dotnet7-client.build": {
+      "workflow": ".github/workflows/samples-dotnet7-client.yml",
+      "matrix": {
+        "sample": [
+          "samples/client/petstore/csharp/restsharp/net4.7/MultipleFrameworks/",
+          "samples/client/petstore/csharp/restsharp/net4.7/Petstore/",
+          "samples/client/petstore/csharp/restsharp/net4.8/Petstore/",
+          "samples/client/petstore/csharp/restsharp/net8/ParameterMappings/",
+          "samples/client/petstore/csharp/restsharp/net8/EnumMappings/",
+          "samples/client/petstore/csharp/restsharp/net8/Petstore/",
+          "samples/client/petstore/csharp/restsharp/net8/UseDateTimeForDate/",
+          "samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/"
+        ]
+      },
+      "shadow_paths": [
+        "samples/client/petstore/csharp/restsharp/net4.7/MultipleFrameworks/**",
+        "samples/client/petstore/csharp/restsharp/net4.7/Petstore/**",
+        "samples/client/petstore/csharp/restsharp/net4.8/Petstore/**",
+        "samples/client/petstore/csharp/restsharp/net8/ParameterMappings/**",
+        "samples/client/petstore/csharp/restsharp/net8/EnumMappings/**",
+        "samples/client/petstore/csharp/restsharp/net8/Petstore/**",
+        "samples/client/petstore/csharp/restsharp/net8/UseDateTimeForDate/**",
+        "samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/**"
+      ]
+    },
+    "samples-dotnet8-client-echo-api.build": {
+      "workflow": ".github/workflows/samples-dotnet8-client-echo-api.yaml",
+      "matrix": {
+        "sample": [
+          "samples/client/echo_api/csharp/restsharp/net8/EchoApi"
+        ]
+      },
+      "shadow_paths": [
+        "samples/client/echo_api/csharp/restsharp/net8/**"
+      ]
+    },
+    "samples-dotnet8-client.build": {
+      "workflow": ".github/workflows/samples-dotnet8-client.yaml",
+      "matrix": {
+        "sample": [
+          "samples/client/petstore/csharp/restsharp/net8/ParameterMappings/",
+          "samples/client/petstore/csharp/restsharp/net8/useVirtualForHooks/"
+        ]
+      },
+      "shadow_paths": [
+        "samples/client/petstore/csharp/restsharp/net8/**"
+      ]
+    },
+    "samples-dotnet8-server.build": {
+      "workflow": ".github/workflows/samples-dotnet8-server.yaml",
+      "matrix": {
+        "sample": [
+          "samples/server/petstore/aspnetcore-8.0",
+          "samples/server/petstore/aspnetcore-8.0-NewtonsoftFalse",
+          "samples/server/petstore/aspnetcore-8.0-nullableReferenceTypes",
+          "samples/server/petstore/aspnetcore-8.0-pocoModels",
+          "samples/server/petstore/aspnetcore-8.0-project4Models",
+          "samples/server/petstore/aspnetcore-8.0-useSwashBuckle",
+          "samples/server/petstore/aspnetcore-8.0-use-centralized-package-version-management"
+        ]
+      },
+      "shadow_paths": [
+        "samples/server/petstore/aspnetcore-8.0/**",
+        "samples/server/petstore/aspnetcore-8.0-*/**"
+      ]
+    },
+    "samples-dotnet8.build": {
+      "workflow": ".github/workflows/samples-dotnet8.yaml",
+      "matrix": {
+        "sample": [
+          "samples/client/petstore/csharp/generichost/net8/AllOf",
+          "samples/client/petstore/csharp/generichost/net8/AnyOf",
+          "samples/client/petstore/csharp/generichost/net8/AnyOfNoCompare",
+          "samples/client/petstore/csharp/generichost/net8/FormModels",
+          "samples/client/petstore/csharp/generichost/net8/ManualPetstoreTests",
+          "samples/client/petstore/csharp/generichost/net8/ManualSourceGenerationTests",
+          "samples/client/petstore/csharp/generichost/net8/NullReferenceTypes",
+          "samples/client/petstore/csharp/generichost/net8/OneOf",
+          "samples/client/petstore/csharp/generichost/net8/Petstore",
+          "samples/client/petstore/csharp/generichost/net8/SourceGeneration",
+          "samples/client/petstore/csharp/generichost/net8/UseDateTimeForDate"
+        ]
+      },
+      "shadow_paths": [
+        "samples/client/petstore/csharp/generichost/net8/**",
+        "samples/client/petstore/csharp/httpclient/net8/**",
+        "samples/client/petstore/csharp/restsharp/net8/**",
+        "samples/client/petstore/csharp/unityWebRequest/net8/**"
+      ]
+    },
+    "samples-dotnet9.build": {
+      "workflow": ".github/workflows/samples-dotnet9.yaml",
+      "matrix": {
+        "sample": [
+          "samples/client/petstore/csharp/generichost/net9/AllOf",
+          "samples/client/petstore/csharp/generichost/net9/AnyOf",
+          "samples/client/petstore/csharp/generichost/net9/AnyOfNoCompare",
+          "samples/client/petstore/csharp/generichost/net9/FormModels",
+          "samples/client/petstore/csharp/generichost/net9/NullReferenceTypes",
+          "samples/client/petstore/csharp/generichost/net9/OneOf",
+          "samples/client/petstore/csharp/generichost/net9/Petstore",
+          "samples/client/petstore/csharp/generichost/net9/SourceGeneration",
+          "samples/client/petstore/csharp/generichost/net9/UseDateTimeForDate",
+          "samples/client/petstore/csharp/restsharp/net9/EnumMappings",
+          "samples/client/petstore/csharp/httpclient/net9/Petstore",
+          "samples/client/petstore/csharp/httpclient/net9/Petstore-nonPublicApi"
+        ]
+      },
+      "shadow_paths": [
+        "samples/client/petstore/csharp/generichost/net9/**",
+        "samples/client/petstore/csharp/httpclient/net9/**",
+        "samples/client/petstore/csharp/restsharp/net9/**",
+        "samples/client/petstore/csharp/unityWebRequest/net9/**"
+      ]
+    },
+    "samples-elixir.build": {
+      "workflow": ".github/workflows/samples-elixir.yaml",
+      "matrix": {
+        "otp": [
+          "25.3.2",
+          "26.2.5",
+          "27.3.3"
+        ],
+        "elixir": [
+          "1.18.3"
+        ],
+        "sample": [
+          "samples/client/petstore/elixir/",
+          "samples/client/petstore/elixir-req/"
+        ]
+      },
+      "shadow_paths": [
+        "samples/client/petstore/elixir/**",
+        "samples/client/petstore/elixir-req/**"
+      ]
+    },
+    "samples-elm.build": {
+      "workflow": ".github/workflows/samples-elm.yaml",
+      "matrix": {
+        "sample": [
+          "samples/client/petstore/elm",
+          "samples/openapi3/client/elm"
+        ]
+      },
+      "shadow_paths": [
+        ".github/workflows/samples-elm.yaml",
+        "samples/client/petstore/elm/**",
+        "samples/openapi3/client/elm/**"
+      ]
+    },
+    "samples-erlang.build": {
+      "workflow": ".github/workflows/samples-erlang.yaml",
+      "matrix": {
+        "sample": [
+          "samples/server/echo_api/erlang-server/",
+          "samples/server/petstore/erlang-server/",
+          "samples/client/petstore/erlang-client/",
+          "samples/client/petstore/erlang-proper/"
+        ]
+      },
+      "shadow_paths": [
+        "samples/server/echo_api/erlang-server/**",
+        "samples/server/petstore/erlang-server/**",
+        "samples/client/petstore/erlang-client/**",
+        "samples/client/petstore/erlang-proper/**"
+      ]
+    },
+    "samples-go-client-echo-api.build": {
+      "workflow": ".github/workflows/samples-go-client-echo-api.yaml",
+      "matrix": {
+        "sample": [
+          "samples/client/echo_api/go"
+        ]
+      },
+      "shadow_paths": [
+        "samples/client/echo_api/go/**",
+        ".github/workflows/samples-go-client-echo-api.yaml"
+      ]
+    },
+    "samples-go-client-petstore.build": {
+      "workflow": ".github/workflows/samples-go-client-petstore.yaml",
+      "matrix": {
+        "sample": [
+          "samples/client/petstore/go/",
+          "samples/openapi3/client/petstore/go/"
+        ]
+      },
+      "shadow_paths": [
+        "samples/client/petstore/go/**",
+        "samples/openapi3/client/petstore/go/**"
+      ]
+    },
+    "samples-go-client.build": {
+      "workflow": ".github/workflows/samples-go-client.yaml",
+      "matrix": {
+        "sample": [
+          "samples/openapi3/client/petstore/go/go-petstore-aws-signature/",
+          "samples/openapi3/client/petstore/go-petstore-withXml/",
+          "samples/openapi3/client/petstore/go-petstore-generateMarshalJSON-false/",
+          "samples/client/others/go/allof_multiple_ref_and_discriminator/",
+          "samples/client/others/go/oneof-anyof-required/",
+          "samples/client/others/go/oneof-discriminator-lookup/",
+          "samples/client/others/go/issue_20079_go_regex_wrongly_translated/"
+        ]
+      },
+      "shadow_paths": [
+        "samples/openapi3/client/petstore/go/go-petstore-aws-signature/**",
+        "samples/openapi3/client/petstore/go-petstore-withXml/**",
+        "samples/openapi3/client/petstore/go-petstore-generateMarshalJSON-false/**",
+        "samples/client/others/go/allof_multiple_ref_and_discriminator/**",
+        "samples/client/others/go/oneof-anyof-required/**",
+        "samples/client/others/go/oneof-discriminator-lookup/**",
+        "samples/client/others/go/issue_20079_go_regex_wrongly_translated/**"
+      ]
+    },
+    "samples-go-gin.build": {
+      "workflow": ".github/workflows/samples-go-gin.yaml",
+      "matrix": {
+        "sample": [
+          "samples/server/petstore/go-gin-api-server/",
+          "samples/server/petstore/go-gin-api-server-interface-only/"
+        ]
+      },
+      "shadow_paths": [
+        "samples/server/petstore/go-gin-api-server/**",
+        "samples/server/petstore/go-gin-api-server-interface-only/**"
+      ]
+    },
+    "samples-go.build": {
+      "workflow": ".github/workflows/samples-go.yaml",
+      "matrix": {
+        "sample": [
+          "samples/server/petstore/go-echo-server/",
+          "samples/server/petstore/go-api-server/",
+          "samples/server/petstore/go-chi-server/",
+          "samples/server/others/go-server/no-body-path-params/",
+          "samples/server/others/go-server/optional-body/",
+          "samples/server/others/go-server/required-zero-value/"
+        ]
+      },
+      "shadow_paths": [
+        "samples/server/petstore/go-echo-server/**",
+        "samples/server/petstore/go-api-server/**",
+        "samples/server/petstore/go-chi-server/**",
+        "samples/server/others/go-server/**"
+      ]
+    },
+    "samples-go.verify": {
+      "workflow": ".github/workflows/samples-go.yaml",
+      "matrix": {
+        "sample": [
+          "samples/server/petstore/go-api-server/"
+        ],
+        "go-version": [
+          "1.25"
+        ]
+      },
+      "shadow_paths": [
+        "samples/server/petstore/go-echo-server/**",
+        "samples/server/petstore/go-api-server/**",
+        "samples/server/petstore/go-chi-server/**",
+        "samples/server/others/go-server/**"
+      ]
+    },
+    "samples-groovy.build": {
+      "workflow": ".github/workflows/samples-groovy.yaml",
+      "matrix": {
+        "sample": [
+          "samples/client/petstore/groovy"
+        ]
+      },
+      "shadow_paths": [
+        "samples/client/petstore/groovy**"
+      ]
+    },
+    "samples-haskell.build": {
+      "workflow": ".github/workflows/samples-haskell.yaml",
+      "matrix": {
+        "sample": [
+          "samples/server/petstore/haskell-yesod/",
+          "samples/server/petstore/haskell-servant/",
+          "samples/server/others/haskell-servant-ping/",
+          "samples/client/petstore/haskell-http-client/"
+        ]
+      },
+      "shadow_paths": [
+        "samples/server/petstore/haskell-yesod/**",
+        "samples/server/petstore/haskell-servant/**",
+        "samples/server/others/haskell-servant-ping/**",
+        "samples/client/petstore/haskell-http-client/**"
+      ]
+    },
+    "samples-java-client-echo-api-jdk11.build": {
+      "workflow": ".github/workflows/samples-java-client-echo-api-jdk11.yaml",
+      "matrix": {
+        "sample": [
+          "samples/client/echo_api/java/apache-httpclient",
+          "samples/client/echo_api/java/native",
+          "samples/client/echo_api/java/feign-gson",
+          "samples/client/echo_api/java/resttemplate",
+          "samples/client/echo_api/java/resteasy"
+        ]
+      },
+      "shared_paths": [
+        "pom.xml",
+        ".mvn/**",
+        "mvnw",
+        "mvnw.cmd",
+        "CI/settings.xml"
+      ],
+      "shadow_paths": [
+        "samples/client/echo_api/java/**"
+      ]
+    },
+    "samples-java-client-echo-api-jdk17.build": {
+      "workflow": ".github/workflows/samples-java-client-echo-api-jdk17.yaml",
+      "matrix": {
+        "sample": [
+          "samples/client/echo_api/java/apache-httpclient",
+          "samples/client/echo_api/java/native",
+          "samples/client/echo_api/java/feign-gson",
+          "samples/client/echo_api/java/resttemplate",
+          "samples/client/echo_api/java/resteasy",
+          "samples/client/echo_api/java/restclient"
+        ]
+      },
+      "shared_paths": [
+        "pom.xml",
+        ".mvn/**",
+        "mvnw",
+        "mvnw.cmd",
+        "CI/settings.xml"
+      ],
+      "shadow_paths": [
+        "samples/client/echo_api/java/**"
+      ]
+    },
+    "samples-java-client-echo-api-jdk8.build": {
+      "workflow": ".github/workflows/samples-java-client-echo-api-jdk8.yaml",
+      "matrix": {
+        "sample": [
+          "samples/client/echo_api/java/apache-httpclient",
+          "samples/client/echo_api/java/feign-gson",
+          "samples/client/echo_api/java/okhttp-gson",
+          "samples/client/echo_api/java/resttemplate",
+          "samples/client/echo_api/java/resteasy"
+        ]
+      },
+      "shared_paths": [
+        "pom.xml",
+        ".mvn/**",
+        "mvnw",
+        "mvnw.cmd",
+        "CI/settings.xml"
+      ],
+      "shadow_paths": [
+        "samples/client/echo_api/java/apache-httpclient/**",
+        "samples/client/echo_api/java/feign-gson/**",
+        "samples/client/echo_api/java/okhttp-gson/**",
+        "samples/client/echo_api/java/resteasy/**"
+      ]
+    },
+    "samples-java-client-jdk11.build": {
+      "workflow": ".github/workflows/samples-java-client-jdk11.yaml",
+      "matrix": {
+        "sample": [
+          "samples/client/petstore/jaxrs-cxf-client-swagger2",
+          "samples/client/petstore/jaxrs-cxf-client",
+          "samples/client/petstore/java/native",
+          "samples/client/petstore/java/native-async",
+          "samples/client/petstore/java/native-jakarta",
+          "samples/client/petstore/java/native-useGzipFeature",
+          "samples/client/petstore/java/retrofit2",
+          "samples/client/petstore/java/retrofit2rx2",
+          "samples/client/petstore/java/retrofit2rx3",
+          "samples/client/petstore/java/retrofit2-play26",
+          "samples/client/petstore/java/resttemplate",
+          "samples/client/petstore/java/resttemplate-withXml",
+          "samples/client/petstore/java/webclient",
+          "samples/client/petstore/java/webclient-nullable-arrays",
+          "samples/client/petstore/java/webclient-swagger2",
+          "samples/client/petstore/java/webclient-useSingleRequestParameter",
+          "samples/client/petstore/java/vertx",
+          "samples/client/petstore/java/vertx5",
+          "samples/client/petstore/java/vertx5-supportVertxFuture",
+          "samples/client/petstore/java/vertx-no-nullable",
+          "samples/client/petstore/java/vertx-supportVertxFuture",
+          "samples/client/petstore/java/jersey2-java8-localdatetime",
+          "samples/client/petstore/java/google-api-client",
+          "samples/client/petstore/java/rest-assured",
+          "samples/client/petstore/java/rest-assured-jackson",
+          "samples/client/petstore/java/microprofile-rest-client",
+          "samples/client/petstore/java/microprofile-rest-client-mutiny",
+          "samples/client/petstore/java/microprofile-rest-client-3.0",
+          "samples/client/petstore/java/microprofile-rest-client-3.0-jackson",
+          "samples/client/petstore/java/microprofile-rest-client-3.0-jackson-mutiny",
+          "samples/client/petstore/java/microprofile-rest-client-3.0-jackson-with-xml",
+          "samples/client/petstore/java/microprofile-rest-client-3.0-mutiny",
+          "samples/client/petstore/java/microprofile-rest-client-3.0-jspecify",
+          "samples/client/petstore/java/microprofile-rest-client-with-useSingleRequestParameter",
+          "samples/client/petstore/java/microprofile-oneof-interface",
+          "samples/client/petstore/java/apache-httpclient",
+          "samples/client/petstore/java/feign",
+          "samples/client/petstore/java/feign-hc5",
+          "samples/client/petstore/java/feign-no-nullable",
+          "samples/client/petstore/java/okhttp-gson-awsv4signature",
+          "samples/openapi3/client/petstore/java/jersey2-java8-special-characters",
+          "samples/openapi3/client/petstore/java/native",
+          "samples/client/petstore/java/okhttp-gson-swagger1/",
+          "samples/client/petstore/java/resttemplate-swagger1/",
+          "samples/openapi3/client/petstore/java/jersey2-java8-swagger1/",
+          "samples/client/petstore/java/okhttp-gson-swagger2/",
+          "samples/client/petstore/java/resttemplate-swagger2/",
+          "samples/openapi3/client/petstore/java/jersey2-java8-swagger2/",
+          "samples/client/others/java/okhttp-gson-oneOf/",
+          "samples/client/others/java/okhttp-gson-oneOf-array/",
+          "samples/client/echo_api/java/okhttp-gson-user-defined-templates/",
+          "samples/client/others/java/resttemplate-useAbstractionForFiles/",
+          "samples/client/others/java/webclient-useAbstractionForFiles/",
+          "samples/client/others/java/jersey2-oneOf-duplicates/",
+          "samples/client/others/java/jersey2-oneOf-Mixed/",
+          "samples/client/others/java/resttemplate-list-schema-validation/",
+          "samples/client/petstore/java/okhttp-gson-3.1-duplicated-operationid/",
+          "samples/client/others/java/okhttp-gson-streaming/",
+          "samples/client/petstore/java/resteasy/",
+          "samples/client/petstore/java/apache-httpclient/"
+        ]
+      },
+      "shared_paths": [
+        "pom.xml",
+        ".mvn/**",
+        "mvnw",
+        "mvnw.cmd",
+        "CI/settings.xml"
+      ],
+      "shadow_paths": [
+        "samples/client/petstore/java/**",
+        "samples/client/petstore/jaxrs-cxf-client/**",
+        "samples/client/petstore/jaxrs-cxf-client-swagger2/**",
+        "samples/client/petstore/java-micronaut-client/**",
+        "samples/openapi3/client/petstore/java/jersey2-java8-special-characters/**",
+        "samples/openapi3/client/petstore/java/jersey2-java8-swagger1/**",
+        "samples/openapi3/client/petstore/java/jersey2-java8-swagger2/**",
+        "samples/openapi3/client/petstore/java/native**",
+        "samples/client/others/java/okhttp-gson-oneOf/**",
+        "samples/client/others/java/okhttp-gson-oneOf-array/**",
+        "samples/client/others/java/resttemplate-useAbstractionForFiles/**",
+        "samples/client/others/java/webclient-useAbstractionForFiles/**",
+        "samples/client/petstore/java/webclient-useSingleRequestParameter/**",
+        "samples/client/others/java/jersey2-oneOf-duplicates/**",
+        "samples/client/others/java/jersey2-oneOf-Mixed/**",
+        "samples/client/others/java/okhttp-gson-streaming/**",
+        "samples/client/others/java/resteasy/**",
+        "samples/client/others/java/apache-httpclient/**",
+        "samples/client/others/java/resttemplate-list-schema-validation/**",
+        "samples/client/petstore/java/okhttp-gson-3.1-duplicated-operationid/**"
+      ]
+    },
+    "samples-java-client-jdk17.build": {
+      "workflow": ".github/workflows/samples-java-client-jdk17.yaml",
+      "matrix": {
+        "sample": [
+          "samples/client/petstore/java/resttemplate-jakarta",
+          "samples/client/petstore/java/resttemplate-springBoot4-jackson2",
+          "samples/client/petstore/java/resttemplate-springBoot4-jackson3",
+          "samples/client/petstore/java/webclient-jakarta",
+          "samples/client/petstore/java/restclient",
+          "samples/client/petstore/java/restclient-nullable-arrays",
+          "samples/client/petstore/java/restclient-springBoot4-jackson2",
+          "samples/client/petstore/java/restclient-springBoot4-jackson3",
+          "samples/client/petstore/java/restclient-springBoot4-jackson3-jspecify",
+          "samples/client/petstore/java/restclient-springBoot4-jackson3-jspecify-openapiNullable",
+          "samples/client/petstore/java/native-jackson3-jspecify",
+          "samples/client/petstore/java/restclient-swagger2",
+          "samples/client/petstore/java/restclient-useSingleRequestParameter",
+          "samples/client/petstore/java/restclient-useSingleRequestParameter-static",
+          "samples/client/petstore/java/native-jackson3",
+          "samples/client/petstore/java/apache-httpclient-jackson3",
+          "samples/client/others/java/webclient-sealedInterface",
+          "samples/client/others/java/webclient-sealedInterface_3_1",
+          "samples/client/petstore/java/webclient-springBoot4-jackson3",
+          "samples/client/petstore/java/webclient-useSingleRequestParameter",
+          "samples/client/others/java/restclient-enum-in-multipart",
+          "samples/client/others/java/restclient-sealedInterface",
+          "samples/client/others/java/restclient-useAbstractionForFiles",
+          "samples/client/petstore/java/jersey3-oneOf",
+          "samples/client/petstore/java/jersey3-jackson3",
+          "samples/client/petstore/java/microprofile-oneof-sealed"
+        ]
+      },
+      "shared_paths": [
+        "pom.xml",
+        ".mvn/**",
+        "mvnw",
+        "mvnw.cmd",
+        "CI/settings.xml"
+      ],
+      "shadow_paths": [
+        "samples/client/petstore/java/resttemplate-jakarta/**",
+        "samples/client/petstore/java/resttemplate-springBoot4-*/**",
+        "samples/client/petstore/java/webclient-jakarta/**",
+        "samples/client/petstore/java/restclient-*/**",
+        "samples/client/petstore/java/native-jackson3/**",
+        "samples/client/petstore/java/apache-httpclient-jackson3/**",
+        "samples/client/petstore/java/native-jackson3-jspecify/**",
+        "samples/client/petstore/java/restclient-springBoot4-jackson3-jspecify/**",
+        "samples/client/petstore/java/restclient-springBoot4-jackson3-jspecify-openapiNullable/**",
+        "samples/client/others/java/webclient-sealedInterface/**",
+        "samples/client/others/java/webclient-sealedInterface_3_1/**",
+        "samples/client/petstore/java/webclient-useSingleRequestParameter/**",
+        "samples/client/others/java/restclient-enum-in-multipart/**",
+        "samples/client/others/java/restclient-sealedInterface/**",
+        "samples/client/others/java/restclient-useAbstractionForFiles/**",
+        "samples/client/petstore/java/jersey3-oneOf/**",
+        "samples/client/petstore/java/jersey3-jackson3/**",
+        "samples/client/petstore/java/microprofile-oneof-sealed/**"
+      ]
+    },
+    "samples-java-dubbo.build": {
+      "workflow": ".github/workflows/samples-java-dubbo.yaml",
+      "matrix": {
+        "sample": [
+          "samples/server/petstore/java-dubbo"
+        ]
+      },
+      "shared_paths": [
+        "pom.xml",
+        ".mvn/**",
+        "mvnw",
+        "mvnw.cmd",
+        "CI/settings.xml"
+      ],
+      "shadow_paths": [
+        "samples/server/petstore/java-dubbo/**"
+      ]
+    },
+    "samples-java-helidon-v3.build": {
+      "workflow": ".github/workflows/samples-java-helidon-v3.yaml",
+      "matrix": {
+        "sample": [
+          "samples/client/petstore/java-helidon-client/v3/mp",
+          "samples/client/petstore/java-helidon-client/v3/se",
+          "samples/server/petstore/java-helidon-server/v3/mp",
+          "samples/server/petstore/java-helidon-server/v3/se",
+          "samples/server/others/java-helidon-server/v3/mp-format-test"
+        ],
+        "version": [
+          17
+        ]
+      },
+      "shared_paths": [
+        "pom.xml",
+        ".mvn/**",
+        "mvnw",
+        "mvnw.cmd",
+        "CI/settings.xml"
+      ],
+      "shadow_paths": [
+        "samples/client/petstore/java-helidon-client/v3/**",
+        "samples/server/petstore/java-helidon-server/v3/**",
+        "samples/server/others/java-helidon-server/v3/**"
+      ]
+    },
+    "samples-java-helidon-v4.build": {
+      "workflow": ".github/workflows/samples-java-helidon-v4.yaml",
+      "matrix": {
+        "sample": [
+          "samples/client/petstore/java-helidon-client/v4/mp",
+          "samples/client/petstore/java-helidon-client/v4/se",
+          "samples/server/petstore/java-helidon-server/v4/mp",
+          "samples/server/petstore/java-helidon-server/v4/se",
+          "samples/server/petstore/java-helidon-server/v4/se-uac",
+          "samples/server/others/java-helidon-server/v4/mp-format-test"
+        ],
+        "version": [
+          21
+        ]
+      },
+      "shared_paths": [
+        "pom.xml",
+        ".mvn/**",
+        "mvnw",
+        "mvnw.cmd",
+        "CI/settings.xml"
+      ],
+      "shadow_paths": [
+        "samples/client/petstore/java-helidon-client/v4/**",
+        "samples/server/petstore/java-helidon-server/v4/**",
+        "samples/server/others/java-helidon-server/v4/**"
+      ]
+    },
+    "samples-java-petsore-client-jdk11.build": {
+      "workflow": ".github/workflows/samples-java-petsore-client-jdk11.yaml",
+      "matrix": {
+        "sample": [
+          "samples/client/petstore/java/jersey2-java8",
+          "samples/openapi3/client/petstore/java/jersey2-java8",
+          "samples/client/petstore/java/okhttp-gson",
+          "samples/client/petstore/java/okhttp-gson-3.1",
+          "samples/client/petstore/java/okhttp-gson-dynamicOperations",
+          "samples/client/petstore/java-micronaut-client"
+        ]
+      },
+      "shared_paths": [
+        "pom.xml",
+        ".mvn/**",
+        "mvnw",
+        "mvnw.cmd",
+        "CI/settings.xml"
+      ],
+      "shadow_paths": [
+        "samples/client/petstore/java/jersey2-java8/**",
+        "samples/openapi3/client/petstore/java/jersey2-java8/**",
+        "samples/client/petstore/java/okhttp-gson/**",
+        "samples/client/petstore/java/okhttp-gson-3.1/**",
+        "samples/client/petstore/java/okhttp-gson-dynamicOperations/**",
+        "samples/client/petstore/java-micronaut-client/**"
+      ]
+    },
+    "samples-java-petsore-client-jdk17.build": {
+      "workflow": ".github/workflows/samples-java-petsore-client-jdk17.yaml",
+      "matrix": {
+        "sample": [
+          "samples/client/petstore/java/jersey3"
+        ]
+      },
+      "shared_paths": [
+        "pom.xml",
+        ".mvn/**",
+        "mvnw",
+        "mvnw.cmd",
+        "CI/settings.xml"
+      ],
+      "shadow_paths": [
+        "samples/client/petstore/java/jersey3/**"
+      ]
+    },
+    "samples-java-play-framework.build": {
+      "workflow": ".github/workflows/samples-java-play-framework.yaml",
+      "matrix": {
+        "sample": [
+          "samples/server/petstore/java-play-framework",
+          "samples/server/petstore/java-play-framework-api-package-override",
+          "samples/server/petstore/java-play-framework-async",
+          "samples/server/petstore/java-play-framework-controller-only",
+          "samples/server/petstore/java-play-framework-fake-endpoints",
+          "samples/server/petstore/java-play-framework-fake-endpoints-with-security",
+          "samples/server/petstore/java-play-framework-no-bean-validation",
+          "samples/server/petstore/java-play-framework-no-excp-handling",
+          "samples/server/petstore/java-play-framework-no-interface",
+          "samples/server/petstore/java-play-framework-no-nullable",
+          "samples/server/petstore/java-play-framework-no-swagger-ui",
+          "samples/server/petstore/java-play-framework-no-wrap-calls"
+        ]
+      },
+      "shared_paths": [
+        "pom.xml",
+        ".mvn/**",
+        "mvnw",
+        "mvnw.cmd",
+        "CI/settings.xml"
+      ],
+      "shadow_paths": [
+        "samples/server/petstore/java-play-framework**"
+      ]
+    },
+    "samples-java-sbt.build": {
+      "workflow": ".github/workflows/samples-java-sbt.yaml",
+      "matrix": {
+        "sample": [
+          "samples/client/petstore/java/okhttp-gson"
+        ]
+      },
+      "shadow_paths": [
+        "samples/client/petstore/java/okhttp-gson/**"
+      ]
+    },
+    "samples-java-server-jdk8.build": {
+      "workflow": ".github/workflows/samples-java-server-jdk8.yaml",
+      "matrix": {
+        "sample": [
+          "samples/server/petstore/java-vertx-web/",
+          "samples/server/petstore/java-vertx-web-interface-only/",
+          "samples/server/petstore/java-inflector/",
+          "samples/server/petstore/java-pkmst/",
+          "samples/server/petstore/java-microprofile/"
+        ]
+      },
+      "shared_paths": [
+        "pom.xml",
+        ".mvn/**",
+        "mvnw",
+        "mvnw.cmd",
+        "CI/settings.xml"
+      ],
+      "shadow_paths": [
+        "samples/server/petstore/java-vertx-web/**",
+        "samples/server/petstore/java-vertx-web-interface-only/**",
+        "samples/server/petstore/java-inflector/**",
+        "samples/server/petstore/java-inflector/**",
+        "samples/server/petstore/java-pkmst/**",
+        "samples/server/petstore/java-microprofile/**"
+      ]
+    },
+    "samples-java-wiremock.build": {
+      "workflow": ".github/workflows/samples-java-wiremock.yaml",
+      "matrix": {
+        "sample": [
+          "samples/server/petstore/java-wiremock"
+        ]
+      },
+      "shared_paths": [
+        "pom.xml",
+        ".mvn/**",
+        "mvnw",
+        "mvnw.cmd",
+        "CI/settings.xml"
+      ],
+      "shadow_paths": [
+        "samples/server/petstore/java-wiremock/**"
+      ]
+    },
+    "samples-javascript.build": {
+      "workflow": ".github/workflows/samples-javascript.yaml",
+      "matrix": {
+        "node": [
+          "18.x",
+          "20.x"
+        ],
+        "sample": [
+          "samples/client/petstore/javascript-es6/",
+          "samples/client/petstore/javascript-promise-es6/"
+        ]
+      },
+      "shadow_paths": [
+        "samples/client/petstore/javascript-es6/**",
+        "samples/client/petstore/javascript-promise-es6/**"
+      ]
+    },
+    "samples-jaxrs-jdk11.build": {
+      "workflow": ".github/workflows/samples-jaxrs-jdk11.yaml",
+      "matrix": {
+        "sample": [
+          "samples/server/petstore/jaxrs/jersey3"
+        ]
+      },
+      "shared_paths": [
+        "pom.xml",
+        ".mvn/**",
+        "mvnw",
+        "mvnw.cmd",
+        "CI/settings.xml"
+      ],
+      "shadow_paths": [
+        "samples/server/petstore/jaxrs/jersey3/**"
+      ]
+    },
+    "samples-jaxrs.build": {
+      "workflow": ".github/workflows/samples-jaxrs.yaml",
+      "matrix": {
+        "sample": [
+          "samples/server/petstore/jaxrs/jersey2",
+          "samples/server/petstore/jaxrs/jersey2-useTags",
+          "samples/server/petstore/jaxrs-jersey",
+          "samples/server/petstore/jaxrs-spec",
+          "samples/server/petstore/jaxrs-spec-withxml",
+          "samples/server/petstore/jaxrs-spec-interface",
+          "samples/server/petstore/jaxrs-spec-interface-response",
+          "samples/server/petstore/jaxrs-spec-oneof-interface",
+          "samples/server/petstore/jaxrs-datelib-j8",
+          "samples/server/petstore/jaxrs-resteasy/default",
+          "samples/server/petstore/jaxrs-resteasy/eap",
+          "samples/server/petstore/jaxrs-resteasy/eap-joda",
+          "samples/server/petstore/jaxrs-resteasy/eap-java8",
+          "samples/server/petstore/jaxrs-resteasy/joda",
+          "samples/server/petstore/jaxrs-cxf",
+          "samples/server/petstore/jaxrs-cxf-annotated-base-path",
+          "samples/server/petstore/jaxrs-cxf-cdi",
+          "samples/server/petstore/jaxrs-cxf-non-spring-app",
+          "samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations",
+          "samples/server/petstore/jaxrs-spec-swagger-annotations",
+          "samples/server/petstore/jaxrs-spec-swagger-v3-annotations-jakarta",
+          "samples/server/petstore/jaxrs-spec-swagger-v3-annotations"
+        ]
+      },
+      "shared_paths": [
+        "pom.xml",
+        ".mvn/**",
+        "mvnw",
+        "mvnw.cmd",
+        "CI/settings.xml"
+      ],
+      "shadow_paths": [
+        "samples/server/petstore/jaxrs*/**"
+      ]
+    },
+    "samples-jdk17.build": {
+      "workflow": ".github/workflows/samples-jdk17.yaml",
+      "matrix": {
+        "sample": [
+          "samples/openapi3/client/petstore/spring-cloud-3",
+          "samples/client/petstore/java-helidon-client/v3/mp/",
+          "samples/client/petstore/java-helidon-client/v3/se",
+          "samples/client/petstore/spring-http-interface-reactive",
+          "samples/client/petstore/spring-http-interface-reactive-bean-validation",
+          "samples/client/petstore/spring-http-interface-bean-validation",
+          "samples/client/petstore/spring-http-interface",
+          "samples/client/petstore/spring-http-interface-reactive-noResponseEntity",
+          "samples/client/petstore/spring-http-interface-noResponseEntity",
+          "samples/client/petstore/spring-http-interface-useHttpServiceProxyFactoryInterfacesConfigurator",
+          "samples/client/petstore/java/webclient-jakarta",
+          "samples/client/petstore/java/microprofile-rest-client-outer-enum",
+          "samples/openapi3/server/petstore/springboot-3",
+          "samples/openapi3/server/petstore/springboot-3-include-http-request-context",
+          "samples/server/petstore/springboot-x-implements-skip",
+          "samples/server/petstore/java-camel/",
+          "samples/server/petstore/java-helidon-server/v3/mp/",
+          "samples/server/petstore/java-helidon-server/v3/se",
+          "samples/server/petstore/jaxrs-spec-sealed",
+          "samples/server/petstore/jaxrs-spec/quarkus-security"
+        ]
+      },
+      "shared_paths": [
+        "pom.xml",
+        ".mvn/**",
+        "mvnw",
+        "mvnw.cmd",
+        "CI/settings.xml"
+      ],
+      "shadow_paths": [
+        "samples/openapi3/client/petstore/spring-cloud-3/**",
+        "samples/client/petstore/java-helidon-client/v3/mp/**",
+        "samples/client/petstore/java-helidon-client/v3/se/**",
+        "samples/client/petstore/spring-http-interface-reactive/**",
+        "samples/client/petstore/spring-http-interface-reactive-bean-validation/**",
+        "samples/client/petstore/spring-http-interface-bean-validation/**",
+        "samples/client/petstore/spring-http-interface/**",
+        "samples/client/petstore/spring-http-interface-reactive-noResponseEntity/**",
+        "samples/client/petstore/spring-http-interface-noResponseEntity/**",
+        "samples/client/petstore/spring-http-interface-useHttpServiceProxyFactoryInterfacesConfigurator/**",
+        "samples/client/petstore/java/webclient-jakarta/**",
+        "samples/client/petstore/java/microprofile-rest-client-outer-enum/**",
+        "samples/openapi3/server/petstore/springboot-3/**",
+        "samples/openapi3/server/petstore/springboot-3-include-http-request-context/**",
+        "samples/server/petstore/springboot-x-implements-skip/**",
+        "samples/server/petstore/java-camel/**",
+        "samples/server/petstore/java-helidon-server/v3/mp/**",
+        "samples/server/petstore/java-helidon-server/v3/se/**",
+        "samples/server/petstore/jaxrs-spec-sealed/**",
+        "samples/server/petstore/jaxrs-spec/quarkus-security/**"
+      ]
+    },
+    "samples-jdk21.build": {
+      "workflow": ".github/workflows/samples-jdk21.yaml",
+      "matrix": {
+        "sample": [
+          "samples/client/petstore/java-helidon-client/v4/mp/",
+          "samples/client/petstore/java-helidon-client/v4/se/",
+          "samples/server/petstore/java-helidon-server/v4/mp/",
+          "samples/server/petstore/java-helidon-server/v4/se/"
+        ]
+      },
+      "shared_paths": [
+        "pom.xml",
+        ".mvn/**",
+        "mvnw",
+        "mvnw.cmd",
+        "CI/settings.xml"
+      ],
+      "shadow_paths": [
+        "samples/client/petstore/java-helidon-client/v4/mp/**",
+        "samples/client/petstore/java-helidon-client/v4/se/**",
+        "samples/server/petstore/java-helidon-server/v4/mp/**",
+        "samples/server/petstore/java-helidon-server/v4/se/**"
+      ]
+    },
+    "samples-julia.tests-julia": {
+      "workflow": ".github/workflows/samples-julia.yaml",
+      "paths": [
+        "samples/client/petstore/julia/**",
+        "samples/server/petstore/julia/**"
+      ],
+      "shadow_paths": [
+        "samples/client/petstore/julia/**",
+        "samples/server/petstore/julia/**"
+      ]
+    },
+    "samples-kotlin-client.build": {
+      "workflow": ".github/workflows/samples-kotlin-client.yaml",
+      "matrix": {
+        "sample": [
+          "samples/client/petstore/kotlin",
+          "samples/client/petstore/kotlin-explicit",
+          "samples/client/petstore/kotlin-gson",
+          "samples/client/petstore/kotlin-jackson",
+          "samples/client/petstore/kotlin-jackson3",
+          "samples/client/petstore/kotlin-model-prefix-type-mappings",
+          "samples/client/petstore/kotlin-jvm-okhttp4-coroutines",
+          "samples/client/petstore/kotlin-moshi-codegen",
+          "samples/client/petstore/kotlin-multiplatform",
+          "samples/client/petstore/kotlin-multiplatform-kotlinx-datetime",
+          "samples/client/petstore/kotlin-multiplatform-allOf-discriminator",
+          "samples/client/petstore/kotlin-nonpublic",
+          "samples/client/petstore/kotlin-nullable",
+          "samples/client/petstore/kotlin-retrofit2",
+          "samples/client/petstore/kotlin-retrofit2-kotlinx_serialization",
+          "samples/client/petstore/kotlin-retrofit2-jackson",
+          "samples/client/petstore/kotlin-retrofit2-rx3",
+          "samples/client/petstore/kotlin-string",
+          "samples/client/petstore/kotlin-threetenbp",
+          "samples/client/petstore/kotlin-kotlinx-datetime",
+          "samples/client/petstore/kotlin-uppercase-enum",
+          "samples/client/petstore/kotlin-array-integer-enum",
+          "samples/client/petstore/kotlin-default-values-jvm-okhttp4",
+          "samples/client/petstore/kotlin-default-values-jvm-retrofit2",
+          "samples/client/petstore/kotlin-default-values-multiplatform",
+          "samples/client/petstore/kotlin-enum-integers-multiplatform",
+          "samples/client/petstore/kotlin-array-simple-string-jvm-okhttp4",
+          "samples/client/petstore/kotlin-array-simple-string-multiplatform",
+          "samples/client/petstore/kotlin-array-nullable-items",
+          "samples/client/petstore/kotlin-array-nullable-items-multiplatform",
+          "samples/client/petstore/kotlin-bigdecimal-default-multiplatform",
+          "samples/client/petstore/kotlin-bigdecimal-default-okhttp4",
+          "samples/client/petstore/kotlin-jvm-jackson",
+          "samples/client/petstore/kotlin-jvm-ktor-jackson",
+          "samples/client/petstore/kotlin-jvm-ktor-gson",
+          "samples/client/petstore/kotlin-jvm-ktor-kotlinx_serialization",
+          "samples/client/petstore/kotlin-jvm-vertx-gson",
+          "samples/client/petstore/kotlin-jvm-vertx-jackson",
+          "samples/client/petstore/kotlin-jvm-vertx-jackson-coroutines",
+          "samples/client/petstore/kotlin-jvm-vertx-moshi",
+          "samples/client/petstore/kotlin-jvm-spring-2-webclient",
+          "samples/client/petstore/kotlin-jvm-spring-3-webclient",
+          "samples/client/echo_api/kotlin-jvm-spring-3-webclient",
+          "samples/client/petstore/kotlin-jvm-spring-3-restclient",
+          "samples/client/echo_api/kotlin-jvm-spring-3-restclient",
+          "samples/client/others/kotlin-jvm-spring-3-restclient-nullable-return",
+          "samples/client/petstore/kotlin-jvm-spring-4-restclient-jackson3",
+          "samples/client/petstore/kotlin-name-parameter-mappings",
+          "samples/client/others/kotlin-jvm-okhttp-parameter-tests",
+          "samples/client/others/kotlin-jvm-okhttp-path-comments",
+          "samples/client/others/kotlin-integer-enum",
+          "samples/client/petstore/kotlin-allOf-discriminator-kotlinx-serialization",
+          "samples/client/others/kotlin-oneOf-discriminator-kotlinx-serialization",
+          "samples/client/others/kotlin-oneOf-anyOf-kotlinx-serialization",
+          "samples/client/others/kotlin-oneOf-anyOf-kotlinx-serialization-nonPublicApi",
+          "samples/client/others/kotlin-oneOf-anyOf-kotlinx-serialization-explicitApi",
+          "samples/client/petstore/kotlin-allOf-special-discriminator-kotlinx-serialization",
+          "samples/client/petstore/kotlin-multiplatform-allOf-special-discriminator"
+        ]
+      },
+      "shadow_paths": [
+        "samples/client/petstore/kotlin*/**",
+        "samples/client/others/kotlin-jvm-okhttp-parameter-tests/**",
+        "samples/client/others/kotlin-integer-enum/**",
+        "samples/client/others/kotlin-jvm-spring-3-restclient-nullable-return/**",
+        "samples/client/others/kotlin-oneOf-anyOf-kotlinx-serialization*/**",
+        "samples/client/others/kotlin-oneOf-discriminator-kotlinx-serialization*/**"
+      ]
+    },
+    "samples-kotlin-echo-api.build": {
+      "workflow": ".github/workflows/samples-kotlin-echo-api.yaml",
+      "matrix": {
+        "sample": [
+          "samples/client/echo_api/kotlin-jvm-spring-3-restclient",
+          "samples/client/echo_api/kotlin-model-prefix-type-mappings",
+          "samples/client/echo_api/kotlin-jvm-okhttp",
+          "samples/client/echo_api/kotlin-jvm-okhttp-multipart-json"
+        ]
+      },
+      "shadow_paths": [
+        "samples/client/echo_api/kotlin**"
+      ]
+    },
+    "samples-kotlin-server-jdk17.build": {
+      "workflow": ".github/workflows/samples-kotlin-server-jdk17.yaml",
+      "matrix": {
+        "sample": [
+          "samples/server/others/kotlin-springboot/oneOf-discriminator",
+          "samples/server/others/kotlin-springboot/oneOf-discriminator-const",
+          "samples/server/others/kotlin-springboot/oneOf-enum-discriminator",
+          "samples/server/others/kotlin-server/polymorphism-allof-and-discriminator",
+          "samples/server/others/kotlin-server/polymorphism-and-discriminator-disabled-jackson-fix",
+          "samples/server/others/kotlin-server/polymorphism-and-discriminator",
+          "samples/server/others/kotlin-server/polymorphism",
+          "samples/server/petstore/kotlin-server-required-and-nullable-properties",
+          "samples/server/petstore/kotlin-springboot-3",
+          "samples/server/petstore/kotlin-springboot-3-no-response-entity",
+          "samples/server/petstore/kotlin-springboot-additionalproperties",
+          "samples/server/petstore/kotlin-springboot-delegate-nodefaults",
+          "samples/server/petstore/kotlin-springboot-request-cookie",
+          "samples/server/petstore/kotlin-springboot-4",
+          "samples/server/petstore/kotlin-server/jaxrs-spec",
+          "samples/server/petstore/kotlin-server/jaxrs-spec-mutiny",
+          "samples/server/petstore/kotlin-server/javalin",
+          "samples/server/petstore/kotlin-server/javalin-6",
+          "samples/server/petstore/kotlin-server/ktor",
+          "samples/server/petstore/kotlin-server/ktor-delegate-pattern/generated",
+          "samples/server/petstore/kotlin-server/ktor2",
+          "samples/server/petstore/kotlin-server-modelMutable",
+          "samples/server/petstore/kotlin-misk",
+          "samples/server/petstore/kotlin-spring-declarative-interface",
+          "samples/server/petstore/kotlin-spring-declarative-interface-bean-validation",
+          "samples/server/petstore/kotlin-spring-declarative-interface-reactive-coroutines",
+          "samples/server/petstore/kotlin-spring-declarative-interface-reactive-reactor-wrapped",
+          "samples/server/petstore/kotlin-spring-declarative-interface-wrapped",
+          "samples/server/petstore/kotlin-spring-sealed-interfaces",
+          "samples/server/petstore/kotlin-springboot-sort-validation",
+          "samples/server/petstore/kotlin-springboot-paged-model"
+        ]
+      },
+      "shadow_paths": [
+        "samples/server/others/kotlin-server/**",
+        "samples/server/others/kotlin-springboot/**",
+        "samples/server/petstore/kotlin-springboot-3*/**",
+        "samples/server/petstore/kotlin-server/**",
+        "samples/server/petstore/kotlin-server-modelMutable/**",
+        "samples/server/petstore/kotlin-springboot-*/**",
+        "samples/server/petstore/kotlin-server-required-and-nullable-properties/**",
+        "samples/server/petstore/kotlin-spring-declarative*/**",
+        "samples/server/petstore/kotlin-spring-sealed-interfaces/**",
+        "samples/server/petstore/kotlin-springboot-sort-validation/**",
+        "samples/server/petstore/kotlin-springboot-paged-model/**",
+        "samples/server/petstore/kotlin-server/ktor-delegate-pattern/generated/**"
+      ]
+    },
+    "samples-kotlin-server-jdk21.build": {
+      "workflow": ".github/workflows/samples-kotlin-server-jdk21.yaml",
+      "matrix": {
+        "sample": [
+          "samples/server/others/kotlin-springboot/oneOf-discriminator",
+          "samples/server/others/kotlin-springboot/oneOf-discriminator-const",
+          "samples/server/others/kotlin-springboot/oneOf-enum-discriminator",
+          "samples/server/others/kotlin-server/polymorphism-allof-and-discriminator",
+          "samples/server/others/kotlin-server/polymorphism-and-discriminator-disabled-jackson-fix",
+          "samples/server/others/kotlin-server/polymorphism-and-discriminator",
+          "samples/server/others/kotlin-server/polymorphism",
+          "samples/server/petstore/kotlin-server/javalin-6",
+          "samples/server/petstore/kotlin-server/ktor",
+          "samples/server/petstore/kotlin-server/ktor2",
+          "samples/server/petstore/kotlin-server-required-and-nullable-properties",
+          "samples/server/petstore/kotlin-misk"
+        ]
+      },
+      "shadow_paths": [
+        "samples/server/others/kotlin-server/**",
+        "samples/server/others/kotlin-springboot/**",
+        "samples/server/petstore/kotlin-server/**",
+        "samples/server/petstore/kotlin-server-required-and-nullable-properties/**"
+      ]
+    },
+    "samples-kotlin-server.build": {
+      "workflow": ".github/workflows/samples-kotlin-server.yaml",
+      "matrix": {
+        "sample": [
+          "samples/server/petstore/kotlin-springboot",
+          "samples/server/petstore/kotlin-springboot-no-response-entity",
+          "samples/server/petstore/kotlin-springboot-no-response-entity-delegate",
+          "samples/server/petstore/kotlin-springboot-multipart-request-model",
+          "samples/server/petstore/kotlin-springboot-bigdecimal-default",
+          "samples/server/petstore/kotlin-springboot-delegate",
+          "samples/server/petstore/kotlin-springboot-modelMutable",
+          "samples/server/petstore/kotlin-springboot-reactive",
+          "samples/server/petstore/kotlin-springboot-reactive-without-flow",
+          "samples/server/petstore/kotlin-springboot-source-swagger1",
+          "samples/server/petstore/kotlin-springboot-source-swagger2",
+          "samples/server/petstore/kotlin-springboot-x-kotlin-implements",
+          "samples/server/petstore/kotlin-springboot-include-http-request-context-delegate",
+          "samples/server/petstore/kotlin-server/ktor2",
+          "samples/server/petstore/kotlin-server/jaxrs-spec",
+          "samples/server/petstore/kotlin-server/jaxrs-spec-mutiny",
+          "samples/server/petstore/kotlin-server/javalin",
+          "samples/server/others/kotlin-server/jaxrs-spec",
+          "samples/server/others/kotlin-server/jaxrs-spec-array-response",
+          "samples/server/petstore/kotlin-spring-cloud",
+          "samples/server/petstore/kotlin-misk",
+          "samples/server/petstore/kotlin-misk-config"
+        ]
+      },
+      "shadow_paths": [
+        "samples/server/others/kotlin-server/jaxrs-spec/**",
+        "samples/server/petstore/kotlin*/**",
+        "samples/server/others/kotlin-server/jaxrs-spec-array-response/**"
+      ]
+    },
+    "samples-kotlin-wiremock.build": {
+      "workflow": ".github/workflows/samples-kotlin-wiremock.yaml",
+      "matrix": {
+        "sample": [
+          "samples/server/petstore/kotlin-wiremock",
+          "samples/server/petstore/kotlin-wiremock-responses",
+          "samples/server/echo_api/kotlin-wiremock"
+        ]
+      },
+      "shadow_paths": [
+        "samples/server/petstore/kotlin-wiremock*/**",
+        "samples/server/echo_api/kotlin-wiremock/**"
+      ]
+    },
+    "samples-ocaml.build": {
+      "workflow": ".github/workflows/samples-ocaml.yaml",
+      "matrix": {
+        "sample": [
+          "samples/client/petstore/ocaml/",
+          "samples/client/petstore/ocaml-fake-petstore/",
+          "samples/client/petstore/ocaml-oneOf-primitive/",
+          "samples/client/petstore/ocaml-additional-properties/",
+          "samples/client/petstore/ocaml-enum-in-composed-schema/",
+          "samples/client/petstore/ocaml-recursion-test/"
+        ]
+      },
+      "shadow_paths": [
+        "samples/client/petstore/ocaml/**",
+        "samples/client/petstore/ocaml-fake-petstore/**",
+        "samples/client/petstore/ocaml-oneOf-primitive/**",
+        "samples/client/petstore/ocaml-additional-properties/**",
+        "samples/client/petstore/ocaml-enum-in-composed-schema/**",
+        "samples/client/petstore/ocaml-recursion-test/**"
+      ]
+    },
+    "samples-php-client.build": {
+      "workflow": ".github/workflows/samples-php-client.yaml",
+      "matrix": {
+        "php": [
+          "8.1",
+          "8.2",
+          "8.3",
+          "8.4"
+        ],
+        "sample": [
+          "samples/client/petstore/php/OpenAPIClient-php/"
+        ]
+      },
+      "shadow_paths": [
+        "samples/client/petstore/php/OpenAPIClient-php/**"
+      ]
+    },
+    "samples-php-nextgen-phpstan.build": {
+      "workflow": ".github/workflows/samples-php-nextgen-phpstan.yaml",
+      "matrix": {
+        "php": [
+          "8.1",
+          "8.2",
+          "8.3",
+          "8.4"
+        ],
+        "sample": [
+          "samples/client/petstore/php-nextgen/OpenAPIClient-php/"
+        ]
+      },
+      "shadow_paths": [
+        "samples/client/petstore/php-nextgen/OpenAPIClient-php/**"
+      ]
+    },
+    "samples-php-server-syntax-check.build": {
+      "workflow": ".github/workflows/samples-php-server-syntax-check.yaml",
+      "matrix": {
+        "php": [
+          "8.1",
+          "8.2",
+          "8.3",
+          "8.4"
+        ],
+        "sample": [
+          "samples/server/petstore/php-symfony/SymfonyBundle-php/",
+          "samples/server/petstore/php-flight/",
+          "samples/server/petstore/php-mezzio-ph-modern/",
+          "samples/server/petstore/php-mezzio-ph/",
+          "samples/server/petstore/php-slim4/"
+        ]
+      },
+      "shadow_paths": [
+        "samples/server/petstore/php-symfony/SymfonyBundle-php/**",
+        "samples/server/petstore/php-flight/**",
+        "samples/server/petstore/php-mezzio-ph-modern/**",
+        "samples/server/petstore/php-mezzio-ph/**",
+        "samples/server/petstore/php-slim4/**"
+      ]
+    },
+    "samples-php-servers-phpstan.build": {
+      "workflow": ".github/workflows/samples-php-servers-phpstan.yaml",
+      "matrix": {
+        "php": [
+          "8.3",
+          "8.4"
+        ],
+        "sample": [
+          "samples/server/petstore/php-laravel-issue-21334/"
+        ]
+      },
+      "shadow_paths": [
+        "samples/server/petstore/php-laravel/**",
+        "samples/server/petstore/php-laravel-issue-21334/**"
+      ]
+    },
+    "samples-php-syntax-check.build": {
+      "workflow": ".github/workflows/samples-php-syntax-check.yaml",
+      "matrix": {
+        "php": [
+          "8.1",
+          "8.2",
+          "8.3",
+          "8.4"
+        ],
+        "sample": [
+          "samples/client/petstore/php/OpenAPIClient-php/",
+          "samples/client/petstore/php-nextgen/OpenAPIClient-php/"
+        ]
+      },
+      "shadow_paths": [
+        "samples/client/petstore/php/OpenAPIClient-php/**",
+        "samples/client/petstore/php-nextgen/OpenAPIClient-php/**"
+      ]
+    },
+    "samples-php8.build": {
+      "workflow": ".github/workflows/samples-php8.yaml",
+      "matrix": {
+        "php": [
+          "8.1",
+          "8.2",
+          "8.3",
+          "8.4"
+        ],
+        "sample": [
+          "samples/server/petstore/php-symfony/SymfonyBundle-php/",
+          "samples/server/petstore/php-flight/"
+        ]
+      },
+      "shadow_paths": [
+        "samples/server/petstore/php-symfony/SymfonyBundle-php/**",
+        "samples/server/petstore/php-flight/**"
+      ]
+    },
+    "samples-postman.build": {
+      "workflow": ".github/workflows/samples-postman.yaml",
+      "matrix": {
+        "sample": [
+          "samples/schema/postman-collection"
+        ],
+        "python-version": [
+          "3.12"
+        ]
+      },
+      "shadow_paths": [
+        "samples/schema/postman-collection/python/**",
+        "samples/schema/postman-collection/postman.json",
+        ".github/workflows/samples-postman.yaml"
+      ]
+    },
+    "samples-powershell.build": {
+      "workflow": ".github/workflows/samples-powershell.yaml",
+      "matrix": {
+        "sample": [
+          "samples/client/petstore/powershell/"
+        ]
+      },
+      "shadow_paths": [
+        "samples/client/petstore/powershell/**"
+      ]
+    },
+    "samples-protobuf.build": {
+      "workflow": ".github/workflows/samples-protobuf.yaml",
+      "matrix": {
+        "sample": [
+          "samples/config/petstore/protobuf-schema/",
+          "samples/config/petstore/protobuf-schema-config/",
+          "samples/config/petstore/protobuf-schema-config-complex/"
+        ]
+      },
+      "shadow_paths": [
+        ".github/workflows/samples-protobuf.yaml",
+        "samples/config/petstore/protobuf-schema/**",
+        "samples/config/petstore/protobuf-schema-config/**"
+      ]
+    },
+    "samples-python-client-echo-api.build": {
+      "workflow": ".github/workflows/samples-python-client-echo-api.yaml",
+      "matrix": {
+        "sample": [
+          "samples/client/echo_api/python",
+          "samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent"
+        ],
+        "python-version": [
+          "3.10",
+          "3.11",
+          "3.12",
+          "3.13",
+          "3.14"
+        ]
+      },
+      "shadow_paths": [
+        "samples/client/echo_api/python/**",
+        "samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/**",
+        ".github/workflows/samples-python-client-echo-api.yaml"
+      ]
+    },
+    "samples-python-client-legacy-model-dictionaries.build": {
+      "workflow": ".github/workflows/samples-python-client-legacy-model-dictionaries.yaml",
+      "matrix": {
+        "python-version": [
+          "3.10",
+          "3.11",
+          "3.12",
+          "3.13",
+          "3.14"
+        ]
+      },
+      "paths": [
+        "samples/client/others/python-legacy-model-dictionaries/**"
+      ],
+      "shadow_paths": [
+        "samples/client/others/python-legacy-model-dictionaries/**",
+        ".github/workflows/samples-python-client-legacy-model-dictionaries.yaml"
+      ]
+    },
+    "samples-python-fastapi-server.build": {
+      "workflow": ".github/workflows/samples-python-fastapi-server.yaml",
+      "matrix": {
+        "sample": [
+          "samples/server/petstore/python-fastapi/"
+        ]
+      },
+      "shadow_paths": [
+        "samples/server/petstore/python-fastapi/**"
+      ]
+    },
+    "samples-python-flask-connexion3-server.build": {
+      "workflow": ".github/workflows/samples-python-flask-connexion3-server.yaml",
+      "matrix": {
+        "sample": [
+          "samples/server/petstore/python-flask-connexion3/"
+        ]
+      },
+      "shadow_paths": [
+        "samples/server/petstore/python-flask-connexion3/**",
+        ".github/workflows/samples-python-flask-connexion3-server.yaml"
+      ]
+    },
+    "samples-python-petstore.validate-pyproject-toml": {
+      "workflow": ".github/workflows/samples-python-petstore.yaml",
+      "paths": [
+        "samples/openapi3/client/petstore/python/pyproject.toml"
+      ],
+      "shadow_paths": [
+        "samples/openapi3/client/petstore/python-aiohttp/**",
+        "samples/openapi3/client/petstore/python-httpx/**",
+        "samples/openapi3/client/petstore/python-httpx-sync/**",
+        "samples/openapi3/client/petstore/python/**",
+        "samples/openapi3/client/petstore/python-lazyImports/**",
+        ".github/workflows/samples-python-petstore.yaml"
+      ]
+    },
+    "samples-python-petstore.build": {
+      "workflow": ".github/workflows/samples-python-petstore.yaml",
+      "matrix": {
+        "python-version": [
+          "3.10",
+          "3.11",
+          "3.12",
+          "3.13",
+          "3.14"
+        ],
+        "sample": [
+          "samples/openapi3/client/petstore/python-aiohttp",
+          "samples/openapi3/client/petstore/python-httpx",
+          "samples/openapi3/client/petstore/python-httpx-sync",
+          "samples/openapi3/client/petstore/python",
+          "samples/openapi3/client/petstore/python-lazyImports"
+        ]
+      },
+      "shadow_paths": [
+        "samples/openapi3/client/petstore/python-aiohttp/**",
+        "samples/openapi3/client/petstore/python-httpx/**",
+        "samples/openapi3/client/petstore/python-httpx-sync/**",
+        "samples/openapi3/client/petstore/python/**",
+        "samples/openapi3/client/petstore/python-lazyImports/**",
+        ".github/workflows/samples-python-petstore.yaml"
+      ]
+    },
+    "samples-python-pydantic-v1-client-echo-api.build": {
+      "workflow": ".github/workflows/samples-python-pydantic-v1-client-echo-api.yaml",
+      "matrix": {
+        "sample": [
+          "samples/client/echo_api/python-pydantic-v1/"
+        ],
+        "python-version": [
+          "3.10",
+          "3.11",
+          "3.12",
+          "3.13"
+        ]
+      },
+      "shadow_paths": [
+        "samples/client/echo_api/python-pydantic-v1/**",
+        ".github/workflows/samples-python-pydantic-v1-client-echo-api.yaml"
+      ]
+    },
+    "samples-python-pydantic-v1-petstore.build": {
+      "workflow": ".github/workflows/samples-python-pydantic-v1-petstore.yaml",
+      "matrix": {
+        "python-version": [
+          "3.10",
+          "3.11",
+          "3.12",
+          "3.13",
+          "3.14"
+        ],
+        "sample": [
+          "samples/openapi3/client/petstore/python-pydantic-v1-aiohttp",
+          "samples/openapi3/client/petstore/python-pydantic-v1"
+        ]
+      },
+      "shadow_paths": [
+        "samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/**",
+        "samples/openapi3/client/petstore/python-pydantic-v1/**",
+        ".github/workflows/samples-python-pydantic-v1-petstore.yaml"
+      ]
+    },
+    "samples-python-server.build": {
+      "workflow": ".github/workflows/samples-python-server.yaml",
+      "matrix": {
+        "sample": [
+          "samples/server/petstore/python-aiohttp-srclayout/"
+        ]
+      },
+      "shadow_paths": [
+        "samples/server/petstore/python-aiohttp-srclayout/**"
+      ]
+    },
+    "samples-r.build": {
+      "workflow": ".github/workflows/samples-r.yaml",
+      "matrix": {
+        "sample": [
+          "samples/client/petstore/R/",
+          "samples/client/petstore/R-httr2/",
+          "samples/client/petstore/R-httr2-wrapper/"
+        ]
+      },
+      "shadow_paths": [
+        "samples/client/petstore/R/**",
+        "samples/client/petstore/R-httr2/**",
+        "samples/client/petstore/R-httr2-wrapper/**"
+      ]
+    },
+    "samples-ruby-nextgen.build": {
+      "workflow": ".github/workflows/samples-ruby-nextgen.yaml",
+      "matrix": {
+        "sample": [
+          "samples/client/petstore/ruby-nextgen"
+        ],
+        "ruby-version": [
+          "3.0",
+          "3.3"
+        ]
+      },
+      "shadow_paths": [
+        "samples/client/petstore/ruby-nextgen/**",
+        "samples/client/others/ruby-nextgen-qdrant/**"
+      ]
+    },
+    "samples-ruby.build": {
+      "workflow": ".github/workflows/samples-ruby.yaml",
+      "matrix": {
+        "sample": [
+          "samples/client/echo_api/ruby-httpx/",
+          "samples/client/echo_api/ruby-faraday/",
+          "samples/client/echo_api/ruby-typhoeus/"
+        ]
+      },
+      "shadow_paths": [
+        "samples/client/echo_api/ruby-httpx/**",
+        "samples/client/echo_api/ruby-faraday/**",
+        "samples/client/echo_api/ruby-typhoeus/**"
+      ]
+    },
+    "samples-rust-client.build": {
+      "workflow": ".github/workflows/samples-rust-client.yaml",
+      "matrix": {
+        "sample": [
+          "samples/client/others/rust/",
+          "samples/client/petstore/rust/"
+        ]
+      },
+      "shadow_paths": [
+        "samples/client/others/rust/**",
+        "samples/client/petstore/rust/**"
+      ]
+    },
+    "samples-rust-server.build": {
+      "workflow": ".github/workflows/samples-rust-server.yaml",
+      "matrix": {
+        "sample": [
+          "samples/server/petstore/rust-server/",
+          "samples/server/petstore/rust-axum/",
+          "samples/server/petstore/rust-salvo/"
+        ]
+      },
+      "shadow_paths": [
+        "samples/server/petstore/rust-server/**",
+        "samples/server/petstore/rust-axum/**",
+        "samples/server/petstore/rust-salvo/**"
+      ]
+    },
+    "samples-scala-client.build": {
+      "workflow": ".github/workflows/samples-scala-client.yaml",
+      "matrix": {
+        "sample": [
+          "samples/client/petstore/scalaz",
+          "samples/client/petstore/scala-pekko",
+          "samples/client/petstore/scala-http4s",
+          "samples/client/petstore/scala-sttp4-jsoniter",
+          "samples/client/petstore/scala-akka",
+          "samples/client/petstore/scala-sttp",
+          "samples/client/petstore/scala-sttp-circe",
+          "samples/client/petstore/scala-sttp4",
+          "samples/client/petstore/scala-sttp4-circe"
+        ]
+      },
+      "shadow_paths": [
+        "samples/client/petstore/scalaz/**",
+        "samples/client/petstore/scala-pekko/**",
+        "samples/client/petstore/scala-http4s/**",
+        "samples/client/petstore/scala-sttp4-jsoniter/**",
+        "samples/client/petstore/scala-akka/**",
+        "samples/client/petstore/scala-sttp/**",
+        "samples/client/petstore/scala-sttp-circe/**",
+        "samples/client/petstore/scala-sttp4/**",
+        "samples/client/petstore/scala-sttp4-circe/**"
+      ]
+    },
+    "samples-scala-server.build": {
+      "workflow": ".github/workflows/samples-scala-server.yaml",
+      "matrix": {
+        "sample": [
+          "samples/server/petstore/scala-play-server",
+          "samples/server/petstore/scala-akka-http-server",
+          "samples/server/petstore/scala-pekko-http-server",
+          "samples/server/petstore/scalatra",
+          "samples/server/petstore/scala-http4s-server",
+          "samples/server/petstore/scala-cask"
+        ]
+      },
+      "shadow_paths": [
+        "samples/server/petstore/scala**"
+      ]
+    },
+    "samples-spring-jdk11.build": {
+      "workflow": ".github/workflows/samples-spring-jdk11.yaml",
+      "matrix": {
+        "sample": [
+          "samples/server/petstore/springboot-implicitHeaders",
+          "samples/server/petstore/springboot-implicitHeaders-annotationLibrary"
+        ]
+      },
+      "shared_paths": [
+        "pom.xml",
+        ".mvn/**",
+        "mvnw",
+        "mvnw.cmd",
+        "CI/settings.xml"
+      ],
+      "shadow_paths": [
+        "samples/server/petstore/springboot-implicitHeaders/**",
+        "samples/server/petstore/springboot-implicitHeaders-annotationLibrary/**"
+      ]
+    },
+    "samples-spring-jdk17.build": {
+      "workflow": ".github/workflows/samples-spring-jdk17.yaml",
+      "matrix": {
+        "sample": [
+          "samples/openapi3/client/petstore/spring-cloud-3-with-optional",
+          "samples/openapi3/client/petstore/spring-cloud-4-with-optional",
+          "samples/client/petstore/spring-http-interface-springboot-4",
+          "samples/openapi3/server/petstore/springboot-3",
+          "samples/openapi3/server/petstore/springboot-4",
+          "samples/openapi3/server/petstore/springboot-4-jspecify",
+          "samples/openapi3/server/petstore/springboot-4-jspecify-openapiNullable",
+          "samples/openapi3/server/petstore/springboot-4-jspecify-useOptional",
+          "samples/server/petstore/springboot-api-response-examples",
+          "samples/server/petstore/springboot-lombok-data",
+          "samples/server/petstore/springboot-lombok-tostring",
+          "samples/server/petstore/springboot-file-delegate-optional",
+          "samples/server/petstore/springboot-petstore-with-api-response-examples",
+          "samples/server/petstore/springboot-sort-validation",
+          "samples/server/petstore/springboot-paged-model",
+          "samples/server/others/springboot-pre-authorize",
+          "samples/openapi3/server/petstore/spring-boot-oneof-sealed",
+          "samples/openapi3/server/petstore/spring-boot-oneof-interface",
+          "samples/client/petstore/spring-http-interface-oauth"
+        ]
+      },
+      "shared_paths": [
+        "pom.xml",
+        ".mvn/**",
+        "mvnw",
+        "mvnw.cmd",
+        "CI/settings.xml"
+      ],
+      "shadow_paths": [
+        "samples/openapi3/client/petstore/spring-cloud-3-with-optional/**",
+        "samples/openapi3/client/petstore/spring-cloud-4-with-optional/**",
+        "samples/client/petstore/spring-http-interface-springboot-4/**",
+        "samples/openapi3/server/petstore/springboot-3/**",
+        "samples/openapi3/server/petstore/springboot-4/**",
+        "samples/openapi3/server/petstore/springboot-4-jspecify/**",
+        "samples/openapi3/server/petstore/springboot-4-jspecify-openapiNullable/**",
+        "samples/openapi3/server/petstore/springboot-4-jspecify-useOptional/**",
+        "samples/server/petstore/springboot-api-response-examples/**",
+        "samples/server/petstore/springboot-lombok-data/**",
+        "samples/server/petstore/springboot-lombok-tostring/**",
+        "samples/server/petstore/springboot-file-delegate-optional/**",
+        "samples/server/petstore/springboot-petstore-with-api-response-examples/**",
+        "samples/server/petstore/springboot-sort-validation/**",
+        "samples/server/petstore/springboot-paged-model/**",
+        "samples/server/others/springboot-pre-authorize/**",
+        "samples/openapi3/server/petstore/spring-boot-oneof-sealed/**",
+        "samples/openapi3/server/petstore/spring-boot-oneof-interface/**",
+        "samples/client/petstore/spring-http-interface-oauth/**"
+      ]
+    },
+    "samples-spring.build": {
+      "workflow": ".github/workflows/samples-spring.yaml",
+      "matrix": {
+        "sample": [
+          "samples/client/petstore/spring-cloud",
+          "samples/client/petstore/spring-cloud-auth",
+          "samples/client/petstore/spring-cloud-date-time",
+          "samples/client/petstore/spring-cloud-deprecated",
+          "samples/client/petstore/spring-cloud-tags",
+          "samples/openapi3/client/petstore/spring-cloud",
+          "samples/openapi3/client/petstore/spring-cloud-async",
+          "samples/openapi3/client/petstore/spring-cloud-date-time",
+          "samples/openapi3/client/petstore/spring-cloud-http-basic",
+          "samples/openapi3/client/petstore/spring-cloud-spring-pageable",
+          "samples/openapi3/client/petstore/spring-stubs",
+          "samples/openapi3/client/petstore/spring-stubs-skip-default-interface",
+          "samples/openapi3/server/petstore/springboot",
+          "samples/openapi3/server/petstore/springboot-implicitHeaders",
+          "samples/openapi3/server/petstore/springboot-delegate",
+          "samples/openapi3/server/petstore/spring-boot-oneof",
+          "samples/server/petstore/spring-boot-nullable-set",
+          "samples/server/petstore/spring-boot-defaultInterface-unhandledExcp",
+          "samples/server/petstore/springboot",
+          "samples/server/petstore/springboot-include-http-request-context",
+          "samples/server/petstore/springboot-beanvalidation",
+          "samples/server/petstore/springboot-builtin-validation",
+          "samples/server/petstore/springboot-delegate",
+          "samples/server/petstore/springboot-delegate-no-response-entity",
+          "samples/server/petstore/springboot-implicitHeaders",
+          "samples/server/petstore/springboot-implicitHeaders-annotationLibrary",
+          "samples/server/petstore/springboot-lombok-data",
+          "samples/server/petstore/springboot-reactive",
+          "samples/server/petstore/springboot-reactive-noResponseEntity",
+          "samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8",
+          "samples/server/petstore/springboot-spring-pageable-delegatePattern",
+          "samples/server/petstore/springboot-spring-pageable-without-j8",
+          "samples/server/petstore/springboot-spring-pageable",
+          "samples/server/petstore/springboot-spring-provide-args",
+          "samples/server/petstore/springboot-useoptional",
+          "samples/server/petstore/springboot-virtualan",
+          "samples/openapi3/server/petstore/spring-boot-oneof-interface"
+        ]
+      },
+      "shared_paths": [
+        "pom.xml",
+        ".mvn/**",
+        "mvnw",
+        "mvnw.cmd",
+        "CI/settings.xml"
+      ],
+      "shadow_paths": [
+        "samples/client/petstore/spring*/**",
+        "samples/server/petstore/spring*/**",
+        "samples/openapi3/server/petstore/spring*/**"
+      ]
+    },
+    "samples-swift5.build": {
+      "workflow": ".github/workflows/samples-swift5.yaml",
+      "matrix": {
+        "os": [
+          "macos-latest"
+        ],
+        "sample": [
+          "samples/client/petstore/swift5/alamofireLibrary",
+          "samples/client/petstore/swift5/asyncAwaitLibrary",
+          "samples/client/petstore/swift5/combineLibrary",
+          "samples/client/petstore/swift5/default",
+          "samples/client/petstore/swift5/objcCompatible",
+          "samples/client/petstore/swift5/oneOf",
+          "samples/client/petstore/swift5/promisekitLibrary",
+          "samples/client/petstore/swift5/resultLibrary",
+          "samples/client/petstore/swift5/rxswiftLibrary",
+          "samples/client/petstore/swift5/urlsessionLibrary",
+          "samples/client/petstore/swift5/validation"
+        ],
+        "include": [
+          {
+            "os": "ubuntu-latest",
+            "sample": "samples/client/petstore/swift5/alamofireLibrary"
+          }
+        ]
+      },
+      "shadow_paths": [
+        "samples/client/petstore/swift5/**"
+      ]
+    },
+    "samples-terraform.build": {
+      "workflow": ".github/workflows/samples-terraform.yaml",
+      "matrix": {
+        "sample": [
+          "samples/client/petstore/terraform/",
+          "samples/client/petstore/terraform-addpet/",
+          "samples/client/petstore/terraform-server/",
+          "samples/client/others/terraform/allof-discriminator/",
+          "samples/client/others/terraform/oneof-anyof-required/",
+          "samples/client/others/terraform/oneof-discriminator-lookup/"
+        ]
+      },
+      "shadow_paths": [
+        "samples/client/petstore/terraform/**",
+        "samples/client/petstore/terraform-addpet/**",
+        "samples/client/petstore/terraform-server/**",
+        "samples/client/others/terraform/**"
+      ]
+    },
+    "samples-typescript-axios-echo-api.build": {
+      "workflow": ".github/workflows/samples-typescript-axios-echo-api.yaml",
+      "matrix": {
+        "sample": [
+          "samples/client/echo_api/typescript-axios/test"
+        ],
+        "node-version": [
+          16,
+          18,
+          20
+        ]
+      },
+      "paths": [
+        "samples/client/echo_api/typescript-axios/**"
+      ],
+      "shadow_paths": [
+        "samples/client/echo_api/typescript-axios/**",
+        ".github/workflows/samples-typescript-axios-echo-api.yaml"
+      ]
+    },
+    "samples-typescript-client.build": {
+      "workflow": ".github/workflows/samples-typescript-client.yaml",
+      "matrix": {
+        "node": [
+          "22.x"
+        ],
+        "sample": [
+          "samples/client/others/typescript-angular/",
+          "samples/client/others/typescript-angular-v20/",
+          "samples/client/petstore/typescript-angular-v18-provided-in-root/",
+          "samples/client/petstore/typescript-angular-v19-provided-in-root/",
+          "samples/client/petstore/typescript-angular-v20-provided-in-root/",
+          "samples/client/petstore/typescript-angular-v21-provided-in-root/",
+          "samples/client/petstore/typescript-angular-v22-provided-in-root/",
+          "samples/openapi3/client/petstore/typescript/builds/default/",
+          "samples/openapi3/client/petstore/typescript/builds/jquery/",
+          "samples/openapi3/client/petstore/typescript/builds/object_params/",
+          "samples/openapi3/client/petstore/typescript/builds/browser/",
+          "samples/client/petstore/typescript-rxjs/builds/with-npm-version/",
+          "samples/client/petstore/typescript-axios/builds/with-npm-version/"
+        ]
+      },
+      "shared_paths": [
+        "pom.xml",
+        ".mvn/**",
+        "mvnw",
+        "mvnw.cmd",
+        "CI/settings.xml"
+      ],
+      "shadow_paths": [
+        "samples/client/others/typescript-angular/**",
+        "samples/client/others/typescript-angular-v20/**",
+        "samples/client/petstore/typescript-angular-v18-provided-in-root/**",
+        "samples/client/petstore/typescript-angular-v19-provided-in-root/**",
+        "samples/client/petstore/typescript-angular-v20-provided-in-root/**",
+        "samples/client/petstore/typescript-angular-v21-provided-in-root/**",
+        "samples/client/petstore/typescript-angular-v22-provided-in-root/**",
+        "samples/openapi3/client/petstore/typescript/builds/default/**",
+        "samples/openapi3/client/petstore/typescript/builds/jquery/**",
+        "samples/openapi3/client/petstore/typescript/builds/object_params/**",
+        "samples/openapi3/client/petstore/typescript/builds/browser/**",
+        "samples/client/petstore/typescript-rxjs/builds/with-npm-version/**",
+        "samples/client/petstore/typescript-axios/builds/with-npm-version/**"
+      ]
+    },
+    "samples-typescript-encode-decode.build": {
+      "workflow": ".github/workflows/samples-typescript-encode-decode.yaml",
+      "matrix": {
+        "sample": [
+          "samples/client/others/typescript/encode-decode/test"
+        ],
+        "node-version": [
+          20,
+          22,
+          24
+        ]
+      },
+      "paths": [
+        "samples/client/others/typescript/encode-decode/**"
+      ],
+      "shadow_paths": [
+        "samples/client/others/typescript/encode-decode/**",
+        ".github/workflows/samples-typescript-encode-decode.yaml"
+      ]
+    },
+    "samples-typescript-fetch-client.build": {
+      "workflow": ".github/workflows/samples-typescript-fetch-client.yaml",
+      "matrix": {
+        "node": [
+          "20.x"
+        ],
+        "sample": [
+          "samples/client/petstore/typescript-fetch/builds/default/",
+          "samples/client/petstore/typescript-fetch/builds/es6-target/",
+          "samples/client/petstore/typescript-fetch/builds/with-npm-version/",
+          "samples/client/petstore/typescript-fetch/tests/default/"
+        ]
+      },
+      "shared_paths": [
+        "pom.xml",
+        ".mvn/**",
+        "mvnw",
+        "mvnw.cmd",
+        "CI/settings.xml",
+        "samples/client/petstore/typescript-fetch/builds/with-npm-version"
+      ],
+      "shadow_paths": [
+        "samples/client/petstore/typescript-fetch/builds/default/**",
+        "samples/client/petstore/typescript-fetch/builds/es6-target/**",
+        "samples/client/petstore/typescript-fetch/builds/with-npm-version/**",
+        "samples/client/petstore/typescript-fetch/tests/default/**"
+      ]
+    },
+    "samples-typescript-nestjs-server.build": {
+      "workflow": ".github/workflows/samples-typescript-nestjs-server.yaml",
+      "matrix": {
+        "sample": [
+          "samples/server/petstore/typescript-nestjs-server"
+        ],
+        "node-version": [
+          20,
+          22
+        ]
+      },
+      "shadow_paths": [
+        "samples/server/petstore/typescript-nestjs-server/**",
+        ".github/workflows/samples-typescript-nestjs-server.yaml",
+        ".github/workflows/samples-typescript-nestjs-server-parameters.yaml"
+      ]
+    },
+    "samples-typescript-node-encode-decode.build": {
+      "workflow": ".github/workflows/samples-typescript-node-encode-decode.yaml",
+      "matrix": {
+        "sample": [
+          "samples/client/others/typescript-node/encode-decode/test"
+        ],
+        "node-version": [
+          16,
+          18,
+          20
+        ]
+      },
+      "paths": [
+        "samples/client/others/typescript-node/encode-decode/**"
+      ],
+      "shadow_paths": [
+        "samples/client/others/typescript-node/encode-decode/**",
+        ".github/workflows/samples-typescript-node-encode-decode.yaml"
+      ]
+    },
+    "samples-typescript-server.build": {
+      "workflow": ".github/workflows/samples-typescript-server.yaml",
+      "matrix": {
+        "node": [
+          "18.x",
+          "20.x"
+        ],
+        "sample": [
+          "samples/server/petstore/typescript-nestjs-server/"
+        ]
+      },
+      "shadow_paths": [
+        "samples/server/petstore/typescript-nestjs-server/**"
+      ]
+    },
+    "samples-typescript-typecheck.build": {
+      "workflow": ".github/workflows/samples-typescript-typecheck.yaml",
+      "matrix": {
+        "node-version": [
+          20
+        ]
+      },
+      "discovery": "typescript",
+      "shared_paths": [
+        "bin/ts-typecheck-all.sh",
+        "samples/client/petstore/typescript-fetch/builds/with-npm-version"
+      ],
+      "shadow_paths": [
+        "samples/client/petstore/typescript*/**",
+        "samples/client/others/typescript*/**",
+        "samples/client/echo_api/typescript*/**",
+        "samples/openapi3/client/petstore*/typescript/**",
+        "samples/server/petstore/typescript-nestjs-server/**",
+        "bin/ts-typecheck-all.sh",
+        ".github/workflows/samples-typescript-typecheck.yaml"
+      ]
+    },
+    "samples-zapier.validate": {
+      "workflow": ".github/workflows/samples-zapier.yaml",
+      "matrix": {
+        "sample": [
+          "samples/client/petstore/zapier"
+        ]
+      },
+      "shadow_paths": [
+        "samples/client/petstore/zapier/**"
+      ]
+    },
+    "openapi-generator.build": {
+      "workflow": ".github/workflows/openapi-generator.yaml",
+      "paths": [
+        "samples",
+        "bin/configs",
+        "bin/generate-samples.sh",
+        "docs",
+        "bin/meta-codegen.sh",
+        "bin/utils/export*",
+        "bin/utils/copy-to-website.sh",
+        "CONTRIBUTING.md",
+        "CODE_OF_CONDUCT.md"
+      ],
+      "shared_paths": [
+        "modules",
+        "pom.xml",
+        "mvnw",
+        "mvnw.cmd",
+        ".mvn",
+        "google_checkstyle.xml",
+        "spotbugs-exclude.xml",
+        ".gitattributes",
+        ".gitignore",
+        "conf"
+      ]
+    },
+    "openapi-generator.test": {
+      "workflow": ".github/workflows/openapi-generator.yaml",
+      "paths": [
+        "modules"
+      ],
+      "shared_paths": [
+        "pom.xml",
+        "mvnw",
+        "mvnw.cmd",
+        ".mvn",
+        "google_checkstyle.xml",
+        "spotbugs-exclude.xml",
+        ".gitattributes",
+        ".github/workflows/openapi-generator-test-results.yaml"
+      ]
+    },
+    "openapi-generator.documentation": {
+      "workflow": ".github/workflows/openapi-generator.yaml",
+      "paths": [
+        "docs",
+        "samples/meta-codegen",
+        "bin/meta-codegen.sh",
+        "bin/utils/export*",
+        "bin/utils/copy-to-website.sh",
+        "CONTRIBUTING.md",
+        "CODE_OF_CONDUCT.md"
+      ],
+      "shared_paths": [
+        "modules",
+        "pom.xml",
+        "mvnw",
+        "mvnw.cmd",
+        ".mvn",
+        "google_checkstyle.xml",
+        "spotbugs-exclude.xml",
+        ".gitattributes",
+        ".gitignore",
+        "conf"
+      ]
+    },
+    "openapi-generator.samples": {
+      "workflow": ".github/workflows/openapi-generator.yaml",
+      "paths": [
+        "samples",
+        "bin/configs",
+        "bin/generate-samples.sh"
+      ],
+      "shared_paths": [
+        "modules",
+        "pom.xml",
+        "mvnw",
+        "mvnw.cmd",
+        ".mvn",
+        "google_checkstyle.xml",
+        "spotbugs-exclude.xml",
+        ".gitattributes",
+        ".gitignore",
+        "conf"
+      ]
+    },
+    "linux.build": {
+      "workflow": ".github/workflows/linux.yaml",
+      "paths": [
+        "modules"
+      ],
+      "shared_paths": [
+        "pom.xml",
+        "mvnw",
+        "mvnw.cmd",
+        ".mvn",
+        "google_checkstyle.xml",
+        "spotbugs-exclude.xml",
+        ".gitattributes"
+      ]
+    },
+    "linux.verify": {
+      "workflow": ".github/workflows/linux.yaml",
+      "paths": [
+        "bin/generate-samples.sh",
+        "bin/configs/java-jersey2-8.yaml",
+        "bin/configs/go-petstore.yaml",
+        "samples/openapi3/client/petstore/java/jersey2-java8",
+        "samples/openapi3/client/petstore/go/go-petstore"
+      ],
+      "shared_paths": [
+        "modules",
+        "pom.xml",
+        "mvnw",
+        "mvnw.cmd",
+        ".mvn",
+        "google_checkstyle.xml",
+        "spotbugs-exclude.xml",
+        ".gitattributes"
+      ]
+    },
+    "windows.build": {
+      "workflow": ".github/workflows/windows.yaml",
+      "paths": [
+        "modules"
+      ],
+      "shared_paths": [
+        "pom.xml",
+        "mvnw",
+        "mvnw.cmd",
+        ".mvn",
+        "google_checkstyle.xml",
+        "spotbugs-exclude.xml",
+        ".gitattributes"
+      ]
+    },
+    "maven-plugin-tests.test": {
+      "workflow": ".github/workflows/maven-plugin-tests.yaml",
+      "paths": [
+        "modules"
+      ],
+      "shared_paths": [
+        "pom.xml",
+        "mvnw",
+        "mvnw.cmd",
+        ".mvn",
+        "google_checkstyle.xml",
+        "spotbugs-exclude.xml",
+        ".gitattributes"
+      ]
+    },
+    "maven-plugin-tests-jdk17.test": {
+      "workflow": ".github/workflows/maven-plugin-tests-jdk17.yaml",
+      "paths": [
+        "modules"
+      ],
+      "shared_paths": [
+        "pom.xml",
+        "mvnw",
+        "mvnw.cmd",
+        ".mvn",
+        "google_checkstyle.xml",
+        "spotbugs-exclude.xml",
+        ".gitattributes"
+      ]
+    },
+    "gradle-plugin-tests.test": {
+      "workflow": ".github/workflows/gradle-plugin-tests.yaml",
+      "paths": [
+        "modules"
+      ],
+      "shared_paths": [
+        "pom.xml",
+        "mvnw",
+        "mvnw.cmd",
+        ".mvn",
+        "google_checkstyle.xml",
+        "spotbugs-exclude.xml",
+        ".gitattributes"
+      ]
+    },
+    "mill-plugin-tests.test": {
+      "workflow": ".github/workflows/mill-plugin-tests.yaml",
+      "paths": [
+        "modules"
+      ],
+      "shared_paths": [
+        "pom.xml",
+        "mvnw",
+        "mvnw.cmd",
+        ".mvn",
+        "google_checkstyle.xml",
+        "spotbugs-exclude.xml",
+        ".gitattributes"
+      ]
+    },
+    "docker.build": {
+      "workflow": ".github/workflows/docker.yaml",
+      "paths": [
+        "modules",
+        "Dockerfile",
+        ".dockerignore",
+        "docker-entrypoint.sh",
+        "run-in-docker.sh",
+        "CI/run-in-docker-settings.xml",
+        "LICENSE"
+      ],
+      "shared_paths": [
+        "pom.xml",
+        "mvnw",
+        "mvnw.cmd",
+        ".mvn",
+        "google_checkstyle.xml",
+        "spotbugs-exclude.xml",
+        ".gitattributes"
+      ]
+    },
+    "circle.node0": {
+      "workflow": ".circleci/config.yml",
+      "paths": [],
+      "shared_paths": [
+        "CI/circle_parallel.sh",
+        "CI/circle_select.sh"
+      ]
+    },
+    "circle.node1": {
+      "workflow": ".circleci/config.yml",
+      "paths": [
+        "samples/client/petstore/perl"
+      ],
+      "shared_paths": [
+        "CI/circle_parallel.sh",
+        "CI/circle_select.sh"
+      ]
+    },
+    "circle.node2": {
+      "workflow": ".circleci/config.yml",
+      "paths": [
+        "samples/client/petstore/cpp-restsdk/client"
+      ],
+      "shared_paths": [
+        "CI/circle_parallel.sh",
+        "CI/circle_select.sh",
+        ".mvn/**"
+      ]
+    },
+    "circle.node3": {
+      "workflow": ".circleci/config.yml",
+      "paths": [],
+      "shared_paths": [
+        "CI/circle_parallel.sh",
+        "CI/circle_select.sh",
+        ".mvn/**"
+      ],
+      "matrix": {
+        "sample": [
+          "samples/client/petstore/ruby",
+          "samples/client/petstore/ruby-faraday",
+          "samples/client/petstore/ruby-httpx",
+          "samples/client/petstore/ruby-autoload"
+        ]
+      }
+    }
+  },
+  "exclusions": [
+    {
+      "path": "samples/client/echo_api/go-external-refs",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/echo_api/php-nextgen",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/echo_api/php-nextgen-streaming",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/echo_api/powershell",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/echo_api/r",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/github/jetbrains/http/client",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/jetbrains/adyen/adyen/http/client",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/jetbrains/adyen/checkoutbasic/http/client",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/opendota/jetbrains/http/client",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/others/crystal-qdrant",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/others/csharp-complex-files",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/others/csharp-complex-files/src/Org.OpenAPITools",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/others/csharp-complex-files/src/Org.OpenAPITools.Test",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/others/k6/basicAuth",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/others/k6/bearerAuth",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/others/kotlin-jvm-okhttp-non-ascii-headers",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/others/ruby-nextgen-qdrant",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/others/typescript-axios/with-separate-models-and-api-inheritance",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/others/typescript-fetch/additional-properties-in-multipart-issue",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/others/typescript-fetch/infinite-recursion-issue",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/others/typescript-fetch/multipart-file-array",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/others/typescript-fetch/self-import-issue",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/others/typescript-rxjs/allOf-composition",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/ada",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/android/httpclient",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/android/volley",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/apex",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/bash",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/cpp-boost-beast",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/cpp-boost-beast/generated",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/cpp-restsdk",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/cpp-restsdk/client",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/cpp-tiny",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/cpp-tizen",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/cpp-ue4",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/csharp/unityWebRequest/net10/Petstore",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/csharp/unityWebRequest/net9/Petstore",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/csharp/unityWebRequest/standard2.0/Petstore",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/eiffel",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/gdscript/addons/oas.petstore.client",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/java/microprofile-rest-client-3.0-jackson-ignore-case",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/java/okhttp-gson-nullable-required",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/java/okhttp-gson-parcelableModel",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/java/resttemplate-springBoot4-jackson3-jspecify",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/java/retrofit",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/java/webclient-springBoot4-jackson3-jspecify",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/javascript-apollo",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/javascript-closure-angular",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/javascript-flowtyped",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/jaxrs-cxf-client-jackson",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/jetbrains/http/client",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/jmeter",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/k6",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/kotlin-allOf-discriminator",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/kotlin-array-simple-string-jvm-retrofit2",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/kotlin-default-values-numbers",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/kotlin-enum-default-value",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/kotlin-json-request-string",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/kotlin-jvm-retrofit2-coroutines",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/kotlin-modelMutable",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/lua",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/n4js",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/nim",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/objc/core-data",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/objc/core-data/SwaggerClientTests",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/objc/default",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/objc/default/SwaggerClientTests",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/perl",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/perl/deep_module_test",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/php-dt",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/php-dt-modern",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/php/psr-18",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/ruby",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/ruby-autoload",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/ruby-faraday",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/ruby-httpx",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/scala-gatling",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/spring-cloud-feign-without-url",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/swift-combine/client",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/swift5/vaporLibrary",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/swift6/alamofireLibrary",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/swift6/alamofireLibrary/SwaggerClientTests",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/swift6/apiNonStaticMethod",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/swift6/apiNonStaticMethod/SwaggerClientTests",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/swift6/asyncAwaitLibrary",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/swift6/asyncAwaitLibrary/SwaggerClientTests",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/swift6/combineDeferredLibrary",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/swift6/combineDeferredLibrary/SwaggerClientTests",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/swift6/combineLibrary",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/swift6/combineLibrary/SwaggerClientTests",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/swift6/default",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/swift6/default/SwaggerClientTests",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/swift6/objcCompatible",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/swift6/oneOf",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/swift6/promisekitLibrary",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/swift6/promisekitLibrary/SwaggerClientTests",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/swift6/resultLibrary",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/swift6/rxswiftLibrary",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/swift6/rxswiftLibrary/SwaggerClientTests",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/swift6/urlsessionLibrary",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/swift6/urlsessionLibrary/SwaggerClientTests",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/swift6/validation",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/swift6/vaporLibrary",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/typescript-angular-v19",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/typescript-axios/builds/composed-schemas",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/typescript-axios/builds/default",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/typescript-axios/builds/test-petstore",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/typescript-axios/builds/with-fake-endpoints-models-for-testing-with-http-signature",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/typescript-axios/builds/with-interfaces",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/typescript-axios/builds/with-interfaces-and-with-single-request-param",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/typescript-axios/builds/with-node-imports",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/typescript-axios/builds/with-single-request-parameters",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/typescript-axios/builds/with-string-enums",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/typescript-axios/tests/default",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/typescript-axios/tests/with-complex-headers",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/typescript-fetch/builds/allOf-nullable",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/typescript-fetch/builds/allOf-readonly",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/typescript-fetch/builds/date-library-date",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/typescript-fetch/builds/date-library-string",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/typescript-fetch/builds/default-v3.0",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/typescript-fetch/builds/enum",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/typescript-fetch/builds/kebab-case",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/typescript-fetch/builds/multiple-parameters",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/typescript-fetch/builds/oneOf",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/typescript-fetch/builds/snakecase-discriminator",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/typescript-fetch/builds/validation-attributes",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/typescript-fetch/builds/with-interfaces",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/typescript-fetch/builds/with-string-enums",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/typescript-inversify",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/typescript-jquery/default",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/typescript-nestjs/builds/reservedParamNames",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/typescript-node/3_0",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/typescript-node/default",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/typescript-rxjs/builds/default",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/typescript-rxjs/builds/with-progress-subscriber",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/xojo/client",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/client/petstore/xojo/client-synchronous",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/config/petstore/apache2",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/config/petstore/graphql-schema",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/documentation/asciidoc",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/documentation/cwiki",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/documentation/dynamic-html",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/documentation/html",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/documentation/html.md",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/documentation/html2",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/documentation/markdown",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/documentation/petstore/plantuml",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/documentation/postman-collection",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/meta-codegen",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/meta-codegen-kotlin/lib",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/meta-codegen-kotlin/usage",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/meta-codegen/lib",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/meta-codegen/usage",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/openapi3/client/extensions/x-auth-id-alias/go-experimental",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/openapi3/client/extensions/x-auth-id-alias/ruby-client",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/openapi3/client/features/dynamic-servers/ruby",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/openapi3/client/features/generate-alias-as-model/ruby-client",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/openapi3/client/petstore/kotlin",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/openapi3/client/petstore/kotlin-jvm-retrofit2-coroutines",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/openapi3/client/petstore/kotlin-multiplatform",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/openapi3/client/petstore/php",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/openapi3/client/petstore/typescript/builds/deno",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/openapi3/client/petstore/typescript/builds/deno_object_params",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/openapi3/client/petstore/typescript/tests/browser",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/openapi3/client/petstore/typescript/tests/default",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/openapi3/client/petstore/typescript/tests/deno",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/openapi3/client/petstore/typescript/tests/inversify",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/openapi3/client/petstore/typescript/tests/jquery",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/openapi3/client/petstore/typescript/tests/object_params",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/openapi3/schema/petstore/avro",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/openapi3/schema/petstore/avro-schema",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/openapi3/schema/petstore/avro-schema-issue6268",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/openapi3/schema/valid-enums/avro-schema-enum",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/openapi3/server/petstore/go",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/openapi3/server/petstore/go/go-petstore",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/openapi3/server/petstore/kotlin-springboot",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/openapi3/server/petstore/kotlin-springboot-reactive",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/openapi3/server/petstore/php-symfony/SymfonyBundle-php",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/openapi3/server/petstore/spring-boot-springdoc",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/openapi3/server/petstore/springboot-source",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/schema/petstore/ktorm",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/schema/petstore/ktorm-modelMutable",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/schema/petstore/mysql",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/schema/petstore/postgresql",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/schema/petstore/wsdl-schema",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/server/petstore/aspnetcore",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/server/petstore/aspnetcore-3.0",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/server/petstore/aspnetcore-3.0/src/Org.OpenAPITools",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/server/petstore/aspnetcore-3.1",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/server/petstore/aspnetcore-3.1/src/Org.OpenAPITools",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/server/petstore/aspnetcore-5.0",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/server/petstore/aspnetcore-5.0/src/Org.OpenAPITools",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/server/petstore/aspnetcore-8.0-abstract-class",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/server/petstore/aspnetcore-8.0-abstract-class/src/Org.OpenAPITools",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/server/petstore/aspnetcore/src/Org.OpenAPITools",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/server/petstore/cpp-pistache",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/server/petstore/cpp-pistache-everything",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/server/petstore/cpp-pistache-nested-schema-refs",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/server/petstore/cpp-qt-qhttpengine-server",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/server/petstore/cpp-restbed",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/server/petstore/cpp-restbed-deprecated",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/server/petstore/cpp-restbed/generated/3_0",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/server/petstore/cpp-restbed/test/java_client_tests/java_client",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/server/petstore/csharp-functions",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/server/petstore/csharp-functions-abstract-class",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/server/petstore/csharp-functions-abstract-class/src/Org.OpenAPITools",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/server/petstore/csharp-functions-isolated",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/server/petstore/csharp-functions-isolated-builtin",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/server/petstore/csharp-functions-isolated-builtin-newtonsoft",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/server/petstore/csharp-functions-isolated-builtin-newtonsoft/src/Org.OpenAPITools",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/server/petstore/csharp-functions-isolated-builtin/src/Org.OpenAPITools",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/server/petstore/csharp-functions-isolated-newtonsoft",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/server/petstore/csharp-functions-isolated-newtonsoft/src/Org.OpenAPITools",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/server/petstore/csharp-functions-isolated-openapi",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/server/petstore/csharp-functions-isolated-openapi/src/Org.OpenAPITools",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/server/petstore/csharp-functions-isolated/src/Org.OpenAPITools",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/server/petstore/csharp-functions/src/Org.OpenAPITools",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/server/petstore/fsharp-functions",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/server/petstore/fsharp-giraffe",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/server/petstore/graphql-nodejs-express-server",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/server/petstore/graphql-nodejs-express-server/petstore",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/server/petstore/java-helidon-server/v4/se-uac-group-by-file-path",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/server/petstore/java-micronaut-server",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/server/petstore/java-msf4j",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/server/petstore/java-undertow",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/server/petstore/jaxrs-cxf-cdi-default-value",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/server/petstore/jaxrs-cxf-test-data",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/server/petstore/jaxrs-resteasy/default-value",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/server/petstore/jaxrs-resteasy/java8",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/server/petstore/jaxrs-spec-enum",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/server/petstore/jaxrs-spec-jakarta",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/server/petstore/jaxrs-spec-quarkus-mutiny",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/server/petstore/jaxrs-spec-required-and-readonly-property",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/server/petstore/kotlin-server/ktor-delegate-pattern",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/server/petstore/kotlin-server/ktor2-usetags-false",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/server/petstore/kotlin-spring-cloud-4",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/server/petstore/kotlin-spring-default",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/server/petstore/kotlin-springboot-integer-enum",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/server/petstore/kotlin-vertx-modelMutable",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/server/petstore/kotlin/vertx",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/server/petstore/nodejs-express-server",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/server/petstore/php-laravel",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/server/petstore/php-lumen",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/server/petstore/php-symfony",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/server/petstore/python-blueplanet",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/server/petstore/python-flask",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/server/petstore/ruby-on-rails",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/server/petstore/ruby-sinatra",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/server/petstore/rust-server-deprecated",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/server/petstore/springboot-beanvalidation-no-nullable",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    },
+    {
+      "path": "samples/server/petstore/springboot-delegate-j8",
+      "reason": "No sample build/test job in the pre-selection CI baseline; generated-output freshness remains covered."
+    }
+  ]
+}

--- a/CI/circle_parallel.sh
+++ b/CI/circle_parallel.sh
@@ -31,10 +31,31 @@ elif [ "$NODE_INDEX" = "3" ]; then
   echo "Running node $NODE_INDEX ... "
 
   echo "Testing ruby"
-  (cd samples/client/petstore/ruby && mvn integration-test)
-  (cd samples/client/petstore/ruby-faraday && mvn integration-test)
-  (cd samples/client/petstore/ruby-httpx && mvn integration-test)
-  (cd samples/client/petstore/ruby-autoload && mvn integration-test)
+  ruby_samples=(
+    samples/client/petstore/ruby
+    samples/client/petstore/ruby-faraday
+    samples/client/petstore/ruby-httpx
+    samples/client/petstore/ruby-autoload
+  )
+  if [ "${CIRCLE_SELECTED_SAMPLES_JSON+x}" ]; then
+    selected=$(python3 - "${ruby_samples[@]}" <<'PY'
+import json
+import os
+import sys
+
+samples = json.loads(os.environ["CIRCLE_SELECTED_SAMPLES_JSON"])
+if (not isinstance(samples, list) or not samples
+        or any(not isinstance(sample, str) or sample not in sys.argv[1:] for sample in samples)
+        or len(samples) != len(set(samples))):
+    raise ValueError("Invalid selected CircleCI Ruby samples")
+print("\n".join(samples))
+PY
+)
+    readarray -t ruby_samples <<< "$selected"
+  fi
+  for sample in "${ruby_samples[@]}"; do
+    (cd "$sample" && mvn integration-test)
+  done
 
 else
   echo "Running node $NODE_INDEX ..."

--- a/CI/circle_select.sh
+++ b/CI/circle_select.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# Only verified PR metadata may enable a skip. Uncertainty keeps the full node.
+set -euo pipefail
+
+node=${CIRCLE_NODE_INDEX:-0}
+[[ "$node" =~ ^[0-3]$ ]] || { echo "Invalid CircleCI node: $node" >&2; exit 1; }
+export CI_IS_PR=false
+unset CI_BASE_SHA CI_HEAD_SHA
+args=()
+case "${CI_FORCE_FULL:-false}" in
+  true|1) args+=(--force-full) ;;
+  false|0) ;;
+  *) echo "Invalid CI_FORCE_FULL" >&2; exit 1 ;;
+esac
+
+pr=
+if [[ "${CIRCLE_PULL_REQUEST:-}" =~ ^https://github.com/OpenAPITools/openapi-generator/pull/([0-9]+)$ ]]; then
+  pr=${BASH_REMATCH[1]}
+elif [[ "${CIRCLE_BRANCH:-}" =~ ^pull/([0-9]+)$ ]]; then
+  pr=${BASH_REMATCH[1]}
+fi
+
+if [ -n "$pr" ] && [ "${#args[@]}" -eq 0 ]; then
+  # GitHub constructs this ref from the actual target branch, including release
+  # branches and fork PRs. A moved/stale/unmergeable ref is not a usable baseline.
+  if [[ "${CIRCLE_SHA1:-}" =~ ^[0-9a-fA-F]{40}$ ]] &&
+     [ "$(git rev-parse HEAD)" = "$CIRCLE_SHA1" ] &&
+     git fetch --no-tags --depth=2 origin "refs/pull/$pr/merge"; then
+    parents=$(git cat-file -p FETCH_HEAD | sed -n '/^$/q; s/^parent //p')
+    readarray -t parents <<< "$parents"
+    if [ "${#parents[@]}" -eq 2 ] && [ "${parents[1]}" = "$CIRCLE_SHA1" ]; then
+      export CI_IS_PR=true CI_BASE_SHA="${parents[0]}" CI_HEAD_SHA="$CIRCLE_SHA1"
+    fi
+  fi
+  if [ "$CI_IS_PR" != true ]; then
+    echo "CircleCI PR baseline could not be verified; running the full node." >&2
+  fi
+fi
+
+python3 CI/select_changes.py --provider circleci --suite "circle.node$node" \
+  --manifest CI/change-scopes.json --mode "${CI_SELECTION_MODE:-shadow}" \
+  "${args[@]}" > .circleci-selection.json
+has_changes=$(python3 - <<'PY'
+import json
+import os
+import shlex
+import sys
+
+with open(".circleci-selection.json", encoding="utf-8") as stream:
+    result = json.load(stream)
+if (type(result.get("has_changes")) is not bool
+        or type(result.get("run_all")) is not bool
+        or not isinstance(result.get("matrix"), dict)
+        or not isinstance(result.get("samples"), list)
+        or any(not isinstance(sample, str) for sample in result["samples"])
+        or not isinstance(result.get("reasons"), list)):
+    raise ValueError("Invalid CircleCI selector output")
+print(json.dumps(result), file=sys.stderr)
+with open(os.environ["BASH_ENV"], "a", encoding="utf-8") as stream:
+    stream.write("export CIRCLE_SELECTED_SAMPLES_JSON=" +
+                 shlex.quote(json.dumps(result["samples"])) + "\n")
+print("true" if result["has_changes"] else "false")
+PY
+)
+if [ "$has_changes" = false ]; then
+  echo "No relevant changes for circle.node$node; halting before setup."
+  circleci-agent step halt
+fi

--- a/CI/select_changes.py
+++ b/CI/select_changes.py
@@ -1,0 +1,442 @@
+#!/usr/bin/env python3
+"""Select CI scopes from cumulative PR changes; uncertainty always runs the suite."""
+
+import argparse
+import copy
+from collections import Counter
+import itertools
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+
+
+GLOBAL_PATHS = (
+    "CI/select_changes.py",
+    "CI/change-scopes.json",
+    "CI/tests/**",
+    ".github/actions/compute-matrix/**",
+    ".github/.test/ci-scopes.js",
+    ".gitattributes",
+    ".gitmodules",
+)
+
+
+class ConfigError(ValueError):
+    """Invalid policy or invocation; unlike diff uncertainty this must fail CI."""
+
+
+class DiffUncertain(Exception):
+    """Comparison could not be verified safely."""
+
+
+def validate_path(value, label, glob=False):
+    if not isinstance(value, str) or not value or "\0" in value:
+        raise ConfigError(f"{label}: expected a nonempty repository-relative path")
+    if "\\" in value or value.startswith("/") or re.match(r"^[A-Za-z]:", value):
+        raise ConfigError(f"{label}: use repository-relative POSIX paths")
+    if any(part in ("", ".", "..") for part in value.rstrip("/").split("/")):
+        raise ConfigError(f"{label}: invalid path components")
+    if glob and ("[" in value or "]" in value):
+        raise ConfigError(f"{label}: only *, ** and ? glob syntax is supported")
+    return value
+
+
+def validate_manifest(manifest):
+    if not isinstance(manifest, dict) or type(manifest.get("version")) is not int or manifest["version"] != 1:
+        raise ConfigError("manifest version must be 1")
+    suites = manifest.get("suites")
+    if not isinstance(suites, dict) or not suites:
+        raise ConfigError("manifest suites must be a nonempty object")
+    for suite_id, suite in suites.items():
+        if not isinstance(suite_id, str) or not suite_id or not isinstance(suite, dict):
+            raise ConfigError("each suite must have an ID and object definition")
+        if "workflow" in suite:
+            validate_path(suite["workflow"], f"{suite_id}.workflow")
+        if "discovery" in suite and suite["discovery"] != "typescript":
+            raise ConfigError(f"{suite_id}.discovery: only typescript discovery is supported")
+        for field in ("paths", "shared_paths", "shadow_paths"):
+            paths = suite.get(field, [])
+            if not isinstance(paths, list):
+                raise ConfigError(f"{suite_id}.{field}: expected an array")
+            for path in paths:
+                validate_path(path, f"{suite_id}.{field}", glob=True)
+        matrix = suite.get("matrix", {})
+        if not isinstance(matrix, dict):
+            raise ConfigError(f"{suite_id}.matrix: expected an object")
+        for axis, values in matrix.items():
+            if not isinstance(axis, str) or not isinstance(values, list) or (not values and axis not in ("include", "exclude")):
+                raise ConfigError(f"{suite_id}.matrix.{axis}: expected a nonempty array")
+            if axis in ("include", "exclude"):
+                if any(not isinstance(row, dict) or not row for row in values):
+                    raise ConfigError(f"{suite_id}.matrix.{axis}: expected nonempty row objects")
+                for row in values:
+                    if "sample" in row:
+                        validate_path(row["sample"], f"{suite_id}.matrix.{axis}.sample")
+                    if axis == "exclude" and any(key not in matrix or key in ("include", "exclude") for key in row):
+                        raise ConfigError(f"{suite_id}.matrix.exclude: unknown axis")
+            elif axis == "sample":
+                for sample in values:
+                    validate_path(sample, f"{suite_id}.matrix.sample")
+            elif any(isinstance(value, (list, dict)) or value is None for value in values):
+                raise ConfigError(f"{suite_id}.matrix.{axis}: only scalar axis values are supported")
+        if "exclude" in matrix and not any(axis not in ("include", "exclude") for axis in matrix):
+            raise ConfigError(f"{suite_id}.matrix.exclude: requires matrix axes")
+        if "discovery" in suite and ("sample" in matrix or any("sample" in row for row in matrix.get("include", []))):
+            raise ConfigError(f"{suite_id}: discovery must not be combined with a sample matrix")
+    return manifest
+
+
+def load_manifest(path):
+    try:
+        with open(path, encoding="utf-8") as stream:
+            return validate_manifest(json.load(stream))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ConfigError(f"cannot read manifest {path}: {exc}") from exc
+
+
+def path_matches(path, pattern):
+    """Git paths are literal; policy patterns support only *, ** and ?."""
+    pattern = pattern.rstrip("/")
+    if "*" not in pattern and "?" not in pattern:
+        return path == pattern or path.startswith(pattern + "/")
+    pieces = []
+    index = 0
+    while index < len(pattern):
+        char = pattern[index]
+        if pattern[index:index + 3] == "**/":
+            pieces.append("(?:.*/)?")
+            index += 3
+        elif pattern[index:index + 2] == "**":
+            pieces.append(".*")
+            index += 2
+        elif char == "*":
+            pieces.append("[^/]*")
+            index += 1
+        elif char == "?":
+            pieces.append("[^/]")
+            index += 1
+        else:
+            pieces.append(re.escape(char))
+            index += 1
+    return re.fullmatch("".join(pieces), path, flags=re.DOTALL) is not None
+
+
+def sample_matches(path, sample):
+    sample = sample.rstrip("/")
+    return path == sample or path.startswith(sample + "/")
+
+
+def discover_typescript_samples(cwd="."):
+    try:
+        data = Git(cwd).run("ls-files", "-z", "--", "samples")
+    except DiffUncertain as exc:
+        raise ConfigError(f"cannot discover TypeScript sample ownership: {exc}") from exc
+    tracked = {path.decode("utf-8", "surrogateescape") for path in data.split(b"\0") if path}
+    roots = {
+        path.rsplit("/", 1)[0] for path in tracked
+        if path.endswith("/tsconfig.json")
+    }
+    return sorted(root for root in roots
+                  if root + "/.openapi-generator-ignore" in tracked and root + "/package.json" in tracked)
+
+
+def suite_samples(suite, cwd="."):
+    if suite.get("discovery") == "typescript":
+        return discover_typescript_samples(cwd)
+    matrix = suite.get("matrix", {})
+    samples = list(matrix.get("sample", []))
+    for row in matrix.get("include", []):
+        if "sample" in row and row["sample"] not in samples:
+            samples.append(row["sample"])
+    return samples
+
+
+def expand_matrix(matrix):
+    """Expand GitHub's Cartesian axes, exclusions, then compatible include rows."""
+    axes = [axis for axis in matrix if axis not in ("include", "exclude")]
+    originals = [dict(zip(axes, values)) for values in itertools.product(*(matrix[axis] for axis in axes))] if axes else []
+    originals = [
+        row for row in originals
+        if not any(all(key in row and row[key] == value for key, value in excluded.items())
+                   for excluded in matrix.get("exclude", []))
+    ]
+    combinations = copy.deepcopy(originals)
+    additions = []
+    for included in matrix.get("include", []):
+        compatible = False
+        for index, original in enumerate(originals):
+            if all(key not in original or original[key] == value for key, value in included.items()):
+                combinations[index].update(included)
+                compatible = True
+        if not compatible:
+            additions.append(copy.deepcopy(included))
+    return combinations + additions
+
+
+def combination_counts(rows):
+    return Counter(json.dumps(row, sort_keys=True, ensure_ascii=True) for row in rows)
+
+
+def full_selection(suite, reasons, samples=None):
+    return {
+        "matrix": copy.deepcopy(suite.get("matrix", {})),
+        "samples": suite_samples(suite) if samples is None else list(samples),
+        "has_changes": True,
+        "run_all": True,
+        "reasons": list(reasons),
+    }
+
+
+def select_changes(manifest, suite_id, changed_paths=None, full_reason=None, mode="enforce", cwd="."):
+    validate_manifest(manifest)
+    if suite_id not in manifest["suites"]:
+        raise ConfigError(f"unknown suite: {suite_id}")
+    if mode not in ("enforce", "shadow"):
+        raise ConfigError(f"unknown selection mode: {mode}")
+    suite = manifest["suites"][suite_id]
+    all_samples = suite_samples(suite, cwd)
+    if full_reason is not None:
+        proposed = full_selection(suite, [full_reason], all_samples)
+    elif changed_paths is None:
+        raise ConfigError("selection requires verified changes or a full-run reason")
+    else:
+        changes = sorted(set(changed_paths))
+        full_matches = [
+            path for path in changes
+            if path == suite.get("workflow")
+            or any(path_matches(path, pattern) for pattern in GLOBAL_PATHS)
+            or any(path_matches(path, pattern) for pattern in suite.get("shared_paths", []))
+            or any(path_matches(path, pattern) for pattern in suite.get("paths", []))
+        ]
+        if full_matches:
+            proposed = full_selection(suite, ["full scope input changed: " + path for path in full_matches], all_samples)
+        else:
+            samples = [
+                sample for sample in all_samples
+                if any(sample_matches(path, sample) for path in changes)
+            ]
+            matrix = copy.deepcopy(suite.get("matrix", {}))
+            if not samples:
+                matrix = {"include": []}
+            elif not suite.get("discovery"):
+                selected = {sample.rstrip("/") for sample in samples}
+                if "sample" in matrix:
+                    matrix["sample"] = [sample for sample in matrix["sample"] if sample.rstrip("/") in selected]
+                    # Include-only samples cannot coexist with an empty Cartesian axis.
+                    if not matrix["sample"]:
+                        matrix = {"include": [
+                            row for row in matrix.get("include", [])
+                            if row.get("sample", "").rstrip("/") in selected
+                        ]}
+                for field in ("include", "exclude"):
+                    if field in matrix:
+                        matrix[field] = [
+                            row for row in matrix[field]
+                            if "sample" not in row or row["sample"].rstrip("/") in selected
+                        ]
+            proposed = {
+                "matrix": matrix,
+                "samples": samples,
+                "has_changes": bool(samples),
+                "run_all": False,
+                "reasons": ["selected sample: " + sample for sample in samples] or ["no owned inputs changed"],
+            }
+            if samples and not suite.get("discovery"):
+                original_rows = expand_matrix(suite.get("matrix", {}))
+                expected = [
+                    row for row in original_rows
+                    if "sample" in row and row["sample"].rstrip("/") in selected
+                ]
+                if combination_counts(expand_matrix(matrix)) != combination_counts(expected):
+                    proposed = full_selection(suite, ["matrix includes cannot be filtered without changing original combinations"], all_samples)
+                elif not expected:
+                    proposed.update(matrix={"include": []}, samples=[], has_changes=False,
+                                    reasons=["selected samples have no runnable matrix combinations"])
+    if mode == "shadow":
+        historical_trigger = (
+            "shadow_paths" not in suite
+            or proposed["has_changes"]
+            or any(path_matches(path, pattern) for path in changes for pattern in suite["shadow_paths"])
+        )
+        if historical_trigger:
+            result = full_selection(suite, ["shadow mode: executing full suite"] + proposed["reasons"], all_samples)
+        else:
+            result = copy.deepcopy(proposed)
+            result["reasons"] = ["shadow mode: no owned input or historical workflow trigger changed"] + proposed["reasons"]
+        result["proposed_selection"] = proposed
+        return result
+    return proposed
+
+
+class Git:
+    def __init__(self, cwd="."):
+        self.cwd = cwd
+
+    def run(self, *args):
+        try:
+            process = subprocess.run(
+                ["git", *args], cwd=self.cwd, stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE, timeout=120, check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            raise DiffUncertain(f"git command unavailable: {exc}") from exc
+        if process.returncode:
+            detail = process.stderr.decode("utf-8", "replace").strip()
+            raise DiffUncertain(f"git {args[0]} failed: {detail}")
+        return process.stdout
+
+    def text(self, *args):
+        return self.run(*args).decode("utf-8", "replace").strip()
+
+    def ensure_commit(self, sha):
+        if not isinstance(sha, str) or not re.fullmatch(r"[0-9a-fA-F]{40}|[0-9a-fA-F]{64}", sha):
+            raise DiffUncertain("missing or invalid full commit SHA")
+        sha = sha.lower()
+        try:
+            resolved = self.text("rev-parse", "--verify", sha + "^{commit}")
+        except DiffUncertain:
+            self.run("fetch", "--no-tags", "--depth=1", "origin", sha)
+            resolved = self.text("rev-parse", "--verify", sha + "^{commit}")
+        if resolved != sha:
+            raise DiffUncertain("commit SHA did not resolve exactly")
+        return sha
+
+    def merge_base(self, base, head):
+        def resolve():
+            candidates = self.text("merge-base", "--all", base, head).splitlines()
+            if len(candidates) != 1:
+                raise DiffUncertain("PR does not have a unique verified merge base")
+            return candidates[0]
+
+        try:
+            return resolve()
+        except DiffUncertain:
+            if self.text("rev-parse", "--is-shallow-repository") != "true":
+                raise
+        for depth in (64, 256, 1024):
+            self.run("fetch", "--no-tags", f"--deepen={depth}", "origin", base, head)
+            try:
+                return resolve()
+            except DiffUncertain:
+                continue
+        raise DiffUncertain("merge base unavailable after bounded history deepening")
+
+    def diff(self, base, head):
+        data = self.run("diff", "--name-only", "--no-renames", "-z", base, head, "--")
+        if data and not data.endswith(b"\0"):
+            raise DiffUncertain("git diff returned malformed NUL-delimited paths")
+        return {path.decode("utf-8", "surrogateescape") for path in data.split(b"\0") if path}
+
+
+def pr_changes(git, base, head, checkout_sha=None, allow_merge=False):
+    base = git.ensure_commit(base)
+    head = git.ensure_commit(head)
+    checkout = git.text("rev-parse", "--verify", "HEAD")
+    if checkout_sha is not None and checkout != checkout_sha.lower():
+        raise DiffUncertain("checkout does not match the event SHA")
+    merge_parent = None
+    if checkout != head:
+        if not allow_merge:
+            raise DiffUncertain("checkout does not match the verified PR head")
+        # Read the commit object, not rev-list: shallow boundaries hide its parents.
+        parents = [
+            line.split()[1] for line in git.text("cat-file", "-p", checkout).split("\n\n", 1)[0].splitlines()
+            if line.startswith("parent ")
+        ]
+        if parents != [base, head]:
+            raise DiffUncertain("checkout is not the verified PR merge (base, head)")
+        merge_parent = base
+    merge_base = git.merge_base(base, head)
+    paths = git.diff(merge_base, head)
+    if merge_parent is not None:
+        paths.update(git.diff(merge_parent, checkout))
+    return sorted(paths)
+
+
+def env_bool(value, name):
+    if value is None or value == "":
+        return False
+    if value.lower() not in ("true", "false", "1", "0"):
+        raise ConfigError(f"{name} must be true or false")
+    return value.lower() in ("true", "1")
+
+
+def resolve_changes(provider, env=None, cwd="."):
+    env = os.environ if env is None else env
+    git = Git(cwd)
+    if provider == "github":
+        if env.get("GITHUB_EVENT_NAME") != "pull_request":
+            return None, "non-PR GitHub event: full suite"
+        try:
+            with open(env.get("GITHUB_EVENT_PATH", ""), encoding="utf-8") as stream:
+                event = json.load(stream)
+            pr = event["pull_request"]
+            base, head = pr["base"]["sha"], pr["head"]["sha"]
+            checkout_sha = env.get("GITHUB_SHA")
+            if not checkout_sha:
+                raise DiffUncertain("missing GitHub event checkout SHA")
+        except (OSError, ValueError, KeyError, TypeError) as exc:
+            return None, f"diff uncertainty: unavailable PR event metadata: {exc}"
+        allow_merge = True
+    elif provider == "circleci":
+        if not env_bool(env.get("CI_IS_PR"), "CI_IS_PR"):
+            return None, "non-PR or unverified CircleCI event: full suite"
+        base, head = env.get("CI_BASE_SHA"), env.get("CI_HEAD_SHA")
+        checkout_sha = env.get("CIRCLE_SHA1") or head
+        allow_merge = False
+    else:
+        raise ConfigError(f"unknown provider: {provider}")
+    try:
+        return pr_changes(git, base, head, checkout_sha, allow_merge), None
+    except DiffUncertain as exc:
+        return None, f"diff uncertainty: {exc}"
+
+
+def emit_outputs(result, output=None, summary=None):
+    encoded = json.dumps(result, ensure_ascii=True, separators=(",", ":"))
+    print(encoded)
+    if output:
+        with open(output, "a", encoding="utf-8") as stream:
+            for key, value in result.items():
+                stream.write(key + "=" + json.dumps(value, ensure_ascii=True, separators=(",", ":")) + "\n")
+    if summary:
+        with open(summary, "a", encoding="utf-8") as stream:
+            stream.write("\n### CI change selection\n\n```json\n" + encoded + "\n```\n")
+
+
+def validate_targets(result, cwd="."):
+    missing = [sample for sample in result["samples"] if not (Path(cwd) / sample).is_dir()]
+    if missing:
+        raise ConfigError("scheduled sample directories do not exist; update ownership: " + ", ".join(missing))
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--suite", required=True)
+    parser.add_argument("--manifest", default="CI/change-scopes.json")
+    parser.add_argument("--provider", choices=("github", "circleci"))
+    parser.add_argument("--mode", choices=("enforce", "shadow"), default="enforce")
+    parser.add_argument("--force-full", action="store_true")
+    parser.add_argument("--output", default=os.environ.get("GITHUB_OUTPUT"))
+    args = parser.parse_args(argv)
+    try:
+        manifest = load_manifest(args.manifest)
+        if args.suite not in manifest["suites"]:
+            raise ConfigError(f"unknown suite: {args.suite}")
+        provider = args.provider or ("circleci" if os.environ.get("CIRCLECI") == "true" else "github")
+        force_full = args.force_full or env_bool(os.environ.get("CI_FORCE_FULL"), "CI_FORCE_FULL")
+        paths, reason = (None, "explicit full-run override") if force_full else resolve_changes(provider)
+        result = select_changes(manifest, args.suite, paths, reason, args.mode)
+        validate_targets(result)
+        emit_outputs(result, args.output, os.environ.get("GITHUB_STEP_SUMMARY"))
+    except (ConfigError, OSError) as exc:
+        print(f"CI selector error: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/CI/tests/test_circle_selection.py
+++ b/CI/tests/test_circle_selection.py
@@ -1,0 +1,221 @@
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+BASH = os.environ.get("CI_TEST_BASH") or shutil.which("bash")
+RUBY = ["samples/client/petstore/" + name for name in
+        ("ruby", "ruby-faraday", "ruby-httpx", "ruby-autoload")]
+
+
+@unittest.skipUnless(BASH and shutil.which("git"), "Requires existing Bash and Git")
+class CircleSelectionTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory(dir=ROOT / "CI" / "tests")
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.source = self.root / "source"
+        self.source.mkdir()
+        self.git("init", "--quiet", cwd=self.source)
+        self.git("config", "user.name", "CI tests", cwd=self.source)
+        self.git("config", "user.email", "ci-tests@example.invalid", cwd=self.source)
+        (self.source / "README.md").write_text("base\n", encoding="utf-8")
+        self.git("add", ".", cwd=self.source)
+        self.git("commit", "--quiet", "-m", "base", cwd=self.source)
+        self.base = self.git("rev-parse", "HEAD", cwd=self.source)
+        for sample in RUBY:
+            directory = self.source / sample
+            directory.mkdir(parents=True)
+            (directory / "pom.xml").write_text("<project/>\n", encoding="utf-8")
+        self.git("add", ".", cwd=self.source)
+        self.git("commit", "--quiet", "-m", "samples", cwd=self.source)
+        self.head = self.git("rev-parse", "HEAD", cwd=self.source)
+        self.set_merge(self.base, self.head)
+        self.work = self.root / "work"
+        self.git("clone", "--quiet", "--depth=1", self.source.as_uri(), str(self.work),
+                 cwd=self.root)
+        (self.work / "CI").mkdir()
+        for name in ("select_changes.py", "circle_select.sh", "circle_parallel.sh"):
+            shutil.copyfile(ROOT / "CI" / name, self.work / "CI" / name)
+        suites = {
+            "circle.node0": {"workflow": ".circleci/config.yml", "paths": []},
+            "circle.node1": {"workflow": ".circleci/config.yml",
+                             "paths": ["samples/client/petstore/perl"]},
+            "circle.node2": {"workflow": ".circleci/config.yml",
+                             "paths": ["samples/client/petstore/cpp-restsdk/client"]},
+            "circle.node3": {"workflow": ".circleci/config.yml",
+                             "matrix": {"sample": RUBY}},
+        }
+        (self.work / "CI" / "change-scopes.json").write_text(
+            json.dumps({"version": 1, "suites": suites}), encoding="utf-8")
+        self.tools = self.root / "tools"
+        self.tools.mkdir()
+        for name in ("circleci-agent", "mvn"):
+            script = self.tools / name
+            script.write_text('#!/bin/bash\nprintf "%s %s\\n" "$PWD" "$*" >> "$CI_CALLS"\n',
+                              encoding="utf-8")
+            script.chmod(0o755)
+        self.env_file = self.root / "bash-env"
+        self.env_file.touch()
+        self.calls = self.root / "calls"
+        self.env = dict(os.environ, CIRCLE_NODE_INDEX="1", CIRCLE_SHA1=self.head,
+                        CIRCLE_PULL_REQUEST="https://github.com/OpenAPITools/openapi-generator/pull/7",
+                        CIRCLE_BRANCH="feature", CI_FORCE_FULL="false", CI_SELECTION_MODE="enforce",
+                        BASH_ENV=self.env_file.as_posix(), CI_CALLS=self.calls.as_posix())
+        self.env["PATH"] = str(self.tools) + os.pathsep + self.env["PATH"]
+        for key in ("CI_IS_PR", "CI_BASE_SHA", "CI_HEAD_SHA", "CIRCLE_SELECTED_SAMPLES_JSON",
+                    "GITHUB_OUTPUT", "GITHUB_STEP_SUMMARY"):
+            self.env.pop(key, None)
+
+    def git(self, *args, cwd):
+        return subprocess.run(["git", *args], cwd=cwd, check=True, text=True,
+                              capture_output=True).stdout.strip()
+
+    def set_merge(self, base, head):
+        tree = self.git("rev-parse", head + "^{tree}", cwd=self.source)
+        merge = self.git("commit-tree", tree, "-p", base, "-p", head, "-m", "PR merge",
+                         cwd=self.source)
+        self.git("update-ref", "refs/pull/7/merge", merge, cwd=self.source)
+
+    def run_script(self, name="circle_select.sh", check=True):
+        result = subprocess.run([BASH, "CI/" + name], cwd=self.work, env=self.env,
+                                text=True, capture_output=True)
+        if check:
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        return result
+
+    def selection(self):
+        self.run_script()
+        return json.loads((self.work / ".circleci-selection.json").read_text(encoding="utf-8"))
+
+    def test_verified_release_or_fork_pr_can_halt_unrelated_node(self):
+        result = self.selection()
+        self.assertFalse(result["has_changes"])
+        self.assertIn("step halt", self.calls.read_text(encoding="utf-8"))
+
+    def test_relevant_ruby_node_runs_without_halt(self):
+        self.env["CIRCLE_NODE_INDEX"] = "3"
+        self.assertEqual(self.selection()["samples"], RUBY)
+        self.assertFalse(self.calls.exists())
+
+    def test_cumulative_ruby_selection_survives_later_docs_commit(self):
+        base = self.head
+        (self.source / RUBY[2] / "pom.xml").write_text("<project>changed</project>\n",
+                                                       encoding="utf-8")
+        self.git("add", ".", cwd=self.source)
+        self.git("commit", "--quiet", "-m", "Ruby input", cwd=self.source)
+        (self.source / "README.md").write_text("later documentation\n", encoding="utf-8")
+        self.git("add", ".", cwd=self.source)
+        self.git("commit", "--quiet", "-m", "documentation", cwd=self.source)
+        self.head = self.git("rev-parse", "HEAD", cwd=self.source)
+        self.set_merge(base, self.head)
+        self.git("fetch", "--quiet", "--depth=1", "origin", self.head, cwd=self.work)
+        self.git("checkout", "--quiet", "--detach", self.head, cwd=self.work)
+        self.env.update(CIRCLE_NODE_INDEX="3", CIRCLE_SHA1=self.head)
+        self.assertEqual(self.selection()["samples"], [RUBY[2]])
+        self.run_script("circle_parallel.sh")
+        calls = self.calls.read_text(encoding="utf-8").splitlines()
+        self.assertEqual(len(calls), 1)
+        self.assertTrue(calls[0].endswith("/ruby-httpx integration-test"), calls)
+
+    def test_missing_merge_ref_runs_full(self):
+        self.git("update-ref", "-d", "refs/pull/7/merge", cwd=self.source)
+        self.assertTrue(self.selection()["run_all"])
+        self.assertFalse(self.calls.exists())
+
+    def test_moved_pr_merge_ref_runs_full(self):
+        self.set_merge(self.head, self.base)
+        self.assertTrue(self.selection()["run_all"])
+
+    def test_wrong_event_revision_runs_full(self):
+        self.env["CIRCLE_SHA1"] = self.base
+        self.assertTrue(self.selection()["run_all"])
+
+    def test_non_pr_ignores_untrusted_inherited_metadata(self):
+        self.env.update(CIRCLE_PULL_REQUEST="", CI_IS_PR="true",
+                        CI_BASE_SHA=self.base, CI_HEAD_SHA=self.head)
+        self.assertTrue(self.selection()["run_all"])
+
+    def test_explicit_full_run(self):
+        self.env["CI_FORCE_FULL"] = "true"
+        self.assertTrue(self.selection()["run_all"])
+        self.assertFalse(self.calls.exists())
+
+    def test_default_shadow_keeps_unrelated_node_running(self):
+        self.env.pop("CI_SELECTION_MODE")
+        result = self.selection()
+        self.assertTrue(result["has_changes"])
+        self.assertTrue(result["run_all"])
+        self.assertFalse(self.calls.exists())
+
+    def test_invalid_mode_fails_instead_of_skipping(self):
+        self.env["CI_SELECTION_MODE"] = "unexpected"
+        self.assertNotEqual(self.run_script(check=False).returncode, 0)
+        self.assertFalse(self.calls.exists())
+
+    def test_pull_branch_metadata(self):
+        self.env.update(CIRCLE_PULL_REQUEST="", CIRCLE_BRANCH="pull/7")
+        self.assertFalse(self.selection()["has_changes"])
+
+    def test_selector_failure_never_halts_successfully(self):
+        (self.work / "CI" / "change-scopes.json").write_text("{}", encoding="utf-8")
+        self.assertNotEqual(self.run_script(check=False).returncode, 0)
+        self.assertFalse(self.calls.exists())
+
+    def test_ruby_payload_is_individually_filtered(self):
+        self.env.update(CIRCLE_NODE_INDEX="3",
+                        CIRCLE_SELECTED_SAMPLES_JSON=json.dumps([RUBY[2]]))
+        self.run_script("circle_parallel.sh")
+        calls = self.calls.read_text(encoding="utf-8").splitlines()
+        self.assertEqual(len(calls), 1)
+        self.assertTrue(calls[0].endswith("/ruby-httpx integration-test"), calls)
+
+    def test_default_ruby_payload_preserves_all_four(self):
+        self.env["CIRCLE_NODE_INDEX"] = "3"
+        self.run_script("circle_parallel.sh")
+        self.assertEqual(len(self.calls.read_text(encoding="utf-8").splitlines()), 4)
+
+    def test_invalid_ruby_json_fails_before_payload(self):
+        self.env["CIRCLE_NODE_INDEX"] = "3"
+        for selection in ('[]', '{}', '["../escape"]', '["$(touch unwanted)"]', 'invalid'):
+            with self.subTest(selection=selection):
+                self.env["CIRCLE_SELECTED_SAMPLES_JSON"] = selection
+                self.assertNotEqual(self.run_script("circle_parallel.sh", check=False).returncode, 0)
+                self.assertFalse(self.calls.exists())
+
+
+@unittest.skipUnless(shutil.which("node"), "Requires existing Node and vendored YAML parser")
+class CircleConfigTests(unittest.TestCase):
+    def test_gate_precedes_all_expensive_setup_and_preserves_jobs(self):
+        script = (
+            "const y=require('./.github/.test/js-yaml.js');"
+            "console.log(JSON.stringify(y.safeLoad(require('fs').readFileSync("
+            "'.circleci/config.yml','utf8'))));"
+        )
+        config = json.loads(subprocess.check_output(["node", "-e", script], cwd=ROOT, text=True))
+        self.assertEqual(config["parameters"]["full_run"], {"type": "boolean", "default": False})
+        self.assertEqual(config["parameters"]["selection_mode"],
+                         {"type": "string", "default": "shadow"})
+        steps = config["commands"]["command_build_and_test"]["steps"]
+        self.assertIn("Checkout source", steps[0]["run"]["name"])
+        self.assertIn("circle_select.sh", steps[1]["run"]["command"])
+        self.assertEqual(steps[1]["run"]["environment"]["CI_SELECTION_MODE"],
+                         "<<pipeline.parameters.selection_mode>>")
+        self.assertIn("restore_cache", steps[2])
+        checkout = steps[0]["run"]["command"]
+        self.assertIn('git checkout --detach "$CIRCLE_SHA1"', checkout)
+        self.assertIn('"$(git rev-parse FETCH_HEAD)" = "$CIRCLE_SHA1"', checkout)
+        self.assertIn("seq 1 5", checkout)
+        self.assertIn("https://github.com/OpenAPITools/openapi-generator.git", checkout)
+        self.assertEqual(config["workflows"]["build"]["jobs"], ["node0", "node1", "node2", "node3"])
+        self.assertTrue(any("store_test_results" in step for step in steps))
+        self.assertTrue(any("store_artifacts" in step for step in steps))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/CI/tests/test_scope_coverage.py
+++ b/CI/tests/test_scope_coverage.py
@@ -1,0 +1,92 @@
+import json
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+@unittest.skipUnless(shutil.which("node") and shutil.which("git"), "Scope coverage uses Node and Git")
+class ScopeCoverageTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        for directory in (".github/.test", ".github/workflows", "bin/configs", "CI", "samples/client/example"):
+            (self.root / directory).mkdir(parents=True)
+        for filename in ("ci-scopes.js", "js-yaml.js"):
+            shutil.copyfile(ROOT / ".github" / ".test" / filename,
+                            self.root / ".github" / ".test" / filename)
+        self.manifest = {
+            "version": 1,
+            "suites": {
+                "samples-example.build": {
+                    "workflow": ".github/workflows/samples-example.yaml",
+                    "matrix": {"sample": ["samples/client/example"]},
+                },
+            },
+        }
+        (self.root / ".github/workflows/samples-example.yaml").write_text(
+            """on:
+  workflow_dispatch:
+  push:
+    branches: ['master', '[5-9]+.[0-9]+.x']
+  pull_request:
+jobs:
+  setup:
+    steps:
+      - uses: ./.github/actions/compute-matrix
+        with:
+          suite: samples-example.build
+  build:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_changed == 'true' }}
+    strategy:
+      matrix: ${{ fromJSON(needs.setup.outputs.build_matrix) }}
+""", encoding="utf-8")
+        (self.root / "samples/client/example/package.json").write_text("{}", encoding="utf-8")
+        subprocess.run(["git", "init", "--quiet", str(self.root)], check=True)
+
+    def check(self):
+        (self.root / "CI/change-scopes.json").write_text(json.dumps(self.manifest), encoding="utf-8")
+        subprocess.run(["git", "add", "samples"], cwd=self.root, check=True)
+        return subprocess.run(["node", ".github/.test/ci-scopes.js"], cwd=self.root,
+                              text=True, capture_output=True)
+
+    def test_registered_sample_passes(self):
+        result = self.check()
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_new_unregistered_build_root_fails(self):
+        new = self.root / "samples/client/new"
+        new.mkdir()
+        (new / "pom.xml").write_text("<project/>", encoding="utf-8")
+        result = self.check()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Unowned sample samples/client/new", result.stderr)
+
+    def test_exclusion_does_not_hide_nested_new_samples(self):
+        self.manifest["exclusions"] = [{"path": "samples/client/new", "reason": "Unsupported baseline"}]
+        new = self.root / "samples/client/new/nested"
+        new.mkdir(parents=True)
+        (new / "package.json").write_text("{}", encoding="utf-8")
+        result = self.check()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Unowned sample samples/client/new/nested", result.stderr)
+
+    def test_local_package_dependency_must_be_declared(self):
+        package = self.root / "samples/client/example/package.json"
+        package.write_text(json.dumps({"dependencies": {"shared": "file:../shared"}}), encoding="utf-8")
+        result = self.check()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("declare external local dependency samples/client/shared", result.stderr)
+        self.manifest["suites"]["samples-example.build"]["shared_paths"] = ["samples/client/shared"]
+        result = self.check()
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/CI/tests/test_select_changes.py
+++ b/CI/tests/test_select_changes.py
@@ -1,0 +1,472 @@
+import importlib.util
+import io
+import json
+import os
+from pathlib import Path
+import shutil
+import stat
+import subprocess
+import unittest
+from unittest import mock
+import uuid
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SPEC = importlib.util.spec_from_file_location("select_changes", ROOT / "CI" / "select_changes.py")
+selector = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(selector)
+
+
+def policy(matrix=None, **kwargs):
+    suite = {
+        "workflow": ".github/workflows/example.yaml",
+        "matrix": matrix if matrix is not None else {
+            "sample": ["samples/a/", "samples/b"],
+            "os": ["ubuntu-latest", "macos-latest"],
+            "runtime": [11, 17],
+        },
+    }
+    suite.update(kwargs)
+    return {"version": 1, "suites": {"example.build": suite}}
+
+
+class SelectionTests(unittest.TestCase):
+    def select(self, paths, manifest=None, **kwargs):
+        return selector.select_changes(manifest or policy(), "example.build", paths, **kwargs)
+
+    def test_no_changes_has_stable_empty_types(self):
+        for paths in ([], ["README.md"], ["samples/ab/file"], ["samples/a-other/file"]):
+            with self.subTest(paths=paths):
+                result = self.select(paths)
+                self.assertEqual(result["matrix"], {"include": []})
+                self.assertEqual(result["samples"], [])
+                self.assertIs(result["has_changes"], False)
+                self.assertIs(result["run_all"], False)
+                self.assertIsInstance(result["reasons"], list)
+
+    def test_sample_only_keeps_every_runtime_and_literal_output(self):
+        result = self.select(["samples/a/.openapi-generator/FILES"])
+        self.assertEqual(result["samples"], ["samples/a/"])
+        self.assertEqual(result["matrix"], {
+            "sample": ["samples/a/"], "os": ["ubuntu-latest", "macos-latest"], "runtime": [11, 17],
+        })
+        self.assertTrue(result["has_changes"])
+
+    def test_all_global_inputs_and_workflow_force_full(self):
+        paths = [
+            "CI/select_changes.py", "CI/change-scopes.json", "CI/tests/new/test.py",
+            ".github/actions/compute-matrix/action.yaml", ".github/.test/ci-scopes.js",
+            ".gitattributes", ".gitmodules", ".github/workflows/example.yaml",
+        ]
+        for path in paths:
+            with self.subTest(path=path):
+                result = self.select([path])
+                self.assertTrue(result["run_all"])
+                self.assertEqual(result["matrix"], policy()["suites"]["example.build"]["matrix"])
+
+    def test_owned_group_and_shared_globs(self):
+        manifest = policy(paths=["fixtures/"], shared_paths=["bin/**/build?.sh", "pom.xml"])
+        for path in ["fixtures/deep/input", "bin/build1.sh", "bin/deep/build2.sh", "pom.xml"]:
+            with self.subTest(path=path):
+                self.assertTrue(self.select([path], manifest)["run_all"])
+        for path in ["fixtures-extra/input", "bin/build12.sh", "bin/deep/build.sh", "pom.xml.backup"]:
+            with self.subTest(path=path):
+                self.assertFalse(self.select([path], manifest)["has_changes"])
+        self.assertFalse(selector.path_matches("bin/deep/file.sh", "bin/*.sh"))
+        self.assertTrue(selector.path_matches("bin/file.sh", "bin/**/*.sh"))
+
+    def test_unusual_samples_are_not_patterns(self):
+        for sample in ["samples/a[1]", "samples/a+b (x)", "samples/a.b", "samples/a'quote", "samples/a?b"]:
+            manifest = policy({"sample": [sample]})
+            self.assertTrue(self.select([sample + "/line\nbreak.txt"], manifest)["has_changes"])
+            self.assertFalse(self.select(["samples/axb/file"], manifest)["has_changes"])
+
+    def test_swift_include_and_exclude_are_filtered(self):
+        matrix = {
+            "sample": ["samples/alamofire", "samples/urlsession"],
+            "os": ["macos-latest"],
+            "include": [{"sample": "samples/alamofire", "os": "ubuntu-latest"}, {"extra": True}],
+            "exclude": [{"sample": "samples/alamofire", "os": "macos-latest"}],
+        }
+        result = self.select(["samples/urlsession/file"], policy(matrix))
+        self.assertEqual(result["matrix"]["sample"], ["samples/urlsession"])
+        self.assertEqual(result["matrix"]["include"], [{"extra": True}])
+        self.assertEqual(result["matrix"]["exclude"], [])
+        self.assertEqual(matrix["sample"], ["samples/alamofire", "samples/urlsession"])
+
+    def test_include_only_sample_does_not_expand_other_axes(self):
+        matrix = {
+            "sample": ["samples/a"], "os": ["macos-latest"],
+            "include": [{"sample": "samples/b", "os": "ubuntu-latest", "runtime": 17}],
+        }
+        result = self.select(["samples/b/test"], policy(matrix))
+        self.assertEqual(result["matrix"], {"include": matrix["include"]})
+        self.assertEqual(result["samples"], ["samples/b"])
+        only = {"include": [{"sample": "samples/a", "os": "linux"}, {"sample": "samples/b", "os": "mac"}]}
+        self.assertEqual(self.select(["samples/b/test"], policy(only))["matrix"], {
+            "include": [{"sample": "samples/b", "os": "mac"}],
+        })
+
+    def test_filtered_combinations_match_original_compatibility(self):
+        matrix = {
+            "sample": ["samples/a", "samples/b"], "os": ["linux", "mac"], "runtime": [11, 17],
+            "exclude": [{"sample": "samples/a", "os": "mac", "runtime": 11}],
+            "include": [
+                {"coverage": True},
+                {"sample": "samples/a", "os": "windows", "runtime": 17},
+                {"sample": "samples/c", "os": "linux", "runtime": 21},
+            ],
+        }
+        original = selector.expand_matrix(matrix)
+        for samples in [["samples/a"], ["samples/b"], ["samples/c"], ["samples/a", "samples/c"]]:
+            with self.subTest(samples=samples):
+                result = self.select([sample + "/test" for sample in samples], policy(matrix))
+                expected = [row for row in original if row["sample"] in samples]
+                self.assertFalse(result["run_all"])
+                self.assertEqual(
+                    selector.combination_counts(selector.expand_matrix(result["matrix"])),
+                    selector.combination_counts(expected),
+                )
+
+    def test_completely_excluded_sample_has_no_jobs(self):
+        matrix = {"sample": ["samples/a", "samples/b"], "exclude": [{"sample": "samples/a"}]}
+        self.assertFalse(self.select(["samples/a/test"], policy(matrix))["has_changes"])
+
+    def test_unbound_include_row_falls_back_instead_of_inventing_jobs(self):
+        matrix = {
+            "sample": ["samples/a", "samples/b"], "os": ["mac"],
+            "include": [{"os": "windows"}],
+        }
+        result = self.select(["samples/a/test"], policy(matrix))
+        self.assertTrue(result["run_all"])
+        self.assertIn("combinations", result["reasons"][0])
+
+    def test_full_mode_preserves_original_exactly(self):
+        matrix = {"sample": ["samples/a/"], "include": [{"sample": "samples/b", "os": "linux"}], "exclude": []}
+        result = self.select(None, policy(matrix), full_reason="forced")
+        self.assertEqual(result["matrix"], matrix)
+        self.assertEqual(result["samples"], ["samples/a/", "samples/b"])
+        result["matrix"]["sample"].append("not in policy")
+        self.assertEqual(matrix["sample"], ["samples/a/"])
+
+    def test_runtime_only_and_matrixless_scopes(self):
+        manifest = policy({"python": ["3.10", "3.11"]}, paths=["samples/legacy"])
+        self.assertTrue(self.select(["samples/legacy/test"], manifest)["run_all"])
+        self.assertFalse(self.select(["samples/other/test"], manifest)["has_changes"])
+        del manifest["suites"]["example.build"]["matrix"]
+        self.assertEqual(self.select(["samples/legacy/test"], manifest)["matrix"], {})
+
+    def test_circle_scope_without_workflow_and_manifest_metadata(self):
+        manifest = policy(paths=["CI/circle_parallel.sh"])
+        del manifest["suites"]["example.build"]["workflow"]
+        manifest["notes"] = ["baseline ownership"]
+        manifest["exclusions"] = [{"path": "samples/unsupported", "reason": "no runnable workflow"}]
+        self.assertTrue(self.select(["CI/circle_parallel.sh"], manifest)["run_all"])
+        self.assertEqual(self.select(["samples/a/test"], manifest)["samples"], ["samples/a/"])
+        self.assertFalse(self.select(["README.md"], manifest)["has_changes"])
+
+    def test_shadow_executes_full_with_filtered_diagnostics(self):
+        result = self.select(["samples/a/test"], mode="shadow")
+        self.assertTrue(result["run_all"])
+        self.assertEqual(result["samples"], ["samples/a/", "samples/b"])
+        self.assertEqual(result["proposed_selection"]["samples"], ["samples/a/"])
+        result = self.select([], mode="shadow")
+        self.assertTrue(result["has_changes"])
+        self.assertFalse(result["proposed_selection"]["has_changes"])
+
+    def test_shadow_historical_paths_avoid_unrelated_workflow_runs(self):
+        manifest = policy(shadow_paths=["samples/legacy/**"])
+        result = self.select(["docs/guide.md"], manifest, mode="shadow")
+        self.assertFalse(result["has_changes"])
+        self.assertFalse(result["run_all"])
+        self.assertEqual(result["matrix"], {"include": []})
+        self.assertFalse(result["proposed_selection"]["has_changes"])
+        for path in ("samples/legacy/old-trigger", "samples/a/new-owner"):
+            with self.subTest(path=path):
+                result = self.select([path], manifest, mode="shadow")
+                self.assertTrue(result["has_changes"])
+                self.assertTrue(result["run_all"])
+                self.assertEqual(result["samples"], ["samples/a/", "samples/b"])
+        result = self.select(["samples/legacy/old-trigger"], manifest, mode="shadow")
+        self.assertFalse(result["proposed_selection"]["has_changes"])
+
+    def test_shadow_shared_changes_and_uncertainty_always_run_full(self):
+        manifest = policy(shadow_paths=["samples/legacy/**"], shared_paths=["root-build.xml"])
+        for path in ("root-build.xml", ".github/workflows/example.yaml", "CI/select_changes.py"):
+            with self.subTest(path=path):
+                self.assertTrue(self.select([path], manifest, mode="shadow")["run_all"])
+        for reason in ("diff uncertainty: missing history", "non-PR event", "explicit full-run override"):
+            with self.subTest(reason=reason):
+                result = self.select(None, manifest, full_reason=reason, mode="shadow")
+                self.assertTrue(result["has_changes"])
+                self.assertTrue(result["run_all"])
+        self.assertTrue(self.select(["docs/guide.md"], policy(shadow_paths=["**"]), mode="shadow")["run_all"])
+        self.assertFalse(self.select(["docs/guide.md"], manifest, mode="enforce")["has_changes"])
+
+    def test_invalid_config_fails_instead_of_running_full(self):
+        bad = [
+            {"version": 2, "suites": {}},
+            policy({"sample": ["../outside"]}),
+            policy({"sample": "samples/a"}),
+            policy({"sample": ["samples/a"], "os": [{"nested": "unsupported"}]}),
+            policy({"sample": ["samples/a"], "exclude": [{"unknown": "value"}]}),
+            policy(paths=["/absolute"]),
+            policy(shared_paths=["C:\\absolute"]),
+            policy(shared_paths=["bin/[a-z].sh"]),
+            policy(shared_paths="bin/**"),
+            policy(shadow_paths="samples/**"),
+            policy(discovery="unknown"),
+            policy(discovery="typescript"),
+        ]
+        for manifest in bad:
+            with self.subTest(manifest=manifest), self.assertRaises(selector.ConfigError):
+                self.select(None, manifest, full_reason="forced")
+        with self.assertRaises(selector.ConfigError):
+            selector.select_changes(policy(), "unknown", [])
+        with self.assertRaises(selector.ConfigError):
+            self.select(None)
+        with self.assertRaises(selector.ConfigError):
+            self.select([], mode="wrong")
+
+    def test_outputs_escape_newlines_and_keep_json_types(self):
+        stream = io.StringIO()
+        result = self.select(["samples/a/new\nline"])
+        result["reasons"] = ["untrusted\nhas_changes=false"]
+        with mock.patch("builtins.open", mock.mock_open()) as opened, mock.patch("sys.stdout", stream):
+            selector.emit_outputs(result, "outputs")
+        lines = "".join(call.args[0] for call in opened().write.call_args_list).splitlines()
+        values = {key: json.loads(value) for key, value in (line.split("=", 1) for line in lines)}
+        self.assertEqual(values, result)
+        self.assertEqual(json.loads(stream.getvalue()), result)
+
+    def test_provider_non_pr_and_force_override(self):
+        for provider, env in [("github", {"GITHUB_EVENT_NAME": "push"}), ("github", {"GITHUB_EVENT_NAME": "workflow_dispatch"}), ("circleci", {})]:
+            self.assertIsNone(selector.resolve_changes(provider, env)[0])
+        with mock.patch.object(selector, "load_manifest", return_value=policy()), \
+                mock.patch.object(selector, "resolve_changes") as resolve, \
+                mock.patch.object(selector, "validate_targets"), \
+                mock.patch.object(selector, "emit_outputs") as emit, \
+                mock.patch.dict(os.environ, {"CI_FORCE_FULL": "true"}, clear=True):
+            self.assertEqual(selector.main(["--suite", "example.build"]), 0)
+            resolve.assert_not_called()
+            self.assertTrue(emit.call_args.args[0]["run_all"])
+
+    def test_invalid_event_and_invalid_manifest_visible(self):
+        paths, reason = selector.resolve_changes("github", {"GITHUB_EVENT_NAME": "pull_request"})
+        self.assertIsNone(paths)
+        self.assertIn("diff uncertainty", reason)
+        with mock.patch.object(selector, "load_manifest", side_effect=selector.ConfigError("bad policy")), \
+                mock.patch("sys.stderr", io.StringIO()) as stderr:
+            self.assertEqual(selector.main(["--suite", "example.build"]), 2)
+            self.assertIn("bad policy", stderr.getvalue())
+
+
+class GitTests(unittest.TestCase):
+    def setUp(self):
+        # Keep all synthetic repositories inside the checkout, never system temp.
+        self.directory = ROOT / "CI" / "tests" / (".selector-test-" + uuid.uuid4().hex)
+        self.directory.mkdir()
+        self.addCleanup(self.remove_repository)
+        self.repo = self.directory / "repo"
+        self.repo.mkdir()
+        self.run_git("init", "--quiet")
+        self.run_git("config", "user.email", "ci-tests@example.invalid")
+        self.run_git("config", "user.name", "CI tests")
+        self.run_git("config", "core.autocrlf", "false")
+        self.write("README.md", "initial\n")
+        self.base = self.commit("initial")
+        self.git = selector.Git(self.repo)
+
+    def remove_repository(self):
+        def writable_retry(function, path, exc_info):
+            os.chmod(path, stat.S_IWRITE)
+            function(path)
+        shutil.rmtree(self.directory, onerror=writable_retry)
+
+    def run_git(self, *args, cwd=None):
+        result = subprocess.run(
+            ["git", *args], cwd=cwd or self.repo, check=True,
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        )
+        return result.stdout.decode("utf-8").strip()
+
+    def write(self, name, content="content\n"):
+        path = self.repo / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+
+    def commit(self, message):
+        self.run_git("add", "--all")
+        self.run_git("commit", "--quiet", "-m", message)
+        return self.run_git("rev-parse", "HEAD")
+
+    def test_cumulative_multiple_commits_and_no_net_changes(self):
+        self.write("samples/a/first")
+        first = self.commit("first PR commit")
+        self.write("samples/b/second")
+        head = self.commit("second PR commit")
+        self.assertEqual(selector.pr_changes(self.git, self.base, head), ["samples/a/first", "samples/b/second"])
+        self.run_git("revert", "--no-edit", head)
+        head = self.run_git("rev-parse", "HEAD")
+        self.assertEqual(selector.pr_changes(self.git, self.base, head), ["samples/a/first"])
+        self.run_git("revert", "--no-edit", first)
+        head = self.run_git("rev-parse", "HEAD")
+        self.assertEqual(selector.pr_changes(self.git, self.base, head), [])
+
+    def test_base_advancement_is_not_pr_change(self):
+        self.run_git("checkout", "-q", "-b", "pr")
+        self.write("samples/a/pr")
+        head = self.commit("PR")
+        self.run_git("checkout", "-q", "-b", "base-advanced", self.base)
+        self.write("samples/b/base")
+        advanced = self.commit("base advanced")
+        self.run_git("checkout", "-q", "pr")
+        self.assertEqual(selector.pr_changes(self.git, advanced, head), ["samples/a/pr"])
+
+    def test_verified_merge_includes_merge_only_effects(self):
+        self.write("samples/a/pr")
+        head = self.commit("PR with unicode \u2603")
+        self.run_git("checkout", "-q", "-b", "advanced", self.base)
+        self.write("samples/b/base")
+        advanced = self.commit("base")
+        self.run_git("merge", "--no-ff", "--no-commit", head)
+        self.write("samples/c/merge-only")
+        merge = self.commit("synthetic merge")
+        self.assertEqual(selector.pr_changes(self.git, advanced, head, merge, True), [
+            "samples/a/pr", "samples/c/merge-only",
+        ])
+        with self.assertRaises(selector.DiffUncertain):
+            selector.pr_changes(self.git, self.base, head, merge, True)
+
+    def test_rename_deletion_and_mode_changes(self):
+        self.write("samples/a/old.txt")
+        self.write("samples/a/deleted.txt")
+        self.write("samples/a/script.sh")
+        base = self.commit("fixtures")
+        self.run_git("mv", "samples/a/old.txt", "samples/a/new [odd] 'name.txt")
+        self.run_git("rm", "samples/a/deleted.txt")
+        self.run_git("update-index", "--chmod=+x", "samples/a/script.sh")
+        self.run_git("commit", "-q", "-m", "rename delete chmod")
+        head = self.run_git("rev-parse", "HEAD")
+        self.assertEqual(selector.pr_changes(self.git, base, head), [
+            "samples/a/deleted.txt", "samples/a/new [odd] 'name.txt", "samples/a/old.txt", "samples/a/script.sh",
+        ])
+
+    def test_nul_parser_handles_newlines_and_non_utf8(self):
+        with mock.patch.object(self.git, "run", return_value=b"samples/a/line\nbreak\0samples/a/\xff\0"):
+            self.assertEqual(self.git.diff(self.base, self.base), {
+                "samples/a/line\nbreak", "samples/a/\udcff",
+            })
+        with mock.patch.object(self.git, "run", return_value=b"unterminated"), self.assertRaises(selector.DiffUncertain):
+            self.git.diff(self.base, self.base)
+
+    def test_more_than_api_limit_of_changed_files(self):
+        for number in range(305):
+            self.write(f"samples/a/{number}.txt")
+        head = self.commit("large PR")
+        self.assertEqual(len(selector.pr_changes(self.git, self.base, head)), 305)
+
+    def test_missing_history_and_checkout_mismatch_are_full(self):
+        env = {"CI_IS_PR": "true", "CI_BASE_SHA": "0" * 40, "CI_HEAD_SHA": self.base}
+        changes, reason = selector.resolve_changes("circleci", env, self.repo)
+        self.assertIsNone(changes)
+        self.assertIn("diff uncertainty", reason)
+        self.write("samples/a/pr")
+        head = self.commit("PR")
+        env.update(CI_BASE_SHA=self.base, CI_HEAD_SHA=head, CIRCLE_SHA1=self.base)
+        changes, reason = selector.resolve_changes("circleci", env, self.repo)
+        self.assertIsNone(changes)
+        self.assertIn("checkout", reason)
+        env["CIRCLE_SHA1"] = head
+        self.assertEqual(selector.resolve_changes("circleci", env, self.repo), (["samples/a/pr"], None))
+        env["CI_BASE_SHA"] = "--upload-pack=malicious"
+        self.assertIn("invalid full commit SHA", selector.resolve_changes("circleci", env, self.repo)[1])
+
+    def test_github_event_uses_verified_head_and_event_checkout(self):
+        self.write("samples/a/pr")
+        head = self.commit("PR")
+        event = self.directory / "event.json"
+        event.write_text(json.dumps({"pull_request": {"base": {"sha": self.base}, "head": {"sha": head}}}), encoding="utf-8")
+        env = {"GITHUB_EVENT_NAME": "pull_request", "GITHUB_EVENT_PATH": str(event), "GITHUB_SHA": head}
+        self.assertEqual(selector.resolve_changes("github", env, self.repo), (["samples/a/pr"], None))
+        env["GITHUB_SHA"] = self.base
+        self.assertIsNone(selector.resolve_changes("github", env, self.repo)[0])
+
+    def test_shallow_checkout_fetches_exact_history(self):
+        self.write("samples/a/first")
+        self.commit("first PR commit")
+        self.write("samples/b/last")
+        head = self.commit("last PR commit")
+        clone = self.directory / "shallow"
+        self.run_git("clone", "--quiet", "--depth=1", self.repo.as_uri(), str(clone))
+        self.assertEqual(self.run_git("rev-parse", "--is-shallow-repository", cwd=clone), "true")
+        self.assertEqual(selector.pr_changes(selector.Git(clone), self.base, head), [
+            "samples/a/first", "samples/b/last",
+        ])
+
+    def test_disconnected_history_does_not_guess(self):
+        self.run_git("checkout", "--orphan", "disconnected")
+        self.run_git("rm", "-rf", ".")
+        self.write("samples/a/new-root")
+        head = self.commit("unrelated history")
+        with self.assertRaises(selector.DiffUncertain):
+            selector.pr_changes(self.git, self.base, head)
+
+    def test_only_executed_sample_directories_must_exist(self):
+        self.write("samples/a/test")
+        selected = selector.select_changes(policy(), "example.build", ["samples/a/test"])
+        selector.validate_targets(selected, self.repo)
+        skipped = selector.select_changes(policy(), "example.build", [])
+        selector.validate_targets(skipped, self.repo)
+        for mode in ("enforce", "shadow"):
+            result = selector.select_changes(policy(), "example.build", ["samples/b/deleted"], mode=mode)
+            with self.assertRaisesRegex(selector.ConfigError, "update ownership"):
+                selector.validate_targets(result, self.repo)
+        full = selector.select_changes(policy(), "example.build", full_reason="forced")
+        with self.assertRaises(selector.ConfigError):
+            selector.validate_targets(full, self.repo)
+
+    def test_typescript_discovery_tracks_new_eligible_roots(self):
+        for root in ("samples/typescript/a", "samples/other-ts/b [literal]", "samples/not-eligible"):
+            self.write(root + "/tsconfig.json", "{}")
+            self.write(root + "/package.json", "{}")
+        for root in ("samples/typescript/a", "samples/other-ts/b [literal]"):
+            self.write(root + "/.openapi-generator-ignore")
+        self.commit("tracked TypeScript roots")
+        self.write("samples/not-eligible/.openapi-generator-ignore")
+        for name in ("tsconfig.json", "package.json", ".openapi-generator-ignore"):
+            self.write("samples/untracked/" + name)
+        self.assertEqual(selector.discover_typescript_samples(self.repo), [
+            "samples/other-ts/b [literal]", "samples/typescript/a",
+        ])
+        self.run_git("add", "samples/not-eligible/.openapi-generator-ignore")
+        self.assertIn("samples/not-eligible", selector.discover_typescript_samples(self.repo))
+
+    def test_typescript_selection_retains_runtime_only_matrix(self):
+        for root in ("samples/ts/a", "samples/ts/b"):
+            for name in ("tsconfig.json", "package.json", ".openapi-generator-ignore"):
+                self.write(root + "/" + name)
+        self.commit("TypeScript samples")
+        manifest = policy({"node-version": [20]}, discovery="typescript")
+        result = selector.select_changes(manifest, "example.build", ["samples/ts/a/test"], cwd=self.repo)
+        self.assertEqual(result["samples"], ["samples/ts/a"])
+        self.assertEqual(result["matrix"], {"node-version": [20]})
+        self.assertFalse(result["run_all"])
+        skipped = selector.select_changes(manifest, "example.build", ["README.md"], cwd=self.repo)
+        self.assertFalse(skipped["has_changes"])
+        self.assertEqual(skipped["matrix"], {"include": []})
+        for kwargs in ({"full_reason": "forced"}, {"changed_paths": [], "mode": "shadow"}):
+            full = selector.select_changes(manifest, "example.build", cwd=self.repo, **kwargs)
+            self.assertEqual(full["samples"], ["samples/ts/a", "samples/ts/b"])
+            self.assertEqual(full["matrix"], {"node-version": [20]})
+            self.assertTrue(full["run_all"])
+
+    def test_typescript_discovery_failure_cannot_silently_skip(self):
+        manifest = policy({"node-version": [20]}, discovery="typescript")
+        with mock.patch.object(selector.Git, "run", side_effect=selector.DiffUncertain("git unavailable")):
+            with self.assertRaisesRegex(selector.ConfigError, "cannot discover"):
+                selector.select_changes(manifest, "example.build", [], cwd=self.repo)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/CI/tests/test_typescript_selection.py
+++ b/CI/tests/test_typescript_selection.py
@@ -1,0 +1,94 @@
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+BASH = os.environ.get("CI_TEST_BASH") or shutil.which("bash")
+
+
+def git_environment():
+    environment = dict(os.environ)
+    count = int(environment.pop("GIT_CONFIG_COUNT", "0"))
+    for index in range(count):
+        environment.pop(f"GIT_CONFIG_KEY_{index}", None)
+        environment.pop(f"GIT_CONFIG_VALUE_{index}", None)
+    return environment
+
+
+@unittest.skipUnless(BASH and shutil.which("node") and shutil.which("git"),
+                     "TypeScript selection requires the existing Bash, Node and Git runtimes")
+class TypeScriptSelectionTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        subprocess.run(["git", "init", "--quiet", str(self.root)], check=True, env=git_environment())
+        for sample in ("first sample", "second"):
+            directory = self.root / "samples" / sample
+            directory.mkdir(parents=True)
+            for filename, content in (("tsconfig.json", "{}"), ("package.json", "{}"),
+                                      (".openapi-generator-ignore", "")):
+                (directory / filename).write_text(content, encoding="utf-8")
+        subprocess.run(["git", "add", "samples"], cwd=self.root, check=True, env=git_environment())
+        self.tools = self.root / "tools"
+        self.tools.mkdir()
+        npm = self.tools / "npm"
+        npm.write_text('#!/bin/sh\nprintf "%s\\n" "$PWD" >> "$CI_NPM_CALLS"\n', encoding="utf-8")
+        npm.chmod(0o755)
+        self.calls = self.root / "calls"
+
+    def run_script(self, *args):
+        environment = git_environment()
+        environment["PATH"] = str(self.tools) + os.pathsep + environment["PATH"]
+        environment["CI_NPM_CALLS"] = self.calls.as_posix()
+        return subprocess.run([BASH, str(ROOT / "bin" / "ts-typecheck-all.sh"), *args],
+                              cwd=self.root, env=environment, text=True, capture_output=True)
+
+    def test_empty_selection_does_not_install_or_typecheck(self):
+        result = self.run_script("--samples-json", "[]")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertFalse(self.calls.exists())
+
+    def test_selected_directory_preserves_spaces(self):
+        result = self.run_script("--samples-json", json.dumps(["samples/first sample"]))
+        self.assertEqual(result.returncode, 0, result.stderr)
+        calls = self.calls.read_text(encoding="utf-8").splitlines()
+        self.assertEqual(len(calls), 2)
+        self.assertTrue(all(call.endswith("/samples/first sample") for call in calls), calls)
+
+    def test_default_still_discovers_all_samples(self):
+        result = self.run_script()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        calls = self.calls.read_text(encoding="utf-8").splitlines()
+        self.assertEqual(len(calls), 4)
+        self.assertTrue(any(call.endswith("/samples/second") for call in calls))
+
+    def test_default_preserves_existing_metadata_presence_rule(self):
+        directory = self.root / "samples" / "new"
+        directory.mkdir()
+        (directory / "tsconfig.json").write_text("{}", encoding="utf-8")
+        subprocess.run(["git", "add", "samples/new/tsconfig.json"], cwd=self.root, check=True,
+                       env=git_environment())
+        (directory / "package.json").write_text("{}", encoding="utf-8")
+        (directory / ".openapi-generator-ignore").write_text("", encoding="utf-8")
+        result = self.run_script()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        calls = self.calls.read_text(encoding="utf-8").splitlines()
+        self.assertEqual(len(calls), 6)
+        self.assertTrue(any(call.endswith("/samples/new") for call in calls))
+
+    def test_invalid_selection_fails_before_npm(self):
+        for value in ('["samples/missing"]', '{"sample":"samples/second"}', 'not-json'):
+            with self.subTest(value=value):
+                result = self.run_script("--samples-json", value)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertFalse(self.calls.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,6 +123,53 @@ To start the CI tests, you can:
 
 See [OpenAPI Tools wiki](https://github.com/OpenAPITools/openapi-generator/wiki/Integration-Tests) for more information about the integration tests.
 
+### Change-aware CI
+
+Repository test workflows use `CI/change-scopes.json` to select affected suites on pull requests.
+Changes to a sample's source, tests, build files, or generated metadata count as relevant; CI does not
+normalize whitespace or attempt semantic equivalence. Shared build/test inputs select all their
+consumers. Generator changes still run generator tests and generated-output freshness checks even
+when checked-in samples are unchanged. Selected jobs keep their existing clean builds and runtime
+coverage.
+
+The rollout defaults to **shadow** mode: compute and report the proposed selection, but keep the
+full matrix within an affected sample workflow. Historical workflow paths are recorded as
+`shadow_paths`: they preserve existing workflow-level coverage, while newly declared dependencies
+can select additional workflows. Unrelated sample workflows do not start expensive jobs merely
+because shadow mode is enabled. Core/platform jobs without these historical path bounds still run
+in full during shadow rollout. Maintainers can set the repository variable `CI_SELECTION_MODE_PILOT=enforce` for the
+Spring, Python Petstore, Swift, and Go pilot workflows, then set `CI_SELECTION_MODE=enforce` for the
+remaining migrated GitHub workflows after reviewing hosted results and required checks. Set these
+variables back to `shadow` to disable skipping. Workflow dispatch and master/release-branch pushes
+always run the full applicable suite. CircleCI has independent `selection_mode` and `force_full`
+pipeline parameters and also defaults to shadow mode.
+
+Add or update the appropriate suite when registering a new sample or changing shared dependencies.
+The manifest owns sample matrices, including runtime axes and special `include` rows; do not add a
+second static matrix to the workflow. Register inputs outside the sample directory, such as a sibling
+package installed through an npm `file:` dependency. Samples without a runnable CI suite need an
+exact-root exclusion with an explanation; existing exclusions record pre-selection coverage, not
+an assertion that those samples are tested. Generated-output freshness is separate from compilation.
+The TypeScript typecheck suite discovers eligible tracked samples rather than maintaining another list.
+
+The Misc tests workflow checks ownership and runs the selector's focused regression suite. These
+checks can also be run locally without building the generator:
+
+```shell
+node .github/.test/ci-scopes.js
+python3 -m unittest discover -s CI/tests -p 'test_*.py'
+```
+
+Selection summaries explain which inputs selected each suite and when comparison uncertainty forced
+a full run. Missing PR history never means "no changes". A failed selector or policy check must be
+treated as a failure, not as an intentional skip; include the selector/policy checks in repository
+rulesets before enabling enforcement. Test-report publication distinguishes intentional unit-test
+skips from missing results after an executed job.
+
+Filtering compares the cumulative PR change, not the last commit or a previous successful CI run.
+It does not cache successful test results across runs. Full branch/manual runs remain important for
+detecting changes in external dependencies and services that are not reflected in a repository diff.
+
 ### Tips
 - Smaller changes are easier to review
 - [Optional] For bug fixes, provide a OpenAPI Spec to repeat the issue so that the reviewer can use it to confirm the fix

--- a/bin/ts-typecheck-all.sh
+++ b/bin/ts-typecheck-all.sh
@@ -25,16 +25,37 @@ main() {
     local root_dir
     root_dir=$(git rev-parse --show-toplevel)
     local dir
+    local selection_file
+    selection_file=$(mktemp)
+    trap 'rm -f -- "$selection_file"' EXIT
 
-    for dir in $(git ls-files samples | grep 'tsconfig.json$' | xargs -n1 dirname | sort -u); do
-        if [[ ! -f "${root_dir}/${dir}/.openapi-generator-ignore" ]]; then
-            # This is not a generated sample; skip it
-            continue
-        fi
-        if [[ ! -f "${root_dir}/${dir}/package.json" ]]; then
-            # we can't really guarantee that all dependencies are there to do a typecheck...
-            continue            
-        fi
+    node - "$root_dir" "$@" > "$selection_file" <<'NODE'
+const {execFileSync} = require('child_process');
+const fs = require('fs');
+const nativePath = require('path');
+const path = require('path').posix;
+const [root, ...args] = process.argv.slice(2);
+const tracked = new Set(execFileSync('git', ['ls-files', '-z', '--', 'samples'], {
+    cwd: root, encoding: 'utf8', maxBuffer: 32 * 1024 * 1024
+}).split('\0').filter(Boolean));
+const eligible = new Set([...tracked].filter(file => file.endsWith('/tsconfig.json'))
+    .map(file => path.dirname(file))
+    .filter(dir => fs.existsSync(nativePath.join(root, dir, '.openapi-generator-ignore')) &&
+        fs.existsSync(nativePath.join(root, dir, 'package.json'))));
+let selected = [...eligible].sort();
+if (args.length) {
+    if (args.length !== 2 || args[0] !== '--samples-json') {
+        throw new Error('Usage: ts-typecheck-all.sh [--samples-json \'["sample/path"]\']');
+    }
+    selected = JSON.parse(args[1]);
+    if (!Array.isArray(selected) || selected.some(dir => typeof dir !== 'string' || !eligible.has(dir))) {
+        throw new Error('Selection must contain only eligible tracked TypeScript sample directories');
+    }
+}
+for (const dir of new Set(selected)) process.stdout.write(`${dir}\0`);
+NODE
+
+    while IFS= read -r -d '' dir; do
         log "➤ ${dir}"
         pushd "${root_dir}/${dir}" > /dev/null
         npm_install \
@@ -43,7 +64,9 @@ main() {
         log "✓ ${dir}"
         log
         popd > /dev/null
-    done
+    done < "$selection_file"
+    rm -f -- "$selection_file"
+    trap - EXIT
 }
 
 main "$@"

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -127,6 +127,49 @@ To start the CI tests, you can:
 
 See [OpenAPI Tools wiki](https://github.com/OpenAPITools/openapi-generator/wiki/Integration-Tests) for more information about the integration tests.
 
+### Change-aware CI
+
+Repository test workflows use `CI/change-scopes.json` to select affected suites on pull requests.
+Changes to a sample's source, tests, build files, or generated metadata count as relevant; CI does not
+normalize whitespace or attempt semantic equivalence. Shared build/test inputs select all their
+consumers. Generator changes still run generator tests and generated-output freshness checks even
+when checked-in samples are unchanged. Selected jobs keep their existing clean builds and runtime
+coverage.
+
+The rollout defaults to **shadow** mode: compute and report the proposed selection, but execute the
+full suite. Maintainers can set the repository variable `CI_SELECTION_MODE_PILOT=enforce` for the
+Spring, Python Petstore, Swift, and Go pilot workflows, then set `CI_SELECTION_MODE=enforce` for the
+remaining migrated GitHub workflows after reviewing hosted results and required checks. Set these
+variables back to `shadow` to disable skipping. Workflow dispatch and master/release-branch pushes
+always run the full applicable suite. CircleCI has independent `selection_mode` and `force_full`
+pipeline parameters and also defaults to shadow mode.
+
+Add or update the appropriate suite when registering a new sample or changing shared dependencies.
+The manifest owns sample matrices, including runtime axes and special `include` rows; do not add a
+second static matrix to the workflow. Register inputs outside the sample directory, such as a sibling
+package installed through an npm `file:` dependency. Samples without a runnable CI suite need an
+exact-root exclusion with an explanation; existing exclusions record pre-selection coverage, not
+an assertion that those samples are tested. Generated-output freshness is separate from compilation.
+The TypeScript typecheck suite discovers eligible tracked samples rather than maintaining another list.
+
+The Misc tests workflow checks ownership and runs the selector's focused regression suite. These
+checks can also be run locally without building the generator:
+
+```shell
+node .github/.test/ci-scopes.js
+python3 -m unittest discover -s CI/tests -p 'test_*.py'
+```
+
+Selection summaries explain which inputs selected each suite and when comparison uncertainty forced
+a full run. Missing PR history never means "no changes". A failed selector or policy check must be
+treated as a failure, not as an intentional skip; include the selector/policy checks in repository
+rulesets before enabling enforcement. Test-report publication distinguishes intentional unit-test
+skips from missing results after an executed job.
+
+Filtering compares the cumulative PR change, not the last commit or a previous successful CI run.
+It does not cache successful test results across runs. Full branch/manual runs remain important for
+detecting changes in external dependencies and services that are not reflected in a repository diff.
+
 ### Tips
 - Smaller changes are easier to review
 - [Optional] For bug fixes, provide a OpenAPI Spec to repeat the issue so that the reviewer can use it to confirm the fix


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces hardcoded path filters in GitHub Actions and CircleCI with a shared CI scoping policy, so sample and test execution can be scoped to the files a PR touches. Shadow mode preserves the existing full runs while logging what would be filtered, giving maintainers a way to validate the new calculation before switching to enforce mode.

- The scope manifest lives in `CI/change-scopes.json` and is validated by `.github/.test/ci-scopes.js`.
- A new `compute-matrix` action reads the manifest and reports the affected matrix, sample paths, and decision reasons per suite.
- Each workflow adds a `setup` job to compute changes and gates its build/test job on that result.
- Workflows gain `workflow_dispatch` and consistent branch filters for `master` and maintenance branches.
- The test-results workflow now inspects the unit test outcome and publishes only when that job actually ran.

<sup>Written for commit 072a3ba3554686763b6ba832276370493a4e0d14. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24932?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

