### PR TITLE
[csharp][generichost] Correct error message on serialization

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/JsonConverter.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/JsonConverter.mustache
@@ -456,9 +456,11 @@
             {{^isDiscriminator}}
             {{^isNullable}}
             {{#vendorExtensions.x-is-reference-type}}
-            if ({{^required}}{{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}.{{name}}Option.IsSet && {{/required}}{{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}.{{name}} == null)
-                throw new ArgumentNullException(nameof({{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}.{{name}}), "Property is required for class {{classname}}.");
+            {{^required}}
+            if ({{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}.{{name}}Option.IsSet && {{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}.{{name}} == null)
+                throw new JsonException("Cannot write null property {{classname}}.{{name}} to non-nullable JSON property '{{baseName}}'.");
 
+            {{/required}}
             {{/vendorExtensions.x-is-reference-type}}
             {{/isNullable}}
             {{/isDiscriminator}}

--- a/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/JsonConverter.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/JsonConverter.mustache
@@ -455,13 +455,11 @@
             {{#allVars}}
             {{^isDiscriminator}}
             {{^isNullable}}
-            {{#vendorExtensions.x-is-reference-type}}
             {{^required}}
             if ({{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}.{{name}}Option.IsSet && {{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}.{{name}} == null)
                 throw new JsonException("Cannot write null property {{classname}}.{{name}} to non-nullable JSON property '{{baseName}}'.");
 
             {{/required}}
-            {{/vendorExtensions.x-is-reference-type}}
             {{/isNullable}}
             {{/isDiscriminator}}
             {{/allVars}}

--- a/samples/client/petstore/csharp/generichost/latest/AnnotatedEnum/src/Org.OpenAPITools/Model/OneOfNullAndRef.cs
+++ b/samples/client/petstore/csharp/generichost/latest/AnnotatedEnum/src/Org.OpenAPITools/Model/OneOfNullAndRef.cs
@@ -168,6 +168,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, OneOfNullAndRef oneOfNullAndRef, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (oneOfNullAndRef.NumberOption.IsSet && oneOfNullAndRef.Number == null)
+                throw new JsonException("Cannot write null property OneOfNullAndRef.Number to non-nullable JSON property 'number'.");
+
             if (oneOfNullAndRef.NumberOption.IsSet)
             {
                 var numberRawValue = NumberValueConverter.ToJsonValue(oneOfNullAndRef.Number!.Value);

--- a/samples/client/petstore/csharp/generichost/latest/AnnotatedEnum/src/Org.OpenAPITools/Model/OneOfNullAndRef2.cs
+++ b/samples/client/petstore/csharp/generichost/latest/AnnotatedEnum/src/Org.OpenAPITools/Model/OneOfNullAndRef2.cs
@@ -168,6 +168,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, OneOfNullAndRef2 oneOfNullAndRef2, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (oneOfNullAndRef2.NumberOption.IsSet && oneOfNullAndRef2.Number == null)
+                throw new JsonException("Cannot write null property OneOfNullAndRef2.Number to non-nullable JSON property 'number'.");
+
             if (oneOfNullAndRef2.NumberOption.IsSet)
             {
                 var numberRawValue = NumberValueConverter.ToJsonValue(oneOfNullAndRef2.Number!.Value);

--- a/samples/client/petstore/csharp/generichost/latest/AnnotatedEnum/src/Org.OpenAPITools/Model/OneOfNullAndRef3.cs
+++ b/samples/client/petstore/csharp/generichost/latest/AnnotatedEnum/src/Org.OpenAPITools/Model/OneOfNullAndRef3.cs
@@ -168,6 +168,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, OneOfNullAndRef3 oneOfNullAndRef3, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (oneOfNullAndRef3.NumberOption.IsSet && oneOfNullAndRef3.Number == null)
+                throw new JsonException("Cannot write null property OneOfNullAndRef3.Number to non-nullable JSON property 'number'.");
+
             if (oneOfNullAndRef3.NumberOption.IsSet)
             {
                 var numberRawValue = NumberValueConverter.ToJsonValue(oneOfNullAndRef3.Number!.Value);

--- a/samples/client/petstore/csharp/generichost/latest/AnnotatedEnum/src/Org.OpenAPITools/Model/Parent.cs
+++ b/samples/client/petstore/csharp/generichost/latest/AnnotatedEnum/src/Org.OpenAPITools/Model/Parent.cs
@@ -168,6 +168,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Parent parent, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (parent.NumberOption.IsSet && parent.Number == null)
+                throw new JsonException("Cannot write null property Parent.Number to non-nullable JSON property 'number'.");
+
             if (parent.NumberOption.IsSet)
             {
                 var numberRawValue = NumberValueConverter.ToJsonValue(parent.Number!.Value);

--- a/samples/client/petstore/csharp/generichost/latest/AnnotatedEnum/src/Org.OpenAPITools/Model/ParentWithOneOfProperty.cs
+++ b/samples/client/petstore/csharp/generichost/latest/AnnotatedEnum/src/Org.OpenAPITools/Model/ParentWithOneOfProperty.cs
@@ -168,6 +168,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ParentWithOneOfProperty parentWithOneOfProperty, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (parentWithOneOfProperty.NumberOption.IsSet && parentWithOneOfProperty.Number == null)
+                throw new JsonException("Cannot write null property ParentWithOneOfProperty.Number to non-nullable JSON property 'number'.");
+
             if (parentWithOneOfProperty.NumberOption.IsSet)
             {
                 var numberRawValue = NumberValueConverter.ToJsonValue(parentWithOneOfProperty.Number!.Value);

--- a/samples/client/petstore/csharp/generichost/latest/AnnotatedEnum/src/Org.OpenAPITools/Model/ParentWithPluralOneOfProperty.cs
+++ b/samples/client/petstore/csharp/generichost/latest/AnnotatedEnum/src/Org.OpenAPITools/Model/ParentWithPluralOneOfProperty.cs
@@ -169,7 +169,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ParentWithPluralOneOfProperty parentWithPluralOneOfProperty, JsonSerializerOptions jsonSerializerOptions)
         {
             if (parentWithPluralOneOfProperty.NumberOption.IsSet && parentWithPluralOneOfProperty.Number == null)
-                throw new ArgumentNullException(nameof(parentWithPluralOneOfProperty.Number), "Property is required for class ParentWithPluralOneOfProperty.");
+                throw new JsonException("Cannot write null property ParentWithPluralOneOfProperty.Number to non-nullable JSON property 'number'.");
 
             if (parentWithPluralOneOfProperty.NumberOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/latest/HelloWorld/src/Org.OpenAPITools/Model/HelloWorldPostRequest.cs
+++ b/samples/client/petstore/csharp/generichost/latest/HelloWorld/src/Org.OpenAPITools/Model/HelloWorldPostRequest.cs
@@ -169,7 +169,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, HelloWorldPostRequest helloWorldPostRequest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (helloWorldPostRequest.MessageOption.IsSet && helloWorldPostRequest.Message == null)
-                throw new ArgumentNullException(nameof(helloWorldPostRequest.Message), "Property is required for class HelloWorldPostRequest.");
+                throw new JsonException("Cannot write null property HelloWorldPostRequest.Message to non-nullable JSON property 'message'.");
 
             if (helloWorldPostRequest.MessageOption.IsSet)
                 writer.WriteString("message", helloWorldPostRequest.Message);

--- a/samples/client/petstore/csharp/generichost/latest/InlineEnumAnyOf/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/generichost/latest/InlineEnumAnyOf/src/Org.OpenAPITools/Model/Foo.cs
@@ -169,7 +169,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Foo foo, JsonSerializerOptions jsonSerializerOptions)
         {
             if (foo.BarOption.IsSet && foo.Bar == null)
-                throw new ArgumentNullException(nameof(foo.Bar), "Property is required for class Foo.");
+                throw new JsonException("Cannot write null property Foo.Bar to non-nullable JSON property 'bar'.");
 
             if (foo.BarOption.IsSet)
                 writer.WriteString("bar", foo.Bar);

--- a/samples/client/petstore/csharp/generichost/latest/InlineEnumAnyOf/src/Org.OpenAPITools/Model/IconsDefaultResponse.cs
+++ b/samples/client/petstore/csharp/generichost/latest/InlineEnumAnyOf/src/Org.OpenAPITools/Model/IconsDefaultResponse.cs
@@ -169,7 +169,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, IconsDefaultResponse iconsDefaultResponse, JsonSerializerOptions jsonSerializerOptions)
         {
             if (iconsDefaultResponse.StringOption.IsSet && iconsDefaultResponse.String == null)
-                throw new ArgumentNullException(nameof(iconsDefaultResponse.String), "Property is required for class IconsDefaultResponse.");
+                throw new JsonException("Cannot write null property IconsDefaultResponse.String to non-nullable JSON property 'string'.");
 
             if (iconsDefaultResponse.StringOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/latest/NullTypes/src/Org.OpenAPITools/Model/Color.cs
+++ b/samples/client/petstore/csharp/generichost/latest/NullTypes/src/Org.OpenAPITools/Model/Color.cs
@@ -250,6 +250,15 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Color color, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (color.BOption.IsSet && color.B == null)
+                throw new JsonException("Cannot write null property Color.B to non-nullable JSON property 'b'.");
+
+            if (color.GOption.IsSet && color.G == null)
+                throw new JsonException("Cannot write null property Color.G to non-nullable JSON property 'g'.");
+
+            if (color.ROption.IsSet && color.R == null)
+                throw new JsonException("Cannot write null property Color.R to non-nullable JSON property 'r'.");
+
             if (color.BOption.IsSet)
                 writer.WriteNumber("b", color.BOption.Value!.Value);
 

--- a/samples/client/petstore/csharp/generichost/latest/NullTypes/src/Org.OpenAPITools/Model/NullTypeDirect.cs
+++ b/samples/client/petstore/csharp/generichost/latest/NullTypes/src/Org.OpenAPITools/Model/NullTypeDirect.cs
@@ -189,6 +189,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, NullTypeDirect nullTypeDirect, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (nullTypeDirect.IdOption.IsSet && nullTypeDirect.Id == null)
+                throw new JsonException("Cannot write null property NullTypeDirect.Id to non-nullable JSON property 'id'.");
+
             if (nullTypeDirect.AlwaysNullOption.IsSet)
                 if (nullTypeDirect.AlwaysNullOption.Value != null)
                 {

--- a/samples/client/petstore/csharp/generichost/latest/NullTypes/src/Org.OpenAPITools/Model/Shape.cs
+++ b/samples/client/petstore/csharp/generichost/latest/NullTypes/src/Org.OpenAPITools/Model/Shape.cs
@@ -189,9 +189,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Shape shape, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (shape.ShapeType == null)
-                throw new ArgumentNullException(nameof(shape.ShapeType), "Property is required for class Shape.");
-
             writer.WriteString("shapeType", shape.ShapeType);
 
             if (shape.AreaOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/latest/NullTypes/src/Org.OpenAPITools/Model/Shape.cs
+++ b/samples/client/petstore/csharp/generichost/latest/NullTypes/src/Org.OpenAPITools/Model/Shape.cs
@@ -189,6 +189,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Shape shape, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (shape.AreaOption.IsSet && shape.Area == null)
+                throw new JsonException("Cannot write null property Shape.Area to non-nullable JSON property 'area'.");
+
             writer.WriteString("shapeType", shape.ShapeType);
 
             if (shape.AreaOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/latest/NullTypes/src/Org.OpenAPITools/Model/ShapeOrNull.cs
+++ b/samples/client/petstore/csharp/generichost/latest/NullTypes/src/Org.OpenAPITools/Model/ShapeOrNull.cs
@@ -189,9 +189,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ShapeOrNull shapeOrNull, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (shapeOrNull.ShapeType == null)
-                throw new ArgumentNullException(nameof(shapeOrNull.ShapeType), "Property is required for class ShapeOrNull.");
-
             writer.WriteString("shapeType", shapeOrNull.ShapeType);
 
             if (shapeOrNull.AreaOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/latest/NullTypes/src/Org.OpenAPITools/Model/ShapeOrNull.cs
+++ b/samples/client/petstore/csharp/generichost/latest/NullTypes/src/Org.OpenAPITools/Model/ShapeOrNull.cs
@@ -189,6 +189,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ShapeOrNull shapeOrNull, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (shapeOrNull.AreaOption.IsSet && shapeOrNull.Area == null)
+                throw new JsonException("Cannot write null property ShapeOrNull.Area to non-nullable JSON property 'area'.");
+
             writer.WriteString("shapeType", shapeOrNull.ShapeType);
 
             if (shapeOrNull.AreaOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/latest/NullTypes/src/Org.OpenAPITools/Model/Widget.cs
+++ b/samples/client/petstore/csharp/generichost/latest/NullTypes/src/Org.OpenAPITools/Model/Widget.cs
@@ -248,9 +248,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Widget widget, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (widget.Name == null)
-                throw new ArgumentNullException(nameof(widget.Name), "Property is required for class Widget.");
-
             writer.WriteNumber("id", widget.Id);
 
             writer.WriteString("name", widget.Name);

--- a/samples/client/petstore/csharp/generichost/latest/OneOfList/src/Org.OpenAPITools/Model/TestObject.cs
+++ b/samples/client/petstore/csharp/generichost/latest/OneOfList/src/Org.OpenAPITools/Model/TestObject.cs
@@ -169,7 +169,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestObject testObject, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testObject.NameOption.IsSet && testObject.Name == null)
-                throw new ArgumentNullException(nameof(testObject.Name), "Property is required for class TestObject.");
+                throw new JsonException("Cannot write null property TestObject.Name to non-nullable JSON property 'name'.");
 
             if (testObject.NameOption.IsSet)
                 writer.WriteString("name", testObject.Name);

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Activity.cs
@@ -169,7 +169,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Activity activity, JsonSerializerOptions jsonSerializerOptions)
         {
             if (activity.ActivityOutputsOption.IsSet && activity.ActivityOutputs == null)
-                throw new ArgumentNullException(nameof(activity.ActivityOutputs), "Property is required for class Activity.");
+                throw new JsonException("Cannot write null property Activity.ActivityOutputs to non-nullable JSON property 'activity_outputs'.");
 
             if (activity.ActivityOutputsOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -192,10 +192,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ActivityOutputElementRepresentation activityOutputElementRepresentation, JsonSerializerOptions jsonSerializerOptions)
         {
             if (activityOutputElementRepresentation.Prop1Option.IsSet && activityOutputElementRepresentation.Prop1 == null)
-                throw new ArgumentNullException(nameof(activityOutputElementRepresentation.Prop1), "Property is required for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Cannot write null property ActivityOutputElementRepresentation.Prop1 to non-nullable JSON property 'prop1'.");
 
             if (activityOutputElementRepresentation.Prop2Option.IsSet && activityOutputElementRepresentation.Prop2 == null)
-                throw new ArgumentNullException(nameof(activityOutputElementRepresentation.Prop2), "Property is required for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Cannot write null property ActivityOutputElementRepresentation.Prop2 to non-nullable JSON property 'prop2'.");
 
             if (activityOutputElementRepresentation.Prop1Option.IsSet)
                 writer.WriteString("prop1", activityOutputElementRepresentation.Prop1);

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -328,25 +328,25 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, AdditionalPropertiesClass additionalPropertiesClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (additionalPropertiesClass.EmptyMapOption.IsSet && additionalPropertiesClass.EmptyMap == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.EmptyMap), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.EmptyMap to non-nullable JSON property 'empty_map'.");
 
             if (additionalPropertiesClass.MapOfMapPropertyOption.IsSet && additionalPropertiesClass.MapOfMapProperty == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapOfMapProperty), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapOfMapProperty to non-nullable JSON property 'map_of_map_property'.");
 
             if (additionalPropertiesClass.MapPropertyOption.IsSet && additionalPropertiesClass.MapProperty == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapProperty), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapProperty to non-nullable JSON property 'map_property'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1Option.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1 == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1 to non-nullable JSON property 'map_with_undeclared_properties_anytype_1'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2Option.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2 == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2 to non-nullable JSON property 'map_with_undeclared_properties_anytype_2'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3Option.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3 == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3 to non-nullable JSON property 'map_with_undeclared_properties_anytype_3'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesStringOption.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesString == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesString), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesString to non-nullable JSON property 'map_with_undeclared_properties_string'.");
 
             if (additionalPropertiesClass.Anytype1Option.IsSet)
                 if (additionalPropertiesClass.Anytype1Option.Value != null)

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Animal.cs
@@ -215,7 +215,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Animal animal, JsonSerializerOptions jsonSerializerOptions)
         {
             if (animal.ColorOption.IsSet && animal.Color == null)
-                throw new ArgumentNullException(nameof(animal.Color), "Property is required for class Animal.");
+                throw new JsonException("Cannot write null property Animal.Color to non-nullable JSON property 'color'.");
 
             writer.WriteString("className", animal.ClassName);
 

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -214,6 +214,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ApiResponse apiResponse, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (apiResponse.CodeOption.IsSet && apiResponse.Code == null)
+                throw new JsonException("Cannot write null property ApiResponse.Code to non-nullable JSON property 'code'.");
+
             if (apiResponse.MessageOption.IsSet && apiResponse.Message == null)
                 throw new JsonException("Cannot write null property ApiResponse.Message to non-nullable JSON property 'message'.");
 

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -215,10 +215,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ApiResponse apiResponse, JsonSerializerOptions jsonSerializerOptions)
         {
             if (apiResponse.MessageOption.IsSet && apiResponse.Message == null)
-                throw new ArgumentNullException(nameof(apiResponse.Message), "Property is required for class ApiResponse.");
+                throw new JsonException("Cannot write null property ApiResponse.Message to non-nullable JSON property 'message'.");
 
             if (apiResponse.TypeOption.IsSet && apiResponse.Type == null)
-                throw new ArgumentNullException(nameof(apiResponse.Type), "Property is required for class ApiResponse.");
+                throw new JsonException("Cannot write null property ApiResponse.Type to non-nullable JSON property 'type'.");
 
             if (apiResponse.CodeOption.IsSet)
                 writer.WriteNumber("code", apiResponse.CodeOption.Value!.Value);

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Apple.cs
@@ -245,13 +245,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Apple apple, JsonSerializerOptions jsonSerializerOptions)
         {
             if (apple.ColorCodeOption.IsSet && apple.ColorCode == null)
-                throw new ArgumentNullException(nameof(apple.ColorCode), "Property is required for class Apple.");
+                throw new JsonException("Cannot write null property Apple.ColorCode to non-nullable JSON property 'color_code'.");
 
             if (apple.CultivarOption.IsSet && apple.Cultivar == null)
-                throw new ArgumentNullException(nameof(apple.Cultivar), "Property is required for class Apple.");
+                throw new JsonException("Cannot write null property Apple.Cultivar to non-nullable JSON property 'cultivar'.");
 
             if (apple.OriginOption.IsSet && apple.Origin == null)
-                throw new ArgumentNullException(nameof(apple.Origin), "Property is required for class Apple.");
+                throw new JsonException("Cannot write null property Apple.Origin to non-nullable JSON property 'origin'.");
 
             if (apple.ColorCodeOption.IsSet)
                 writer.WriteString("color_code", apple.ColorCode);

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -187,6 +187,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, AppleReq appleReq, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (appleReq.MealyOption.IsSet && appleReq.Mealy == null)
+                throw new JsonException("Cannot write null property AppleReq.Mealy to non-nullable JSON property 'mealy'.");
+
             writer.WriteString("cultivar", appleReq.Cultivar);
 
             if (appleReq.MealyOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -187,9 +187,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, AppleReq appleReq, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (appleReq.Cultivar == null)
-                throw new ArgumentNullException(nameof(appleReq.Cultivar), "Property is required for class AppleReq.");
-
             writer.WriteString("cultivar", appleReq.Cultivar);
 
             if (appleReq.MealyOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -169,7 +169,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ArrayOfArrayOfNumberOnly arrayOfArrayOfNumberOnly, JsonSerializerOptions jsonSerializerOptions)
         {
             if (arrayOfArrayOfNumberOnly.ArrayArrayNumberOption.IsSet && arrayOfArrayOfNumberOnly.ArrayArrayNumber == null)
-                throw new ArgumentNullException(nameof(arrayOfArrayOfNumberOnly.ArrayArrayNumber), "Property is required for class ArrayOfArrayOfNumberOnly.");
+                throw new JsonException("Cannot write null property ArrayOfArrayOfNumberOnly.ArrayArrayNumber to non-nullable JSON property 'ArrayArrayNumber'.");
 
             if (arrayOfArrayOfNumberOnly.ArrayArrayNumberOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -169,7 +169,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ArrayOfNumberOnly arrayOfNumberOnly, JsonSerializerOptions jsonSerializerOptions)
         {
             if (arrayOfNumberOnly.ArrayNumberOption.IsSet && arrayOfNumberOnly.ArrayNumber == null)
-                throw new ArgumentNullException(nameof(arrayOfNumberOnly.ArrayNumber), "Property is required for class ArrayOfNumberOnly.");
+                throw new JsonException("Cannot write null property ArrayOfNumberOnly.ArrayNumber to non-nullable JSON property 'ArrayNumber'.");
 
             if (arrayOfNumberOnly.ArrayNumberOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -215,13 +215,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ArrayTest arrayTest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (arrayTest.ArrayArrayOfIntegerOption.IsSet && arrayTest.ArrayArrayOfInteger == null)
-                throw new ArgumentNullException(nameof(arrayTest.ArrayArrayOfInteger), "Property is required for class ArrayTest.");
+                throw new JsonException("Cannot write null property ArrayTest.ArrayArrayOfInteger to non-nullable JSON property 'array_array_of_integer'.");
 
             if (arrayTest.ArrayArrayOfModelOption.IsSet && arrayTest.ArrayArrayOfModel == null)
-                throw new ArgumentNullException(nameof(arrayTest.ArrayArrayOfModel), "Property is required for class ArrayTest.");
+                throw new JsonException("Cannot write null property ArrayTest.ArrayArrayOfModel to non-nullable JSON property 'array_array_of_model'.");
 
             if (arrayTest.ArrayOfStringOption.IsSet && arrayTest.ArrayOfString == null)
-                throw new ArgumentNullException(nameof(arrayTest.ArrayOfString), "Property is required for class ArrayTest.");
+                throw new JsonException("Cannot write null property ArrayTest.ArrayOfString to non-nullable JSON property 'array_of_string'.");
 
             if (arrayTest.ArrayArrayOfIntegerOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Banana.cs
@@ -168,6 +168,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Banana banana, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (banana.LengthCmOption.IsSet && banana.LengthCm == null)
+                throw new JsonException("Cannot write null property Banana.LengthCm to non-nullable JSON property 'lengthCm'.");
+
             if (banana.LengthCmOption.IsSet)
                 writer.WriteNumber("lengthCm", banana.LengthCmOption.Value!.Value);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -187,6 +187,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, BananaReq bananaReq, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (bananaReq.SweetOption.IsSet && bananaReq.Sweet == null)
+                throw new JsonException("Cannot write null property BananaReq.Sweet to non-nullable JSON property 'sweet'.");
+
             writer.WriteNumber("lengthCm", bananaReq.LengthCm);
 
             if (bananaReq.SweetOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/BasquePig.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/BasquePig.cs
@@ -164,9 +164,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, BasquePig basquePig, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (basquePig.ClassName == null)
-                throw new ArgumentNullException(nameof(basquePig.ClassName), "Property is required for class BasquePig.");
-
             writer.WriteString("className", basquePig.ClassName);
         }
     }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -285,22 +285,22 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Capitalization capitalization, JsonSerializerOptions jsonSerializerOptions)
         {
             if (capitalization.ATT_NAMEOption.IsSet && capitalization.ATT_NAME == null)
-                throw new ArgumentNullException(nameof(capitalization.ATT_NAME), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.ATT_NAME to non-nullable JSON property 'ATT_NAME'.");
 
             if (capitalization.CapitalCamelOption.IsSet && capitalization.CapitalCamel == null)
-                throw new ArgumentNullException(nameof(capitalization.CapitalCamel), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.CapitalCamel to non-nullable JSON property 'CapitalCamel'.");
 
             if (capitalization.CapitalSnakeOption.IsSet && capitalization.CapitalSnake == null)
-                throw new ArgumentNullException(nameof(capitalization.CapitalSnake), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.CapitalSnake to non-nullable JSON property 'Capital_Snake'.");
 
             if (capitalization.SCAETHFlowPointsOption.IsSet && capitalization.SCAETHFlowPoints == null)
-                throw new ArgumentNullException(nameof(capitalization.SCAETHFlowPoints), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.SCAETHFlowPoints to non-nullable JSON property 'SCA_ETH_Flow_Points'.");
 
             if (capitalization.SmallCamelOption.IsSet && capitalization.SmallCamel == null)
-                throw new ArgumentNullException(nameof(capitalization.SmallCamel), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.SmallCamel to non-nullable JSON property 'smallCamel'.");
 
             if (capitalization.SmallSnakeOption.IsSet && capitalization.SmallSnake == null)
-                throw new ArgumentNullException(nameof(capitalization.SmallSnake), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.SmallSnake to non-nullable JSON property 'small_Snake'.");
 
             if (capitalization.ATT_NAMEOption.IsSet)
                 writer.WriteString("ATT_NAME", capitalization.ATT_NAME);

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Cat.cs
@@ -180,6 +180,9 @@ namespace Org.OpenAPITools.Model
             if (cat.ColorOption.IsSet && cat.Color == null)
                 throw new JsonException("Cannot write null property Cat.Color to non-nullable JSON property 'color'.");
 
+            if (cat.DeclawedOption.IsSet && cat.Declawed == null)
+                throw new JsonException("Cannot write null property Cat.Declawed to non-nullable JSON property 'declawed'.");
+
             writer.WriteString("className", cat.ClassName);
 
             if (cat.ColorOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Cat.cs
@@ -178,7 +178,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Cat cat, JsonSerializerOptions jsonSerializerOptions)
         {
             if (cat.ColorOption.IsSet && cat.Color == null)
-                throw new ArgumentNullException(nameof(cat.Color), "Property is required for class Cat.");
+                throw new JsonException("Cannot write null property Cat.Color to non-nullable JSON property 'color'.");
 
             writer.WriteString("className", cat.ClassName);
 

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Category.cs
@@ -187,9 +187,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Category category, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (category.Name == null)
-                throw new ArgumentNullException(nameof(category.Name), "Property is required for class Category.");
-
             if (category.IdOption.IsSet)
                 writer.WriteNumber("id", category.IdOption.Value!.Value);
 

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Category.cs
@@ -187,6 +187,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Category category, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (category.IdOption.IsSet && category.Id == null)
+                throw new JsonException("Cannot write null property Category.Id to non-nullable JSON property 'id'.");
+
             if (category.IdOption.IsSet)
                 writer.WriteNumber("id", category.IdOption.Value!.Value);
 

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -237,7 +237,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ChildCat childCat, JsonSerializerOptions jsonSerializerOptions)
         {
             if (childCat.NameOption.IsSet && childCat.Name == null)
-                throw new ArgumentNullException(nameof(childCat.Name), "Property is required for class ChildCat.");
+                throw new JsonException("Cannot write null property ChildCat.Name to non-nullable JSON property 'name'.");
 
             if (childCat.NameOption.IsSet)
                 writer.WriteString("name", childCat.Name);

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -169,7 +169,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ClassModel classModel, JsonSerializerOptions jsonSerializerOptions)
         {
             if (classModel.ClassOption.IsSet && classModel.Class == null)
-                throw new ArgumentNullException(nameof(classModel.Class), "Property is required for class ClassModel.");
+                throw new JsonException("Cannot write null property ClassModel.Class to non-nullable JSON property '_class'.");
 
             if (classModel.ClassOption.IsSet)
                 writer.WriteString("_class", classModel.Class);

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
@@ -183,12 +183,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ComplexQuadrilateral complexQuadrilateral, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (complexQuadrilateral.QuadrilateralType == null)
-                throw new ArgumentNullException(nameof(complexQuadrilateral.QuadrilateralType), "Property is required for class ComplexQuadrilateral.");
-
-            if (complexQuadrilateral.ShapeType == null)
-                throw new ArgumentNullException(nameof(complexQuadrilateral.ShapeType), "Property is required for class ComplexQuadrilateral.");
-
             writer.WriteString("quadrilateralType", complexQuadrilateral.QuadrilateralType);
 
             writer.WriteString("shapeType", complexQuadrilateral.ShapeType);

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/CopyActivity.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/CopyActivity.cs
@@ -232,9 +232,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, CopyActivity copyActivity, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (copyActivity.CopyActivitytt == null)
-                throw new ArgumentNullException(nameof(copyActivity.CopyActivitytt), "Property is required for class CopyActivity.");
-
             writer.WriteString("copyActivitytt", copyActivity.CopyActivitytt);
 
             writer.WriteString("$schema", CopyActivity.SchemaEnumToJsonValue(copyActivity.Schema));

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/DanishPig.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/DanishPig.cs
@@ -164,9 +164,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, DanishPig danishPig, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (danishPig.ClassName == null)
-                throw new ArgumentNullException(nameof(danishPig.ClassName), "Property is required for class DanishPig.");
-
             writer.WriteString("className", danishPig.ClassName);
         }
     }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -174,6 +174,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, DateOnlyClass dateOnlyClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (dateOnlyClass.DateOnlyPropertyOption.IsSet && dateOnlyClass.DateOnlyProperty == null)
+                throw new JsonException("Cannot write null property DateOnlyClass.DateOnlyProperty to non-nullable JSON property 'dateOnlyProperty'.");
+
             if (dateOnlyClass.DateOnlyPropertyOption.IsSet)
                 writer.WriteString("dateOnlyProperty", dateOnlyClass.DateOnlyPropertyOption.Value!.Value.ToString(DateOnlyPropertyFormat));
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -169,7 +169,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, DeprecatedObject deprecatedObject, JsonSerializerOptions jsonSerializerOptions)
         {
             if (deprecatedObject.NameOption.IsSet && deprecatedObject.Name == null)
-                throw new ArgumentNullException(nameof(deprecatedObject.Name), "Property is required for class DeprecatedObject.");
+                throw new JsonException("Cannot write null property DeprecatedObject.Name to non-nullable JSON property 'name'.");
 
             if (deprecatedObject.NameOption.IsSet)
                 writer.WriteString("name", deprecatedObject.Name);

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Descendant1.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Descendant1.cs
@@ -183,12 +183,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Descendant1 descendant1, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (descendant1.AlternativeName == null)
-                throw new ArgumentNullException(nameof(descendant1.AlternativeName), "Property is required for class Descendant1.");
-
-            if (descendant1.DescendantName == null)
-                throw new ArgumentNullException(nameof(descendant1.DescendantName), "Property is required for class Descendant1.");
-
             writer.WriteString("alternativeName", descendant1.AlternativeName);
 
             writer.WriteString("descendantName", descendant1.DescendantName);

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Descendant2.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Descendant2.cs
@@ -183,12 +183,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Descendant2 descendant2, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (descendant2.AlternativeName == null)
-                throw new ArgumentNullException(nameof(descendant2.AlternativeName), "Property is required for class Descendant2.");
-
-            if (descendant2.Confidentiality == null)
-                throw new ArgumentNullException(nameof(descendant2.Confidentiality), "Property is required for class Descendant2.");
-
             writer.WriteString("alternativeName", descendant2.AlternativeName);
 
             writer.WriteString("confidentiality", descendant2.Confidentiality);

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Dog.cs
@@ -178,10 +178,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Dog dog, JsonSerializerOptions jsonSerializerOptions)
         {
             if (dog.BreedOption.IsSet && dog.Breed == null)
-                throw new ArgumentNullException(nameof(dog.Breed), "Property is required for class Dog.");
+                throw new JsonException("Cannot write null property Dog.Breed to non-nullable JSON property 'breed'.");
 
             if (dog.ColorOption.IsSet && dog.Color == null)
-                throw new ArgumentNullException(nameof(dog.Color), "Property is required for class Dog.");
+                throw new JsonException("Cannot write null property Dog.Color to non-nullable JSON property 'color'.");
 
             writer.WriteString("className", dog.ClassName);
 

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Drawing.cs
@@ -239,10 +239,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Drawing drawing, JsonSerializerOptions jsonSerializerOptions)
         {
             if (drawing.MainShapeOption.IsSet && drawing.MainShape == null)
-                throw new ArgumentNullException(nameof(drawing.MainShape), "Property is required for class Drawing.");
+                throw new JsonException("Cannot write null property Drawing.MainShape to non-nullable JSON property 'mainShape'.");
 
             if (drawing.ShapesOption.IsSet && drawing.Shapes == null)
-                throw new ArgumentNullException(nameof(drawing.Shapes), "Property is required for class Drawing.");
+                throw new JsonException("Cannot write null property Drawing.Shapes to non-nullable JSON property 'shapes'.");
 
             if (drawing.MainShapeOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -333,6 +333,9 @@ namespace Org.OpenAPITools.Model
             if (enumArrays.ArrayEnumOption.IsSet && enumArrays.ArrayEnum == null)
                 throw new JsonException("Cannot write null property EnumArrays.ArrayEnum to non-nullable JSON property 'array_enum'.");
 
+            if (enumArrays.JustSymbolOption.IsSet && enumArrays.JustSymbol == null)
+                throw new JsonException("Cannot write null property EnumArrays.JustSymbol to non-nullable JSON property 'just_symbol'.");
+
             if (enumArrays.ArrayEnumOption.IsSet)
             {
                 writer.WritePropertyName("array_enum");

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -331,7 +331,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, EnumArrays enumArrays, JsonSerializerOptions jsonSerializerOptions)
         {
             if (enumArrays.ArrayEnumOption.IsSet && enumArrays.ArrayEnum == null)
-                throw new ArgumentNullException(nameof(enumArrays.ArrayEnum), "Property is required for class EnumArrays.");
+                throw new JsonException("Cannot write null property EnumArrays.ArrayEnum to non-nullable JSON property 'array_enum'.");
 
             if (enumArrays.ArrayEnumOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -869,6 +869,27 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, EnumTest enumTest, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (enumTest.EnumIntegerOption.IsSet && enumTest.EnumInteger == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumInteger to non-nullable JSON property 'enum_integer'.");
+
+            if (enumTest.EnumIntegerOnlyOption.IsSet && enumTest.EnumIntegerOnly == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumIntegerOnly to non-nullable JSON property 'enum_integer_only'.");
+
+            if (enumTest.EnumNumberOption.IsSet && enumTest.EnumNumber == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumNumber to non-nullable JSON property 'enum_number'.");
+
+            if (enumTest.EnumStringOption.IsSet && enumTest.EnumString == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumString to non-nullable JSON property 'enum_string'.");
+
+            if (enumTest.OuterEnumDefaultValueOption.IsSet && enumTest.OuterEnumDefaultValue == null)
+                throw new JsonException("Cannot write null property EnumTest.OuterEnumDefaultValue to non-nullable JSON property 'outerEnumDefaultValue'.");
+
+            if (enumTest.OuterEnumIntegerOption.IsSet && enumTest.OuterEnumInteger == null)
+                throw new JsonException("Cannot write null property EnumTest.OuterEnumInteger to non-nullable JSON property 'outerEnumInteger'.");
+
+            if (enumTest.OuterEnumIntegerDefaultValueOption.IsSet && enumTest.OuterEnumIntegerDefaultValue == null)
+                throw new JsonException("Cannot write null property EnumTest.OuterEnumIntegerDefaultValue to non-nullable JSON property 'outerEnumIntegerDefaultValue'.");
+
             var enumStringRequiredRawValue = EnumTest.EnumStringRequiredEnumToJsonValue(enumTest.EnumStringRequired);
             writer.WriteString("enum_string_required", enumStringRequiredRawValue);
             if (enumTest.EnumIntegerOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
@@ -183,12 +183,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, EquilateralTriangle equilateralTriangle, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (equilateralTriangle.ShapeType == null)
-                throw new ArgumentNullException(nameof(equilateralTriangle.ShapeType), "Property is required for class EquilateralTriangle.");
-
-            if (equilateralTriangle.TriangleType == null)
-                throw new ArgumentNullException(nameof(equilateralTriangle.TriangleType), "Property is required for class EquilateralTriangle.");
-
             writer.WriteString("shapeType", equilateralTriangle.ShapeType);
 
             writer.WriteString("triangleType", equilateralTriangle.TriangleType);

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/File.cs
@@ -170,7 +170,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, File file, JsonSerializerOptions jsonSerializerOptions)
         {
             if (file.SourceURIOption.IsSet && file.SourceURI == null)
-                throw new ArgumentNullException(nameof(file.SourceURI), "Property is required for class File.");
+                throw new JsonException("Cannot write null property File.SourceURI to non-nullable JSON property 'sourceURI'.");
 
             if (file.SourceURIOption.IsSet)
                 writer.WriteString("sourceURI", file.SourceURI);

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -192,10 +192,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, FileSchemaTestClass fileSchemaTestClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (fileSchemaTestClass.FileOption.IsSet && fileSchemaTestClass.File == null)
-                throw new ArgumentNullException(nameof(fileSchemaTestClass.File), "Property is required for class FileSchemaTestClass.");
+                throw new JsonException("Cannot write null property FileSchemaTestClass.File to non-nullable JSON property 'file'.");
 
             if (fileSchemaTestClass.FilesOption.IsSet && fileSchemaTestClass.Files == null)
-                throw new ArgumentNullException(nameof(fileSchemaTestClass.Files), "Property is required for class FileSchemaTestClass.");
+                throw new JsonException("Cannot write null property FileSchemaTestClass.Files to non-nullable JSON property 'files'.");
 
             if (fileSchemaTestClass.FileOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Foo.cs
@@ -169,7 +169,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Foo foo, JsonSerializerOptions jsonSerializerOptions)
         {
             if (foo.BarOption.IsSet && foo.Bar == null)
-                throw new ArgumentNullException(nameof(foo.Bar), "Property is required for class Foo.");
+                throw new JsonException("Cannot write null property Foo.Bar to non-nullable JSON property 'bar'.");
 
             if (foo.BarOption.IsSet)
                 writer.WriteString("bar", foo.Bar);

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -169,7 +169,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, FooGetDefaultResponse fooGetDefaultResponse, JsonSerializerOptions jsonSerializerOptions)
         {
             if (fooGetDefaultResponse.StringOption.IsSet && fooGetDefaultResponse.String == null)
-                throw new ArgumentNullException(nameof(fooGetDefaultResponse.String), "Property is required for class FooGetDefaultResponse.");
+                throw new JsonException("Cannot write null property FooGetDefaultResponse.String to non-nullable JSON property 'string'.");
 
             if (fooGetDefaultResponse.StringOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -945,32 +945,26 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, FormatTest formatTest, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (formatTest.Byte == null)
-                throw new ArgumentNullException(nameof(formatTest.Byte), "Property is required for class FormatTest.");
-
-            if (formatTest.Password == null)
-                throw new ArgumentNullException(nameof(formatTest.Password), "Property is required for class FormatTest.");
-
             if (formatTest.BinaryOption.IsSet && formatTest.Binary == null)
-                throw new ArgumentNullException(nameof(formatTest.Binary), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.Binary to non-nullable JSON property 'binary'.");
 
             if (formatTest.DuplicatePropertyName2Option.IsSet && formatTest.DuplicatePropertyName2 == null)
-                throw new ArgumentNullException(nameof(formatTest.DuplicatePropertyName2), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName2 to non-nullable JSON property 'duplicate_property_name'.");
 
             if (formatTest.DuplicatePropertyNameOption.IsSet && formatTest.DuplicatePropertyName == null)
-                throw new ArgumentNullException(nameof(formatTest.DuplicatePropertyName), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName to non-nullable JSON property '@duplicate_property_name'.");
 
             if (formatTest.PatternWithBackslashOption.IsSet && formatTest.PatternWithBackslash == null)
-                throw new ArgumentNullException(nameof(formatTest.PatternWithBackslash), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.PatternWithBackslash to non-nullable JSON property 'pattern_with_backslash'.");
 
             if (formatTest.PatternWithDigitsOption.IsSet && formatTest.PatternWithDigits == null)
-                throw new ArgumentNullException(nameof(formatTest.PatternWithDigits), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.PatternWithDigits to non-nullable JSON property 'pattern_with_digits'.");
 
             if (formatTest.PatternWithDigitsAndDelimiterOption.IsSet && formatTest.PatternWithDigitsAndDelimiter == null)
-                throw new ArgumentNullException(nameof(formatTest.PatternWithDigitsAndDelimiter), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.PatternWithDigitsAndDelimiter to non-nullable JSON property 'pattern_with_digits_and_delimiter'.");
 
             if (formatTest.StringOption.IsSet && formatTest.String == null)
-                throw new ArgumentNullException(nameof(formatTest.String), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.String to non-nullable JSON property 'string'.");
 
             writer.WritePropertyName("byte");
             JsonSerializer.Serialize(writer, formatTest.Byte, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -948,11 +948,47 @@ namespace Org.OpenAPITools.Model
             if (formatTest.BinaryOption.IsSet && formatTest.Binary == null)
                 throw new JsonException("Cannot write null property FormatTest.Binary to non-nullable JSON property 'binary'.");
 
+            if (formatTest.DateTimeOption.IsSet && formatTest.DateTime == null)
+                throw new JsonException("Cannot write null property FormatTest.DateTime to non-nullable JSON property 'dateTime'.");
+
+            if (formatTest.DecimalOption.IsSet && formatTest.Decimal == null)
+                throw new JsonException("Cannot write null property FormatTest.Decimal to non-nullable JSON property 'decimal'.");
+
+            if (formatTest.DoubleOption.IsSet && formatTest.Double == null)
+                throw new JsonException("Cannot write null property FormatTest.Double to non-nullable JSON property 'double'.");
+
             if (formatTest.DuplicatePropertyName2Option.IsSet && formatTest.DuplicatePropertyName2 == null)
                 throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName2 to non-nullable JSON property 'duplicate_property_name'.");
 
             if (formatTest.DuplicatePropertyNameOption.IsSet && formatTest.DuplicatePropertyName == null)
                 throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName to non-nullable JSON property '@duplicate_property_name'.");
+
+            if (formatTest.FloatOption.IsSet && formatTest.Float == null)
+                throw new JsonException("Cannot write null property FormatTest.Float to non-nullable JSON property 'float'.");
+
+            if (formatTest.Int32Option.IsSet && formatTest.Int32 == null)
+                throw new JsonException("Cannot write null property FormatTest.Int32 to non-nullable JSON property 'int32'.");
+
+            if (formatTest.Int32RangeOption.IsSet && formatTest.Int32Range == null)
+                throw new JsonException("Cannot write null property FormatTest.Int32Range to non-nullable JSON property 'int32Range'.");
+
+            if (formatTest.Int64Option.IsSet && formatTest.Int64 == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64 to non-nullable JSON property 'int64'.");
+
+            if (formatTest.Int64NegativeOption.IsSet && formatTest.Int64Negative == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64Negative to non-nullable JSON property 'int64Negative'.");
+
+            if (formatTest.Int64NegativeExclusiveOption.IsSet && formatTest.Int64NegativeExclusive == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64NegativeExclusive to non-nullable JSON property 'int64NegativeExclusive'.");
+
+            if (formatTest.Int64PositiveOption.IsSet && formatTest.Int64Positive == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64Positive to non-nullable JSON property 'int64Positive'.");
+
+            if (formatTest.Int64PositiveExclusiveOption.IsSet && formatTest.Int64PositiveExclusive == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64PositiveExclusive to non-nullable JSON property 'int64PositiveExclusive'.");
+
+            if (formatTest.IntegerOption.IsSet && formatTest.Integer == null)
+                throw new JsonException("Cannot write null property FormatTest.Integer to non-nullable JSON property 'integer'.");
 
             if (formatTest.PatternWithBackslashOption.IsSet && formatTest.PatternWithBackslash == null)
                 throw new JsonException("Cannot write null property FormatTest.PatternWithBackslash to non-nullable JSON property 'pattern_with_backslash'.");
@@ -965,6 +1001,18 @@ namespace Org.OpenAPITools.Model
 
             if (formatTest.StringOption.IsSet && formatTest.String == null)
                 throw new JsonException("Cannot write null property FormatTest.String to non-nullable JSON property 'string'.");
+
+            if (formatTest.StringFormattedAsDecimalOption.IsSet && formatTest.StringFormattedAsDecimal == null)
+                throw new JsonException("Cannot write null property FormatTest.StringFormattedAsDecimal to non-nullable JSON property 'string_formatted_as_decimal'.");
+
+            if (formatTest.UnsignedIntegerOption.IsSet && formatTest.UnsignedInteger == null)
+                throw new JsonException("Cannot write null property FormatTest.UnsignedInteger to non-nullable JSON property 'unsigned_integer'.");
+
+            if (formatTest.UnsignedLongOption.IsSet && formatTest.UnsignedLong == null)
+                throw new JsonException("Cannot write null property FormatTest.UnsignedLong to non-nullable JSON property 'unsigned_long'.");
+
+            if (formatTest.UuidOption.IsSet && formatTest.Uuid == null)
+                throw new JsonException("Cannot write null property FormatTest.Uuid to non-nullable JSON property 'uuid'.");
 
             writer.WritePropertyName("byte");
             JsonSerializer.Serialize(writer, formatTest.Byte, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Fruit.cs
@@ -220,7 +220,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Fruit fruit, JsonSerializerOptions jsonSerializerOptions)
         {
             if (fruit.ColorOption.IsSet && fruit.Color == null)
-                throw new ArgumentNullException(nameof(fruit.Color), "Property is required for class Fruit.");
+                throw new JsonException("Cannot write null property Fruit.Color to non-nullable JSON property 'color'.");
 
             if (fruit.ColorOption.IsSet)
                 writer.WriteString("color", fruit.Color);

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -237,7 +237,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, GmFruit gmFruit, JsonSerializerOptions jsonSerializerOptions)
         {
             if (gmFruit.ColorOption.IsSet && gmFruit.Color == null)
-                throw new ArgumentNullException(nameof(gmFruit.Color), "Property is required for class GmFruit.");
+                throw new JsonException("Cannot write null property GmFruit.Color to non-nullable JSON property 'color'.");
 
             if (gmFruit.ColorOption.IsSet)
                 writer.WriteString("color", gmFruit.Color);

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -192,10 +192,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, HasOnlyReadOnly hasOnlyReadOnly, JsonSerializerOptions jsonSerializerOptions)
         {
             if (hasOnlyReadOnly.BarOption.IsSet && hasOnlyReadOnly.Bar == null)
-                throw new ArgumentNullException(nameof(hasOnlyReadOnly.Bar), "Property is required for class HasOnlyReadOnly.");
+                throw new JsonException("Cannot write null property HasOnlyReadOnly.Bar to non-nullable JSON property 'bar'.");
 
             if (hasOnlyReadOnly.FooOption.IsSet && hasOnlyReadOnly.Foo == null)
-                throw new ArgumentNullException(nameof(hasOnlyReadOnly.Foo), "Property is required for class HasOnlyReadOnly.");
+                throw new JsonException("Cannot write null property HasOnlyReadOnly.Foo to non-nullable JSON property 'foo'.");
 
             if (hasOnlyReadOnly.BarOption.IsSet)
                 writer.WriteString("bar", hasOnlyReadOnly.Bar);

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
@@ -284,22 +284,22 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, InjectedVendorExtensionsTest injectedVendorExtensionsTest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessorOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor to non-nullable JSON property 'potentiallyOverriddenPropertyAccessor'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternalOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternal == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternal), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternal to non-nullable JSON property 'potentiallyOverriddenPropertyToInternal'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivateOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivate == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivate), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivate to non-nullable JSON property 'potentiallyOverriddenPropertyToPrivate'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublicOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublic == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublic), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublic to non-nullable JSON property 'potentiallyOverriddenPropertyToPublic'.");
 
             if (injectedVendorExtensionsTest.UnalteredPropertyOption.IsSet && injectedVendorExtensionsTest.UnalteredProperty == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.UnalteredProperty), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.UnalteredProperty to non-nullable JSON property 'unalteredProperty'.");
 
             if (injectedVendorExtensionsTest.UnalteredPropertyAccessorOption.IsSet && injectedVendorExtensionsTest.UnalteredPropertyAccessor == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.UnalteredPropertyAccessor), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.UnalteredPropertyAccessor to non-nullable JSON property 'unalteredPropertyAccessor'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessorOption.IsSet)
                 writer.WriteString("potentiallyOverriddenPropertyAccessor", injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor);

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
@@ -183,12 +183,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, IsoscelesTriangle isoscelesTriangle, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (isoscelesTriangle.ShapeType == null)
-                throw new ArgumentNullException(nameof(isoscelesTriangle.ShapeType), "Property is required for class IsoscelesTriangle.");
-
-            if (isoscelesTriangle.TriangleType == null)
-                throw new ArgumentNullException(nameof(isoscelesTriangle.TriangleType), "Property is required for class IsoscelesTriangle.");
-
             writer.WriteString("shapeType", isoscelesTriangle.ShapeType);
 
             writer.WriteString("triangleType", isoscelesTriangle.TriangleType);

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/List.cs
@@ -169,7 +169,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, List list, JsonSerializerOptions jsonSerializerOptions)
         {
             if (list.Var123ListOption.IsSet && list.Var123List == null)
-                throw new ArgumentNullException(nameof(list.Var123List), "Property is required for class List.");
+                throw new JsonException("Cannot write null property List.Var123List to non-nullable JSON property '123-list'.");
 
             if (list.Var123ListOption.IsSet)
                 writer.WriteString("123-list", list.Var123List);

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -192,10 +192,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, LiteralStringClass literalStringClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (literalStringClass.EscapedLiteralStringOption.IsSet && literalStringClass.EscapedLiteralString == null)
-                throw new ArgumentNullException(nameof(literalStringClass.EscapedLiteralString), "Property is required for class LiteralStringClass.");
+                throw new JsonException("Cannot write null property LiteralStringClass.EscapedLiteralString to non-nullable JSON property 'escapedLiteralString'.");
 
             if (literalStringClass.UnescapedLiteralStringOption.IsSet && literalStringClass.UnescapedLiteralString == null)
-                throw new ArgumentNullException(nameof(literalStringClass.UnescapedLiteralString), "Property is required for class LiteralStringClass.");
+                throw new JsonException("Cannot write null property LiteralStringClass.UnescapedLiteralString to non-nullable JSON property 'unescapedLiteralString'.");
 
             if (literalStringClass.EscapedLiteralStringOption.IsSet)
                 writer.WriteString("escapedLiteralString", literalStringClass.EscapedLiteralString);

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/MapTest.cs
@@ -304,16 +304,16 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MapTest mapTest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mapTest.DirectMapOption.IsSet && mapTest.DirectMap == null)
-                throw new ArgumentNullException(nameof(mapTest.DirectMap), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.DirectMap to non-nullable JSON property 'direct_map'.");
 
             if (mapTest.IndirectMapOption.IsSet && mapTest.IndirectMap == null)
-                throw new ArgumentNullException(nameof(mapTest.IndirectMap), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.IndirectMap to non-nullable JSON property 'indirect_map'.");
 
             if (mapTest.MapMapOfStringOption.IsSet && mapTest.MapMapOfString == null)
-                throw new ArgumentNullException(nameof(mapTest.MapMapOfString), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.MapMapOfString to non-nullable JSON property 'map_map_of_string'.");
 
             if (mapTest.MapOfEnumStringOption.IsSet && mapTest.MapOfEnumString == null)
-                throw new ArgumentNullException(nameof(mapTest.MapOfEnumString), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.MapOfEnumString to non-nullable JSON property 'map_of_enum_string'.");
 
             if (mapTest.DirectMapOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/MixedAnyOf.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/MixedAnyOf.cs
@@ -169,7 +169,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedAnyOf mixedAnyOf, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedAnyOf.ContentOption.IsSet && mixedAnyOf.Content == null)
-                throw new ArgumentNullException(nameof(mixedAnyOf.Content), "Property is required for class MixedAnyOf.");
+                throw new JsonException("Cannot write null property MixedAnyOf.Content to non-nullable JSON property 'content'.");
 
             if (mixedAnyOf.ContentOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/MixedOneOf.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/MixedOneOf.cs
@@ -169,7 +169,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedOneOf mixedOneOf, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedOneOf.ContentOption.IsSet && mixedOneOf.Content == null)
-                throw new ArgumentNullException(nameof(mixedOneOf.Content), "Property is required for class MixedOneOf.");
+                throw new JsonException("Cannot write null property MixedOneOf.Content to non-nullable JSON property 'content'.");
 
             if (mixedOneOf.ContentOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -249,8 +249,17 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, MixedPropertiesAndAdditionalPropertiesClass mixedPropertiesAndAdditionalPropertiesClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.DateTime == null)
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.DateTime to non-nullable JSON property 'dateTime'.");
+
             if (mixedPropertiesAndAdditionalPropertiesClass.MapOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.Map == null)
                 throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.Map to non-nullable JSON property 'map'.");
+
+            if (mixedPropertiesAndAdditionalPropertiesClass.UuidOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.Uuid == null)
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.Uuid to non-nullable JSON property 'uuid'.");
+
+            if (mixedPropertiesAndAdditionalPropertiesClass.UuidWithPatternOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.UuidWithPattern == null)
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.UuidWithPattern to non-nullable JSON property 'uuid_with_pattern'.");
 
             if (mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.IsSet)
                 writer.WriteString("dateTime", mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.Value!.Value.ToString(DateTimeFormat));

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -250,7 +250,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedPropertiesAndAdditionalPropertiesClass mixedPropertiesAndAdditionalPropertiesClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedPropertiesAndAdditionalPropertiesClass.MapOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.Map == null)
-                throw new ArgumentNullException(nameof(mixedPropertiesAndAdditionalPropertiesClass.Map), "Property is required for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.Map to non-nullable JSON property 'map'.");
 
             if (mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.IsSet)
                 writer.WriteString("dateTime", mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.Value!.Value.ToString(DateTimeFormat));

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/MixedSubId.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/MixedSubId.cs
@@ -169,7 +169,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedSubId mixedSubId, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedSubId.IdOption.IsSet && mixedSubId.Id == null)
-                throw new ArgumentNullException(nameof(mixedSubId.Id), "Property is required for class MixedSubId.");
+                throw new JsonException("Cannot write null property MixedSubId.Id to non-nullable JSON property 'id'.");
 
             if (mixedSubId.IdOption.IsSet)
                 writer.WriteString("id", mixedSubId.Id);

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -192,7 +192,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Model200Response model200Response, JsonSerializerOptions jsonSerializerOptions)
         {
             if (model200Response.ClassOption.IsSet && model200Response.Class == null)
-                throw new ArgumentNullException(nameof(model200Response.Class), "Property is required for class Model200Response.");
+                throw new JsonException("Cannot write null property Model200Response.Class to non-nullable JSON property 'class'.");
 
             if (model200Response.ClassOption.IsSet)
                 writer.WriteString("class", model200Response.Class);

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -194,6 +194,9 @@ namespace Org.OpenAPITools.Model
             if (model200Response.ClassOption.IsSet && model200Response.Class == null)
                 throw new JsonException("Cannot write null property Model200Response.Class to non-nullable JSON property 'class'.");
 
+            if (model200Response.NameOption.IsSet && model200Response.Name == null)
+                throw new JsonException("Cannot write null property Model200Response.Name to non-nullable JSON property 'name'.");
+
             if (model200Response.ClassOption.IsSet)
                 writer.WriteString("class", model200Response.Class);
 

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -169,7 +169,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ModelClient modelClient, JsonSerializerOptions jsonSerializerOptions)
         {
             if (modelClient.VarClientOption.IsSet && modelClient.VarClient == null)
-                throw new ArgumentNullException(nameof(modelClient.VarClient), "Property is required for class ModelClient.");
+                throw new JsonException("Cannot write null property ModelClient.VarClient to non-nullable JSON property 'client'.");
 
             if (modelClient.VarClientOption.IsSet)
                 writer.WriteString("client", modelClient.VarClient);

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Name.cs
@@ -234,7 +234,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Name name, JsonSerializerOptions jsonSerializerOptions)
         {
             if (name.PropertyOption.IsSet && name.Property == null)
-                throw new ArgumentNullException(nameof(name.Property), "Property is required for class Name.");
+                throw new JsonException("Cannot write null property Name.Property to non-nullable JSON property 'property'.");
 
             writer.WriteNumber("name", name.VarName);
 

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Name.cs
@@ -236,6 +236,12 @@ namespace Org.OpenAPITools.Model
             if (name.PropertyOption.IsSet && name.Property == null)
                 throw new JsonException("Cannot write null property Name.Property to non-nullable JSON property 'property'.");
 
+            if (name.SnakeCaseOption.IsSet && name.SnakeCase == null)
+                throw new JsonException("Cannot write null property Name.SnakeCase to non-nullable JSON property 'snake_case'.");
+
+            if (name.Var123NumberOption.IsSet && name.Var123Number == null)
+                throw new JsonException("Cannot write null property Name.Var123Number to non-nullable JSON property '123Number'.");
+
             writer.WriteNumber("name", name.VarName);
 
             if (name.PropertyOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
@@ -183,9 +183,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, NotificationtestGetElementsV1ResponseMPayload notificationtestGetElementsV1ResponseMPayload, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (notificationtestGetElementsV1ResponseMPayload.AObjVariableobject == null)
-                throw new ArgumentNullException(nameof(notificationtestGetElementsV1ResponseMPayload.AObjVariableobject), "Property is required for class NotificationtestGetElementsV1ResponseMPayload.");
-
             writer.WritePropertyName("a_objVariableobject");
             JsonSerializer.Serialize(writer, notificationtestGetElementsV1ResponseMPayload.AObjVariableobject, jsonSerializerOptions);
             writer.WriteNumber("pkiNotificationtestID", notificationtestGetElementsV1ResponseMPayload.PkiNotificationtestID);

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -409,10 +409,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, NullableClass nullableClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (nullableClass.ArrayItemsNullableOption.IsSet && nullableClass.ArrayItemsNullable == null)
-                throw new ArgumentNullException(nameof(nullableClass.ArrayItemsNullable), "Property is required for class NullableClass.");
+                throw new JsonException("Cannot write null property NullableClass.ArrayItemsNullable to non-nullable JSON property 'array_items_nullable'.");
 
             if (nullableClass.ObjectItemsNullableOption.IsSet && nullableClass.ObjectItemsNullable == null)
-                throw new ArgumentNullException(nameof(nullableClass.ObjectItemsNullable), "Property is required for class NullableClass.");
+                throw new JsonException("Cannot write null property NullableClass.ObjectItemsNullable to non-nullable JSON property 'object_items_nullable'.");
 
             if (nullableClass.ArrayAndItemsNullablePropOption.IsSet)
                 if (nullableClass.ArrayAndItemsNullablePropOption.Value != null)

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -168,6 +168,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, NumberOnly numberOnly, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (numberOnly.JustNumberOption.IsSet && numberOnly.JustNumber == null)
+                throw new JsonException("Cannot write null property NumberOnly.JustNumber to non-nullable JSON property 'JustNumber'.");
+
             if (numberOnly.JustNumberOption.IsSet)
                 writer.WriteNumber("JustNumber", numberOnly.JustNumberOption.Value!.Value);
         }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -241,13 +241,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ObjectWithDeprecatedFields objectWithDeprecatedFields, JsonSerializerOptions jsonSerializerOptions)
         {
             if (objectWithDeprecatedFields.BarsOption.IsSet && objectWithDeprecatedFields.Bars == null)
-                throw new ArgumentNullException(nameof(objectWithDeprecatedFields.Bars), "Property is required for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Bars to non-nullable JSON property 'bars'.");
 
             if (objectWithDeprecatedFields.DeprecatedRefOption.IsSet && objectWithDeprecatedFields.DeprecatedRef == null)
-                throw new ArgumentNullException(nameof(objectWithDeprecatedFields.DeprecatedRef), "Property is required for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.DeprecatedRef to non-nullable JSON property 'deprecatedRef'.");
 
             if (objectWithDeprecatedFields.UuidOption.IsSet && objectWithDeprecatedFields.Uuid == null)
-                throw new ArgumentNullException(nameof(objectWithDeprecatedFields.Uuid), "Property is required for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Uuid to non-nullable JSON property 'uuid'.");
 
             if (objectWithDeprecatedFields.BarsOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -246,6 +246,9 @@ namespace Org.OpenAPITools.Model
             if (objectWithDeprecatedFields.DeprecatedRefOption.IsSet && objectWithDeprecatedFields.DeprecatedRef == null)
                 throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.DeprecatedRef to non-nullable JSON property 'deprecatedRef'.");
 
+            if (objectWithDeprecatedFields.IdOption.IsSet && objectWithDeprecatedFields.Id == null)
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Id to non-nullable JSON property 'id'.");
+
             if (objectWithDeprecatedFields.UuidOption.IsSet && objectWithDeprecatedFields.Uuid == null)
                 throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Uuid to non-nullable JSON property 'uuid'.");
 

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Order.cs
@@ -378,6 +378,24 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Order order, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (order.CompleteOption.IsSet && order.Complete == null)
+                throw new JsonException("Cannot write null property Order.Complete to non-nullable JSON property 'complete'.");
+
+            if (order.IdOption.IsSet && order.Id == null)
+                throw new JsonException("Cannot write null property Order.Id to non-nullable JSON property 'id'.");
+
+            if (order.PetIdOption.IsSet && order.PetId == null)
+                throw new JsonException("Cannot write null property Order.PetId to non-nullable JSON property 'petId'.");
+
+            if (order.QuantityOption.IsSet && order.Quantity == null)
+                throw new JsonException("Cannot write null property Order.Quantity to non-nullable JSON property 'quantity'.");
+
+            if (order.ShipDateOption.IsSet && order.ShipDate == null)
+                throw new JsonException("Cannot write null property Order.ShipDate to non-nullable JSON property 'shipDate'.");
+
+            if (order.StatusOption.IsSet && order.Status == null)
+                throw new JsonException("Cannot write null property Order.Status to non-nullable JSON property 'status'.");
+
             if (order.CompleteOption.IsSet)
                 writer.WriteBoolean("complete", order.CompleteOption.Value!.Value);
 

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -215,7 +215,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, OuterComposite outerComposite, JsonSerializerOptions jsonSerializerOptions)
         {
             if (outerComposite.MyStringOption.IsSet && outerComposite.MyString == null)
-                throw new ArgumentNullException(nameof(outerComposite.MyString), "Property is required for class OuterComposite.");
+                throw new JsonException("Cannot write null property OuterComposite.MyString to non-nullable JSON property 'my_string'.");
 
             if (outerComposite.MyBooleanOption.IsSet)
                 writer.WriteBoolean("my_boolean", outerComposite.MyBooleanOption.Value!.Value);

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -214,6 +214,12 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, OuterComposite outerComposite, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (outerComposite.MyBooleanOption.IsSet && outerComposite.MyBoolean == null)
+                throw new JsonException("Cannot write null property OuterComposite.MyBoolean to non-nullable JSON property 'my_boolean'.");
+
+            if (outerComposite.MyNumberOption.IsSet && outerComposite.MyNumber == null)
+                throw new JsonException("Cannot write null property OuterComposite.MyNumber to non-nullable JSON property 'my_number'.");
+
             if (outerComposite.MyStringOption.IsSet && outerComposite.MyString == null)
                 throw new JsonException("Cannot write null property OuterComposite.MyString to non-nullable JSON property 'my_string'.");
 

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Pet.cs
@@ -368,6 +368,12 @@ namespace Org.OpenAPITools.Model
             if (pet.CategoryOption.IsSet && pet.Category == null)
                 throw new JsonException("Cannot write null property Pet.Category to non-nullable JSON property 'category'.");
 
+            if (pet.IdOption.IsSet && pet.Id == null)
+                throw new JsonException("Cannot write null property Pet.Id to non-nullable JSON property 'id'.");
+
+            if (pet.StatusOption.IsSet && pet.Status == null)
+                throw new JsonException("Cannot write null property Pet.Status to non-nullable JSON property 'status'.");
+
             if (pet.TagsOption.IsSet && pet.Tags == null)
                 throw new JsonException("Cannot write null property Pet.Tags to non-nullable JSON property 'tags'.");
 

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Pet.cs
@@ -365,17 +365,11 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Pet pet, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (pet.Name == null)
-                throw new ArgumentNullException(nameof(pet.Name), "Property is required for class Pet.");
-
-            if (pet.PhotoUrls == null)
-                throw new ArgumentNullException(nameof(pet.PhotoUrls), "Property is required for class Pet.");
-
             if (pet.CategoryOption.IsSet && pet.Category == null)
-                throw new ArgumentNullException(nameof(pet.Category), "Property is required for class Pet.");
+                throw new JsonException("Cannot write null property Pet.Category to non-nullable JSON property 'category'.");
 
             if (pet.TagsOption.IsSet && pet.Tags == null)
-                throw new ArgumentNullException(nameof(pet.Tags), "Property is required for class Pet.");
+                throw new JsonException("Cannot write null property Pet.Tags to non-nullable JSON property 'tags'.");
 
             writer.WriteString("name", pet.Name);
 

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
@@ -164,9 +164,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, QuadrilateralInterface quadrilateralInterface, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (quadrilateralInterface.QuadrilateralType == null)
-                throw new ArgumentNullException(nameof(quadrilateralInterface.QuadrilateralType), "Property is required for class QuadrilateralInterface.");
-
             writer.WriteString("quadrilateralType", quadrilateralInterface.QuadrilateralType);
         }
     }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -192,10 +192,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ReadOnlyFirst readOnlyFirst, JsonSerializerOptions jsonSerializerOptions)
         {
             if (readOnlyFirst.BarOption.IsSet && readOnlyFirst.Bar == null)
-                throw new ArgumentNullException(nameof(readOnlyFirst.Bar), "Property is required for class ReadOnlyFirst.");
+                throw new JsonException("Cannot write null property ReadOnlyFirst.Bar to non-nullable JSON property 'bar'.");
 
             if (readOnlyFirst.BazOption.IsSet && readOnlyFirst.Baz == null)
-                throw new ArgumentNullException(nameof(readOnlyFirst.Baz), "Property is required for class ReadOnlyFirst.");
+                throw new JsonException("Cannot write null property ReadOnlyFirst.Baz to non-nullable JSON property 'baz'.");
 
             if (readOnlyFirst.BarOption.IsSet)
                 writer.WriteString("bar", readOnlyFirst.Bar);

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -2229,17 +2229,11 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, RequiredClass requiredClass, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (requiredClass.RequiredNotnullableArrayOfString == null)
-                throw new ArgumentNullException(nameof(requiredClass.RequiredNotnullableArrayOfString), "Property is required for class RequiredClass.");
-
-            if (requiredClass.RequiredNotnullableStringProp == null)
-                throw new ArgumentNullException(nameof(requiredClass.RequiredNotnullableStringProp), "Property is required for class RequiredClass.");
-
             if (requiredClass.NotrequiredNotnullableArrayOfStringOption.IsSet && requiredClass.NotrequiredNotnullableArrayOfString == null)
-                throw new ArgumentNullException(nameof(requiredClass.NotrequiredNotnullableArrayOfString), "Property is required for class RequiredClass.");
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableArrayOfString to non-nullable JSON property 'notrequired_notnullable_array_of_string'.");
 
             if (requiredClass.NotrequiredNotnullableStringPropOption.IsSet && requiredClass.NotrequiredNotnullableStringProp == null)
-                throw new ArgumentNullException(nameof(requiredClass.NotrequiredNotnullableStringProp), "Property is required for class RequiredClass.");
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableStringProp to non-nullable JSON property 'notrequired_notnullable_string_prop'.");
 
             writer.WriteString("required_not_nullable_date_prop", requiredClass.RequiredNotNullableDateProp.ToString(RequiredNotNullableDatePropFormat));
 

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -2229,11 +2229,38 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, RequiredClass requiredClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (requiredClass.NotRequiredNotnullableDatePropOption.IsSet && requiredClass.NotRequiredNotnullableDateProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotRequiredNotnullableDateProp to non-nullable JSON property 'not_required_notnullable_date_prop'.");
+
+            if (requiredClass.NotRequiredNotnullableintegerPropOption.IsSet && requiredClass.NotRequiredNotnullableintegerProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotRequiredNotnullableintegerProp to non-nullable JSON property 'not_required_notnullableinteger_prop'.");
+
             if (requiredClass.NotrequiredNotnullableArrayOfStringOption.IsSet && requiredClass.NotrequiredNotnullableArrayOfString == null)
                 throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableArrayOfString to non-nullable JSON property 'notrequired_notnullable_array_of_string'.");
 
+            if (requiredClass.NotrequiredNotnullableBooleanPropOption.IsSet && requiredClass.NotrequiredNotnullableBooleanProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableBooleanProp to non-nullable JSON property 'notrequired_notnullable_boolean_prop'.");
+
+            if (requiredClass.NotrequiredNotnullableDatetimePropOption.IsSet && requiredClass.NotrequiredNotnullableDatetimeProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableDatetimeProp to non-nullable JSON property 'notrequired_notnullable_datetime_prop'.");
+
+            if (requiredClass.NotrequiredNotnullableEnumIntegerOption.IsSet && requiredClass.NotrequiredNotnullableEnumInteger == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableEnumInteger to non-nullable JSON property 'notrequired_notnullable_enum_integer'.");
+
+            if (requiredClass.NotrequiredNotnullableEnumIntegerOnlyOption.IsSet && requiredClass.NotrequiredNotnullableEnumIntegerOnly == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableEnumIntegerOnly to non-nullable JSON property 'notrequired_notnullable_enum_integer_only'.");
+
+            if (requiredClass.NotrequiredNotnullableEnumStringOption.IsSet && requiredClass.NotrequiredNotnullableEnumString == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableEnumString to non-nullable JSON property 'notrequired_notnullable_enum_string'.");
+
+            if (requiredClass.NotrequiredNotnullableOuterEnumDefaultValueOption.IsSet && requiredClass.NotrequiredNotnullableOuterEnumDefaultValue == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableOuterEnumDefaultValue to non-nullable JSON property 'notrequired_notnullable_outerEnumDefaultValue'.");
+
             if (requiredClass.NotrequiredNotnullableStringPropOption.IsSet && requiredClass.NotrequiredNotnullableStringProp == null)
                 throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableStringProp to non-nullable JSON property 'notrequired_notnullable_string_prop'.");
+
+            if (requiredClass.NotrequiredNotnullableUuidOption.IsSet && requiredClass.NotrequiredNotnullableUuid == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableUuid to non-nullable JSON property 'notrequired_notnullable_uuid'.");
 
             writer.WriteString("required_not_nullable_date_prop", requiredClass.RequiredNotNullableDateProp.ToString(RequiredNotNullableDatePropFormat));
 

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Result.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Result.cs
@@ -218,13 +218,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Result result, JsonSerializerOptions jsonSerializerOptions)
         {
             if (result.CodeOption.IsSet && result.Code == null)
-                throw new ArgumentNullException(nameof(result.Code), "Property is required for class Result.");
+                throw new JsonException("Cannot write null property Result.Code to non-nullable JSON property 'code'.");
 
             if (result.DataOption.IsSet && result.Data == null)
-                throw new ArgumentNullException(nameof(result.Data), "Property is required for class Result.");
+                throw new JsonException("Cannot write null property Result.Data to non-nullable JSON property 'data'.");
 
             if (result.UuidOption.IsSet && result.Uuid == null)
-                throw new ArgumentNullException(nameof(result.Uuid), "Property is required for class Result.");
+                throw new JsonException("Cannot write null property Result.Uuid to non-nullable JSON property 'uuid'.");
 
             if (result.CodeOption.IsSet)
                 writer.WriteString("code", result.Code);

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Return.cs
@@ -226,11 +226,8 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Return varReturn, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (varReturn.Lock == null)
-                throw new ArgumentNullException(nameof(varReturn.Lock), "Property is required for class Return.");
-
             if (varReturn.UnsafeOption.IsSet && varReturn.Unsafe == null)
-                throw new ArgumentNullException(nameof(varReturn.Unsafe), "Property is required for class Return.");
+                throw new JsonException("Cannot write null property Return.Unsafe to non-nullable JSON property 'unsafe'.");
 
             writer.WriteString("lock", varReturn.Lock);
 

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Return.cs
@@ -226,6 +226,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Return varReturn, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (varReturn.VarReturnOption.IsSet && varReturn.VarReturn == null)
+                throw new JsonException("Cannot write null property Return.VarReturn to non-nullable JSON property 'return'.");
+
             if (varReturn.UnsafeOption.IsSet && varReturn.Unsafe == null)
                 throw new JsonException("Cannot write null property Return.Unsafe to non-nullable JSON property 'unsafe'.");
 

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -194,6 +194,9 @@ namespace Org.OpenAPITools.Model
             if (rolesReportsHash.RoleOption.IsSet && rolesReportsHash.Role == null)
                 throw new JsonException("Cannot write null property RolesReportsHash.Role to non-nullable JSON property 'role'.");
 
+            if (rolesReportsHash.RoleUuidOption.IsSet && rolesReportsHash.RoleUuid == null)
+                throw new JsonException("Cannot write null property RolesReportsHash.RoleUuid to non-nullable JSON property 'role_uuid'.");
+
             if (rolesReportsHash.RoleOption.IsSet)
             {
                 writer.WritePropertyName("role");

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -192,7 +192,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, RolesReportsHash rolesReportsHash, JsonSerializerOptions jsonSerializerOptions)
         {
             if (rolesReportsHash.RoleOption.IsSet && rolesReportsHash.Role == null)
-                throw new ArgumentNullException(nameof(rolesReportsHash.Role), "Property is required for class RolesReportsHash.");
+                throw new JsonException("Cannot write null property RolesReportsHash.Role to non-nullable JSON property 'role'.");
 
             if (rolesReportsHash.RoleOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
@@ -169,7 +169,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, RolesReportsHashRole rolesReportsHashRole, JsonSerializerOptions jsonSerializerOptions)
         {
             if (rolesReportsHashRole.NameOption.IsSet && rolesReportsHashRole.Name == null)
-                throw new ArgumentNullException(nameof(rolesReportsHashRole.Name), "Property is required for class RolesReportsHashRole.");
+                throw new JsonException("Cannot write null property RolesReportsHashRole.Name to non-nullable JSON property 'name'.");
 
             if (rolesReportsHashRole.NameOption.IsSet)
                 writer.WriteString("name", rolesReportsHashRole.Name);

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
@@ -183,12 +183,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ScaleneTriangle scaleneTriangle, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (scaleneTriangle.ShapeType == null)
-                throw new ArgumentNullException(nameof(scaleneTriangle.ShapeType), "Property is required for class ScaleneTriangle.");
-
-            if (scaleneTriangle.TriangleType == null)
-                throw new ArgumentNullException(nameof(scaleneTriangle.TriangleType), "Property is required for class ScaleneTriangle.");
-
             writer.WriteString("shapeType", scaleneTriangle.ShapeType);
 
             writer.WriteString("triangleType", scaleneTriangle.TriangleType);

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/ShapeInterface.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/ShapeInterface.cs
@@ -164,9 +164,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ShapeInterface shapeInterface, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (shapeInterface.ShapeType == null)
-                throw new ArgumentNullException(nameof(shapeInterface.ShapeType), "Property is required for class ShapeInterface.");
-
             writer.WriteString("shapeType", shapeInterface.ShapeType);
         }
     }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
@@ -183,12 +183,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, SimpleQuadrilateral simpleQuadrilateral, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (simpleQuadrilateral.QuadrilateralType == null)
-                throw new ArgumentNullException(nameof(simpleQuadrilateral.QuadrilateralType), "Property is required for class SimpleQuadrilateral.");
-
-            if (simpleQuadrilateral.ShapeType == null)
-                throw new ArgumentNullException(nameof(simpleQuadrilateral.ShapeType), "Property is required for class SimpleQuadrilateral.");
-
             writer.WriteString("quadrilateralType", simpleQuadrilateral.QuadrilateralType);
 
             writer.WriteString("shapeType", simpleQuadrilateral.ShapeType);

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -194,6 +194,9 @@ namespace Org.OpenAPITools.Model
             if (specialModelName.VarSpecialModelNameOption.IsSet && specialModelName.VarSpecialModelName == null)
                 throw new JsonException("Cannot write null property SpecialModelName.VarSpecialModelName to non-nullable JSON property '_special_model.name_'.");
 
+            if (specialModelName.SpecialPropertyNameOption.IsSet && specialModelName.SpecialPropertyName == null)
+                throw new JsonException("Cannot write null property SpecialModelName.SpecialPropertyName to non-nullable JSON property '$special[property.name]'.");
+
             if (specialModelName.VarSpecialModelNameOption.IsSet)
                 writer.WriteString("_special_model.name_", specialModelName.VarSpecialModelName);
 

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -192,7 +192,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, SpecialModelName specialModelName, JsonSerializerOptions jsonSerializerOptions)
         {
             if (specialModelName.VarSpecialModelNameOption.IsSet && specialModelName.VarSpecialModelName == null)
-                throw new ArgumentNullException(nameof(specialModelName.VarSpecialModelName), "Property is required for class SpecialModelName.");
+                throw new JsonException("Cannot write null property SpecialModelName.VarSpecialModelName to non-nullable JSON property '_special_model.name_'.");
 
             if (specialModelName.VarSpecialModelNameOption.IsSet)
                 writer.WriteString("_special_model.name_", specialModelName.VarSpecialModelName);

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Tag.cs
@@ -191,6 +191,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Tag tag, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (tag.IdOption.IsSet && tag.Id == null)
+                throw new JsonException("Cannot write null property Tag.Id to non-nullable JSON property 'id'.");
+
             if (tag.NameOption.IsSet && tag.Name == null)
                 throw new JsonException("Cannot write null property Tag.Name to non-nullable JSON property 'name'.");
 

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Tag.cs
@@ -192,7 +192,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Tag tag, JsonSerializerOptions jsonSerializerOptions)
         {
             if (tag.NameOption.IsSet && tag.Name == null)
-                throw new ArgumentNullException(nameof(tag.Name), "Property is required for class Tag.");
+                throw new JsonException("Cannot write null property Tag.Name to non-nullable JSON property 'name'.");
 
             if (tag.IdOption.IsSet)
                 writer.WriteNumber("id", tag.IdOption.Value!.Value);

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -169,7 +169,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestCollectionEndingWithWordList testCollectionEndingWithWordList, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testCollectionEndingWithWordList.ValueOption.IsSet && testCollectionEndingWithWordList.Value == null)
-                throw new ArgumentNullException(nameof(testCollectionEndingWithWordList.Value), "Property is required for class TestCollectionEndingWithWordList.");
+                throw new JsonException("Cannot write null property TestCollectionEndingWithWordList.Value to non-nullable JSON property 'value'.");
 
             if (testCollectionEndingWithWordList.ValueOption.IsSet)
                 writer.WriteString("value", testCollectionEndingWithWordList.Value);

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -169,7 +169,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestCollectionEndingWithWordListObject testCollectionEndingWithWordListObject, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testCollectionEndingWithWordListObject.TestCollectionEndingWithWordListOption.IsSet && testCollectionEndingWithWordListObject.TestCollectionEndingWithWordList == null)
-                throw new ArgumentNullException(nameof(testCollectionEndingWithWordListObject.TestCollectionEndingWithWordList), "Property is required for class TestCollectionEndingWithWordListObject.");
+                throw new JsonException("Cannot write null property TestCollectionEndingWithWordListObject.TestCollectionEndingWithWordList to non-nullable JSON property 'TestCollectionEndingWithWordList'.");
 
             if (testCollectionEndingWithWordListObject.TestCollectionEndingWithWordListOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/TestDescendants.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/TestDescendants.cs
@@ -283,9 +283,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, TestDescendants testDescendants, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (testDescendants.AlternativeName == null)
-                throw new ArgumentNullException(nameof(testDescendants.AlternativeName), "Property is required for class TestDescendants.");
-
             writer.WriteString("alternativeName", testDescendants.AlternativeName);
 
             writer.WriteString("objectType", TestDescendants.ObjectTypeEnumToJsonValue(testDescendants.ObjectType));

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
@@ -176,7 +176,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestInlineFreeformAdditionalPropertiesRequest testInlineFreeformAdditionalPropertiesRequest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testInlineFreeformAdditionalPropertiesRequest.SomePropertyOption.IsSet && testInlineFreeformAdditionalPropertiesRequest.SomeProperty == null)
-                throw new ArgumentNullException(nameof(testInlineFreeformAdditionalPropertiesRequest.SomeProperty), "Property is required for class TestInlineFreeformAdditionalPropertiesRequest.");
+                throw new JsonException("Cannot write null property TestInlineFreeformAdditionalPropertiesRequest.SomeProperty to non-nullable JSON property 'someProperty'.");
 
             if (testInlineFreeformAdditionalPropertiesRequest.SomePropertyOption.IsSet)
                 writer.WriteString("someProperty", testInlineFreeformAdditionalPropertiesRequest.SomeProperty);

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/TestResult.cs
@@ -217,10 +217,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestResult testResult, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testResult.DataOption.IsSet && testResult.Data == null)
-                throw new ArgumentNullException(nameof(testResult.Data), "Property is required for class TestResult.");
+                throw new JsonException("Cannot write null property TestResult.Data to non-nullable JSON property 'data'.");
 
             if (testResult.UuidOption.IsSet && testResult.Uuid == null)
-                throw new ArgumentNullException(nameof(testResult.Uuid), "Property is required for class TestResult.");
+                throw new JsonException("Cannot write null property TestResult.Uuid to non-nullable JSON property 'uuid'.");
 
             if (testResult.CodeOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/TestResult.cs
@@ -216,6 +216,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, TestResult testResult, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (testResult.CodeOption.IsSet && testResult.Code == null)
+                throw new JsonException("Cannot write null property TestResult.Code to non-nullable JSON property 'code'.");
+
             if (testResult.DataOption.IsSet && testResult.Data == null)
                 throw new JsonException("Cannot write null property TestResult.Data to non-nullable JSON property 'data'.");
 

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/TriangleInterface.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/TriangleInterface.cs
@@ -164,9 +164,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, TriangleInterface triangleInterface, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (triangleInterface.TriangleType == null)
-                throw new ArgumentNullException(nameof(triangleInterface.TriangleType), "Property is required for class TriangleInterface.");
-
             writer.WriteString("triangleType", triangleInterface.TriangleType);
         }
     }

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/User.cs
@@ -418,25 +418,25 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, User user, JsonSerializerOptions jsonSerializerOptions)
         {
             if (user.EmailOption.IsSet && user.Email == null)
-                throw new ArgumentNullException(nameof(user.Email), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Email to non-nullable JSON property 'email'.");
 
             if (user.FirstNameOption.IsSet && user.FirstName == null)
-                throw new ArgumentNullException(nameof(user.FirstName), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.FirstName to non-nullable JSON property 'firstName'.");
 
             if (user.LastNameOption.IsSet && user.LastName == null)
-                throw new ArgumentNullException(nameof(user.LastName), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.LastName to non-nullable JSON property 'lastName'.");
 
             if (user.ObjectWithNoDeclaredPropsOption.IsSet && user.ObjectWithNoDeclaredProps == null)
-                throw new ArgumentNullException(nameof(user.ObjectWithNoDeclaredProps), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.ObjectWithNoDeclaredProps to non-nullable JSON property 'objectWithNoDeclaredProps'.");
 
             if (user.PasswordOption.IsSet && user.Password == null)
-                throw new ArgumentNullException(nameof(user.Password), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Password to non-nullable JSON property 'password'.");
 
             if (user.PhoneOption.IsSet && user.Phone == null)
-                throw new ArgumentNullException(nameof(user.Phone), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Phone to non-nullable JSON property 'phone'.");
 
             if (user.UsernameOption.IsSet && user.Username == null)
-                throw new ArgumentNullException(nameof(user.Username), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Username to non-nullable JSON property 'username'.");
 
             if (user.AnyTypePropOption.IsSet)
                 if (user.AnyTypePropOption.Value != null)

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/User.cs
@@ -423,6 +423,9 @@ namespace Org.OpenAPITools.Model
             if (user.FirstNameOption.IsSet && user.FirstName == null)
                 throw new JsonException("Cannot write null property User.FirstName to non-nullable JSON property 'firstName'.");
 
+            if (user.IdOption.IsSet && user.Id == null)
+                throw new JsonException("Cannot write null property User.Id to non-nullable JSON property 'id'.");
+
             if (user.LastNameOption.IsSet && user.LastName == null)
                 throw new JsonException("Cannot write null property User.LastName to non-nullable JSON property 'lastName'.");
 
@@ -434,6 +437,9 @@ namespace Org.OpenAPITools.Model
 
             if (user.PhoneOption.IsSet && user.Phone == null)
                 throw new JsonException("Cannot write null property User.Phone to non-nullable JSON property 'phone'.");
+
+            if (user.UserStatusOption.IsSet && user.UserStatus == null)
+                throw new JsonException("Cannot write null property User.UserStatus to non-nullable JSON property 'userStatus'.");
 
             if (user.UsernameOption.IsSet && user.Username == null)
                 throw new JsonException("Cannot write null property User.Username to non-nullable JSON property 'username'.");

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Whale.cs
@@ -210,9 +210,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Whale whale, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (whale.ClassName == null)
-                throw new ArgumentNullException(nameof(whale.ClassName), "Property is required for class Whale.");
-
             writer.WriteString("className", whale.ClassName);
 
             if (whale.HasBaleenOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Whale.cs
@@ -210,6 +210,12 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Whale whale, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (whale.HasBaleenOption.IsSet && whale.HasBaleen == null)
+                throw new JsonException("Cannot write null property Whale.HasBaleen to non-nullable JSON property 'hasBaleen'.");
+
+            if (whale.HasTeethOption.IsSet && whale.HasTeeth == null)
+                throw new JsonException("Cannot write null property Whale.HasTeeth to non-nullable JSON property 'hasTeeth'.");
+
             writer.WriteString("className", whale.ClassName);
 
             if (whale.HasBaleenOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Zebra.cs
@@ -281,9 +281,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Zebra zebra, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (zebra.ClassName == null)
-                throw new ArgumentNullException(nameof(zebra.ClassName), "Property is required for class Zebra.");
-
             writer.WriteString("className", zebra.ClassName);
 
             var typeRawValue = Zebra.TypeEnumToJsonValue(zebra.TypeOption.Value!.Value);

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/Zebra.cs
@@ -281,6 +281,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Zebra zebra, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (zebra.TypeOption.IsSet && zebra.Type == null)
+                throw new JsonException("Cannot write null property Zebra.Type to non-nullable JSON property 'type'.");
+
             writer.WriteString("className", zebra.ClassName);
 
             var typeRawValue = Zebra.TypeEnumToJsonValue(zebra.TypeOption.Value!.Value);

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
@@ -241,6 +241,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ZeroBasedEnumClass zeroBasedEnumClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (zeroBasedEnumClass.ZeroBasedEnumOption.IsSet && zeroBasedEnumClass.ZeroBasedEnum == null)
+                throw new JsonException("Cannot write null property ZeroBasedEnumClass.ZeroBasedEnum to non-nullable JSON property 'ZeroBasedEnum'.");
+
             var zeroBasedEnumRawValue = ZeroBasedEnumClass.ZeroBasedEnumEnumToJsonValue(zeroBasedEnumClass.ZeroBasedEnumOption.Value!.Value);
             writer.WriteString("ZeroBasedEnum", zeroBasedEnumRawValue);
         }

--- a/samples/client/petstore/csharp/generichost/net10/AllOf/src/Org.OpenAPITools/Model/Adult.cs
+++ b/samples/client/petstore/csharp/generichost/net10/AllOf/src/Org.OpenAPITools/Model/Adult.cs
@@ -184,13 +184,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Adult adult, JsonSerializerOptions jsonSerializerOptions)
         {
             if (adult.ChildrenOption.IsSet && adult.Children == null)
-                throw new ArgumentNullException(nameof(adult.Children), "Property is required for class Adult.");
+                throw new JsonException("Cannot write null property Adult.Children to non-nullable JSON property 'children'.");
 
             if (adult.FirstNameOption.IsSet && adult.FirstName == null)
-                throw new ArgumentNullException(nameof(adult.FirstName), "Property is required for class Adult.");
+                throw new JsonException("Cannot write null property Adult.FirstName to non-nullable JSON property 'firstName'.");
 
             if (adult.LastNameOption.IsSet && adult.LastName == null)
-                throw new ArgumentNullException(nameof(adult.LastName), "Property is required for class Adult.");
+                throw new JsonException("Cannot write null property Adult.LastName to non-nullable JSON property 'lastName'.");
 
             if (adult.ChildrenOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net10/AllOf/src/Org.OpenAPITools/Model/Child.cs
+++ b/samples/client/petstore/csharp/generichost/net10/AllOf/src/Org.OpenAPITools/Model/Child.cs
@@ -206,6 +206,12 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Child child, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (child.AgeOption.IsSet && child.Age == null)
+                throw new JsonException("Cannot write null property Child.Age to non-nullable JSON property 'age'.");
+
+            if (child.BoosterSeatOption.IsSet && child.BoosterSeat == null)
+                throw new JsonException("Cannot write null property Child.BoosterSeat to non-nullable JSON property 'boosterSeat'.");
+
             if (child.FirstNameOption.IsSet && child.FirstName == null)
                 throw new JsonException("Cannot write null property Child.FirstName to non-nullable JSON property 'firstName'.");
 

--- a/samples/client/petstore/csharp/generichost/net10/AllOf/src/Org.OpenAPITools/Model/Child.cs
+++ b/samples/client/petstore/csharp/generichost/net10/AllOf/src/Org.OpenAPITools/Model/Child.cs
@@ -207,10 +207,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Child child, JsonSerializerOptions jsonSerializerOptions)
         {
             if (child.FirstNameOption.IsSet && child.FirstName == null)
-                throw new ArgumentNullException(nameof(child.FirstName), "Property is required for class Child.");
+                throw new JsonException("Cannot write null property Child.FirstName to non-nullable JSON property 'firstName'.");
 
             if (child.LastNameOption.IsSet && child.LastName == null)
-                throw new ArgumentNullException(nameof(child.LastName), "Property is required for class Child.");
+                throw new JsonException("Cannot write null property Child.LastName to non-nullable JSON property 'lastName'.");
 
             if (child.AgeOption.IsSet)
                 writer.WriteNumber("age", child.AgeOption.Value!.Value);

--- a/samples/client/petstore/csharp/generichost/net10/AllOf/src/Org.OpenAPITools/Model/Person.cs
+++ b/samples/client/petstore/csharp/generichost/net10/AllOf/src/Org.OpenAPITools/Model/Person.cs
@@ -243,10 +243,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Person person, JsonSerializerOptions jsonSerializerOptions)
         {
             if (person.FirstNameOption.IsSet && person.FirstName == null)
-                throw new ArgumentNullException(nameof(person.FirstName), "Property is required for class Person.");
+                throw new JsonException("Cannot write null property Person.FirstName to non-nullable JSON property 'firstName'.");
 
             if (person.LastNameOption.IsSet && person.LastName == null)
-                throw new ArgumentNullException(nameof(person.LastName), "Property is required for class Person.");
+                throw new JsonException("Cannot write null property Person.LastName to non-nullable JSON property 'lastName'.");
 
             if (person.FirstNameOption.IsSet)
                 writer.WriteString("firstName", person.FirstName);

--- a/samples/client/petstore/csharp/generichost/net10/AnyOf/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net10/AnyOf/src/Org.OpenAPITools/Model/Apple.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Apple apple, JsonSerializerOptions jsonSerializerOptions)
         {
             if (apple.KindOption.IsSet && apple.Kind == null)
-                throw new ArgumentNullException(nameof(apple.Kind), "Property is required for class Apple.");
+                throw new JsonException("Cannot write null property Apple.Kind to non-nullable JSON property 'kind'.");
 
             if (apple.KindOption.IsSet)
                 writer.WriteString("kind", apple.Kind);

--- a/samples/client/petstore/csharp/generichost/net10/AnyOf/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net10/AnyOf/src/Org.OpenAPITools/Model/Banana.cs
@@ -176,6 +176,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Banana banana, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (banana.CountOption.IsSet && banana.Count == null)
+                throw new JsonException("Cannot write null property Banana.Count to non-nullable JSON property 'count'.");
+
             if (banana.CountOption.IsSet)
                 writer.WriteNumber("count", banana.CountOption.Value!.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net10/AnyOf/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net10/AnyOf/src/Org.OpenAPITools/Model/Fruit.cs
@@ -245,7 +245,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Fruit fruit, JsonSerializerOptions jsonSerializerOptions)
         {
             if (fruit.ColorOption.IsSet && fruit.Color == null)
-                throw new ArgumentNullException(nameof(fruit.Color), "Property is required for class Fruit.");
+                throw new JsonException("Cannot write null property Fruit.Color to non-nullable JSON property 'color'.");
 
             if (fruit.ColorOption.IsSet)
                 writer.WriteString("color", fruit.Color);

--- a/samples/client/petstore/csharp/generichost/net10/AnyOfNoCompare/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net10/AnyOfNoCompare/src/Org.OpenAPITools/Model/Apple.cs
@@ -176,7 +176,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Apple apple, JsonSerializerOptions jsonSerializerOptions)
         {
             if (apple.KindOption.IsSet && apple.Kind == null)
-                throw new ArgumentNullException(nameof(apple.Kind), "Property is required for class Apple.");
+                throw new JsonException("Cannot write null property Apple.Kind to non-nullable JSON property 'kind'.");
 
             if (apple.KindOption.IsSet)
                 writer.WriteString("kind", apple.Kind);

--- a/samples/client/petstore/csharp/generichost/net10/AnyOfNoCompare/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net10/AnyOfNoCompare/src/Org.OpenAPITools/Model/Banana.cs
@@ -175,6 +175,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Banana banana, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (banana.CountOption.IsSet && banana.Count == null)
+                throw new JsonException("Cannot write null property Banana.Count to non-nullable JSON property 'count'.");
+
             if (banana.CountOption.IsSet)
                 writer.WriteNumber("count", banana.CountOption.Value!.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net10/AnyOfNoCompare/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net10/AnyOfNoCompare/src/Org.OpenAPITools/Model/Fruit.cs
@@ -244,7 +244,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Fruit fruit, JsonSerializerOptions jsonSerializerOptions)
         {
             if (fruit.ColorOption.IsSet && fruit.Color == null)
-                throw new ArgumentNullException(nameof(fruit.Color), "Property is required for class Fruit.");
+                throw new JsonException("Cannot write null property Fruit.Color to non-nullable JSON property 'color'.");
 
             if (fruit.ColorOption.IsSet)
                 writer.WriteString("color", fruit.Color);

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Activity.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Activity activity, JsonSerializerOptions jsonSerializerOptions)
         {
             if (activity.ActivityOutputsOption.IsSet && activity.ActivityOutputs == null)
-                throw new ArgumentNullException(nameof(activity.ActivityOutputs), "Property is required for class Activity.");
+                throw new JsonException("Cannot write null property Activity.ActivityOutputs to non-nullable JSON property 'activity_outputs'.");
 
             if (activity.ActivityOutputsOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -198,10 +198,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ActivityOutputElementRepresentation activityOutputElementRepresentation, JsonSerializerOptions jsonSerializerOptions)
         {
             if (activityOutputElementRepresentation.Prop1Option.IsSet && activityOutputElementRepresentation.Prop1 == null)
-                throw new ArgumentNullException(nameof(activityOutputElementRepresentation.Prop1), "Property is required for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Cannot write null property ActivityOutputElementRepresentation.Prop1 to non-nullable JSON property 'prop1'.");
 
             if (activityOutputElementRepresentation.Prop2Option.IsSet && activityOutputElementRepresentation.Prop2 == null)
-                throw new ArgumentNullException(nameof(activityOutputElementRepresentation.Prop2), "Property is required for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Cannot write null property ActivityOutputElementRepresentation.Prop2 to non-nullable JSON property 'prop2'.");
 
             if (activityOutputElementRepresentation.Prop1Option.IsSet)
                 writer.WriteString("prop1", activityOutputElementRepresentation.Prop1);

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -334,25 +334,25 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, AdditionalPropertiesClass additionalPropertiesClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (additionalPropertiesClass.EmptyMapOption.IsSet && additionalPropertiesClass.EmptyMap == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.EmptyMap), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.EmptyMap to non-nullable JSON property 'empty_map'.");
 
             if (additionalPropertiesClass.MapOfMapPropertyOption.IsSet && additionalPropertiesClass.MapOfMapProperty == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapOfMapProperty), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapOfMapProperty to non-nullable JSON property 'map_of_map_property'.");
 
             if (additionalPropertiesClass.MapPropertyOption.IsSet && additionalPropertiesClass.MapProperty == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapProperty), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapProperty to non-nullable JSON property 'map_property'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1Option.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1 == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1 to non-nullable JSON property 'map_with_undeclared_properties_anytype_1'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2Option.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2 == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2 to non-nullable JSON property 'map_with_undeclared_properties_anytype_2'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3Option.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3 == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3 to non-nullable JSON property 'map_with_undeclared_properties_anytype_3'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesStringOption.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesString == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesString), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesString to non-nullable JSON property 'map_with_undeclared_properties_string'.");
 
             if (additionalPropertiesClass.Anytype1Option.IsSet)
                 if (additionalPropertiesClass.Anytype1Option.Value != null)

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Animal.cs
@@ -221,7 +221,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Animal animal, JsonSerializerOptions jsonSerializerOptions)
         {
             if (animal.ColorOption.IsSet && animal.Color == null)
-                throw new ArgumentNullException(nameof(animal.Color), "Property is required for class Animal.");
+                throw new JsonException("Cannot write null property Animal.Color to non-nullable JSON property 'color'.");
 
             writer.WriteString("className", animal.ClassName);
 

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -221,10 +221,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ApiResponse apiResponse, JsonSerializerOptions jsonSerializerOptions)
         {
             if (apiResponse.MessageOption.IsSet && apiResponse.Message == null)
-                throw new ArgumentNullException(nameof(apiResponse.Message), "Property is required for class ApiResponse.");
+                throw new JsonException("Cannot write null property ApiResponse.Message to non-nullable JSON property 'message'.");
 
             if (apiResponse.TypeOption.IsSet && apiResponse.Type == null)
-                throw new ArgumentNullException(nameof(apiResponse.Type), "Property is required for class ApiResponse.");
+                throw new JsonException("Cannot write null property ApiResponse.Type to non-nullable JSON property 'type'.");
 
             if (apiResponse.CodeOption.IsSet)
                 writer.WriteNumber("code", apiResponse.CodeOption.Value.Value);

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -220,6 +220,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ApiResponse apiResponse, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (apiResponse.CodeOption.IsSet && apiResponse.Code == null)
+                throw new JsonException("Cannot write null property ApiResponse.Code to non-nullable JSON property 'code'.");
+
             if (apiResponse.MessageOption.IsSet && apiResponse.Message == null)
                 throw new JsonException("Cannot write null property ApiResponse.Message to non-nullable JSON property 'message'.");
 

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Apple.cs
@@ -251,13 +251,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Apple apple, JsonSerializerOptions jsonSerializerOptions)
         {
             if (apple.ColorCodeOption.IsSet && apple.ColorCode == null)
-                throw new ArgumentNullException(nameof(apple.ColorCode), "Property is required for class Apple.");
+                throw new JsonException("Cannot write null property Apple.ColorCode to non-nullable JSON property 'color_code'.");
 
             if (apple.CultivarOption.IsSet && apple.Cultivar == null)
-                throw new ArgumentNullException(nameof(apple.Cultivar), "Property is required for class Apple.");
+                throw new JsonException("Cannot write null property Apple.Cultivar to non-nullable JSON property 'cultivar'.");
 
             if (apple.OriginOption.IsSet && apple.Origin == null)
-                throw new ArgumentNullException(nameof(apple.Origin), "Property is required for class Apple.");
+                throw new JsonException("Cannot write null property Apple.Origin to non-nullable JSON property 'origin'.");
 
             if (apple.ColorCodeOption.IsSet)
                 writer.WriteString("color_code", apple.ColorCode);

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -186,9 +186,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, AppleReq appleReq, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (appleReq.Cultivar == null)
-                throw new ArgumentNullException(nameof(appleReq.Cultivar), "Property is required for class AppleReq.");
-
             writer.WriteString("cultivar", appleReq.Cultivar);
 
             if (appleReq.MealyOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -186,6 +186,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, AppleReq appleReq, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (appleReq.MealyOption.IsSet && appleReq.Mealy == null)
+                throw new JsonException("Cannot write null property AppleReq.Mealy to non-nullable JSON property 'mealy'.");
+
             writer.WriteString("cultivar", appleReq.Cultivar);
 
             if (appleReq.MealyOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ArrayOfArrayOfNumberOnly arrayOfArrayOfNumberOnly, JsonSerializerOptions jsonSerializerOptions)
         {
             if (arrayOfArrayOfNumberOnly.ArrayArrayNumberOption.IsSet && arrayOfArrayOfNumberOnly.ArrayArrayNumber == null)
-                throw new ArgumentNullException(nameof(arrayOfArrayOfNumberOnly.ArrayArrayNumber), "Property is required for class ArrayOfArrayOfNumberOnly.");
+                throw new JsonException("Cannot write null property ArrayOfArrayOfNumberOnly.ArrayArrayNumber to non-nullable JSON property 'ArrayArrayNumber'.");
 
             if (arrayOfArrayOfNumberOnly.ArrayArrayNumberOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ArrayOfNumberOnly arrayOfNumberOnly, JsonSerializerOptions jsonSerializerOptions)
         {
             if (arrayOfNumberOnly.ArrayNumberOption.IsSet && arrayOfNumberOnly.ArrayNumber == null)
-                throw new ArgumentNullException(nameof(arrayOfNumberOnly.ArrayNumber), "Property is required for class ArrayOfNumberOnly.");
+                throw new JsonException("Cannot write null property ArrayOfNumberOnly.ArrayNumber to non-nullable JSON property 'ArrayNumber'.");
 
             if (arrayOfNumberOnly.ArrayNumberOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -221,13 +221,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ArrayTest arrayTest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (arrayTest.ArrayArrayOfIntegerOption.IsSet && arrayTest.ArrayArrayOfInteger == null)
-                throw new ArgumentNullException(nameof(arrayTest.ArrayArrayOfInteger), "Property is required for class ArrayTest.");
+                throw new JsonException("Cannot write null property ArrayTest.ArrayArrayOfInteger to non-nullable JSON property 'array_array_of_integer'.");
 
             if (arrayTest.ArrayArrayOfModelOption.IsSet && arrayTest.ArrayArrayOfModel == null)
-                throw new ArgumentNullException(nameof(arrayTest.ArrayArrayOfModel), "Property is required for class ArrayTest.");
+                throw new JsonException("Cannot write null property ArrayTest.ArrayArrayOfModel to non-nullable JSON property 'array_array_of_model'.");
 
             if (arrayTest.ArrayOfStringOption.IsSet && arrayTest.ArrayOfString == null)
-                throw new ArgumentNullException(nameof(arrayTest.ArrayOfString), "Property is required for class ArrayTest.");
+                throw new JsonException("Cannot write null property ArrayTest.ArrayOfString to non-nullable JSON property 'array_of_string'.");
 
             if (arrayTest.ArrayArrayOfIntegerOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Banana.cs
@@ -174,6 +174,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Banana banana, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (banana.LengthCmOption.IsSet && banana.LengthCm == null)
+                throw new JsonException("Cannot write null property Banana.LengthCm to non-nullable JSON property 'lengthCm'.");
+
             if (banana.LengthCmOption.IsSet)
                 writer.WriteNumber("lengthCm", banana.LengthCmOption.Value.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -186,6 +186,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, BananaReq bananaReq, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (bananaReq.SweetOption.IsSet && bananaReq.Sweet == null)
+                throw new JsonException("Cannot write null property BananaReq.Sweet to non-nullable JSON property 'sweet'.");
+
             writer.WriteNumber("lengthCm", bananaReq.LengthCm);
 
             if (bananaReq.SweetOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/BasquePig.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/BasquePig.cs
@@ -170,9 +170,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, BasquePig basquePig, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (basquePig.ClassName == null)
-                throw new ArgumentNullException(nameof(basquePig.ClassName), "Property is required for class BasquePig.");
-
             writer.WriteString("className", basquePig.ClassName);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -291,22 +291,22 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Capitalization capitalization, JsonSerializerOptions jsonSerializerOptions)
         {
             if (capitalization.ATT_NAMEOption.IsSet && capitalization.ATT_NAME == null)
-                throw new ArgumentNullException(nameof(capitalization.ATT_NAME), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.ATT_NAME to non-nullable JSON property 'ATT_NAME'.");
 
             if (capitalization.CapitalCamelOption.IsSet && capitalization.CapitalCamel == null)
-                throw new ArgumentNullException(nameof(capitalization.CapitalCamel), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.CapitalCamel to non-nullable JSON property 'CapitalCamel'.");
 
             if (capitalization.CapitalSnakeOption.IsSet && capitalization.CapitalSnake == null)
-                throw new ArgumentNullException(nameof(capitalization.CapitalSnake), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.CapitalSnake to non-nullable JSON property 'Capital_Snake'.");
 
             if (capitalization.SCAETHFlowPointsOption.IsSet && capitalization.SCAETHFlowPoints == null)
-                throw new ArgumentNullException(nameof(capitalization.SCAETHFlowPoints), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.SCAETHFlowPoints to non-nullable JSON property 'SCA_ETH_Flow_Points'.");
 
             if (capitalization.SmallCamelOption.IsSet && capitalization.SmallCamel == null)
-                throw new ArgumentNullException(nameof(capitalization.SmallCamel), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.SmallCamel to non-nullable JSON property 'smallCamel'.");
 
             if (capitalization.SmallSnakeOption.IsSet && capitalization.SmallSnake == null)
-                throw new ArgumentNullException(nameof(capitalization.SmallSnake), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.SmallSnake to non-nullable JSON property 'small_Snake'.");
 
             if (capitalization.ATT_NAMEOption.IsSet)
                 writer.WriteString("ATT_NAME", capitalization.ATT_NAME);

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Cat.cs
@@ -179,6 +179,9 @@ namespace Org.OpenAPITools.Model
             if (cat.ColorOption.IsSet && cat.Color == null)
                 throw new JsonException("Cannot write null property Cat.Color to non-nullable JSON property 'color'.");
 
+            if (cat.DeclawedOption.IsSet && cat.Declawed == null)
+                throw new JsonException("Cannot write null property Cat.Declawed to non-nullable JSON property 'declawed'.");
+
             writer.WriteString("className", cat.ClassName);
 
             if (cat.ColorOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Cat.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Cat cat, JsonSerializerOptions jsonSerializerOptions)
         {
             if (cat.ColorOption.IsSet && cat.Color == null)
-                throw new ArgumentNullException(nameof(cat.Color), "Property is required for class Cat.");
+                throw new JsonException("Cannot write null property Cat.Color to non-nullable JSON property 'color'.");
 
             writer.WriteString("className", cat.ClassName);
 

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Category.cs
@@ -193,9 +193,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Category category, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (category.Name == null)
-                throw new ArgumentNullException(nameof(category.Name), "Property is required for class Category.");
-
             if (category.IdOption.IsSet)
                 writer.WriteNumber("id", category.IdOption.Value.Value);
 

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Category.cs
@@ -193,6 +193,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Category category, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (category.IdOption.IsSet && category.Id == null)
+                throw new JsonException("Cannot write null property Category.Id to non-nullable JSON property 'id'.");
+
             if (category.IdOption.IsSet)
                 writer.WriteNumber("id", category.IdOption.Value.Value);
 

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ChildCat childCat, JsonSerializerOptions jsonSerializerOptions)
         {
             if (childCat.NameOption.IsSet && childCat.Name == null)
-                throw new ArgumentNullException(nameof(childCat.Name), "Property is required for class ChildCat.");
+                throw new JsonException("Cannot write null property ChildCat.Name to non-nullable JSON property 'name'.");
 
             writer.WriteString("pet_type", ChildCatAllOfPetTypeValueConverter.ToJsonValue(childCat.PetType));
 

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ClassModel classModel, JsonSerializerOptions jsonSerializerOptions)
         {
             if (classModel.ClassOption.IsSet && classModel.Class == null)
-                throw new ArgumentNullException(nameof(classModel.Class), "Property is required for class ClassModel.");
+                throw new JsonException("Cannot write null property ClassModel.Class to non-nullable JSON property '_class'.");
 
             if (classModel.ClassOption.IsSet)
                 writer.WriteString("_class", classModel.Class);

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
@@ -189,12 +189,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ComplexQuadrilateral complexQuadrilateral, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (complexQuadrilateral.QuadrilateralType == null)
-                throw new ArgumentNullException(nameof(complexQuadrilateral.QuadrilateralType), "Property is required for class ComplexQuadrilateral.");
-
-            if (complexQuadrilateral.ShapeType == null)
-                throw new ArgumentNullException(nameof(complexQuadrilateral.ShapeType), "Property is required for class ComplexQuadrilateral.");
-
             writer.WriteString("quadrilateralType", complexQuadrilateral.QuadrilateralType);
 
             writer.WriteString("shapeType", complexQuadrilateral.ShapeType);

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/CopyActivity.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/CopyActivity.cs
@@ -172,9 +172,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, CopyActivity copyActivity, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (copyActivity.CopyActivitytt == null)
-                throw new ArgumentNullException(nameof(copyActivity.CopyActivitytt), "Property is required for class CopyActivity.");
-
             writer.WriteString("copyActivitytt", copyActivity.CopyActivitytt);
 
             writer.WriteString("$schema", CopyActivityAllOfSchemaValueConverter.ToJsonValue(copyActivity.Schema));

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/DanishPig.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/DanishPig.cs
@@ -170,9 +170,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, DanishPig danishPig, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (danishPig.ClassName == null)
-                throw new ArgumentNullException(nameof(danishPig.ClassName), "Property is required for class DanishPig.");
-
             writer.WriteString("className", danishPig.ClassName);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -180,6 +180,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, DateOnlyClass dateOnlyClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (dateOnlyClass.DateOnlyPropertyOption.IsSet && dateOnlyClass.DateOnlyProperty == null)
+                throw new JsonException("Cannot write null property DateOnlyClass.DateOnlyProperty to non-nullable JSON property 'dateOnlyProperty'.");
+
             if (dateOnlyClass.DateOnlyPropertyOption.IsSet)
                 writer.WriteString("dateOnlyProperty", dateOnlyClass.DateOnlyPropertyOption.Value.Value.ToString(DateOnlyPropertyFormat));
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, DeprecatedObject deprecatedObject, JsonSerializerOptions jsonSerializerOptions)
         {
             if (deprecatedObject.NameOption.IsSet && deprecatedObject.Name == null)
-                throw new ArgumentNullException(nameof(deprecatedObject.Name), "Property is required for class DeprecatedObject.");
+                throw new JsonException("Cannot write null property DeprecatedObject.Name to non-nullable JSON property 'name'.");
 
             if (deprecatedObject.NameOption.IsSet)
                 writer.WriteString("name", deprecatedObject.Name);

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Descendant1.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Descendant1.cs
@@ -175,12 +175,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Descendant1 descendant1, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (descendant1.AlternativeName == null)
-                throw new ArgumentNullException(nameof(descendant1.AlternativeName), "Property is required for class Descendant1.");
-
-            if (descendant1.DescendantName == null)
-                throw new ArgumentNullException(nameof(descendant1.DescendantName), "Property is required for class Descendant1.");
-
             writer.WriteString("alternativeName", descendant1.AlternativeName);
 
             writer.WriteString("descendantName", descendant1.DescendantName);

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Descendant2.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Descendant2.cs
@@ -175,12 +175,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Descendant2 descendant2, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (descendant2.AlternativeName == null)
-                throw new ArgumentNullException(nameof(descendant2.AlternativeName), "Property is required for class Descendant2.");
-
-            if (descendant2.Confidentiality == null)
-                throw new ArgumentNullException(nameof(descendant2.Confidentiality), "Property is required for class Descendant2.");
-
             writer.WriteString("alternativeName", descendant2.AlternativeName);
 
             writer.WriteString("confidentiality", descendant2.Confidentiality);

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Dog.cs
@@ -177,10 +177,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Dog dog, JsonSerializerOptions jsonSerializerOptions)
         {
             if (dog.BreedOption.IsSet && dog.Breed == null)
-                throw new ArgumentNullException(nameof(dog.Breed), "Property is required for class Dog.");
+                throw new JsonException("Cannot write null property Dog.Breed to non-nullable JSON property 'breed'.");
 
             if (dog.ColorOption.IsSet && dog.Color == null)
-                throw new ArgumentNullException(nameof(dog.Color), "Property is required for class Dog.");
+                throw new JsonException("Cannot write null property Dog.Color to non-nullable JSON property 'color'.");
 
             writer.WriteString("className", dog.ClassName);
 

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Drawing.cs
@@ -238,10 +238,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Drawing drawing, JsonSerializerOptions jsonSerializerOptions)
         {
             if (drawing.MainShapeOption.IsSet && drawing.MainShape == null)
-                throw new ArgumentNullException(nameof(drawing.MainShape), "Property is required for class Drawing.");
+                throw new JsonException("Cannot write null property Drawing.MainShape to non-nullable JSON property 'mainShape'.");
 
             if (drawing.ShapesOption.IsSet && drawing.Shapes == null)
-                throw new ArgumentNullException(nameof(drawing.Shapes), "Property is required for class Drawing.");
+                throw new JsonException("Cannot write null property Drawing.Shapes to non-nullable JSON property 'shapes'.");
 
             if (drawing.MainShapeOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -200,6 +200,9 @@ namespace Org.OpenAPITools.Model
             if (enumArrays.ArrayEnumOption.IsSet && enumArrays.ArrayEnum == null)
                 throw new JsonException("Cannot write null property EnumArrays.ArrayEnum to non-nullable JSON property 'array_enum'.");
 
+            if (enumArrays.JustSymbolOption.IsSet && enumArrays.JustSymbol == null)
+                throw new JsonException("Cannot write null property EnumArrays.JustSymbol to non-nullable JSON property 'just_symbol'.");
+
             if (enumArrays.ArrayEnumOption.IsSet)
             {
                 writer.WritePropertyName("array_enum");

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -198,7 +198,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, EnumArrays enumArrays, JsonSerializerOptions jsonSerializerOptions)
         {
             if (enumArrays.ArrayEnumOption.IsSet && enumArrays.ArrayEnum == null)
-                throw new ArgumentNullException(nameof(enumArrays.ArrayEnum), "Property is required for class EnumArrays.");
+                throw new JsonException("Cannot write null property EnumArrays.ArrayEnum to non-nullable JSON property 'array_enum'.");
 
             if (enumArrays.ArrayEnumOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -351,6 +351,27 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, EnumTest enumTest, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (enumTest.EnumIntegerOption.IsSet && enumTest.EnumInteger == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumInteger to non-nullable JSON property 'enum_integer'.");
+
+            if (enumTest.EnumIntegerOnlyOption.IsSet && enumTest.EnumIntegerOnly == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumIntegerOnly to non-nullable JSON property 'enum_integer_only'.");
+
+            if (enumTest.EnumNumberOption.IsSet && enumTest.EnumNumber == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumNumber to non-nullable JSON property 'enum_number'.");
+
+            if (enumTest.EnumStringOption.IsSet && enumTest.EnumString == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumString to non-nullable JSON property 'enum_string'.");
+
+            if (enumTest.OuterEnumDefaultValueOption.IsSet && enumTest.OuterEnumDefaultValue == null)
+                throw new JsonException("Cannot write null property EnumTest.OuterEnumDefaultValue to non-nullable JSON property 'outerEnumDefaultValue'.");
+
+            if (enumTest.OuterEnumIntegerOption.IsSet && enumTest.OuterEnumInteger == null)
+                throw new JsonException("Cannot write null property EnumTest.OuterEnumInteger to non-nullable JSON property 'outerEnumInteger'.");
+
+            if (enumTest.OuterEnumIntegerDefaultValueOption.IsSet && enumTest.OuterEnumIntegerDefaultValue == null)
+                throw new JsonException("Cannot write null property EnumTest.OuterEnumIntegerDefaultValue to non-nullable JSON property 'outerEnumIntegerDefaultValue'.");
+
             var enumStringRequiredRawValue = EnumTestEnumStringValueConverter.ToJsonValue(enumTest.EnumStringRequired);
             writer.WriteString("enum_string_required", enumStringRequiredRawValue);
 

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
@@ -189,12 +189,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, EquilateralTriangle equilateralTriangle, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (equilateralTriangle.ShapeType == null)
-                throw new ArgumentNullException(nameof(equilateralTriangle.ShapeType), "Property is required for class EquilateralTriangle.");
-
-            if (equilateralTriangle.TriangleType == null)
-                throw new ArgumentNullException(nameof(equilateralTriangle.TriangleType), "Property is required for class EquilateralTriangle.");
-
             writer.WriteString("shapeType", equilateralTriangle.ShapeType);
 
             writer.WriteString("triangleType", equilateralTriangle.TriangleType);

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/File.cs
@@ -176,7 +176,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, File file, JsonSerializerOptions jsonSerializerOptions)
         {
             if (file.SourceURIOption.IsSet && file.SourceURI == null)
-                throw new ArgumentNullException(nameof(file.SourceURI), "Property is required for class File.");
+                throw new JsonException("Cannot write null property File.SourceURI to non-nullable JSON property 'sourceURI'.");
 
             if (file.SourceURIOption.IsSet)
                 writer.WriteString("sourceURI", file.SourceURI);

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -198,10 +198,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, FileSchemaTestClass fileSchemaTestClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (fileSchemaTestClass.FileOption.IsSet && fileSchemaTestClass.File == null)
-                throw new ArgumentNullException(nameof(fileSchemaTestClass.File), "Property is required for class FileSchemaTestClass.");
+                throw new JsonException("Cannot write null property FileSchemaTestClass.File to non-nullable JSON property 'file'.");
 
             if (fileSchemaTestClass.FilesOption.IsSet && fileSchemaTestClass.Files == null)
-                throw new ArgumentNullException(nameof(fileSchemaTestClass.Files), "Property is required for class FileSchemaTestClass.");
+                throw new JsonException("Cannot write null property FileSchemaTestClass.Files to non-nullable JSON property 'files'.");
 
             if (fileSchemaTestClass.FileOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Foo.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Foo foo, JsonSerializerOptions jsonSerializerOptions)
         {
             if (foo.BarOption.IsSet && foo.Bar == null)
-                throw new ArgumentNullException(nameof(foo.Bar), "Property is required for class Foo.");
+                throw new JsonException("Cannot write null property Foo.Bar to non-nullable JSON property 'bar'.");
 
             if (foo.BarOption.IsSet)
                 writer.WriteString("bar", foo.Bar);

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, FooGetDefaultResponse fooGetDefaultResponse, JsonSerializerOptions jsonSerializerOptions)
         {
             if (fooGetDefaultResponse.StringOption.IsSet && fooGetDefaultResponse.String == null)
-                throw new ArgumentNullException(nameof(fooGetDefaultResponse.String), "Property is required for class FooGetDefaultResponse.");
+                throw new JsonException("Cannot write null property FooGetDefaultResponse.String to non-nullable JSON property 'string'.");
 
             if (fooGetDefaultResponse.StringOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -954,11 +954,47 @@ namespace Org.OpenAPITools.Model
             if (formatTest.BinaryOption.IsSet && formatTest.Binary == null)
                 throw new JsonException("Cannot write null property FormatTest.Binary to non-nullable JSON property 'binary'.");
 
+            if (formatTest.DateTimeOption.IsSet && formatTest.DateTime == null)
+                throw new JsonException("Cannot write null property FormatTest.DateTime to non-nullable JSON property 'dateTime'.");
+
+            if (formatTest.DecimalOption.IsSet && formatTest.Decimal == null)
+                throw new JsonException("Cannot write null property FormatTest.Decimal to non-nullable JSON property 'decimal'.");
+
+            if (formatTest.DoubleOption.IsSet && formatTest.Double == null)
+                throw new JsonException("Cannot write null property FormatTest.Double to non-nullable JSON property 'double'.");
+
             if (formatTest.DuplicatePropertyName2Option.IsSet && formatTest.DuplicatePropertyName2 == null)
                 throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName2 to non-nullable JSON property 'duplicate_property_name'.");
 
             if (formatTest.DuplicatePropertyNameOption.IsSet && formatTest.DuplicatePropertyName == null)
                 throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName to non-nullable JSON property '@duplicate_property_name'.");
+
+            if (formatTest.FloatOption.IsSet && formatTest.Float == null)
+                throw new JsonException("Cannot write null property FormatTest.Float to non-nullable JSON property 'float'.");
+
+            if (formatTest.Int32Option.IsSet && formatTest.Int32 == null)
+                throw new JsonException("Cannot write null property FormatTest.Int32 to non-nullable JSON property 'int32'.");
+
+            if (formatTest.Int32RangeOption.IsSet && formatTest.Int32Range == null)
+                throw new JsonException("Cannot write null property FormatTest.Int32Range to non-nullable JSON property 'int32Range'.");
+
+            if (formatTest.Int64Option.IsSet && formatTest.Int64 == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64 to non-nullable JSON property 'int64'.");
+
+            if (formatTest.Int64NegativeOption.IsSet && formatTest.Int64Negative == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64Negative to non-nullable JSON property 'int64Negative'.");
+
+            if (formatTest.Int64NegativeExclusiveOption.IsSet && formatTest.Int64NegativeExclusive == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64NegativeExclusive to non-nullable JSON property 'int64NegativeExclusive'.");
+
+            if (formatTest.Int64PositiveOption.IsSet && formatTest.Int64Positive == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64Positive to non-nullable JSON property 'int64Positive'.");
+
+            if (formatTest.Int64PositiveExclusiveOption.IsSet && formatTest.Int64PositiveExclusive == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64PositiveExclusive to non-nullable JSON property 'int64PositiveExclusive'.");
+
+            if (formatTest.IntegerOption.IsSet && formatTest.Integer == null)
+                throw new JsonException("Cannot write null property FormatTest.Integer to non-nullable JSON property 'integer'.");
 
             if (formatTest.PatternWithBackslashOption.IsSet && formatTest.PatternWithBackslash == null)
                 throw new JsonException("Cannot write null property FormatTest.PatternWithBackslash to non-nullable JSON property 'pattern_with_backslash'.");
@@ -971,6 +1007,18 @@ namespace Org.OpenAPITools.Model
 
             if (formatTest.StringOption.IsSet && formatTest.String == null)
                 throw new JsonException("Cannot write null property FormatTest.String to non-nullable JSON property 'string'.");
+
+            if (formatTest.StringFormattedAsDecimalOption.IsSet && formatTest.StringFormattedAsDecimal == null)
+                throw new JsonException("Cannot write null property FormatTest.StringFormattedAsDecimal to non-nullable JSON property 'string_formatted_as_decimal'.");
+
+            if (formatTest.UnsignedIntegerOption.IsSet && formatTest.UnsignedInteger == null)
+                throw new JsonException("Cannot write null property FormatTest.UnsignedInteger to non-nullable JSON property 'unsigned_integer'.");
+
+            if (formatTest.UnsignedLongOption.IsSet && formatTest.UnsignedLong == null)
+                throw new JsonException("Cannot write null property FormatTest.UnsignedLong to non-nullable JSON property 'unsigned_long'.");
+
+            if (formatTest.UuidOption.IsSet && formatTest.Uuid == null)
+                throw new JsonException("Cannot write null property FormatTest.Uuid to non-nullable JSON property 'uuid'.");
 
             writer.WritePropertyName("byte");
             JsonSerializer.Serialize(writer, formatTest.Byte, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -951,32 +951,26 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, FormatTest formatTest, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (formatTest.Byte == null)
-                throw new ArgumentNullException(nameof(formatTest.Byte), "Property is required for class FormatTest.");
-
-            if (formatTest.Password == null)
-                throw new ArgumentNullException(nameof(formatTest.Password), "Property is required for class FormatTest.");
-
             if (formatTest.BinaryOption.IsSet && formatTest.Binary == null)
-                throw new ArgumentNullException(nameof(formatTest.Binary), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.Binary to non-nullable JSON property 'binary'.");
 
             if (formatTest.DuplicatePropertyName2Option.IsSet && formatTest.DuplicatePropertyName2 == null)
-                throw new ArgumentNullException(nameof(formatTest.DuplicatePropertyName2), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName2 to non-nullable JSON property 'duplicate_property_name'.");
 
             if (formatTest.DuplicatePropertyNameOption.IsSet && formatTest.DuplicatePropertyName == null)
-                throw new ArgumentNullException(nameof(formatTest.DuplicatePropertyName), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName to non-nullable JSON property '@duplicate_property_name'.");
 
             if (formatTest.PatternWithBackslashOption.IsSet && formatTest.PatternWithBackslash == null)
-                throw new ArgumentNullException(nameof(formatTest.PatternWithBackslash), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.PatternWithBackslash to non-nullable JSON property 'pattern_with_backslash'.");
 
             if (formatTest.PatternWithDigitsOption.IsSet && formatTest.PatternWithDigits == null)
-                throw new ArgumentNullException(nameof(formatTest.PatternWithDigits), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.PatternWithDigits to non-nullable JSON property 'pattern_with_digits'.");
 
             if (formatTest.PatternWithDigitsAndDelimiterOption.IsSet && formatTest.PatternWithDigitsAndDelimiter == null)
-                throw new ArgumentNullException(nameof(formatTest.PatternWithDigitsAndDelimiter), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.PatternWithDigitsAndDelimiter to non-nullable JSON property 'pattern_with_digits_and_delimiter'.");
 
             if (formatTest.StringOption.IsSet && formatTest.String == null)
-                throw new ArgumentNullException(nameof(formatTest.String), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.String to non-nullable JSON property 'string'.");
 
             writer.WritePropertyName("byte");
             JsonSerializer.Serialize(writer, formatTest.Byte, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Fruit.cs
@@ -219,7 +219,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Fruit fruit, JsonSerializerOptions jsonSerializerOptions)
         {
             if (fruit.ColorOption.IsSet && fruit.Color == null)
-                throw new ArgumentNullException(nameof(fruit.Color), "Property is required for class Fruit.");
+                throw new JsonException("Cannot write null property Fruit.Color to non-nullable JSON property 'color'.");
 
             if (fruit.ColorOption.IsSet)
                 writer.WriteString("color", fruit.Color);

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -236,7 +236,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, GmFruit gmFruit, JsonSerializerOptions jsonSerializerOptions)
         {
             if (gmFruit.ColorOption.IsSet && gmFruit.Color == null)
-                throw new ArgumentNullException(nameof(gmFruit.Color), "Property is required for class GmFruit.");
+                throw new JsonException("Cannot write null property GmFruit.Color to non-nullable JSON property 'color'.");
 
             if (gmFruit.ColorOption.IsSet)
                 writer.WriteString("color", gmFruit.Color);

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -239,10 +239,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, HasOnlyReadOnly hasOnlyReadOnly, JsonSerializerOptions jsonSerializerOptions)
         {
             if (hasOnlyReadOnly.BarOption.IsSet && hasOnlyReadOnly.Bar == null)
-                throw new ArgumentNullException(nameof(hasOnlyReadOnly.Bar), "Property is required for class HasOnlyReadOnly.");
+                throw new JsonException("Cannot write null property HasOnlyReadOnly.Bar to non-nullable JSON property 'bar'.");
 
             if (hasOnlyReadOnly.FooOption.IsSet && hasOnlyReadOnly.Foo == null)
-                throw new ArgumentNullException(nameof(hasOnlyReadOnly.Foo), "Property is required for class HasOnlyReadOnly.");
+                throw new JsonException("Cannot write null property HasOnlyReadOnly.Foo to non-nullable JSON property 'foo'.");
 
             if (hasOnlyReadOnly.BarOption.IsSet)
                 writer.WriteString("bar", hasOnlyReadOnly.Bar);

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
@@ -337,22 +337,22 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, InjectedVendorExtensionsTest injectedVendorExtensionsTest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessorOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor to non-nullable JSON property 'potentiallyOverriddenPropertyAccessor'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternalOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternal == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternal), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternal to non-nullable JSON property 'potentiallyOverriddenPropertyToInternal'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivateOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivate == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivate), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivate to non-nullable JSON property 'potentiallyOverriddenPropertyToPrivate'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublicOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublic == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublic), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublic to non-nullable JSON property 'potentiallyOverriddenPropertyToPublic'.");
 
             if (injectedVendorExtensionsTest.UnalteredPropertyOption.IsSet && injectedVendorExtensionsTest.UnalteredProperty == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.UnalteredProperty), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.UnalteredProperty to non-nullable JSON property 'unalteredProperty'.");
 
             if (injectedVendorExtensionsTest.UnalteredPropertyAccessorOption.IsSet && injectedVendorExtensionsTest.UnalteredPropertyAccessor == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.UnalteredPropertyAccessor), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.UnalteredPropertyAccessor to non-nullable JSON property 'unalteredPropertyAccessor'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessorOption.IsSet)
                 writer.WriteString("potentiallyOverriddenPropertyAccessor", injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor);

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
@@ -182,12 +182,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, IsoscelesTriangle isoscelesTriangle, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (isoscelesTriangle.ShapeType == null)
-                throw new ArgumentNullException(nameof(isoscelesTriangle.ShapeType), "Property is required for class IsoscelesTriangle.");
-
-            if (isoscelesTriangle.TriangleType == null)
-                throw new ArgumentNullException(nameof(isoscelesTriangle.TriangleType), "Property is required for class IsoscelesTriangle.");
-
             writer.WriteString("shapeType", isoscelesTriangle.ShapeType);
 
             writer.WriteString("triangleType", isoscelesTriangle.TriangleType);

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/List.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, List list, JsonSerializerOptions jsonSerializerOptions)
         {
             if (list.Var123ListOption.IsSet && list.Var123List == null)
-                throw new ArgumentNullException(nameof(list.Var123List), "Property is required for class List.");
+                throw new JsonException("Cannot write null property List.Var123List to non-nullable JSON property '123-list'.");
 
             if (list.Var123ListOption.IsSet)
                 writer.WriteString("123-list", list.Var123List);

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -198,10 +198,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, LiteralStringClass literalStringClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (literalStringClass.EscapedLiteralStringOption.IsSet && literalStringClass.EscapedLiteralString == null)
-                throw new ArgumentNullException(nameof(literalStringClass.EscapedLiteralString), "Property is required for class LiteralStringClass.");
+                throw new JsonException("Cannot write null property LiteralStringClass.EscapedLiteralString to non-nullable JSON property 'escapedLiteralString'.");
 
             if (literalStringClass.UnescapedLiteralStringOption.IsSet && literalStringClass.UnescapedLiteralString == null)
-                throw new ArgumentNullException(nameof(literalStringClass.UnescapedLiteralString), "Property is required for class LiteralStringClass.");
+                throw new JsonException("Cannot write null property LiteralStringClass.UnescapedLiteralString to non-nullable JSON property 'unescapedLiteralString'.");
 
             if (literalStringClass.EscapedLiteralStringOption.IsSet)
                 writer.WriteString("escapedLiteralString", literalStringClass.EscapedLiteralString);

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/MapTest.cs
@@ -244,16 +244,16 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MapTest mapTest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mapTest.DirectMapOption.IsSet && mapTest.DirectMap == null)
-                throw new ArgumentNullException(nameof(mapTest.DirectMap), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.DirectMap to non-nullable JSON property 'direct_map'.");
 
             if (mapTest.IndirectMapOption.IsSet && mapTest.IndirectMap == null)
-                throw new ArgumentNullException(nameof(mapTest.IndirectMap), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.IndirectMap to non-nullable JSON property 'indirect_map'.");
 
             if (mapTest.MapMapOfStringOption.IsSet && mapTest.MapMapOfString == null)
-                throw new ArgumentNullException(nameof(mapTest.MapMapOfString), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.MapMapOfString to non-nullable JSON property 'map_map_of_string'.");
 
             if (mapTest.MapOfEnumStringOption.IsSet && mapTest.MapOfEnumString == null)
-                throw new ArgumentNullException(nameof(mapTest.MapOfEnumString), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.MapOfEnumString to non-nullable JSON property 'map_of_enum_string'.");
 
             if (mapTest.DirectMapOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/MixedAnyOf.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/MixedAnyOf.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedAnyOf mixedAnyOf, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedAnyOf.ContentOption.IsSet && mixedAnyOf.Content == null)
-                throw new ArgumentNullException(nameof(mixedAnyOf.Content), "Property is required for class MixedAnyOf.");
+                throw new JsonException("Cannot write null property MixedAnyOf.Content to non-nullable JSON property 'content'.");
 
             if (mixedAnyOf.ContentOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/MixedOneOf.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/MixedOneOf.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedOneOf mixedOneOf, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedOneOf.ContentOption.IsSet && mixedOneOf.Content == null)
-                throw new ArgumentNullException(nameof(mixedOneOf.Content), "Property is required for class MixedOneOf.");
+                throw new JsonException("Cannot write null property MixedOneOf.Content to non-nullable JSON property 'content'.");
 
             if (mixedOneOf.ContentOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -255,8 +255,17 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, MixedPropertiesAndAdditionalPropertiesClass mixedPropertiesAndAdditionalPropertiesClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.DateTime == null)
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.DateTime to non-nullable JSON property 'dateTime'.");
+
             if (mixedPropertiesAndAdditionalPropertiesClass.MapOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.Map == null)
                 throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.Map to non-nullable JSON property 'map'.");
+
+            if (mixedPropertiesAndAdditionalPropertiesClass.UuidOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.Uuid == null)
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.Uuid to non-nullable JSON property 'uuid'.");
+
+            if (mixedPropertiesAndAdditionalPropertiesClass.UuidWithPatternOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.UuidWithPattern == null)
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.UuidWithPattern to non-nullable JSON property 'uuid_with_pattern'.");
 
             if (mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.IsSet)
                 writer.WriteString("dateTime", mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.Value.Value.ToString(DateTimeFormat));

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -256,7 +256,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedPropertiesAndAdditionalPropertiesClass mixedPropertiesAndAdditionalPropertiesClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedPropertiesAndAdditionalPropertiesClass.MapOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.Map == null)
-                throw new ArgumentNullException(nameof(mixedPropertiesAndAdditionalPropertiesClass.Map), "Property is required for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.Map to non-nullable JSON property 'map'.");
 
             if (mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.IsSet)
                 writer.WriteString("dateTime", mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.Value.Value.ToString(DateTimeFormat));

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/MixedSubId.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/MixedSubId.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedSubId mixedSubId, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedSubId.IdOption.IsSet && mixedSubId.Id == null)
-                throw new ArgumentNullException(nameof(mixedSubId.Id), "Property is required for class MixedSubId.");
+                throw new JsonException("Cannot write null property MixedSubId.Id to non-nullable JSON property 'id'.");
 
             if (mixedSubId.IdOption.IsSet)
                 writer.WriteString("id", mixedSubId.Id);

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -198,7 +198,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Model200Response model200Response, JsonSerializerOptions jsonSerializerOptions)
         {
             if (model200Response.ClassOption.IsSet && model200Response.Class == null)
-                throw new ArgumentNullException(nameof(model200Response.Class), "Property is required for class Model200Response.");
+                throw new JsonException("Cannot write null property Model200Response.Class to non-nullable JSON property 'class'.");
 
             if (model200Response.ClassOption.IsSet)
                 writer.WriteString("class", model200Response.Class);

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -200,6 +200,9 @@ namespace Org.OpenAPITools.Model
             if (model200Response.ClassOption.IsSet && model200Response.Class == null)
                 throw new JsonException("Cannot write null property Model200Response.Class to non-nullable JSON property 'class'.");
 
+            if (model200Response.NameOption.IsSet && model200Response.Name == null)
+                throw new JsonException("Cannot write null property Model200Response.Name to non-nullable JSON property 'name'.");
+
             if (model200Response.ClassOption.IsSet)
                 writer.WriteString("class", model200Response.Class);
 

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ModelClient modelClient, JsonSerializerOptions jsonSerializerOptions)
         {
             if (modelClient.VarClientOption.IsSet && modelClient.VarClient == null)
-                throw new ArgumentNullException(nameof(modelClient.VarClient), "Property is required for class ModelClient.");
+                throw new JsonException("Cannot write null property ModelClient.VarClient to non-nullable JSON property 'client'.");
 
             if (modelClient.VarClientOption.IsSet)
                 writer.WriteString("client", modelClient.VarClient);

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Name.cs
@@ -281,7 +281,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Name name, JsonSerializerOptions jsonSerializerOptions)
         {
             if (name.PropertyOption.IsSet && name.Property == null)
-                throw new ArgumentNullException(nameof(name.Property), "Property is required for class Name.");
+                throw new JsonException("Cannot write null property Name.Property to non-nullable JSON property 'property'.");
 
             writer.WriteNumber("name", name.VarName);
 

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Name.cs
@@ -283,6 +283,12 @@ namespace Org.OpenAPITools.Model
             if (name.PropertyOption.IsSet && name.Property == null)
                 throw new JsonException("Cannot write null property Name.Property to non-nullable JSON property 'property'.");
 
+            if (name.SnakeCaseOption.IsSet && name.SnakeCase == null)
+                throw new JsonException("Cannot write null property Name.SnakeCase to non-nullable JSON property 'snake_case'.");
+
+            if (name.Var123NumberOption.IsSet && name.Var123Number == null)
+                throw new JsonException("Cannot write null property Name.Var123Number to non-nullable JSON property '123Number'.");
+
             writer.WriteNumber("name", name.VarName);
 
             if (name.PropertyOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
@@ -189,9 +189,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, NotificationtestGetElementsV1ResponseMPayload notificationtestGetElementsV1ResponseMPayload, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (notificationtestGetElementsV1ResponseMPayload.AObjVariableobject == null)
-                throw new ArgumentNullException(nameof(notificationtestGetElementsV1ResponseMPayload.AObjVariableobject), "Property is required for class NotificationtestGetElementsV1ResponseMPayload.");
-
             writer.WritePropertyName("a_objVariableobject");
             JsonSerializer.Serialize(writer, notificationtestGetElementsV1ResponseMPayload.AObjVariableobject, jsonSerializerOptions);
             writer.WriteNumber("pkiNotificationtestID", notificationtestGetElementsV1ResponseMPayload.PkiNotificationtestID);

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -408,10 +408,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, NullableClass nullableClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (nullableClass.ArrayItemsNullableOption.IsSet && nullableClass.ArrayItemsNullable == null)
-                throw new ArgumentNullException(nameof(nullableClass.ArrayItemsNullable), "Property is required for class NullableClass.");
+                throw new JsonException("Cannot write null property NullableClass.ArrayItemsNullable to non-nullable JSON property 'array_items_nullable'.");
 
             if (nullableClass.ObjectItemsNullableOption.IsSet && nullableClass.ObjectItemsNullable == null)
-                throw new ArgumentNullException(nameof(nullableClass.ObjectItemsNullable), "Property is required for class NullableClass.");
+                throw new JsonException("Cannot write null property NullableClass.ObjectItemsNullable to non-nullable JSON property 'object_items_nullable'.");
 
             if (nullableClass.ArrayAndItemsNullablePropOption.IsSet)
                 if (nullableClass.ArrayAndItemsNullablePropOption.Value != null)

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -174,6 +174,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, NumberOnly numberOnly, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (numberOnly.JustNumberOption.IsSet && numberOnly.JustNumber == null)
+                throw new JsonException("Cannot write null property NumberOnly.JustNumber to non-nullable JSON property 'JustNumber'.");
+
             if (numberOnly.JustNumberOption.IsSet)
                 writer.WriteNumber("JustNumber", numberOnly.JustNumberOption.Value.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -247,13 +247,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ObjectWithDeprecatedFields objectWithDeprecatedFields, JsonSerializerOptions jsonSerializerOptions)
         {
             if (objectWithDeprecatedFields.BarsOption.IsSet && objectWithDeprecatedFields.Bars == null)
-                throw new ArgumentNullException(nameof(objectWithDeprecatedFields.Bars), "Property is required for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Bars to non-nullable JSON property 'bars'.");
 
             if (objectWithDeprecatedFields.DeprecatedRefOption.IsSet && objectWithDeprecatedFields.DeprecatedRef == null)
-                throw new ArgumentNullException(nameof(objectWithDeprecatedFields.DeprecatedRef), "Property is required for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.DeprecatedRef to non-nullable JSON property 'deprecatedRef'.");
 
             if (objectWithDeprecatedFields.UuidOption.IsSet && objectWithDeprecatedFields.Uuid == null)
-                throw new ArgumentNullException(nameof(objectWithDeprecatedFields.Uuid), "Property is required for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Uuid to non-nullable JSON property 'uuid'.");
 
             if (objectWithDeprecatedFields.BarsOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -252,6 +252,9 @@ namespace Org.OpenAPITools.Model
             if (objectWithDeprecatedFields.DeprecatedRefOption.IsSet && objectWithDeprecatedFields.DeprecatedRef == null)
                 throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.DeprecatedRef to non-nullable JSON property 'deprecatedRef'.");
 
+            if (objectWithDeprecatedFields.IdOption.IsSet && objectWithDeprecatedFields.Id == null)
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Id to non-nullable JSON property 'id'.");
+
             if (objectWithDeprecatedFields.UuidOption.IsSet && objectWithDeprecatedFields.Uuid == null)
                 throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Uuid to non-nullable JSON property 'uuid'.");
 

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Order.cs
@@ -295,6 +295,24 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Order order, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (order.CompleteOption.IsSet && order.Complete == null)
+                throw new JsonException("Cannot write null property Order.Complete to non-nullable JSON property 'complete'.");
+
+            if (order.IdOption.IsSet && order.Id == null)
+                throw new JsonException("Cannot write null property Order.Id to non-nullable JSON property 'id'.");
+
+            if (order.PetIdOption.IsSet && order.PetId == null)
+                throw new JsonException("Cannot write null property Order.PetId to non-nullable JSON property 'petId'.");
+
+            if (order.QuantityOption.IsSet && order.Quantity == null)
+                throw new JsonException("Cannot write null property Order.Quantity to non-nullable JSON property 'quantity'.");
+
+            if (order.ShipDateOption.IsSet && order.ShipDate == null)
+                throw new JsonException("Cannot write null property Order.ShipDate to non-nullable JSON property 'shipDate'.");
+
+            if (order.StatusOption.IsSet && order.Status == null)
+                throw new JsonException("Cannot write null property Order.Status to non-nullable JSON property 'status'.");
+
             if (order.CompleteOption.IsSet)
                 writer.WriteBoolean("complete", order.CompleteOption.Value.Value);
 

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -220,6 +220,12 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, OuterComposite outerComposite, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (outerComposite.MyBooleanOption.IsSet && outerComposite.MyBoolean == null)
+                throw new JsonException("Cannot write null property OuterComposite.MyBoolean to non-nullable JSON property 'my_boolean'.");
+
+            if (outerComposite.MyNumberOption.IsSet && outerComposite.MyNumber == null)
+                throw new JsonException("Cannot write null property OuterComposite.MyNumber to non-nullable JSON property 'my_number'.");
+
             if (outerComposite.MyStringOption.IsSet && outerComposite.MyString == null)
                 throw new JsonException("Cannot write null property OuterComposite.MyString to non-nullable JSON property 'my_string'.");
 

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -221,7 +221,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, OuterComposite outerComposite, JsonSerializerOptions jsonSerializerOptions)
         {
             if (outerComposite.MyStringOption.IsSet && outerComposite.MyString == null)
-                throw new ArgumentNullException(nameof(outerComposite.MyString), "Property is required for class OuterComposite.");
+                throw new JsonException("Cannot write null property OuterComposite.MyString to non-nullable JSON property 'my_string'.");
 
             if (outerComposite.MyBooleanOption.IsSet)
                 writer.WriteBoolean("my_boolean", outerComposite.MyBooleanOption.Value.Value);

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Pet.cs
@@ -282,17 +282,11 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Pet pet, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (pet.Name == null)
-                throw new ArgumentNullException(nameof(pet.Name), "Property is required for class Pet.");
-
-            if (pet.PhotoUrls == null)
-                throw new ArgumentNullException(nameof(pet.PhotoUrls), "Property is required for class Pet.");
-
             if (pet.CategoryOption.IsSet && pet.Category == null)
-                throw new ArgumentNullException(nameof(pet.Category), "Property is required for class Pet.");
+                throw new JsonException("Cannot write null property Pet.Category to non-nullable JSON property 'category'.");
 
             if (pet.TagsOption.IsSet && pet.Tags == null)
-                throw new ArgumentNullException(nameof(pet.Tags), "Property is required for class Pet.");
+                throw new JsonException("Cannot write null property Pet.Tags to non-nullable JSON property 'tags'.");
 
             writer.WriteString("name", pet.Name);
 

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Pet.cs
@@ -285,6 +285,12 @@ namespace Org.OpenAPITools.Model
             if (pet.CategoryOption.IsSet && pet.Category == null)
                 throw new JsonException("Cannot write null property Pet.Category to non-nullable JSON property 'category'.");
 
+            if (pet.IdOption.IsSet && pet.Id == null)
+                throw new JsonException("Cannot write null property Pet.Id to non-nullable JSON property 'id'.");
+
+            if (pet.StatusOption.IsSet && pet.Status == null)
+                throw new JsonException("Cannot write null property Pet.Status to non-nullable JSON property 'status'.");
+
             if (pet.TagsOption.IsSet && pet.Tags == null)
                 throw new JsonException("Cannot write null property Pet.Tags to non-nullable JSON property 'tags'.");
 

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
@@ -170,9 +170,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, QuadrilateralInterface quadrilateralInterface, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (quadrilateralInterface.QuadrilateralType == null)
-                throw new ArgumentNullException(nameof(quadrilateralInterface.QuadrilateralType), "Property is required for class QuadrilateralInterface.");
-
             writer.WriteString("quadrilateralType", quadrilateralInterface.QuadrilateralType);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -236,10 +236,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ReadOnlyFirst readOnlyFirst, JsonSerializerOptions jsonSerializerOptions)
         {
             if (readOnlyFirst.BarOption.IsSet && readOnlyFirst.Bar == null)
-                throw new ArgumentNullException(nameof(readOnlyFirst.Bar), "Property is required for class ReadOnlyFirst.");
+                throw new JsonException("Cannot write null property ReadOnlyFirst.Bar to non-nullable JSON property 'bar'.");
 
             if (readOnlyFirst.BazOption.IsSet && readOnlyFirst.Baz == null)
-                throw new ArgumentNullException(nameof(readOnlyFirst.Baz), "Property is required for class ReadOnlyFirst.");
+                throw new JsonException("Cannot write null property ReadOnlyFirst.Baz to non-nullable JSON property 'baz'.");
 
             if (readOnlyFirst.BarOption.IsSet)
                 writer.WriteString("bar", readOnlyFirst.Bar);

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -1053,11 +1053,38 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, RequiredClass requiredClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (requiredClass.NotRequiredNotnullableDatePropOption.IsSet && requiredClass.NotRequiredNotnullableDateProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotRequiredNotnullableDateProp to non-nullable JSON property 'not_required_notnullable_date_prop'.");
+
+            if (requiredClass.NotRequiredNotnullableintegerPropOption.IsSet && requiredClass.NotRequiredNotnullableintegerProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotRequiredNotnullableintegerProp to non-nullable JSON property 'not_required_notnullableinteger_prop'.");
+
             if (requiredClass.NotrequiredNotnullableArrayOfStringOption.IsSet && requiredClass.NotrequiredNotnullableArrayOfString == null)
                 throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableArrayOfString to non-nullable JSON property 'notrequired_notnullable_array_of_string'.");
 
+            if (requiredClass.NotrequiredNotnullableBooleanPropOption.IsSet && requiredClass.NotrequiredNotnullableBooleanProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableBooleanProp to non-nullable JSON property 'notrequired_notnullable_boolean_prop'.");
+
+            if (requiredClass.NotrequiredNotnullableDatetimePropOption.IsSet && requiredClass.NotrequiredNotnullableDatetimeProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableDatetimeProp to non-nullable JSON property 'notrequired_notnullable_datetime_prop'.");
+
+            if (requiredClass.NotrequiredNotnullableEnumIntegerOption.IsSet && requiredClass.NotrequiredNotnullableEnumInteger == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableEnumInteger to non-nullable JSON property 'notrequired_notnullable_enum_integer'.");
+
+            if (requiredClass.NotrequiredNotnullableEnumIntegerOnlyOption.IsSet && requiredClass.NotrequiredNotnullableEnumIntegerOnly == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableEnumIntegerOnly to non-nullable JSON property 'notrequired_notnullable_enum_integer_only'.");
+
+            if (requiredClass.NotrequiredNotnullableEnumStringOption.IsSet && requiredClass.NotrequiredNotnullableEnumString == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableEnumString to non-nullable JSON property 'notrequired_notnullable_enum_string'.");
+
+            if (requiredClass.NotrequiredNotnullableOuterEnumDefaultValueOption.IsSet && requiredClass.NotrequiredNotnullableOuterEnumDefaultValue == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableOuterEnumDefaultValue to non-nullable JSON property 'notrequired_notnullable_outerEnumDefaultValue'.");
+
             if (requiredClass.NotrequiredNotnullableStringPropOption.IsSet && requiredClass.NotrequiredNotnullableStringProp == null)
                 throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableStringProp to non-nullable JSON property 'notrequired_notnullable_string_prop'.");
+
+            if (requiredClass.NotrequiredNotnullableUuidOption.IsSet && requiredClass.NotrequiredNotnullableUuid == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableUuid to non-nullable JSON property 'notrequired_notnullable_uuid'.");
 
             writer.WriteString("required_not_nullable_date_prop", requiredClass.RequiredNotNullableDateProp.ToString(RequiredNotNullableDatePropFormat));
 

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -1053,17 +1053,11 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, RequiredClass requiredClass, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (requiredClass.RequiredNotnullableArrayOfString == null)
-                throw new ArgumentNullException(nameof(requiredClass.RequiredNotnullableArrayOfString), "Property is required for class RequiredClass.");
-
-            if (requiredClass.RequiredNotnullableStringProp == null)
-                throw new ArgumentNullException(nameof(requiredClass.RequiredNotnullableStringProp), "Property is required for class RequiredClass.");
-
             if (requiredClass.NotrequiredNotnullableArrayOfStringOption.IsSet && requiredClass.NotrequiredNotnullableArrayOfString == null)
-                throw new ArgumentNullException(nameof(requiredClass.NotrequiredNotnullableArrayOfString), "Property is required for class RequiredClass.");
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableArrayOfString to non-nullable JSON property 'notrequired_notnullable_array_of_string'.");
 
             if (requiredClass.NotrequiredNotnullableStringPropOption.IsSet && requiredClass.NotrequiredNotnullableStringProp == null)
-                throw new ArgumentNullException(nameof(requiredClass.NotrequiredNotnullableStringProp), "Property is required for class RequiredClass.");
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableStringProp to non-nullable JSON property 'notrequired_notnullable_string_prop'.");
 
             writer.WriteString("required_not_nullable_date_prop", requiredClass.RequiredNotNullableDateProp.ToString(RequiredNotNullableDatePropFormat));
 

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Result.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Result.cs
@@ -224,13 +224,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Result result, JsonSerializerOptions jsonSerializerOptions)
         {
             if (result.CodeOption.IsSet && result.Code == null)
-                throw new ArgumentNullException(nameof(result.Code), "Property is required for class Result.");
+                throw new JsonException("Cannot write null property Result.Code to non-nullable JSON property 'code'.");
 
             if (result.DataOption.IsSet && result.Data == null)
-                throw new ArgumentNullException(nameof(result.Data), "Property is required for class Result.");
+                throw new JsonException("Cannot write null property Result.Data to non-nullable JSON property 'data'.");
 
             if (result.UuidOption.IsSet && result.Uuid == null)
-                throw new ArgumentNullException(nameof(result.Uuid), "Property is required for class Result.");
+                throw new JsonException("Cannot write null property Result.Uuid to non-nullable JSON property 'uuid'.");
 
             if (result.CodeOption.IsSet)
                 writer.WriteString("code", result.Code);

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Return.cs
@@ -232,11 +232,8 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Return varReturn, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (varReturn.Lock == null)
-                throw new ArgumentNullException(nameof(varReturn.Lock), "Property is required for class Return.");
-
             if (varReturn.UnsafeOption.IsSet && varReturn.Unsafe == null)
-                throw new ArgumentNullException(nameof(varReturn.Unsafe), "Property is required for class Return.");
+                throw new JsonException("Cannot write null property Return.Unsafe to non-nullable JSON property 'unsafe'.");
 
             writer.WriteString("lock", varReturn.Lock);
 

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Return.cs
@@ -232,6 +232,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Return varReturn, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (varReturn.VarReturnOption.IsSet && varReturn.VarReturn == null)
+                throw new JsonException("Cannot write null property Return.VarReturn to non-nullable JSON property 'return'.");
+
             if (varReturn.UnsafeOption.IsSet && varReturn.Unsafe == null)
                 throw new JsonException("Cannot write null property Return.Unsafe to non-nullable JSON property 'unsafe'.");
 

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -198,7 +198,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, RolesReportsHash rolesReportsHash, JsonSerializerOptions jsonSerializerOptions)
         {
             if (rolesReportsHash.RoleOption.IsSet && rolesReportsHash.Role == null)
-                throw new ArgumentNullException(nameof(rolesReportsHash.Role), "Property is required for class RolesReportsHash.");
+                throw new JsonException("Cannot write null property RolesReportsHash.Role to non-nullable JSON property 'role'.");
 
             if (rolesReportsHash.RoleOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -200,6 +200,9 @@ namespace Org.OpenAPITools.Model
             if (rolesReportsHash.RoleOption.IsSet && rolesReportsHash.Role == null)
                 throw new JsonException("Cannot write null property RolesReportsHash.Role to non-nullable JSON property 'role'.");
 
+            if (rolesReportsHash.RoleUuidOption.IsSet && rolesReportsHash.RoleUuid == null)
+                throw new JsonException("Cannot write null property RolesReportsHash.RoleUuid to non-nullable JSON property 'role_uuid'.");
+
             if (rolesReportsHash.RoleOption.IsSet)
             {
                 writer.WritePropertyName("role");

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, RolesReportsHashRole rolesReportsHashRole, JsonSerializerOptions jsonSerializerOptions)
         {
             if (rolesReportsHashRole.NameOption.IsSet && rolesReportsHashRole.Name == null)
-                throw new ArgumentNullException(nameof(rolesReportsHashRole.Name), "Property is required for class RolesReportsHashRole.");
+                throw new JsonException("Cannot write null property RolesReportsHashRole.Name to non-nullable JSON property 'name'.");
 
             if (rolesReportsHashRole.NameOption.IsSet)
                 writer.WriteString("name", rolesReportsHashRole.Name);

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
@@ -189,12 +189,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ScaleneTriangle scaleneTriangle, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (scaleneTriangle.ShapeType == null)
-                throw new ArgumentNullException(nameof(scaleneTriangle.ShapeType), "Property is required for class ScaleneTriangle.");
-
-            if (scaleneTriangle.TriangleType == null)
-                throw new ArgumentNullException(nameof(scaleneTriangle.TriangleType), "Property is required for class ScaleneTriangle.");
-
             writer.WriteString("shapeType", scaleneTriangle.ShapeType);
 
             writer.WriteString("triangleType", scaleneTriangle.TriangleType);

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ShapeInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ShapeInterface.cs
@@ -170,9 +170,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ShapeInterface shapeInterface, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (shapeInterface.ShapeType == null)
-                throw new ArgumentNullException(nameof(shapeInterface.ShapeType), "Property is required for class ShapeInterface.");
-
             writer.WriteString("shapeType", shapeInterface.ShapeType);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
@@ -189,12 +189,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, SimpleQuadrilateral simpleQuadrilateral, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (simpleQuadrilateral.QuadrilateralType == null)
-                throw new ArgumentNullException(nameof(simpleQuadrilateral.QuadrilateralType), "Property is required for class SimpleQuadrilateral.");
-
-            if (simpleQuadrilateral.ShapeType == null)
-                throw new ArgumentNullException(nameof(simpleQuadrilateral.ShapeType), "Property is required for class SimpleQuadrilateral.");
-
             writer.WriteString("quadrilateralType", simpleQuadrilateral.QuadrilateralType);
 
             writer.WriteString("shapeType", simpleQuadrilateral.ShapeType);

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -200,6 +200,9 @@ namespace Org.OpenAPITools.Model
             if (specialModelName.VarSpecialModelNameOption.IsSet && specialModelName.VarSpecialModelName == null)
                 throw new JsonException("Cannot write null property SpecialModelName.VarSpecialModelName to non-nullable JSON property '_special_model.name_'.");
 
+            if (specialModelName.SpecialPropertyNameOption.IsSet && specialModelName.SpecialPropertyName == null)
+                throw new JsonException("Cannot write null property SpecialModelName.SpecialPropertyName to non-nullable JSON property '$special[property.name]'.");
+
             if (specialModelName.VarSpecialModelNameOption.IsSet)
                 writer.WriteString("_special_model.name_", specialModelName.VarSpecialModelName);
 

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -198,7 +198,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, SpecialModelName specialModelName, JsonSerializerOptions jsonSerializerOptions)
         {
             if (specialModelName.VarSpecialModelNameOption.IsSet && specialModelName.VarSpecialModelName == null)
-                throw new ArgumentNullException(nameof(specialModelName.VarSpecialModelName), "Property is required for class SpecialModelName.");
+                throw new JsonException("Cannot write null property SpecialModelName.VarSpecialModelName to non-nullable JSON property '_special_model.name_'.");
 
             if (specialModelName.VarSpecialModelNameOption.IsSet)
                 writer.WriteString("_special_model.name_", specialModelName.VarSpecialModelName);

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Tag.cs
@@ -198,7 +198,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Tag tag, JsonSerializerOptions jsonSerializerOptions)
         {
             if (tag.NameOption.IsSet && tag.Name == null)
-                throw new ArgumentNullException(nameof(tag.Name), "Property is required for class Tag.");
+                throw new JsonException("Cannot write null property Tag.Name to non-nullable JSON property 'name'.");
 
             if (tag.IdOption.IsSet)
                 writer.WriteNumber("id", tag.IdOption.Value.Value);

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Tag.cs
@@ -197,6 +197,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Tag tag, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (tag.IdOption.IsSet && tag.Id == null)
+                throw new JsonException("Cannot write null property Tag.Id to non-nullable JSON property 'id'.");
+
             if (tag.NameOption.IsSet && tag.Name == null)
                 throw new JsonException("Cannot write null property Tag.Name to non-nullable JSON property 'name'.");
 

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestCollectionEndingWithWordList testCollectionEndingWithWordList, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testCollectionEndingWithWordList.ValueOption.IsSet && testCollectionEndingWithWordList.Value == null)
-                throw new ArgumentNullException(nameof(testCollectionEndingWithWordList.Value), "Property is required for class TestCollectionEndingWithWordList.");
+                throw new JsonException("Cannot write null property TestCollectionEndingWithWordList.Value to non-nullable JSON property 'value'.");
 
             if (testCollectionEndingWithWordList.ValueOption.IsSet)
                 writer.WriteString("value", testCollectionEndingWithWordList.Value);

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestCollectionEndingWithWordListObject testCollectionEndingWithWordListObject, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testCollectionEndingWithWordListObject.TestCollectionEndingWithWordListOption.IsSet && testCollectionEndingWithWordListObject.TestCollectionEndingWithWordList == null)
-                throw new ArgumentNullException(nameof(testCollectionEndingWithWordListObject.TestCollectionEndingWithWordList), "Property is required for class TestCollectionEndingWithWordListObject.");
+                throw new JsonException("Cannot write null property TestCollectionEndingWithWordListObject.TestCollectionEndingWithWordList to non-nullable JSON property 'TestCollectionEndingWithWordList'.");
 
             if (testCollectionEndingWithWordListObject.TestCollectionEndingWithWordListOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/TestDescendants.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/TestDescendants.cs
@@ -216,9 +216,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, TestDescendants testDescendants, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (testDescendants.AlternativeName == null)
-                throw new ArgumentNullException(nameof(testDescendants.AlternativeName), "Property is required for class TestDescendants.");
-
             writer.WriteString("alternativeName", testDescendants.AlternativeName);
 
             writer.WriteString("objectType", TestDescendantsObjectTypeValueConverter.ToJsonValue(testDescendants.ObjectType));

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestInlineFreeformAdditionalPropertiesRequest testInlineFreeformAdditionalPropertiesRequest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testInlineFreeformAdditionalPropertiesRequest.SomePropertyOption.IsSet && testInlineFreeformAdditionalPropertiesRequest.SomeProperty == null)
-                throw new ArgumentNullException(nameof(testInlineFreeformAdditionalPropertiesRequest.SomeProperty), "Property is required for class TestInlineFreeformAdditionalPropertiesRequest.");
+                throw new JsonException("Cannot write null property TestInlineFreeformAdditionalPropertiesRequest.SomeProperty to non-nullable JSON property 'someProperty'.");
 
             if (testInlineFreeformAdditionalPropertiesRequest.SomePropertyOption.IsSet)
                 writer.WriteString("someProperty", testInlineFreeformAdditionalPropertiesRequest.SomeProperty);

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/TestResult.cs
@@ -222,6 +222,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, TestResult testResult, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (testResult.CodeOption.IsSet && testResult.Code == null)
+                throw new JsonException("Cannot write null property TestResult.Code to non-nullable JSON property 'code'.");
+
             if (testResult.DataOption.IsSet && testResult.Data == null)
                 throw new JsonException("Cannot write null property TestResult.Data to non-nullable JSON property 'data'.");
 

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/TestResult.cs
@@ -223,10 +223,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestResult testResult, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testResult.DataOption.IsSet && testResult.Data == null)
-                throw new ArgumentNullException(nameof(testResult.Data), "Property is required for class TestResult.");
+                throw new JsonException("Cannot write null property TestResult.Data to non-nullable JSON property 'data'.");
 
             if (testResult.UuidOption.IsSet && testResult.Uuid == null)
-                throw new ArgumentNullException(nameof(testResult.Uuid), "Property is required for class TestResult.");
+                throw new JsonException("Cannot write null property TestResult.Uuid to non-nullable JSON property 'uuid'.");
 
             if (testResult.CodeOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/TriangleInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/TriangleInterface.cs
@@ -170,9 +170,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, TriangleInterface triangleInterface, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (triangleInterface.TriangleType == null)
-                throw new ArgumentNullException(nameof(triangleInterface.TriangleType), "Property is required for class TriangleInterface.");
-
             writer.WriteString("triangleType", triangleInterface.TriangleType);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/User.cs
@@ -429,6 +429,9 @@ namespace Org.OpenAPITools.Model
             if (user.FirstNameOption.IsSet && user.FirstName == null)
                 throw new JsonException("Cannot write null property User.FirstName to non-nullable JSON property 'firstName'.");
 
+            if (user.IdOption.IsSet && user.Id == null)
+                throw new JsonException("Cannot write null property User.Id to non-nullable JSON property 'id'.");
+
             if (user.LastNameOption.IsSet && user.LastName == null)
                 throw new JsonException("Cannot write null property User.LastName to non-nullable JSON property 'lastName'.");
 
@@ -440,6 +443,9 @@ namespace Org.OpenAPITools.Model
 
             if (user.PhoneOption.IsSet && user.Phone == null)
                 throw new JsonException("Cannot write null property User.Phone to non-nullable JSON property 'phone'.");
+
+            if (user.UserStatusOption.IsSet && user.UserStatus == null)
+                throw new JsonException("Cannot write null property User.UserStatus to non-nullable JSON property 'userStatus'.");
 
             if (user.UsernameOption.IsSet && user.Username == null)
                 throw new JsonException("Cannot write null property User.Username to non-nullable JSON property 'username'.");

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/User.cs
@@ -424,25 +424,25 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, User user, JsonSerializerOptions jsonSerializerOptions)
         {
             if (user.EmailOption.IsSet && user.Email == null)
-                throw new ArgumentNullException(nameof(user.Email), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Email to non-nullable JSON property 'email'.");
 
             if (user.FirstNameOption.IsSet && user.FirstName == null)
-                throw new ArgumentNullException(nameof(user.FirstName), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.FirstName to non-nullable JSON property 'firstName'.");
 
             if (user.LastNameOption.IsSet && user.LastName == null)
-                throw new ArgumentNullException(nameof(user.LastName), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.LastName to non-nullable JSON property 'lastName'.");
 
             if (user.ObjectWithNoDeclaredPropsOption.IsSet && user.ObjectWithNoDeclaredProps == null)
-                throw new ArgumentNullException(nameof(user.ObjectWithNoDeclaredProps), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.ObjectWithNoDeclaredProps to non-nullable JSON property 'objectWithNoDeclaredProps'.");
 
             if (user.PasswordOption.IsSet && user.Password == null)
-                throw new ArgumentNullException(nameof(user.Password), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Password to non-nullable JSON property 'password'.");
 
             if (user.PhoneOption.IsSet && user.Phone == null)
-                throw new ArgumentNullException(nameof(user.Phone), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Phone to non-nullable JSON property 'phone'.");
 
             if (user.UsernameOption.IsSet && user.Username == null)
-                throw new ArgumentNullException(nameof(user.Username), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Username to non-nullable JSON property 'username'.");
 
             if (user.AnyTypePropOption.IsSet)
                 if (user.AnyTypePropOption.Value != null)

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Whale.cs
@@ -216,9 +216,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Whale whale, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (whale.ClassName == null)
-                throw new ArgumentNullException(nameof(whale.ClassName), "Property is required for class Whale.");
-
             writer.WriteString("className", whale.ClassName);
 
             if (whale.HasBaleenOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Whale.cs
@@ -216,6 +216,12 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Whale whale, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (whale.HasBaleenOption.IsSet && whale.HasBaleen == null)
+                throw new JsonException("Cannot write null property Whale.HasBaleen to non-nullable JSON property 'hasBaleen'.");
+
+            if (whale.HasTeethOption.IsSet && whale.HasTeeth == null)
+                throw new JsonException("Cannot write null property Whale.HasTeeth to non-nullable JSON property 'hasTeeth'.");
+
             writer.WriteString("className", whale.ClassName);
 
             if (whale.HasBaleenOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Zebra.cs
@@ -193,6 +193,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Zebra zebra, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (zebra.TypeOption.IsSet && zebra.Type == null)
+                throw new JsonException("Cannot write null property Zebra.Type to non-nullable JSON property 'type'.");
+
             writer.WriteString("className", zebra.ClassName);
 
             if (zebra.TypeOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Zebra.cs
@@ -193,9 +193,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Zebra zebra, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (zebra.ClassName == null)
-                throw new ArgumentNullException(nameof(zebra.ClassName), "Property is required for class Zebra.");
-
             writer.WriteString("className", zebra.ClassName);
 
             if (zebra.TypeOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
@@ -174,6 +174,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ZeroBasedEnumClass zeroBasedEnumClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (zeroBasedEnumClass.ZeroBasedEnumOption.IsSet && zeroBasedEnumClass.ZeroBasedEnum == null)
+                throw new JsonException("Cannot write null property ZeroBasedEnumClass.ZeroBasedEnum to non-nullable JSON property 'ZeroBasedEnum'.");
+
             if (zeroBasedEnumClass.ZeroBasedEnumOption.IsSet)
             {
                 var zeroBasedEnumRawValue = ZeroBasedEnumClassZeroBasedEnumValueConverter.ToJsonValue(zeroBasedEnumClass.ZeroBasedEnum.Value);

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Activity.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Activity activity, JsonSerializerOptions jsonSerializerOptions)
         {
             if (activity.ActivityOutputsOption.IsSet && activity.ActivityOutputs == null)
-                throw new ArgumentNullException(nameof(activity.ActivityOutputs), "Property is required for class Activity.");
+                throw new JsonException("Cannot write null property Activity.ActivityOutputs to non-nullable JSON property 'activity_outputs'.");
 
             if (activity.ActivityOutputsOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -200,10 +200,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ActivityOutputElementRepresentation activityOutputElementRepresentation, JsonSerializerOptions jsonSerializerOptions)
         {
             if (activityOutputElementRepresentation.Prop1Option.IsSet && activityOutputElementRepresentation.Prop1 == null)
-                throw new ArgumentNullException(nameof(activityOutputElementRepresentation.Prop1), "Property is required for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Cannot write null property ActivityOutputElementRepresentation.Prop1 to non-nullable JSON property 'prop1'.");
 
             if (activityOutputElementRepresentation.Prop2Option.IsSet && activityOutputElementRepresentation.Prop2 == null)
-                throw new ArgumentNullException(nameof(activityOutputElementRepresentation.Prop2), "Property is required for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Cannot write null property ActivityOutputElementRepresentation.Prop2 to non-nullable JSON property 'prop2'.");
 
             if (activityOutputElementRepresentation.Prop1Option.IsSet)
                 writer.WriteString("prop1", activityOutputElementRepresentation.Prop1);

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -336,25 +336,25 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, AdditionalPropertiesClass additionalPropertiesClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (additionalPropertiesClass.EmptyMapOption.IsSet && additionalPropertiesClass.EmptyMap == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.EmptyMap), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.EmptyMap to non-nullable JSON property 'empty_map'.");
 
             if (additionalPropertiesClass.MapOfMapPropertyOption.IsSet && additionalPropertiesClass.MapOfMapProperty == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapOfMapProperty), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapOfMapProperty to non-nullable JSON property 'map_of_map_property'.");
 
             if (additionalPropertiesClass.MapPropertyOption.IsSet && additionalPropertiesClass.MapProperty == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapProperty), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapProperty to non-nullable JSON property 'map_property'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1Option.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1 == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1 to non-nullable JSON property 'map_with_undeclared_properties_anytype_1'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2Option.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2 == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2 to non-nullable JSON property 'map_with_undeclared_properties_anytype_2'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3Option.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3 == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3 to non-nullable JSON property 'map_with_undeclared_properties_anytype_3'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesStringOption.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesString == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesString), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesString to non-nullable JSON property 'map_with_undeclared_properties_string'.");
 
             if (additionalPropertiesClass.Anytype1Option.IsSet)
                 if (additionalPropertiesClass.Anytype1Option.Value != null)

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Animal.cs
@@ -223,7 +223,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Animal animal, JsonSerializerOptions jsonSerializerOptions)
         {
             if (animal.ColorOption.IsSet && animal.Color == null)
-                throw new ArgumentNullException(nameof(animal.Color), "Property is required for class Animal.");
+                throw new JsonException("Cannot write null property Animal.Color to non-nullable JSON property 'color'.");
 
             writer.WriteString("className", animal.ClassName);
 

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -223,10 +223,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ApiResponse apiResponse, JsonSerializerOptions jsonSerializerOptions)
         {
             if (apiResponse.MessageOption.IsSet && apiResponse.Message == null)
-                throw new ArgumentNullException(nameof(apiResponse.Message), "Property is required for class ApiResponse.");
+                throw new JsonException("Cannot write null property ApiResponse.Message to non-nullable JSON property 'message'.");
 
             if (apiResponse.TypeOption.IsSet && apiResponse.Type == null)
-                throw new ArgumentNullException(nameof(apiResponse.Type), "Property is required for class ApiResponse.");
+                throw new JsonException("Cannot write null property ApiResponse.Type to non-nullable JSON property 'type'.");
 
             if (apiResponse.CodeOption.IsSet)
                 writer.WriteNumber("code", apiResponse.CodeOption.Value!.Value);

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -222,6 +222,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ApiResponse apiResponse, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (apiResponse.CodeOption.IsSet && apiResponse.Code == null)
+                throw new JsonException("Cannot write null property ApiResponse.Code to non-nullable JSON property 'code'.");
+
             if (apiResponse.MessageOption.IsSet && apiResponse.Message == null)
                 throw new JsonException("Cannot write null property ApiResponse.Message to non-nullable JSON property 'message'.");
 

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Apple.cs
@@ -253,13 +253,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Apple apple, JsonSerializerOptions jsonSerializerOptions)
         {
             if (apple.ColorCodeOption.IsSet && apple.ColorCode == null)
-                throw new ArgumentNullException(nameof(apple.ColorCode), "Property is required for class Apple.");
+                throw new JsonException("Cannot write null property Apple.ColorCode to non-nullable JSON property 'color_code'.");
 
             if (apple.CultivarOption.IsSet && apple.Cultivar == null)
-                throw new ArgumentNullException(nameof(apple.Cultivar), "Property is required for class Apple.");
+                throw new JsonException("Cannot write null property Apple.Cultivar to non-nullable JSON property 'cultivar'.");
 
             if (apple.OriginOption.IsSet && apple.Origin == null)
-                throw new ArgumentNullException(nameof(apple.Origin), "Property is required for class Apple.");
+                throw new JsonException("Cannot write null property Apple.Origin to non-nullable JSON property 'origin'.");
 
             if (apple.ColorCodeOption.IsSet)
                 writer.WriteString("color_code", apple.ColorCode);

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -188,6 +188,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, AppleReq appleReq, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (appleReq.MealyOption.IsSet && appleReq.Mealy == null)
+                throw new JsonException("Cannot write null property AppleReq.Mealy to non-nullable JSON property 'mealy'.");
+
             writer.WriteString("cultivar", appleReq.Cultivar);
 
             if (appleReq.MealyOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -188,9 +188,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, AppleReq appleReq, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (appleReq.Cultivar == null)
-                throw new ArgumentNullException(nameof(appleReq.Cultivar), "Property is required for class AppleReq.");
-
             writer.WriteString("cultivar", appleReq.Cultivar);
 
             if (appleReq.MealyOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ArrayOfArrayOfNumberOnly arrayOfArrayOfNumberOnly, JsonSerializerOptions jsonSerializerOptions)
         {
             if (arrayOfArrayOfNumberOnly.ArrayArrayNumberOption.IsSet && arrayOfArrayOfNumberOnly.ArrayArrayNumber == null)
-                throw new ArgumentNullException(nameof(arrayOfArrayOfNumberOnly.ArrayArrayNumber), "Property is required for class ArrayOfArrayOfNumberOnly.");
+                throw new JsonException("Cannot write null property ArrayOfArrayOfNumberOnly.ArrayArrayNumber to non-nullable JSON property 'ArrayArrayNumber'.");
 
             if (arrayOfArrayOfNumberOnly.ArrayArrayNumberOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ArrayOfNumberOnly arrayOfNumberOnly, JsonSerializerOptions jsonSerializerOptions)
         {
             if (arrayOfNumberOnly.ArrayNumberOption.IsSet && arrayOfNumberOnly.ArrayNumber == null)
-                throw new ArgumentNullException(nameof(arrayOfNumberOnly.ArrayNumber), "Property is required for class ArrayOfNumberOnly.");
+                throw new JsonException("Cannot write null property ArrayOfNumberOnly.ArrayNumber to non-nullable JSON property 'ArrayNumber'.");
 
             if (arrayOfNumberOnly.ArrayNumberOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -223,13 +223,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ArrayTest arrayTest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (arrayTest.ArrayArrayOfIntegerOption.IsSet && arrayTest.ArrayArrayOfInteger == null)
-                throw new ArgumentNullException(nameof(arrayTest.ArrayArrayOfInteger), "Property is required for class ArrayTest.");
+                throw new JsonException("Cannot write null property ArrayTest.ArrayArrayOfInteger to non-nullable JSON property 'array_array_of_integer'.");
 
             if (arrayTest.ArrayArrayOfModelOption.IsSet && arrayTest.ArrayArrayOfModel == null)
-                throw new ArgumentNullException(nameof(arrayTest.ArrayArrayOfModel), "Property is required for class ArrayTest.");
+                throw new JsonException("Cannot write null property ArrayTest.ArrayArrayOfModel to non-nullable JSON property 'array_array_of_model'.");
 
             if (arrayTest.ArrayOfStringOption.IsSet && arrayTest.ArrayOfString == null)
-                throw new ArgumentNullException(nameof(arrayTest.ArrayOfString), "Property is required for class ArrayTest.");
+                throw new JsonException("Cannot write null property ArrayTest.ArrayOfString to non-nullable JSON property 'array_of_string'.");
 
             if (arrayTest.ArrayArrayOfIntegerOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Banana.cs
@@ -176,6 +176,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Banana banana, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (banana.LengthCmOption.IsSet && banana.LengthCm == null)
+                throw new JsonException("Cannot write null property Banana.LengthCm to non-nullable JSON property 'lengthCm'.");
+
             if (banana.LengthCmOption.IsSet)
                 writer.WriteNumber("lengthCm", banana.LengthCmOption.Value!.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -188,6 +188,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, BananaReq bananaReq, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (bananaReq.SweetOption.IsSet && bananaReq.Sweet == null)
+                throw new JsonException("Cannot write null property BananaReq.Sweet to non-nullable JSON property 'sweet'.");
+
             writer.WriteNumber("lengthCm", bananaReq.LengthCm);
 
             if (bananaReq.SweetOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/BasquePig.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/BasquePig.cs
@@ -172,9 +172,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, BasquePig basquePig, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (basquePig.ClassName == null)
-                throw new ArgumentNullException(nameof(basquePig.ClassName), "Property is required for class BasquePig.");
-
             writer.WriteString("className", basquePig.ClassName);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -293,22 +293,22 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Capitalization capitalization, JsonSerializerOptions jsonSerializerOptions)
         {
             if (capitalization.ATT_NAMEOption.IsSet && capitalization.ATT_NAME == null)
-                throw new ArgumentNullException(nameof(capitalization.ATT_NAME), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.ATT_NAME to non-nullable JSON property 'ATT_NAME'.");
 
             if (capitalization.CapitalCamelOption.IsSet && capitalization.CapitalCamel == null)
-                throw new ArgumentNullException(nameof(capitalization.CapitalCamel), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.CapitalCamel to non-nullable JSON property 'CapitalCamel'.");
 
             if (capitalization.CapitalSnakeOption.IsSet && capitalization.CapitalSnake == null)
-                throw new ArgumentNullException(nameof(capitalization.CapitalSnake), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.CapitalSnake to non-nullable JSON property 'Capital_Snake'.");
 
             if (capitalization.SCAETHFlowPointsOption.IsSet && capitalization.SCAETHFlowPoints == null)
-                throw new ArgumentNullException(nameof(capitalization.SCAETHFlowPoints), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.SCAETHFlowPoints to non-nullable JSON property 'SCA_ETH_Flow_Points'.");
 
             if (capitalization.SmallCamelOption.IsSet && capitalization.SmallCamel == null)
-                throw new ArgumentNullException(nameof(capitalization.SmallCamel), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.SmallCamel to non-nullable JSON property 'smallCamel'.");
 
             if (capitalization.SmallSnakeOption.IsSet && capitalization.SmallSnake == null)
-                throw new ArgumentNullException(nameof(capitalization.SmallSnake), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.SmallSnake to non-nullable JSON property 'small_Snake'.");
 
             if (capitalization.ATT_NAMEOption.IsSet)
                 writer.WriteString("ATT_NAME", capitalization.ATT_NAME);

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Cat.cs
@@ -179,7 +179,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Cat cat, JsonSerializerOptions jsonSerializerOptions)
         {
             if (cat.ColorOption.IsSet && cat.Color == null)
-                throw new ArgumentNullException(nameof(cat.Color), "Property is required for class Cat.");
+                throw new JsonException("Cannot write null property Cat.Color to non-nullable JSON property 'color'.");
 
             writer.WriteString("className", cat.ClassName);
 

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Cat.cs
@@ -181,6 +181,9 @@ namespace Org.OpenAPITools.Model
             if (cat.ColorOption.IsSet && cat.Color == null)
                 throw new JsonException("Cannot write null property Cat.Color to non-nullable JSON property 'color'.");
 
+            if (cat.DeclawedOption.IsSet && cat.Declawed == null)
+                throw new JsonException("Cannot write null property Cat.Declawed to non-nullable JSON property 'declawed'.");
+
             writer.WriteString("className", cat.ClassName);
 
             if (cat.ColorOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Category.cs
@@ -195,9 +195,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Category category, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (category.Name == null)
-                throw new ArgumentNullException(nameof(category.Name), "Property is required for class Category.");
-
             if (category.IdOption.IsSet)
                 writer.WriteNumber("id", category.IdOption.Value!.Value);
 

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Category.cs
@@ -195,6 +195,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Category category, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (category.IdOption.IsSet && category.Id == null)
+                throw new JsonException("Cannot write null property Category.Id to non-nullable JSON property 'id'.");
+
             if (category.IdOption.IsSet)
                 writer.WriteNumber("id", category.IdOption.Value!.Value);
 

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -238,7 +238,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ChildCat childCat, JsonSerializerOptions jsonSerializerOptions)
         {
             if (childCat.NameOption.IsSet && childCat.Name == null)
-                throw new ArgumentNullException(nameof(childCat.Name), "Property is required for class ChildCat.");
+                throw new JsonException("Cannot write null property ChildCat.Name to non-nullable JSON property 'name'.");
 
             if (childCat.NameOption.IsSet)
                 writer.WriteString("name", childCat.Name);

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ClassModel classModel, JsonSerializerOptions jsonSerializerOptions)
         {
             if (classModel.ClassOption.IsSet && classModel.Class == null)
-                throw new ArgumentNullException(nameof(classModel.Class), "Property is required for class ClassModel.");
+                throw new JsonException("Cannot write null property ClassModel.Class to non-nullable JSON property '_class'.");
 
             if (classModel.ClassOption.IsSet)
                 writer.WriteString("_class", classModel.Class);

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
@@ -191,12 +191,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ComplexQuadrilateral complexQuadrilateral, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (complexQuadrilateral.QuadrilateralType == null)
-                throw new ArgumentNullException(nameof(complexQuadrilateral.QuadrilateralType), "Property is required for class ComplexQuadrilateral.");
-
-            if (complexQuadrilateral.ShapeType == null)
-                throw new ArgumentNullException(nameof(complexQuadrilateral.ShapeType), "Property is required for class ComplexQuadrilateral.");
-
             writer.WriteString("quadrilateralType", complexQuadrilateral.QuadrilateralType);
 
             writer.WriteString("shapeType", complexQuadrilateral.ShapeType);

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/CopyActivity.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/CopyActivity.cs
@@ -233,9 +233,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, CopyActivity copyActivity, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (copyActivity.CopyActivitytt == null)
-                throw new ArgumentNullException(nameof(copyActivity.CopyActivitytt), "Property is required for class CopyActivity.");
-
             writer.WriteString("copyActivitytt", copyActivity.CopyActivitytt);
 
             writer.WriteString("$schema", CopyActivity.SchemaEnumToJsonValue(copyActivity.Schema));

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/DanishPig.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/DanishPig.cs
@@ -172,9 +172,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, DanishPig danishPig, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (danishPig.ClassName == null)
-                throw new ArgumentNullException(nameof(danishPig.ClassName), "Property is required for class DanishPig.");
-
             writer.WriteString("className", danishPig.ClassName);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -182,6 +182,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, DateOnlyClass dateOnlyClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (dateOnlyClass.DateOnlyPropertyOption.IsSet && dateOnlyClass.DateOnlyProperty == null)
+                throw new JsonException("Cannot write null property DateOnlyClass.DateOnlyProperty to non-nullable JSON property 'dateOnlyProperty'.");
+
             if (dateOnlyClass.DateOnlyPropertyOption.IsSet)
                 writer.WriteString("dateOnlyProperty", dateOnlyClass.DateOnlyPropertyOption.Value!.Value.ToString(DateOnlyPropertyFormat));
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, DeprecatedObject deprecatedObject, JsonSerializerOptions jsonSerializerOptions)
         {
             if (deprecatedObject.NameOption.IsSet && deprecatedObject.Name == null)
-                throw new ArgumentNullException(nameof(deprecatedObject.Name), "Property is required for class DeprecatedObject.");
+                throw new JsonException("Cannot write null property DeprecatedObject.Name to non-nullable JSON property 'name'.");
 
             if (deprecatedObject.NameOption.IsSet)
                 writer.WriteString("name", deprecatedObject.Name);

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Descendant1.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Descendant1.cs
@@ -184,12 +184,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Descendant1 descendant1, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (descendant1.AlternativeName == null)
-                throw new ArgumentNullException(nameof(descendant1.AlternativeName), "Property is required for class Descendant1.");
-
-            if (descendant1.DescendantName == null)
-                throw new ArgumentNullException(nameof(descendant1.DescendantName), "Property is required for class Descendant1.");
-
             writer.WriteString("alternativeName", descendant1.AlternativeName);
 
             writer.WriteString("descendantName", descendant1.DescendantName);

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Descendant2.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Descendant2.cs
@@ -184,12 +184,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Descendant2 descendant2, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (descendant2.AlternativeName == null)
-                throw new ArgumentNullException(nameof(descendant2.AlternativeName), "Property is required for class Descendant2.");
-
-            if (descendant2.Confidentiality == null)
-                throw new ArgumentNullException(nameof(descendant2.Confidentiality), "Property is required for class Descendant2.");
-
             writer.WriteString("alternativeName", descendant2.AlternativeName);
 
             writer.WriteString("confidentiality", descendant2.Confidentiality);

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Dog.cs
@@ -179,10 +179,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Dog dog, JsonSerializerOptions jsonSerializerOptions)
         {
             if (dog.BreedOption.IsSet && dog.Breed == null)
-                throw new ArgumentNullException(nameof(dog.Breed), "Property is required for class Dog.");
+                throw new JsonException("Cannot write null property Dog.Breed to non-nullable JSON property 'breed'.");
 
             if (dog.ColorOption.IsSet && dog.Color == null)
-                throw new ArgumentNullException(nameof(dog.Color), "Property is required for class Dog.");
+                throw new JsonException("Cannot write null property Dog.Color to non-nullable JSON property 'color'.");
 
             writer.WriteString("className", dog.ClassName);
 

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Drawing.cs
@@ -240,10 +240,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Drawing drawing, JsonSerializerOptions jsonSerializerOptions)
         {
             if (drawing.MainShapeOption.IsSet && drawing.MainShape == null)
-                throw new ArgumentNullException(nameof(drawing.MainShape), "Property is required for class Drawing.");
+                throw new JsonException("Cannot write null property Drawing.MainShape to non-nullable JSON property 'mainShape'.");
 
             if (drawing.ShapesOption.IsSet && drawing.Shapes == null)
-                throw new ArgumentNullException(nameof(drawing.Shapes), "Property is required for class Drawing.");
+                throw new JsonException("Cannot write null property Drawing.Shapes to non-nullable JSON property 'shapes'.");
 
             if (drawing.MainShapeOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -339,7 +339,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, EnumArrays enumArrays, JsonSerializerOptions jsonSerializerOptions)
         {
             if (enumArrays.ArrayEnumOption.IsSet && enumArrays.ArrayEnum == null)
-                throw new ArgumentNullException(nameof(enumArrays.ArrayEnum), "Property is required for class EnumArrays.");
+                throw new JsonException("Cannot write null property EnumArrays.ArrayEnum to non-nullable JSON property 'array_enum'.");
 
             if (enumArrays.ArrayEnumOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -341,6 +341,9 @@ namespace Org.OpenAPITools.Model
             if (enumArrays.ArrayEnumOption.IsSet && enumArrays.ArrayEnum == null)
                 throw new JsonException("Cannot write null property EnumArrays.ArrayEnum to non-nullable JSON property 'array_enum'.");
 
+            if (enumArrays.JustSymbolOption.IsSet && enumArrays.JustSymbol == null)
+                throw new JsonException("Cannot write null property EnumArrays.JustSymbol to non-nullable JSON property 'just_symbol'.");
+
             if (enumArrays.ArrayEnumOption.IsSet)
             {
                 writer.WritePropertyName("array_enum");

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -877,6 +877,27 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, EnumTest enumTest, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (enumTest.EnumIntegerOption.IsSet && enumTest.EnumInteger == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumInteger to non-nullable JSON property 'enum_integer'.");
+
+            if (enumTest.EnumIntegerOnlyOption.IsSet && enumTest.EnumIntegerOnly == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumIntegerOnly to non-nullable JSON property 'enum_integer_only'.");
+
+            if (enumTest.EnumNumberOption.IsSet && enumTest.EnumNumber == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumNumber to non-nullable JSON property 'enum_number'.");
+
+            if (enumTest.EnumStringOption.IsSet && enumTest.EnumString == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumString to non-nullable JSON property 'enum_string'.");
+
+            if (enumTest.OuterEnumDefaultValueOption.IsSet && enumTest.OuterEnumDefaultValue == null)
+                throw new JsonException("Cannot write null property EnumTest.OuterEnumDefaultValue to non-nullable JSON property 'outerEnumDefaultValue'.");
+
+            if (enumTest.OuterEnumIntegerOption.IsSet && enumTest.OuterEnumInteger == null)
+                throw new JsonException("Cannot write null property EnumTest.OuterEnumInteger to non-nullable JSON property 'outerEnumInteger'.");
+
+            if (enumTest.OuterEnumIntegerDefaultValueOption.IsSet && enumTest.OuterEnumIntegerDefaultValue == null)
+                throw new JsonException("Cannot write null property EnumTest.OuterEnumIntegerDefaultValue to non-nullable JSON property 'outerEnumIntegerDefaultValue'.");
+
             var enumStringRequiredRawValue = EnumTest.EnumStringRequiredEnumToJsonValue(enumTest.EnumStringRequired);
             writer.WriteString("enum_string_required", enumStringRequiredRawValue);
             if (enumTest.EnumIntegerOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
@@ -191,12 +191,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, EquilateralTriangle equilateralTriangle, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (equilateralTriangle.ShapeType == null)
-                throw new ArgumentNullException(nameof(equilateralTriangle.ShapeType), "Property is required for class EquilateralTriangle.");
-
-            if (equilateralTriangle.TriangleType == null)
-                throw new ArgumentNullException(nameof(equilateralTriangle.TriangleType), "Property is required for class EquilateralTriangle.");
-
             writer.WriteString("shapeType", equilateralTriangle.ShapeType);
 
             writer.WriteString("triangleType", equilateralTriangle.TriangleType);

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/File.cs
@@ -178,7 +178,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, File file, JsonSerializerOptions jsonSerializerOptions)
         {
             if (file.SourceURIOption.IsSet && file.SourceURI == null)
-                throw new ArgumentNullException(nameof(file.SourceURI), "Property is required for class File.");
+                throw new JsonException("Cannot write null property File.SourceURI to non-nullable JSON property 'sourceURI'.");
 
             if (file.SourceURIOption.IsSet)
                 writer.WriteString("sourceURI", file.SourceURI);

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -200,10 +200,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, FileSchemaTestClass fileSchemaTestClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (fileSchemaTestClass.FileOption.IsSet && fileSchemaTestClass.File == null)
-                throw new ArgumentNullException(nameof(fileSchemaTestClass.File), "Property is required for class FileSchemaTestClass.");
+                throw new JsonException("Cannot write null property FileSchemaTestClass.File to non-nullable JSON property 'file'.");
 
             if (fileSchemaTestClass.FilesOption.IsSet && fileSchemaTestClass.Files == null)
-                throw new ArgumentNullException(nameof(fileSchemaTestClass.Files), "Property is required for class FileSchemaTestClass.");
+                throw new JsonException("Cannot write null property FileSchemaTestClass.Files to non-nullable JSON property 'files'.");
 
             if (fileSchemaTestClass.FileOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Foo.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Foo foo, JsonSerializerOptions jsonSerializerOptions)
         {
             if (foo.BarOption.IsSet && foo.Bar == null)
-                throw new ArgumentNullException(nameof(foo.Bar), "Property is required for class Foo.");
+                throw new JsonException("Cannot write null property Foo.Bar to non-nullable JSON property 'bar'.");
 
             if (foo.BarOption.IsSet)
                 writer.WriteString("bar", foo.Bar);

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, FooGetDefaultResponse fooGetDefaultResponse, JsonSerializerOptions jsonSerializerOptions)
         {
             if (fooGetDefaultResponse.StringOption.IsSet && fooGetDefaultResponse.String == null)
-                throw new ArgumentNullException(nameof(fooGetDefaultResponse.String), "Property is required for class FooGetDefaultResponse.");
+                throw new JsonException("Cannot write null property FooGetDefaultResponse.String to non-nullable JSON property 'string'.");
 
             if (fooGetDefaultResponse.StringOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -956,11 +956,47 @@ namespace Org.OpenAPITools.Model
             if (formatTest.BinaryOption.IsSet && formatTest.Binary == null)
                 throw new JsonException("Cannot write null property FormatTest.Binary to non-nullable JSON property 'binary'.");
 
+            if (formatTest.DateTimeOption.IsSet && formatTest.DateTime == null)
+                throw new JsonException("Cannot write null property FormatTest.DateTime to non-nullable JSON property 'dateTime'.");
+
+            if (formatTest.DecimalOption.IsSet && formatTest.Decimal == null)
+                throw new JsonException("Cannot write null property FormatTest.Decimal to non-nullable JSON property 'decimal'.");
+
+            if (formatTest.DoubleOption.IsSet && formatTest.Double == null)
+                throw new JsonException("Cannot write null property FormatTest.Double to non-nullable JSON property 'double'.");
+
             if (formatTest.DuplicatePropertyName2Option.IsSet && formatTest.DuplicatePropertyName2 == null)
                 throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName2 to non-nullable JSON property 'duplicate_property_name'.");
 
             if (formatTest.DuplicatePropertyNameOption.IsSet && formatTest.DuplicatePropertyName == null)
                 throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName to non-nullable JSON property '@duplicate_property_name'.");
+
+            if (formatTest.FloatOption.IsSet && formatTest.Float == null)
+                throw new JsonException("Cannot write null property FormatTest.Float to non-nullable JSON property 'float'.");
+
+            if (formatTest.Int32Option.IsSet && formatTest.Int32 == null)
+                throw new JsonException("Cannot write null property FormatTest.Int32 to non-nullable JSON property 'int32'.");
+
+            if (formatTest.Int32RangeOption.IsSet && formatTest.Int32Range == null)
+                throw new JsonException("Cannot write null property FormatTest.Int32Range to non-nullable JSON property 'int32Range'.");
+
+            if (formatTest.Int64Option.IsSet && formatTest.Int64 == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64 to non-nullable JSON property 'int64'.");
+
+            if (formatTest.Int64NegativeOption.IsSet && formatTest.Int64Negative == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64Negative to non-nullable JSON property 'int64Negative'.");
+
+            if (formatTest.Int64NegativeExclusiveOption.IsSet && formatTest.Int64NegativeExclusive == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64NegativeExclusive to non-nullable JSON property 'int64NegativeExclusive'.");
+
+            if (formatTest.Int64PositiveOption.IsSet && formatTest.Int64Positive == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64Positive to non-nullable JSON property 'int64Positive'.");
+
+            if (formatTest.Int64PositiveExclusiveOption.IsSet && formatTest.Int64PositiveExclusive == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64PositiveExclusive to non-nullable JSON property 'int64PositiveExclusive'.");
+
+            if (formatTest.IntegerOption.IsSet && formatTest.Integer == null)
+                throw new JsonException("Cannot write null property FormatTest.Integer to non-nullable JSON property 'integer'.");
 
             if (formatTest.PatternWithBackslashOption.IsSet && formatTest.PatternWithBackslash == null)
                 throw new JsonException("Cannot write null property FormatTest.PatternWithBackslash to non-nullable JSON property 'pattern_with_backslash'.");
@@ -973,6 +1009,18 @@ namespace Org.OpenAPITools.Model
 
             if (formatTest.StringOption.IsSet && formatTest.String == null)
                 throw new JsonException("Cannot write null property FormatTest.String to non-nullable JSON property 'string'.");
+
+            if (formatTest.StringFormattedAsDecimalOption.IsSet && formatTest.StringFormattedAsDecimal == null)
+                throw new JsonException("Cannot write null property FormatTest.StringFormattedAsDecimal to non-nullable JSON property 'string_formatted_as_decimal'.");
+
+            if (formatTest.UnsignedIntegerOption.IsSet && formatTest.UnsignedInteger == null)
+                throw new JsonException("Cannot write null property FormatTest.UnsignedInteger to non-nullable JSON property 'unsigned_integer'.");
+
+            if (formatTest.UnsignedLongOption.IsSet && formatTest.UnsignedLong == null)
+                throw new JsonException("Cannot write null property FormatTest.UnsignedLong to non-nullable JSON property 'unsigned_long'.");
+
+            if (formatTest.UuidOption.IsSet && formatTest.Uuid == null)
+                throw new JsonException("Cannot write null property FormatTest.Uuid to non-nullable JSON property 'uuid'.");
 
             writer.WritePropertyName("byte");
             JsonSerializer.Serialize(writer, formatTest.Byte, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -953,32 +953,26 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, FormatTest formatTest, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (formatTest.Byte == null)
-                throw new ArgumentNullException(nameof(formatTest.Byte), "Property is required for class FormatTest.");
-
-            if (formatTest.Password == null)
-                throw new ArgumentNullException(nameof(formatTest.Password), "Property is required for class FormatTest.");
-
             if (formatTest.BinaryOption.IsSet && formatTest.Binary == null)
-                throw new ArgumentNullException(nameof(formatTest.Binary), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.Binary to non-nullable JSON property 'binary'.");
 
             if (formatTest.DuplicatePropertyName2Option.IsSet && formatTest.DuplicatePropertyName2 == null)
-                throw new ArgumentNullException(nameof(formatTest.DuplicatePropertyName2), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName2 to non-nullable JSON property 'duplicate_property_name'.");
 
             if (formatTest.DuplicatePropertyNameOption.IsSet && formatTest.DuplicatePropertyName == null)
-                throw new ArgumentNullException(nameof(formatTest.DuplicatePropertyName), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName to non-nullable JSON property '@duplicate_property_name'.");
 
             if (formatTest.PatternWithBackslashOption.IsSet && formatTest.PatternWithBackslash == null)
-                throw new ArgumentNullException(nameof(formatTest.PatternWithBackslash), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.PatternWithBackslash to non-nullable JSON property 'pattern_with_backslash'.");
 
             if (formatTest.PatternWithDigitsOption.IsSet && formatTest.PatternWithDigits == null)
-                throw new ArgumentNullException(nameof(formatTest.PatternWithDigits), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.PatternWithDigits to non-nullable JSON property 'pattern_with_digits'.");
 
             if (formatTest.PatternWithDigitsAndDelimiterOption.IsSet && formatTest.PatternWithDigitsAndDelimiter == null)
-                throw new ArgumentNullException(nameof(formatTest.PatternWithDigitsAndDelimiter), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.PatternWithDigitsAndDelimiter to non-nullable JSON property 'pattern_with_digits_and_delimiter'.");
 
             if (formatTest.StringOption.IsSet && formatTest.String == null)
-                throw new ArgumentNullException(nameof(formatTest.String), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.String to non-nullable JSON property 'string'.");
 
             writer.WritePropertyName("byte");
             JsonSerializer.Serialize(writer, formatTest.Byte, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Fruit.cs
@@ -221,7 +221,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Fruit fruit, JsonSerializerOptions jsonSerializerOptions)
         {
             if (fruit.ColorOption.IsSet && fruit.Color == null)
-                throw new ArgumentNullException(nameof(fruit.Color), "Property is required for class Fruit.");
+                throw new JsonException("Cannot write null property Fruit.Color to non-nullable JSON property 'color'.");
 
             if (fruit.ColorOption.IsSet)
                 writer.WriteString("color", fruit.Color);

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -238,7 +238,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, GmFruit gmFruit, JsonSerializerOptions jsonSerializerOptions)
         {
             if (gmFruit.ColorOption.IsSet && gmFruit.Color == null)
-                throw new ArgumentNullException(nameof(gmFruit.Color), "Property is required for class GmFruit.");
+                throw new JsonException("Cannot write null property GmFruit.Color to non-nullable JSON property 'color'.");
 
             if (gmFruit.ColorOption.IsSet)
                 writer.WriteString("color", gmFruit.Color);

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -241,10 +241,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, HasOnlyReadOnly hasOnlyReadOnly, JsonSerializerOptions jsonSerializerOptions)
         {
             if (hasOnlyReadOnly.BarOption.IsSet && hasOnlyReadOnly.Bar == null)
-                throw new ArgumentNullException(nameof(hasOnlyReadOnly.Bar), "Property is required for class HasOnlyReadOnly.");
+                throw new JsonException("Cannot write null property HasOnlyReadOnly.Bar to non-nullable JSON property 'bar'.");
 
             if (hasOnlyReadOnly.FooOption.IsSet && hasOnlyReadOnly.Foo == null)
-                throw new ArgumentNullException(nameof(hasOnlyReadOnly.Foo), "Property is required for class HasOnlyReadOnly.");
+                throw new JsonException("Cannot write null property HasOnlyReadOnly.Foo to non-nullable JSON property 'foo'.");
 
             if (hasOnlyReadOnly.BarOption.IsSet)
                 writer.WriteString("bar", hasOnlyReadOnly.Bar);

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
@@ -339,22 +339,22 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, InjectedVendorExtensionsTest injectedVendorExtensionsTest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessorOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor to non-nullable JSON property 'potentiallyOverriddenPropertyAccessor'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternalOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternal == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternal), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternal to non-nullable JSON property 'potentiallyOverriddenPropertyToInternal'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivateOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivate == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivate), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivate to non-nullable JSON property 'potentiallyOverriddenPropertyToPrivate'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublicOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublic == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublic), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublic to non-nullable JSON property 'potentiallyOverriddenPropertyToPublic'.");
 
             if (injectedVendorExtensionsTest.UnalteredPropertyOption.IsSet && injectedVendorExtensionsTest.UnalteredProperty == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.UnalteredProperty), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.UnalteredProperty to non-nullable JSON property 'unalteredProperty'.");
 
             if (injectedVendorExtensionsTest.UnalteredPropertyAccessorOption.IsSet && injectedVendorExtensionsTest.UnalteredPropertyAccessor == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.UnalteredPropertyAccessor), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.UnalteredPropertyAccessor to non-nullable JSON property 'unalteredPropertyAccessor'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessorOption.IsSet)
                 writer.WriteString("potentiallyOverriddenPropertyAccessor", injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor);

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
@@ -184,12 +184,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, IsoscelesTriangle isoscelesTriangle, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (isoscelesTriangle.ShapeType == null)
-                throw new ArgumentNullException(nameof(isoscelesTriangle.ShapeType), "Property is required for class IsoscelesTriangle.");
-
-            if (isoscelesTriangle.TriangleType == null)
-                throw new ArgumentNullException(nameof(isoscelesTriangle.TriangleType), "Property is required for class IsoscelesTriangle.");
-
             writer.WriteString("shapeType", isoscelesTriangle.ShapeType);
 
             writer.WriteString("triangleType", isoscelesTriangle.TriangleType);

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/List.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, List list, JsonSerializerOptions jsonSerializerOptions)
         {
             if (list.Var123ListOption.IsSet && list.Var123List == null)
-                throw new ArgumentNullException(nameof(list.Var123List), "Property is required for class List.");
+                throw new JsonException("Cannot write null property List.Var123List to non-nullable JSON property '123-list'.");
 
             if (list.Var123ListOption.IsSet)
                 writer.WriteString("123-list", list.Var123List);

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -200,10 +200,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, LiteralStringClass literalStringClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (literalStringClass.EscapedLiteralStringOption.IsSet && literalStringClass.EscapedLiteralString == null)
-                throw new ArgumentNullException(nameof(literalStringClass.EscapedLiteralString), "Property is required for class LiteralStringClass.");
+                throw new JsonException("Cannot write null property LiteralStringClass.EscapedLiteralString to non-nullable JSON property 'escapedLiteralString'.");
 
             if (literalStringClass.UnescapedLiteralStringOption.IsSet && literalStringClass.UnescapedLiteralString == null)
-                throw new ArgumentNullException(nameof(literalStringClass.UnescapedLiteralString), "Property is required for class LiteralStringClass.");
+                throw new JsonException("Cannot write null property LiteralStringClass.UnescapedLiteralString to non-nullable JSON property 'unescapedLiteralString'.");
 
             if (literalStringClass.EscapedLiteralStringOption.IsSet)
                 writer.WriteString("escapedLiteralString", literalStringClass.EscapedLiteralString);

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/MapTest.cs
@@ -312,16 +312,16 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MapTest mapTest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mapTest.DirectMapOption.IsSet && mapTest.DirectMap == null)
-                throw new ArgumentNullException(nameof(mapTest.DirectMap), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.DirectMap to non-nullable JSON property 'direct_map'.");
 
             if (mapTest.IndirectMapOption.IsSet && mapTest.IndirectMap == null)
-                throw new ArgumentNullException(nameof(mapTest.IndirectMap), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.IndirectMap to non-nullable JSON property 'indirect_map'.");
 
             if (mapTest.MapMapOfStringOption.IsSet && mapTest.MapMapOfString == null)
-                throw new ArgumentNullException(nameof(mapTest.MapMapOfString), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.MapMapOfString to non-nullable JSON property 'map_map_of_string'.");
 
             if (mapTest.MapOfEnumStringOption.IsSet && mapTest.MapOfEnumString == null)
-                throw new ArgumentNullException(nameof(mapTest.MapOfEnumString), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.MapOfEnumString to non-nullable JSON property 'map_of_enum_string'.");
 
             if (mapTest.DirectMapOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedAnyOf.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedAnyOf.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedAnyOf mixedAnyOf, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedAnyOf.ContentOption.IsSet && mixedAnyOf.Content == null)
-                throw new ArgumentNullException(nameof(mixedAnyOf.Content), "Property is required for class MixedAnyOf.");
+                throw new JsonException("Cannot write null property MixedAnyOf.Content to non-nullable JSON property 'content'.");
 
             if (mixedAnyOf.ContentOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedOneOf.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedOneOf.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedOneOf mixedOneOf, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedOneOf.ContentOption.IsSet && mixedOneOf.Content == null)
-                throw new ArgumentNullException(nameof(mixedOneOf.Content), "Property is required for class MixedOneOf.");
+                throw new JsonException("Cannot write null property MixedOneOf.Content to non-nullable JSON property 'content'.");
 
             if (mixedOneOf.ContentOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -257,8 +257,17 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, MixedPropertiesAndAdditionalPropertiesClass mixedPropertiesAndAdditionalPropertiesClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.DateTime == null)
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.DateTime to non-nullable JSON property 'dateTime'.");
+
             if (mixedPropertiesAndAdditionalPropertiesClass.MapOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.Map == null)
                 throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.Map to non-nullable JSON property 'map'.");
+
+            if (mixedPropertiesAndAdditionalPropertiesClass.UuidOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.Uuid == null)
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.Uuid to non-nullable JSON property 'uuid'.");
+
+            if (mixedPropertiesAndAdditionalPropertiesClass.UuidWithPatternOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.UuidWithPattern == null)
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.UuidWithPattern to non-nullable JSON property 'uuid_with_pattern'.");
 
             if (mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.IsSet)
                 writer.WriteString("dateTime", mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.Value!.Value.ToString(DateTimeFormat));

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -258,7 +258,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedPropertiesAndAdditionalPropertiesClass mixedPropertiesAndAdditionalPropertiesClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedPropertiesAndAdditionalPropertiesClass.MapOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.Map == null)
-                throw new ArgumentNullException(nameof(mixedPropertiesAndAdditionalPropertiesClass.Map), "Property is required for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.Map to non-nullable JSON property 'map'.");
 
             if (mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.IsSet)
                 writer.WriteString("dateTime", mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.Value!.Value.ToString(DateTimeFormat));

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedSubId.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedSubId.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedSubId mixedSubId, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedSubId.IdOption.IsSet && mixedSubId.Id == null)
-                throw new ArgumentNullException(nameof(mixedSubId.Id), "Property is required for class MixedSubId.");
+                throw new JsonException("Cannot write null property MixedSubId.Id to non-nullable JSON property 'id'.");
 
             if (mixedSubId.IdOption.IsSet)
                 writer.WriteString("id", mixedSubId.Id);

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -202,6 +202,9 @@ namespace Org.OpenAPITools.Model
             if (model200Response.ClassOption.IsSet && model200Response.Class == null)
                 throw new JsonException("Cannot write null property Model200Response.Class to non-nullable JSON property 'class'.");
 
+            if (model200Response.NameOption.IsSet && model200Response.Name == null)
+                throw new JsonException("Cannot write null property Model200Response.Name to non-nullable JSON property 'name'.");
+
             if (model200Response.ClassOption.IsSet)
                 writer.WriteString("class", model200Response.Class);
 

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -200,7 +200,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Model200Response model200Response, JsonSerializerOptions jsonSerializerOptions)
         {
             if (model200Response.ClassOption.IsSet && model200Response.Class == null)
-                throw new ArgumentNullException(nameof(model200Response.Class), "Property is required for class Model200Response.");
+                throw new JsonException("Cannot write null property Model200Response.Class to non-nullable JSON property 'class'.");
 
             if (model200Response.ClassOption.IsSet)
                 writer.WriteString("class", model200Response.Class);

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ModelClient modelClient, JsonSerializerOptions jsonSerializerOptions)
         {
             if (modelClient.VarClientOption.IsSet && modelClient.VarClient == null)
-                throw new ArgumentNullException(nameof(modelClient.VarClient), "Property is required for class ModelClient.");
+                throw new JsonException("Cannot write null property ModelClient.VarClient to non-nullable JSON property 'client'.");
 
             if (modelClient.VarClientOption.IsSet)
                 writer.WriteString("client", modelClient.VarClient);

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Name.cs
@@ -283,7 +283,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Name name, JsonSerializerOptions jsonSerializerOptions)
         {
             if (name.PropertyOption.IsSet && name.Property == null)
-                throw new ArgumentNullException(nameof(name.Property), "Property is required for class Name.");
+                throw new JsonException("Cannot write null property Name.Property to non-nullable JSON property 'property'.");
 
             writer.WriteNumber("name", name.VarName);
 

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Name.cs
@@ -285,6 +285,12 @@ namespace Org.OpenAPITools.Model
             if (name.PropertyOption.IsSet && name.Property == null)
                 throw new JsonException("Cannot write null property Name.Property to non-nullable JSON property 'property'.");
 
+            if (name.SnakeCaseOption.IsSet && name.SnakeCase == null)
+                throw new JsonException("Cannot write null property Name.SnakeCase to non-nullable JSON property 'snake_case'.");
+
+            if (name.Var123NumberOption.IsSet && name.Var123Number == null)
+                throw new JsonException("Cannot write null property Name.Var123Number to non-nullable JSON property '123Number'.");
+
             writer.WriteNumber("name", name.VarName);
 
             if (name.PropertyOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
@@ -191,9 +191,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, NotificationtestGetElementsV1ResponseMPayload notificationtestGetElementsV1ResponseMPayload, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (notificationtestGetElementsV1ResponseMPayload.AObjVariableobject == null)
-                throw new ArgumentNullException(nameof(notificationtestGetElementsV1ResponseMPayload.AObjVariableobject), "Property is required for class NotificationtestGetElementsV1ResponseMPayload.");
-
             writer.WritePropertyName("a_objVariableobject");
             JsonSerializer.Serialize(writer, notificationtestGetElementsV1ResponseMPayload.AObjVariableobject, jsonSerializerOptions);
             writer.WriteNumber("pkiNotificationtestID", notificationtestGetElementsV1ResponseMPayload.PkiNotificationtestID);

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -410,10 +410,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, NullableClass nullableClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (nullableClass.ArrayItemsNullableOption.IsSet && nullableClass.ArrayItemsNullable == null)
-                throw new ArgumentNullException(nameof(nullableClass.ArrayItemsNullable), "Property is required for class NullableClass.");
+                throw new JsonException("Cannot write null property NullableClass.ArrayItemsNullable to non-nullable JSON property 'array_items_nullable'.");
 
             if (nullableClass.ObjectItemsNullableOption.IsSet && nullableClass.ObjectItemsNullable == null)
-                throw new ArgumentNullException(nameof(nullableClass.ObjectItemsNullable), "Property is required for class NullableClass.");
+                throw new JsonException("Cannot write null property NullableClass.ObjectItemsNullable to non-nullable JSON property 'object_items_nullable'.");
 
             if (nullableClass.ArrayAndItemsNullablePropOption.IsSet)
                 if (nullableClass.ArrayAndItemsNullablePropOption.Value != null)

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -176,6 +176,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, NumberOnly numberOnly, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (numberOnly.JustNumberOption.IsSet && numberOnly.JustNumber == null)
+                throw new JsonException("Cannot write null property NumberOnly.JustNumber to non-nullable JSON property 'JustNumber'.");
+
             if (numberOnly.JustNumberOption.IsSet)
                 writer.WriteNumber("JustNumber", numberOnly.JustNumberOption.Value!.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -254,6 +254,9 @@ namespace Org.OpenAPITools.Model
             if (objectWithDeprecatedFields.DeprecatedRefOption.IsSet && objectWithDeprecatedFields.DeprecatedRef == null)
                 throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.DeprecatedRef to non-nullable JSON property 'deprecatedRef'.");
 
+            if (objectWithDeprecatedFields.IdOption.IsSet && objectWithDeprecatedFields.Id == null)
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Id to non-nullable JSON property 'id'.");
+
             if (objectWithDeprecatedFields.UuidOption.IsSet && objectWithDeprecatedFields.Uuid == null)
                 throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Uuid to non-nullable JSON property 'uuid'.");
 

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -249,13 +249,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ObjectWithDeprecatedFields objectWithDeprecatedFields, JsonSerializerOptions jsonSerializerOptions)
         {
             if (objectWithDeprecatedFields.BarsOption.IsSet && objectWithDeprecatedFields.Bars == null)
-                throw new ArgumentNullException(nameof(objectWithDeprecatedFields.Bars), "Property is required for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Bars to non-nullable JSON property 'bars'.");
 
             if (objectWithDeprecatedFields.DeprecatedRefOption.IsSet && objectWithDeprecatedFields.DeprecatedRef == null)
-                throw new ArgumentNullException(nameof(objectWithDeprecatedFields.DeprecatedRef), "Property is required for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.DeprecatedRef to non-nullable JSON property 'deprecatedRef'.");
 
             if (objectWithDeprecatedFields.UuidOption.IsSet && objectWithDeprecatedFields.Uuid == null)
-                throw new ArgumentNullException(nameof(objectWithDeprecatedFields.Uuid), "Property is required for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Uuid to non-nullable JSON property 'uuid'.");
 
             if (objectWithDeprecatedFields.BarsOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Order.cs
@@ -386,6 +386,24 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Order order, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (order.CompleteOption.IsSet && order.Complete == null)
+                throw new JsonException("Cannot write null property Order.Complete to non-nullable JSON property 'complete'.");
+
+            if (order.IdOption.IsSet && order.Id == null)
+                throw new JsonException("Cannot write null property Order.Id to non-nullable JSON property 'id'.");
+
+            if (order.PetIdOption.IsSet && order.PetId == null)
+                throw new JsonException("Cannot write null property Order.PetId to non-nullable JSON property 'petId'.");
+
+            if (order.QuantityOption.IsSet && order.Quantity == null)
+                throw new JsonException("Cannot write null property Order.Quantity to non-nullable JSON property 'quantity'.");
+
+            if (order.ShipDateOption.IsSet && order.ShipDate == null)
+                throw new JsonException("Cannot write null property Order.ShipDate to non-nullable JSON property 'shipDate'.");
+
+            if (order.StatusOption.IsSet && order.Status == null)
+                throw new JsonException("Cannot write null property Order.Status to non-nullable JSON property 'status'.");
+
             if (order.CompleteOption.IsSet)
                 writer.WriteBoolean("complete", order.CompleteOption.Value!.Value);
 

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -223,7 +223,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, OuterComposite outerComposite, JsonSerializerOptions jsonSerializerOptions)
         {
             if (outerComposite.MyStringOption.IsSet && outerComposite.MyString == null)
-                throw new ArgumentNullException(nameof(outerComposite.MyString), "Property is required for class OuterComposite.");
+                throw new JsonException("Cannot write null property OuterComposite.MyString to non-nullable JSON property 'my_string'.");
 
             if (outerComposite.MyBooleanOption.IsSet)
                 writer.WriteBoolean("my_boolean", outerComposite.MyBooleanOption.Value!.Value);

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -222,6 +222,12 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, OuterComposite outerComposite, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (outerComposite.MyBooleanOption.IsSet && outerComposite.MyBoolean == null)
+                throw new JsonException("Cannot write null property OuterComposite.MyBoolean to non-nullable JSON property 'my_boolean'.");
+
+            if (outerComposite.MyNumberOption.IsSet && outerComposite.MyNumber == null)
+                throw new JsonException("Cannot write null property OuterComposite.MyNumber to non-nullable JSON property 'my_number'.");
+
             if (outerComposite.MyStringOption.IsSet && outerComposite.MyString == null)
                 throw new JsonException("Cannot write null property OuterComposite.MyString to non-nullable JSON property 'my_string'.");
 

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Pet.cs
@@ -376,6 +376,12 @@ namespace Org.OpenAPITools.Model
             if (pet.CategoryOption.IsSet && pet.Category == null)
                 throw new JsonException("Cannot write null property Pet.Category to non-nullable JSON property 'category'.");
 
+            if (pet.IdOption.IsSet && pet.Id == null)
+                throw new JsonException("Cannot write null property Pet.Id to non-nullable JSON property 'id'.");
+
+            if (pet.StatusOption.IsSet && pet.Status == null)
+                throw new JsonException("Cannot write null property Pet.Status to non-nullable JSON property 'status'.");
+
             if (pet.TagsOption.IsSet && pet.Tags == null)
                 throw new JsonException("Cannot write null property Pet.Tags to non-nullable JSON property 'tags'.");
 

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Pet.cs
@@ -373,17 +373,11 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Pet pet, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (pet.Name == null)
-                throw new ArgumentNullException(nameof(pet.Name), "Property is required for class Pet.");
-
-            if (pet.PhotoUrls == null)
-                throw new ArgumentNullException(nameof(pet.PhotoUrls), "Property is required for class Pet.");
-
             if (pet.CategoryOption.IsSet && pet.Category == null)
-                throw new ArgumentNullException(nameof(pet.Category), "Property is required for class Pet.");
+                throw new JsonException("Cannot write null property Pet.Category to non-nullable JSON property 'category'.");
 
             if (pet.TagsOption.IsSet && pet.Tags == null)
-                throw new ArgumentNullException(nameof(pet.Tags), "Property is required for class Pet.");
+                throw new JsonException("Cannot write null property Pet.Tags to non-nullable JSON property 'tags'.");
 
             writer.WriteString("name", pet.Name);
 

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
@@ -172,9 +172,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, QuadrilateralInterface quadrilateralInterface, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (quadrilateralInterface.QuadrilateralType == null)
-                throw new ArgumentNullException(nameof(quadrilateralInterface.QuadrilateralType), "Property is required for class QuadrilateralInterface.");
-
             writer.WriteString("quadrilateralType", quadrilateralInterface.QuadrilateralType);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -238,10 +238,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ReadOnlyFirst readOnlyFirst, JsonSerializerOptions jsonSerializerOptions)
         {
             if (readOnlyFirst.BarOption.IsSet && readOnlyFirst.Bar == null)
-                throw new ArgumentNullException(nameof(readOnlyFirst.Bar), "Property is required for class ReadOnlyFirst.");
+                throw new JsonException("Cannot write null property ReadOnlyFirst.Bar to non-nullable JSON property 'bar'.");
 
             if (readOnlyFirst.BazOption.IsSet && readOnlyFirst.Baz == null)
-                throw new ArgumentNullException(nameof(readOnlyFirst.Baz), "Property is required for class ReadOnlyFirst.");
+                throw new JsonException("Cannot write null property ReadOnlyFirst.Baz to non-nullable JSON property 'baz'.");
 
             if (readOnlyFirst.BarOption.IsSet)
                 writer.WriteString("bar", readOnlyFirst.Bar);

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -2237,17 +2237,11 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, RequiredClass requiredClass, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (requiredClass.RequiredNotnullableArrayOfString == null)
-                throw new ArgumentNullException(nameof(requiredClass.RequiredNotnullableArrayOfString), "Property is required for class RequiredClass.");
-
-            if (requiredClass.RequiredNotnullableStringProp == null)
-                throw new ArgumentNullException(nameof(requiredClass.RequiredNotnullableStringProp), "Property is required for class RequiredClass.");
-
             if (requiredClass.NotrequiredNotnullableArrayOfStringOption.IsSet && requiredClass.NotrequiredNotnullableArrayOfString == null)
-                throw new ArgumentNullException(nameof(requiredClass.NotrequiredNotnullableArrayOfString), "Property is required for class RequiredClass.");
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableArrayOfString to non-nullable JSON property 'notrequired_notnullable_array_of_string'.");
 
             if (requiredClass.NotrequiredNotnullableStringPropOption.IsSet && requiredClass.NotrequiredNotnullableStringProp == null)
-                throw new ArgumentNullException(nameof(requiredClass.NotrequiredNotnullableStringProp), "Property is required for class RequiredClass.");
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableStringProp to non-nullable JSON property 'notrequired_notnullable_string_prop'.");
 
             writer.WriteString("required_not_nullable_date_prop", requiredClass.RequiredNotNullableDateProp.ToString(RequiredNotNullableDatePropFormat));
 

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -2237,11 +2237,38 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, RequiredClass requiredClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (requiredClass.NotRequiredNotnullableDatePropOption.IsSet && requiredClass.NotRequiredNotnullableDateProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotRequiredNotnullableDateProp to non-nullable JSON property 'not_required_notnullable_date_prop'.");
+
+            if (requiredClass.NotRequiredNotnullableintegerPropOption.IsSet && requiredClass.NotRequiredNotnullableintegerProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotRequiredNotnullableintegerProp to non-nullable JSON property 'not_required_notnullableinteger_prop'.");
+
             if (requiredClass.NotrequiredNotnullableArrayOfStringOption.IsSet && requiredClass.NotrequiredNotnullableArrayOfString == null)
                 throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableArrayOfString to non-nullable JSON property 'notrequired_notnullable_array_of_string'.");
 
+            if (requiredClass.NotrequiredNotnullableBooleanPropOption.IsSet && requiredClass.NotrequiredNotnullableBooleanProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableBooleanProp to non-nullable JSON property 'notrequired_notnullable_boolean_prop'.");
+
+            if (requiredClass.NotrequiredNotnullableDatetimePropOption.IsSet && requiredClass.NotrequiredNotnullableDatetimeProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableDatetimeProp to non-nullable JSON property 'notrequired_notnullable_datetime_prop'.");
+
+            if (requiredClass.NotrequiredNotnullableEnumIntegerOption.IsSet && requiredClass.NotrequiredNotnullableEnumInteger == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableEnumInteger to non-nullable JSON property 'notrequired_notnullable_enum_integer'.");
+
+            if (requiredClass.NotrequiredNotnullableEnumIntegerOnlyOption.IsSet && requiredClass.NotrequiredNotnullableEnumIntegerOnly == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableEnumIntegerOnly to non-nullable JSON property 'notrequired_notnullable_enum_integer_only'.");
+
+            if (requiredClass.NotrequiredNotnullableEnumStringOption.IsSet && requiredClass.NotrequiredNotnullableEnumString == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableEnumString to non-nullable JSON property 'notrequired_notnullable_enum_string'.");
+
+            if (requiredClass.NotrequiredNotnullableOuterEnumDefaultValueOption.IsSet && requiredClass.NotrequiredNotnullableOuterEnumDefaultValue == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableOuterEnumDefaultValue to non-nullable JSON property 'notrequired_notnullable_outerEnumDefaultValue'.");
+
             if (requiredClass.NotrequiredNotnullableStringPropOption.IsSet && requiredClass.NotrequiredNotnullableStringProp == null)
                 throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableStringProp to non-nullable JSON property 'notrequired_notnullable_string_prop'.");
+
+            if (requiredClass.NotrequiredNotnullableUuidOption.IsSet && requiredClass.NotrequiredNotnullableUuid == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableUuid to non-nullable JSON property 'notrequired_notnullable_uuid'.");
 
             writer.WriteString("required_not_nullable_date_prop", requiredClass.RequiredNotNullableDateProp.ToString(RequiredNotNullableDatePropFormat));
 

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Result.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Result.cs
@@ -226,13 +226,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Result result, JsonSerializerOptions jsonSerializerOptions)
         {
             if (result.CodeOption.IsSet && result.Code == null)
-                throw new ArgumentNullException(nameof(result.Code), "Property is required for class Result.");
+                throw new JsonException("Cannot write null property Result.Code to non-nullable JSON property 'code'.");
 
             if (result.DataOption.IsSet && result.Data == null)
-                throw new ArgumentNullException(nameof(result.Data), "Property is required for class Result.");
+                throw new JsonException("Cannot write null property Result.Data to non-nullable JSON property 'data'.");
 
             if (result.UuidOption.IsSet && result.Uuid == null)
-                throw new ArgumentNullException(nameof(result.Uuid), "Property is required for class Result.");
+                throw new JsonException("Cannot write null property Result.Uuid to non-nullable JSON property 'uuid'.");
 
             if (result.CodeOption.IsSet)
                 writer.WriteString("code", result.Code);

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Return.cs
@@ -234,11 +234,8 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Return varReturn, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (varReturn.Lock == null)
-                throw new ArgumentNullException(nameof(varReturn.Lock), "Property is required for class Return.");
-
             if (varReturn.UnsafeOption.IsSet && varReturn.Unsafe == null)
-                throw new ArgumentNullException(nameof(varReturn.Unsafe), "Property is required for class Return.");
+                throw new JsonException("Cannot write null property Return.Unsafe to non-nullable JSON property 'unsafe'.");
 
             writer.WriteString("lock", varReturn.Lock);
 

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Return.cs
@@ -234,6 +234,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Return varReturn, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (varReturn.VarReturnOption.IsSet && varReturn.VarReturn == null)
+                throw new JsonException("Cannot write null property Return.VarReturn to non-nullable JSON property 'return'.");
+
             if (varReturn.UnsafeOption.IsSet && varReturn.Unsafe == null)
                 throw new JsonException("Cannot write null property Return.Unsafe to non-nullable JSON property 'unsafe'.");
 

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -200,7 +200,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, RolesReportsHash rolesReportsHash, JsonSerializerOptions jsonSerializerOptions)
         {
             if (rolesReportsHash.RoleOption.IsSet && rolesReportsHash.Role == null)
-                throw new ArgumentNullException(nameof(rolesReportsHash.Role), "Property is required for class RolesReportsHash.");
+                throw new JsonException("Cannot write null property RolesReportsHash.Role to non-nullable JSON property 'role'.");
 
             if (rolesReportsHash.RoleOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -202,6 +202,9 @@ namespace Org.OpenAPITools.Model
             if (rolesReportsHash.RoleOption.IsSet && rolesReportsHash.Role == null)
                 throw new JsonException("Cannot write null property RolesReportsHash.Role to non-nullable JSON property 'role'.");
 
+            if (rolesReportsHash.RoleUuidOption.IsSet && rolesReportsHash.RoleUuid == null)
+                throw new JsonException("Cannot write null property RolesReportsHash.RoleUuid to non-nullable JSON property 'role_uuid'.");
+
             if (rolesReportsHash.RoleOption.IsSet)
             {
                 writer.WritePropertyName("role");

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, RolesReportsHashRole rolesReportsHashRole, JsonSerializerOptions jsonSerializerOptions)
         {
             if (rolesReportsHashRole.NameOption.IsSet && rolesReportsHashRole.Name == null)
-                throw new ArgumentNullException(nameof(rolesReportsHashRole.Name), "Property is required for class RolesReportsHashRole.");
+                throw new JsonException("Cannot write null property RolesReportsHashRole.Name to non-nullable JSON property 'name'.");
 
             if (rolesReportsHashRole.NameOption.IsSet)
                 writer.WriteString("name", rolesReportsHashRole.Name);

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
@@ -191,12 +191,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ScaleneTriangle scaleneTriangle, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (scaleneTriangle.ShapeType == null)
-                throw new ArgumentNullException(nameof(scaleneTriangle.ShapeType), "Property is required for class ScaleneTriangle.");
-
-            if (scaleneTriangle.TriangleType == null)
-                throw new ArgumentNullException(nameof(scaleneTriangle.TriangleType), "Property is required for class ScaleneTriangle.");
-
             writer.WriteString("shapeType", scaleneTriangle.ShapeType);
 
             writer.WriteString("triangleType", scaleneTriangle.TriangleType);

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ShapeInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ShapeInterface.cs
@@ -172,9 +172,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ShapeInterface shapeInterface, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (shapeInterface.ShapeType == null)
-                throw new ArgumentNullException(nameof(shapeInterface.ShapeType), "Property is required for class ShapeInterface.");
-
             writer.WriteString("shapeType", shapeInterface.ShapeType);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
@@ -191,12 +191,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, SimpleQuadrilateral simpleQuadrilateral, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (simpleQuadrilateral.QuadrilateralType == null)
-                throw new ArgumentNullException(nameof(simpleQuadrilateral.QuadrilateralType), "Property is required for class SimpleQuadrilateral.");
-
-            if (simpleQuadrilateral.ShapeType == null)
-                throw new ArgumentNullException(nameof(simpleQuadrilateral.ShapeType), "Property is required for class SimpleQuadrilateral.");
-
             writer.WriteString("quadrilateralType", simpleQuadrilateral.QuadrilateralType);
 
             writer.WriteString("shapeType", simpleQuadrilateral.ShapeType);

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -202,6 +202,9 @@ namespace Org.OpenAPITools.Model
             if (specialModelName.VarSpecialModelNameOption.IsSet && specialModelName.VarSpecialModelName == null)
                 throw new JsonException("Cannot write null property SpecialModelName.VarSpecialModelName to non-nullable JSON property '_special_model.name_'.");
 
+            if (specialModelName.SpecialPropertyNameOption.IsSet && specialModelName.SpecialPropertyName == null)
+                throw new JsonException("Cannot write null property SpecialModelName.SpecialPropertyName to non-nullable JSON property '$special[property.name]'.");
+
             if (specialModelName.VarSpecialModelNameOption.IsSet)
                 writer.WriteString("_special_model.name_", specialModelName.VarSpecialModelName);
 

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -200,7 +200,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, SpecialModelName specialModelName, JsonSerializerOptions jsonSerializerOptions)
         {
             if (specialModelName.VarSpecialModelNameOption.IsSet && specialModelName.VarSpecialModelName == null)
-                throw new ArgumentNullException(nameof(specialModelName.VarSpecialModelName), "Property is required for class SpecialModelName.");
+                throw new JsonException("Cannot write null property SpecialModelName.VarSpecialModelName to non-nullable JSON property '_special_model.name_'.");
 
             if (specialModelName.VarSpecialModelNameOption.IsSet)
                 writer.WriteString("_special_model.name_", specialModelName.VarSpecialModelName);

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Tag.cs
@@ -199,6 +199,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Tag tag, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (tag.IdOption.IsSet && tag.Id == null)
+                throw new JsonException("Cannot write null property Tag.Id to non-nullable JSON property 'id'.");
+
             if (tag.NameOption.IsSet && tag.Name == null)
                 throw new JsonException("Cannot write null property Tag.Name to non-nullable JSON property 'name'.");
 

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Tag.cs
@@ -200,7 +200,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Tag tag, JsonSerializerOptions jsonSerializerOptions)
         {
             if (tag.NameOption.IsSet && tag.Name == null)
-                throw new ArgumentNullException(nameof(tag.Name), "Property is required for class Tag.");
+                throw new JsonException("Cannot write null property Tag.Name to non-nullable JSON property 'name'.");
 
             if (tag.IdOption.IsSet)
                 writer.WriteNumber("id", tag.IdOption.Value!.Value);

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestCollectionEndingWithWordList testCollectionEndingWithWordList, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testCollectionEndingWithWordList.ValueOption.IsSet && testCollectionEndingWithWordList.Value == null)
-                throw new ArgumentNullException(nameof(testCollectionEndingWithWordList.Value), "Property is required for class TestCollectionEndingWithWordList.");
+                throw new JsonException("Cannot write null property TestCollectionEndingWithWordList.Value to non-nullable JSON property 'value'.");
 
             if (testCollectionEndingWithWordList.ValueOption.IsSet)
                 writer.WriteString("value", testCollectionEndingWithWordList.Value);

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestCollectionEndingWithWordListObject testCollectionEndingWithWordListObject, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testCollectionEndingWithWordListObject.TestCollectionEndingWithWordListOption.IsSet && testCollectionEndingWithWordListObject.TestCollectionEndingWithWordList == null)
-                throw new ArgumentNullException(nameof(testCollectionEndingWithWordListObject.TestCollectionEndingWithWordList), "Property is required for class TestCollectionEndingWithWordListObject.");
+                throw new JsonException("Cannot write null property TestCollectionEndingWithWordListObject.TestCollectionEndingWithWordList to non-nullable JSON property 'TestCollectionEndingWithWordList'.");
 
             if (testCollectionEndingWithWordListObject.TestCollectionEndingWithWordListOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/TestDescendants.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/TestDescendants.cs
@@ -291,9 +291,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, TestDescendants testDescendants, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (testDescendants.AlternativeName == null)
-                throw new ArgumentNullException(nameof(testDescendants.AlternativeName), "Property is required for class TestDescendants.");
-
             writer.WriteString("alternativeName", testDescendants.AlternativeName);
 
             writer.WriteString("objectType", TestDescendants.ObjectTypeEnumToJsonValue(testDescendants.ObjectType));

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestInlineFreeformAdditionalPropertiesRequest testInlineFreeformAdditionalPropertiesRequest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testInlineFreeformAdditionalPropertiesRequest.SomePropertyOption.IsSet && testInlineFreeformAdditionalPropertiesRequest.SomeProperty == null)
-                throw new ArgumentNullException(nameof(testInlineFreeformAdditionalPropertiesRequest.SomeProperty), "Property is required for class TestInlineFreeformAdditionalPropertiesRequest.");
+                throw new JsonException("Cannot write null property TestInlineFreeformAdditionalPropertiesRequest.SomeProperty to non-nullable JSON property 'someProperty'.");
 
             if (testInlineFreeformAdditionalPropertiesRequest.SomePropertyOption.IsSet)
                 writer.WriteString("someProperty", testInlineFreeformAdditionalPropertiesRequest.SomeProperty);

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/TestResult.cs
@@ -224,6 +224,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, TestResult testResult, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (testResult.CodeOption.IsSet && testResult.Code == null)
+                throw new JsonException("Cannot write null property TestResult.Code to non-nullable JSON property 'code'.");
+
             if (testResult.DataOption.IsSet && testResult.Data == null)
                 throw new JsonException("Cannot write null property TestResult.Data to non-nullable JSON property 'data'.");
 

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/TestResult.cs
@@ -225,10 +225,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestResult testResult, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testResult.DataOption.IsSet && testResult.Data == null)
-                throw new ArgumentNullException(nameof(testResult.Data), "Property is required for class TestResult.");
+                throw new JsonException("Cannot write null property TestResult.Data to non-nullable JSON property 'data'.");
 
             if (testResult.UuidOption.IsSet && testResult.Uuid == null)
-                throw new ArgumentNullException(nameof(testResult.Uuid), "Property is required for class TestResult.");
+                throw new JsonException("Cannot write null property TestResult.Uuid to non-nullable JSON property 'uuid'.");
 
             if (testResult.CodeOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/TriangleInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/TriangleInterface.cs
@@ -172,9 +172,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, TriangleInterface triangleInterface, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (triangleInterface.TriangleType == null)
-                throw new ArgumentNullException(nameof(triangleInterface.TriangleType), "Property is required for class TriangleInterface.");
-
             writer.WriteString("triangleType", triangleInterface.TriangleType);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/User.cs
@@ -431,6 +431,9 @@ namespace Org.OpenAPITools.Model
             if (user.FirstNameOption.IsSet && user.FirstName == null)
                 throw new JsonException("Cannot write null property User.FirstName to non-nullable JSON property 'firstName'.");
 
+            if (user.IdOption.IsSet && user.Id == null)
+                throw new JsonException("Cannot write null property User.Id to non-nullable JSON property 'id'.");
+
             if (user.LastNameOption.IsSet && user.LastName == null)
                 throw new JsonException("Cannot write null property User.LastName to non-nullable JSON property 'lastName'.");
 
@@ -442,6 +445,9 @@ namespace Org.OpenAPITools.Model
 
             if (user.PhoneOption.IsSet && user.Phone == null)
                 throw new JsonException("Cannot write null property User.Phone to non-nullable JSON property 'phone'.");
+
+            if (user.UserStatusOption.IsSet && user.UserStatus == null)
+                throw new JsonException("Cannot write null property User.UserStatus to non-nullable JSON property 'userStatus'.");
 
             if (user.UsernameOption.IsSet && user.Username == null)
                 throw new JsonException("Cannot write null property User.Username to non-nullable JSON property 'username'.");

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/User.cs
@@ -426,25 +426,25 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, User user, JsonSerializerOptions jsonSerializerOptions)
         {
             if (user.EmailOption.IsSet && user.Email == null)
-                throw new ArgumentNullException(nameof(user.Email), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Email to non-nullable JSON property 'email'.");
 
             if (user.FirstNameOption.IsSet && user.FirstName == null)
-                throw new ArgumentNullException(nameof(user.FirstName), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.FirstName to non-nullable JSON property 'firstName'.");
 
             if (user.LastNameOption.IsSet && user.LastName == null)
-                throw new ArgumentNullException(nameof(user.LastName), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.LastName to non-nullable JSON property 'lastName'.");
 
             if (user.ObjectWithNoDeclaredPropsOption.IsSet && user.ObjectWithNoDeclaredProps == null)
-                throw new ArgumentNullException(nameof(user.ObjectWithNoDeclaredProps), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.ObjectWithNoDeclaredProps to non-nullable JSON property 'objectWithNoDeclaredProps'.");
 
             if (user.PasswordOption.IsSet && user.Password == null)
-                throw new ArgumentNullException(nameof(user.Password), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Password to non-nullable JSON property 'password'.");
 
             if (user.PhoneOption.IsSet && user.Phone == null)
-                throw new ArgumentNullException(nameof(user.Phone), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Phone to non-nullable JSON property 'phone'.");
 
             if (user.UsernameOption.IsSet && user.Username == null)
-                throw new ArgumentNullException(nameof(user.Username), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Username to non-nullable JSON property 'username'.");
 
             if (user.AnyTypePropOption.IsSet)
                 if (user.AnyTypePropOption.Value != null)

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Whale.cs
@@ -218,6 +218,12 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Whale whale, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (whale.HasBaleenOption.IsSet && whale.HasBaleen == null)
+                throw new JsonException("Cannot write null property Whale.HasBaleen to non-nullable JSON property 'hasBaleen'.");
+
+            if (whale.HasTeethOption.IsSet && whale.HasTeeth == null)
+                throw new JsonException("Cannot write null property Whale.HasTeeth to non-nullable JSON property 'hasTeeth'.");
+
             writer.WriteString("className", whale.ClassName);
 
             if (whale.HasBaleenOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Whale.cs
@@ -218,9 +218,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Whale whale, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (whale.ClassName == null)
-                throw new ArgumentNullException(nameof(whale.ClassName), "Property is required for class Whale.");
-
             writer.WriteString("className", whale.ClassName);
 
             if (whale.HasBaleenOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Zebra.cs
@@ -282,6 +282,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Zebra zebra, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (zebra.TypeOption.IsSet && zebra.Type == null)
+                throw new JsonException("Cannot write null property Zebra.Type to non-nullable JSON property 'type'.");
+
             writer.WriteString("className", zebra.ClassName);
 
             var typeRawValue = Zebra.TypeEnumToJsonValue(zebra.TypeOption.Value!.Value);

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Zebra.cs
@@ -282,9 +282,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Zebra zebra, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (zebra.ClassName == null)
-                throw new ArgumentNullException(nameof(zebra.ClassName), "Property is required for class Zebra.");
-
             writer.WriteString("className", zebra.ClassName);
 
             var typeRawValue = Zebra.TypeEnumToJsonValue(zebra.TypeOption.Value!.Value);

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
@@ -249,6 +249,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ZeroBasedEnumClass zeroBasedEnumClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (zeroBasedEnumClass.ZeroBasedEnumOption.IsSet && zeroBasedEnumClass.ZeroBasedEnum == null)
+                throw new JsonException("Cannot write null property ZeroBasedEnumClass.ZeroBasedEnum to non-nullable JSON property 'ZeroBasedEnum'.");
+
             var zeroBasedEnumRawValue = ZeroBasedEnumClass.ZeroBasedEnumEnumToJsonValue(zeroBasedEnumClass.ZeroBasedEnumOption.Value!.Value);
             writer.WriteString("ZeroBasedEnum", zeroBasedEnumRawValue);
         }

--- a/samples/client/petstore/csharp/generichost/net10/OneOf/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net10/OneOf/src/Org.OpenAPITools/Model/Apple.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Apple apple, JsonSerializerOptions jsonSerializerOptions)
         {
             if (apple.KindOption.IsSet && apple.Kind == null)
-                throw new ArgumentNullException(nameof(apple.Kind), "Property is required for class Apple.");
+                throw new JsonException("Cannot write null property Apple.Kind to non-nullable JSON property 'kind'.");
 
             if (apple.KindOption.IsSet)
                 writer.WriteString("kind", apple.Kind);

--- a/samples/client/petstore/csharp/generichost/net10/OneOf/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net10/OneOf/src/Org.OpenAPITools/Model/Banana.cs
@@ -176,6 +176,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Banana banana, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (banana.CountOption.IsSet && banana.Count == null)
+                throw new JsonException("Cannot write null property Banana.Count to non-nullable JSON property 'count'.");
+
             if (banana.CountOption.IsSet)
                 writer.WriteNumber("count", banana.CountOption.Value!.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net10/OneOf/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net10/OneOf/src/Org.OpenAPITools/Model/Fruit.cs
@@ -252,7 +252,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Fruit fruit, JsonSerializerOptions jsonSerializerOptions)
         {
             if (fruit.ColorOption.IsSet && fruit.Color == null)
-                throw new ArgumentNullException(nameof(fruit.Color), "Property is required for class Fruit.");
+                throw new JsonException("Cannot write null property Fruit.Color to non-nullable JSON property 'color'.");
 
             if (fruit.ColorOption.IsSet)
                 writer.WriteString("color", fruit.Color);

--- a/samples/client/petstore/csharp/generichost/net10/OneOf/src/Org.OpenAPITools/Model/Orange.cs
+++ b/samples/client/petstore/csharp/generichost/net10/OneOf/src/Org.OpenAPITools/Model/Orange.cs
@@ -176,6 +176,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Orange orange, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (orange.SweetOption.IsSet && orange.Sweet == null)
+                throw new JsonException("Cannot write null property Orange.Sweet to non-nullable JSON property 'sweet'.");
+
             if (orange.SweetOption.IsSet)
                 writer.WriteBoolean("sweet", orange.SweetOption.Value!.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Activity.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Activity activity, JsonSerializerOptions jsonSerializerOptions)
         {
             if (activity.ActivityOutputsOption.IsSet && activity.ActivityOutputs == null)
-                throw new ArgumentNullException(nameof(activity.ActivityOutputs), "Property is required for class Activity.");
+                throw new JsonException("Cannot write null property Activity.ActivityOutputs to non-nullable JSON property 'activity_outputs'.");
 
             if (activity.ActivityOutputsOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -198,10 +198,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ActivityOutputElementRepresentation activityOutputElementRepresentation, JsonSerializerOptions jsonSerializerOptions)
         {
             if (activityOutputElementRepresentation.Prop1Option.IsSet && activityOutputElementRepresentation.Prop1 == null)
-                throw new ArgumentNullException(nameof(activityOutputElementRepresentation.Prop1), "Property is required for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Cannot write null property ActivityOutputElementRepresentation.Prop1 to non-nullable JSON property 'prop1'.");
 
             if (activityOutputElementRepresentation.Prop2Option.IsSet && activityOutputElementRepresentation.Prop2 == null)
-                throw new ArgumentNullException(nameof(activityOutputElementRepresentation.Prop2), "Property is required for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Cannot write null property ActivityOutputElementRepresentation.Prop2 to non-nullable JSON property 'prop2'.");
 
             if (activityOutputElementRepresentation.Prop1Option.IsSet)
                 writer.WriteString("prop1", activityOutputElementRepresentation.Prop1);

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -334,25 +334,25 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, AdditionalPropertiesClass additionalPropertiesClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (additionalPropertiesClass.EmptyMapOption.IsSet && additionalPropertiesClass.EmptyMap == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.EmptyMap), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.EmptyMap to non-nullable JSON property 'empty_map'.");
 
             if (additionalPropertiesClass.MapOfMapPropertyOption.IsSet && additionalPropertiesClass.MapOfMapProperty == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapOfMapProperty), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapOfMapProperty to non-nullable JSON property 'map_of_map_property'.");
 
             if (additionalPropertiesClass.MapPropertyOption.IsSet && additionalPropertiesClass.MapProperty == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapProperty), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapProperty to non-nullable JSON property 'map_property'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1Option.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1 == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1 to non-nullable JSON property 'map_with_undeclared_properties_anytype_1'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2Option.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2 == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2 to non-nullable JSON property 'map_with_undeclared_properties_anytype_2'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3Option.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3 == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3 to non-nullable JSON property 'map_with_undeclared_properties_anytype_3'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesStringOption.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesString == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesString), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesString to non-nullable JSON property 'map_with_undeclared_properties_string'.");
 
             if (additionalPropertiesClass.Anytype1Option.IsSet)
                 if (additionalPropertiesClass.Anytype1Option.Value != null)

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Animal.cs
@@ -221,7 +221,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Animal animal, JsonSerializerOptions jsonSerializerOptions)
         {
             if (animal.ColorOption.IsSet && animal.Color == null)
-                throw new ArgumentNullException(nameof(animal.Color), "Property is required for class Animal.");
+                throw new JsonException("Cannot write null property Animal.Color to non-nullable JSON property 'color'.");
 
             writer.WriteString("className", animal.ClassName);
 

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -221,10 +221,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ApiResponse apiResponse, JsonSerializerOptions jsonSerializerOptions)
         {
             if (apiResponse.MessageOption.IsSet && apiResponse.Message == null)
-                throw new ArgumentNullException(nameof(apiResponse.Message), "Property is required for class ApiResponse.");
+                throw new JsonException("Cannot write null property ApiResponse.Message to non-nullable JSON property 'message'.");
 
             if (apiResponse.TypeOption.IsSet && apiResponse.Type == null)
-                throw new ArgumentNullException(nameof(apiResponse.Type), "Property is required for class ApiResponse.");
+                throw new JsonException("Cannot write null property ApiResponse.Type to non-nullable JSON property 'type'.");
 
             if (apiResponse.CodeOption.IsSet)
                 writer.WriteNumber("code", apiResponse.CodeOption.Value.Value);

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -220,6 +220,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ApiResponse apiResponse, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (apiResponse.CodeOption.IsSet && apiResponse.Code == null)
+                throw new JsonException("Cannot write null property ApiResponse.Code to non-nullable JSON property 'code'.");
+
             if (apiResponse.MessageOption.IsSet && apiResponse.Message == null)
                 throw new JsonException("Cannot write null property ApiResponse.Message to non-nullable JSON property 'message'.");
 

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Apple.cs
@@ -251,13 +251,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Apple apple, JsonSerializerOptions jsonSerializerOptions)
         {
             if (apple.ColorCodeOption.IsSet && apple.ColorCode == null)
-                throw new ArgumentNullException(nameof(apple.ColorCode), "Property is required for class Apple.");
+                throw new JsonException("Cannot write null property Apple.ColorCode to non-nullable JSON property 'color_code'.");
 
             if (apple.CultivarOption.IsSet && apple.Cultivar == null)
-                throw new ArgumentNullException(nameof(apple.Cultivar), "Property is required for class Apple.");
+                throw new JsonException("Cannot write null property Apple.Cultivar to non-nullable JSON property 'cultivar'.");
 
             if (apple.OriginOption.IsSet && apple.Origin == null)
-                throw new ArgumentNullException(nameof(apple.Origin), "Property is required for class Apple.");
+                throw new JsonException("Cannot write null property Apple.Origin to non-nullable JSON property 'origin'.");
 
             if (apple.ColorCodeOption.IsSet)
                 writer.WriteString("color_code", apple.ColorCode);

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -186,9 +186,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, AppleReq appleReq, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (appleReq.Cultivar == null)
-                throw new ArgumentNullException(nameof(appleReq.Cultivar), "Property is required for class AppleReq.");
-
             writer.WriteString("cultivar", appleReq.Cultivar);
 
             if (appleReq.MealyOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -186,6 +186,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, AppleReq appleReq, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (appleReq.MealyOption.IsSet && appleReq.Mealy == null)
+                throw new JsonException("Cannot write null property AppleReq.Mealy to non-nullable JSON property 'mealy'.");
+
             writer.WriteString("cultivar", appleReq.Cultivar);
 
             if (appleReq.MealyOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ArrayOfArrayOfNumberOnly arrayOfArrayOfNumberOnly, JsonSerializerOptions jsonSerializerOptions)
         {
             if (arrayOfArrayOfNumberOnly.ArrayArrayNumberOption.IsSet && arrayOfArrayOfNumberOnly.ArrayArrayNumber == null)
-                throw new ArgumentNullException(nameof(arrayOfArrayOfNumberOnly.ArrayArrayNumber), "Property is required for class ArrayOfArrayOfNumberOnly.");
+                throw new JsonException("Cannot write null property ArrayOfArrayOfNumberOnly.ArrayArrayNumber to non-nullable JSON property 'ArrayArrayNumber'.");
 
             if (arrayOfArrayOfNumberOnly.ArrayArrayNumberOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ArrayOfNumberOnly arrayOfNumberOnly, JsonSerializerOptions jsonSerializerOptions)
         {
             if (arrayOfNumberOnly.ArrayNumberOption.IsSet && arrayOfNumberOnly.ArrayNumber == null)
-                throw new ArgumentNullException(nameof(arrayOfNumberOnly.ArrayNumber), "Property is required for class ArrayOfNumberOnly.");
+                throw new JsonException("Cannot write null property ArrayOfNumberOnly.ArrayNumber to non-nullable JSON property 'ArrayNumber'.");
 
             if (arrayOfNumberOnly.ArrayNumberOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -221,13 +221,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ArrayTest arrayTest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (arrayTest.ArrayArrayOfIntegerOption.IsSet && arrayTest.ArrayArrayOfInteger == null)
-                throw new ArgumentNullException(nameof(arrayTest.ArrayArrayOfInteger), "Property is required for class ArrayTest.");
+                throw new JsonException("Cannot write null property ArrayTest.ArrayArrayOfInteger to non-nullable JSON property 'array_array_of_integer'.");
 
             if (arrayTest.ArrayArrayOfModelOption.IsSet && arrayTest.ArrayArrayOfModel == null)
-                throw new ArgumentNullException(nameof(arrayTest.ArrayArrayOfModel), "Property is required for class ArrayTest.");
+                throw new JsonException("Cannot write null property ArrayTest.ArrayArrayOfModel to non-nullable JSON property 'array_array_of_model'.");
 
             if (arrayTest.ArrayOfStringOption.IsSet && arrayTest.ArrayOfString == null)
-                throw new ArgumentNullException(nameof(arrayTest.ArrayOfString), "Property is required for class ArrayTest.");
+                throw new JsonException("Cannot write null property ArrayTest.ArrayOfString to non-nullable JSON property 'array_of_string'.");
 
             if (arrayTest.ArrayArrayOfIntegerOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Banana.cs
@@ -174,6 +174,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Banana banana, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (banana.LengthCmOption.IsSet && banana.LengthCm == null)
+                throw new JsonException("Cannot write null property Banana.LengthCm to non-nullable JSON property 'lengthCm'.");
+
             if (banana.LengthCmOption.IsSet)
                 writer.WriteNumber("lengthCm", banana.LengthCmOption.Value.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -186,6 +186,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, BananaReq bananaReq, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (bananaReq.SweetOption.IsSet && bananaReq.Sweet == null)
+                throw new JsonException("Cannot write null property BananaReq.Sweet to non-nullable JSON property 'sweet'.");
+
             writer.WriteNumber("lengthCm", bananaReq.LengthCm);
 
             if (bananaReq.SweetOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/BasquePig.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/BasquePig.cs
@@ -170,9 +170,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, BasquePig basquePig, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (basquePig.ClassName == null)
-                throw new ArgumentNullException(nameof(basquePig.ClassName), "Property is required for class BasquePig.");
-
             writer.WriteString("className", basquePig.ClassName);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -291,22 +291,22 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Capitalization capitalization, JsonSerializerOptions jsonSerializerOptions)
         {
             if (capitalization.ATT_NAMEOption.IsSet && capitalization.ATT_NAME == null)
-                throw new ArgumentNullException(nameof(capitalization.ATT_NAME), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.ATT_NAME to non-nullable JSON property 'ATT_NAME'.");
 
             if (capitalization.CapitalCamelOption.IsSet && capitalization.CapitalCamel == null)
-                throw new ArgumentNullException(nameof(capitalization.CapitalCamel), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.CapitalCamel to non-nullable JSON property 'CapitalCamel'.");
 
             if (capitalization.CapitalSnakeOption.IsSet && capitalization.CapitalSnake == null)
-                throw new ArgumentNullException(nameof(capitalization.CapitalSnake), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.CapitalSnake to non-nullable JSON property 'Capital_Snake'.");
 
             if (capitalization.SCAETHFlowPointsOption.IsSet && capitalization.SCAETHFlowPoints == null)
-                throw new ArgumentNullException(nameof(capitalization.SCAETHFlowPoints), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.SCAETHFlowPoints to non-nullable JSON property 'SCA_ETH_Flow_Points'.");
 
             if (capitalization.SmallCamelOption.IsSet && capitalization.SmallCamel == null)
-                throw new ArgumentNullException(nameof(capitalization.SmallCamel), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.SmallCamel to non-nullable JSON property 'smallCamel'.");
 
             if (capitalization.SmallSnakeOption.IsSet && capitalization.SmallSnake == null)
-                throw new ArgumentNullException(nameof(capitalization.SmallSnake), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.SmallSnake to non-nullable JSON property 'small_Snake'.");
 
             if (capitalization.ATT_NAMEOption.IsSet)
                 writer.WriteString("ATT_NAME", capitalization.ATT_NAME);

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Cat.cs
@@ -179,6 +179,9 @@ namespace Org.OpenAPITools.Model
             if (cat.ColorOption.IsSet && cat.Color == null)
                 throw new JsonException("Cannot write null property Cat.Color to non-nullable JSON property 'color'.");
 
+            if (cat.DeclawedOption.IsSet && cat.Declawed == null)
+                throw new JsonException("Cannot write null property Cat.Declawed to non-nullable JSON property 'declawed'.");
+
             writer.WriteString("className", cat.ClassName);
 
             if (cat.ColorOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Cat.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Cat cat, JsonSerializerOptions jsonSerializerOptions)
         {
             if (cat.ColorOption.IsSet && cat.Color == null)
-                throw new ArgumentNullException(nameof(cat.Color), "Property is required for class Cat.");
+                throw new JsonException("Cannot write null property Cat.Color to non-nullable JSON property 'color'.");
 
             writer.WriteString("className", cat.ClassName);
 

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Category.cs
@@ -193,9 +193,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Category category, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (category.Name == null)
-                throw new ArgumentNullException(nameof(category.Name), "Property is required for class Category.");
-
             if (category.IdOption.IsSet)
                 writer.WriteNumber("id", category.IdOption.Value.Value);
 

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Category.cs
@@ -193,6 +193,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Category category, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (category.IdOption.IsSet && category.Id == null)
+                throw new JsonException("Cannot write null property Category.Id to non-nullable JSON property 'id'.");
+
             if (category.IdOption.IsSet)
                 writer.WriteNumber("id", category.IdOption.Value.Value);
 

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -236,7 +236,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ChildCat childCat, JsonSerializerOptions jsonSerializerOptions)
         {
             if (childCat.NameOption.IsSet && childCat.Name == null)
-                throw new ArgumentNullException(nameof(childCat.Name), "Property is required for class ChildCat.");
+                throw new JsonException("Cannot write null property ChildCat.Name to non-nullable JSON property 'name'.");
 
             if (childCat.NameOption.IsSet)
                 writer.WriteString("name", childCat.Name);

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ClassModel classModel, JsonSerializerOptions jsonSerializerOptions)
         {
             if (classModel.ClassOption.IsSet && classModel.Class == null)
-                throw new ArgumentNullException(nameof(classModel.Class), "Property is required for class ClassModel.");
+                throw new JsonException("Cannot write null property ClassModel.Class to non-nullable JSON property '_class'.");
 
             if (classModel.ClassOption.IsSet)
                 writer.WriteString("_class", classModel.Class);

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
@@ -189,12 +189,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ComplexQuadrilateral complexQuadrilateral, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (complexQuadrilateral.QuadrilateralType == null)
-                throw new ArgumentNullException(nameof(complexQuadrilateral.QuadrilateralType), "Property is required for class ComplexQuadrilateral.");
-
-            if (complexQuadrilateral.ShapeType == null)
-                throw new ArgumentNullException(nameof(complexQuadrilateral.ShapeType), "Property is required for class ComplexQuadrilateral.");
-
             writer.WriteString("quadrilateralType", complexQuadrilateral.QuadrilateralType);
 
             writer.WriteString("shapeType", complexQuadrilateral.ShapeType);

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/CopyActivity.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/CopyActivity.cs
@@ -231,9 +231,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, CopyActivity copyActivity, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (copyActivity.CopyActivitytt == null)
-                throw new ArgumentNullException(nameof(copyActivity.CopyActivitytt), "Property is required for class CopyActivity.");
-
             writer.WriteString("copyActivitytt", copyActivity.CopyActivitytt);
 
             writer.WriteString("$schema", CopyActivity.SchemaEnumToJsonValue(copyActivity.Schema));

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/DanishPig.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/DanishPig.cs
@@ -170,9 +170,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, DanishPig danishPig, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (danishPig.ClassName == null)
-                throw new ArgumentNullException(nameof(danishPig.ClassName), "Property is required for class DanishPig.");
-
             writer.WriteString("className", danishPig.ClassName);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -180,6 +180,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, DateOnlyClass dateOnlyClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (dateOnlyClass.DateOnlyPropertyOption.IsSet && dateOnlyClass.DateOnlyProperty == null)
+                throw new JsonException("Cannot write null property DateOnlyClass.DateOnlyProperty to non-nullable JSON property 'dateOnlyProperty'.");
+
             if (dateOnlyClass.DateOnlyPropertyOption.IsSet)
                 writer.WriteString("dateOnlyProperty", dateOnlyClass.DateOnlyPropertyOption.Value.Value.ToString(DateOnlyPropertyFormat));
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, DeprecatedObject deprecatedObject, JsonSerializerOptions jsonSerializerOptions)
         {
             if (deprecatedObject.NameOption.IsSet && deprecatedObject.Name == null)
-                throw new ArgumentNullException(nameof(deprecatedObject.Name), "Property is required for class DeprecatedObject.");
+                throw new JsonException("Cannot write null property DeprecatedObject.Name to non-nullable JSON property 'name'.");
 
             if (deprecatedObject.NameOption.IsSet)
                 writer.WriteString("name", deprecatedObject.Name);

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Descendant1.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Descendant1.cs
@@ -182,12 +182,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Descendant1 descendant1, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (descendant1.AlternativeName == null)
-                throw new ArgumentNullException(nameof(descendant1.AlternativeName), "Property is required for class Descendant1.");
-
-            if (descendant1.DescendantName == null)
-                throw new ArgumentNullException(nameof(descendant1.DescendantName), "Property is required for class Descendant1.");
-
             writer.WriteString("alternativeName", descendant1.AlternativeName);
 
             writer.WriteString("descendantName", descendant1.DescendantName);

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Descendant2.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Descendant2.cs
@@ -182,12 +182,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Descendant2 descendant2, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (descendant2.AlternativeName == null)
-                throw new ArgumentNullException(nameof(descendant2.AlternativeName), "Property is required for class Descendant2.");
-
-            if (descendant2.Confidentiality == null)
-                throw new ArgumentNullException(nameof(descendant2.Confidentiality), "Property is required for class Descendant2.");
-
             writer.WriteString("alternativeName", descendant2.AlternativeName);
 
             writer.WriteString("confidentiality", descendant2.Confidentiality);

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Dog.cs
@@ -177,10 +177,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Dog dog, JsonSerializerOptions jsonSerializerOptions)
         {
             if (dog.BreedOption.IsSet && dog.Breed == null)
-                throw new ArgumentNullException(nameof(dog.Breed), "Property is required for class Dog.");
+                throw new JsonException("Cannot write null property Dog.Breed to non-nullable JSON property 'breed'.");
 
             if (dog.ColorOption.IsSet && dog.Color == null)
-                throw new ArgumentNullException(nameof(dog.Color), "Property is required for class Dog.");
+                throw new JsonException("Cannot write null property Dog.Color to non-nullable JSON property 'color'.");
 
             writer.WriteString("className", dog.ClassName);
 

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Drawing.cs
@@ -238,10 +238,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Drawing drawing, JsonSerializerOptions jsonSerializerOptions)
         {
             if (drawing.MainShapeOption.IsSet && drawing.MainShape == null)
-                throw new ArgumentNullException(nameof(drawing.MainShape), "Property is required for class Drawing.");
+                throw new JsonException("Cannot write null property Drawing.MainShape to non-nullable JSON property 'mainShape'.");
 
             if (drawing.ShapesOption.IsSet && drawing.Shapes == null)
-                throw new ArgumentNullException(nameof(drawing.Shapes), "Property is required for class Drawing.");
+                throw new JsonException("Cannot write null property Drawing.Shapes to non-nullable JSON property 'shapes'.");
 
             if (drawing.MainShapeOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -337,7 +337,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, EnumArrays enumArrays, JsonSerializerOptions jsonSerializerOptions)
         {
             if (enumArrays.ArrayEnumOption.IsSet && enumArrays.ArrayEnum == null)
-                throw new ArgumentNullException(nameof(enumArrays.ArrayEnum), "Property is required for class EnumArrays.");
+                throw new JsonException("Cannot write null property EnumArrays.ArrayEnum to non-nullable JSON property 'array_enum'.");
 
             if (enumArrays.ArrayEnumOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -339,6 +339,9 @@ namespace Org.OpenAPITools.Model
             if (enumArrays.ArrayEnumOption.IsSet && enumArrays.ArrayEnum == null)
                 throw new JsonException("Cannot write null property EnumArrays.ArrayEnum to non-nullable JSON property 'array_enum'.");
 
+            if (enumArrays.JustSymbolOption.IsSet && enumArrays.JustSymbol == null)
+                throw new JsonException("Cannot write null property EnumArrays.JustSymbol to non-nullable JSON property 'just_symbol'.");
+
             if (enumArrays.ArrayEnumOption.IsSet)
             {
                 writer.WritePropertyName("array_enum");

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -875,6 +875,27 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, EnumTest enumTest, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (enumTest.EnumIntegerOption.IsSet && enumTest.EnumInteger == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumInteger to non-nullable JSON property 'enum_integer'.");
+
+            if (enumTest.EnumIntegerOnlyOption.IsSet && enumTest.EnumIntegerOnly == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumIntegerOnly to non-nullable JSON property 'enum_integer_only'.");
+
+            if (enumTest.EnumNumberOption.IsSet && enumTest.EnumNumber == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumNumber to non-nullable JSON property 'enum_number'.");
+
+            if (enumTest.EnumStringOption.IsSet && enumTest.EnumString == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumString to non-nullable JSON property 'enum_string'.");
+
+            if (enumTest.OuterEnumDefaultValueOption.IsSet && enumTest.OuterEnumDefaultValue == null)
+                throw new JsonException("Cannot write null property EnumTest.OuterEnumDefaultValue to non-nullable JSON property 'outerEnumDefaultValue'.");
+
+            if (enumTest.OuterEnumIntegerOption.IsSet && enumTest.OuterEnumInteger == null)
+                throw new JsonException("Cannot write null property EnumTest.OuterEnumInteger to non-nullable JSON property 'outerEnumInteger'.");
+
+            if (enumTest.OuterEnumIntegerDefaultValueOption.IsSet && enumTest.OuterEnumIntegerDefaultValue == null)
+                throw new JsonException("Cannot write null property EnumTest.OuterEnumIntegerDefaultValue to non-nullable JSON property 'outerEnumIntegerDefaultValue'.");
+
             var enumStringRequiredRawValue = EnumTest.EnumStringRequiredEnumToJsonValue(enumTest.EnumStringRequired);
             writer.WriteString("enum_string_required", enumStringRequiredRawValue);
             if (enumTest.EnumIntegerOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
@@ -189,12 +189,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, EquilateralTriangle equilateralTriangle, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (equilateralTriangle.ShapeType == null)
-                throw new ArgumentNullException(nameof(equilateralTriangle.ShapeType), "Property is required for class EquilateralTriangle.");
-
-            if (equilateralTriangle.TriangleType == null)
-                throw new ArgumentNullException(nameof(equilateralTriangle.TriangleType), "Property is required for class EquilateralTriangle.");
-
             writer.WriteString("shapeType", equilateralTriangle.ShapeType);
 
             writer.WriteString("triangleType", equilateralTriangle.TriangleType);

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/File.cs
@@ -176,7 +176,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, File file, JsonSerializerOptions jsonSerializerOptions)
         {
             if (file.SourceURIOption.IsSet && file.SourceURI == null)
-                throw new ArgumentNullException(nameof(file.SourceURI), "Property is required for class File.");
+                throw new JsonException("Cannot write null property File.SourceURI to non-nullable JSON property 'sourceURI'.");
 
             if (file.SourceURIOption.IsSet)
                 writer.WriteString("sourceURI", file.SourceURI);

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -198,10 +198,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, FileSchemaTestClass fileSchemaTestClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (fileSchemaTestClass.FileOption.IsSet && fileSchemaTestClass.File == null)
-                throw new ArgumentNullException(nameof(fileSchemaTestClass.File), "Property is required for class FileSchemaTestClass.");
+                throw new JsonException("Cannot write null property FileSchemaTestClass.File to non-nullable JSON property 'file'.");
 
             if (fileSchemaTestClass.FilesOption.IsSet && fileSchemaTestClass.Files == null)
-                throw new ArgumentNullException(nameof(fileSchemaTestClass.Files), "Property is required for class FileSchemaTestClass.");
+                throw new JsonException("Cannot write null property FileSchemaTestClass.Files to non-nullable JSON property 'files'.");
 
             if (fileSchemaTestClass.FileOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Foo.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Foo foo, JsonSerializerOptions jsonSerializerOptions)
         {
             if (foo.BarOption.IsSet && foo.Bar == null)
-                throw new ArgumentNullException(nameof(foo.Bar), "Property is required for class Foo.");
+                throw new JsonException("Cannot write null property Foo.Bar to non-nullable JSON property 'bar'.");
 
             if (foo.BarOption.IsSet)
                 writer.WriteString("bar", foo.Bar);

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, FooGetDefaultResponse fooGetDefaultResponse, JsonSerializerOptions jsonSerializerOptions)
         {
             if (fooGetDefaultResponse.StringOption.IsSet && fooGetDefaultResponse.String == null)
-                throw new ArgumentNullException(nameof(fooGetDefaultResponse.String), "Property is required for class FooGetDefaultResponse.");
+                throw new JsonException("Cannot write null property FooGetDefaultResponse.String to non-nullable JSON property 'string'.");
 
             if (fooGetDefaultResponse.StringOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -954,11 +954,47 @@ namespace Org.OpenAPITools.Model
             if (formatTest.BinaryOption.IsSet && formatTest.Binary == null)
                 throw new JsonException("Cannot write null property FormatTest.Binary to non-nullable JSON property 'binary'.");
 
+            if (formatTest.DateTimeOption.IsSet && formatTest.DateTime == null)
+                throw new JsonException("Cannot write null property FormatTest.DateTime to non-nullable JSON property 'dateTime'.");
+
+            if (formatTest.DecimalOption.IsSet && formatTest.Decimal == null)
+                throw new JsonException("Cannot write null property FormatTest.Decimal to non-nullable JSON property 'decimal'.");
+
+            if (formatTest.DoubleOption.IsSet && formatTest.Double == null)
+                throw new JsonException("Cannot write null property FormatTest.Double to non-nullable JSON property 'double'.");
+
             if (formatTest.DuplicatePropertyName2Option.IsSet && formatTest.DuplicatePropertyName2 == null)
                 throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName2 to non-nullable JSON property 'duplicate_property_name'.");
 
             if (formatTest.DuplicatePropertyNameOption.IsSet && formatTest.DuplicatePropertyName == null)
                 throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName to non-nullable JSON property '@duplicate_property_name'.");
+
+            if (formatTest.FloatOption.IsSet && formatTest.Float == null)
+                throw new JsonException("Cannot write null property FormatTest.Float to non-nullable JSON property 'float'.");
+
+            if (formatTest.Int32Option.IsSet && formatTest.Int32 == null)
+                throw new JsonException("Cannot write null property FormatTest.Int32 to non-nullable JSON property 'int32'.");
+
+            if (formatTest.Int32RangeOption.IsSet && formatTest.Int32Range == null)
+                throw new JsonException("Cannot write null property FormatTest.Int32Range to non-nullable JSON property 'int32Range'.");
+
+            if (formatTest.Int64Option.IsSet && formatTest.Int64 == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64 to non-nullable JSON property 'int64'.");
+
+            if (formatTest.Int64NegativeOption.IsSet && formatTest.Int64Negative == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64Negative to non-nullable JSON property 'int64Negative'.");
+
+            if (formatTest.Int64NegativeExclusiveOption.IsSet && formatTest.Int64NegativeExclusive == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64NegativeExclusive to non-nullable JSON property 'int64NegativeExclusive'.");
+
+            if (formatTest.Int64PositiveOption.IsSet && formatTest.Int64Positive == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64Positive to non-nullable JSON property 'int64Positive'.");
+
+            if (formatTest.Int64PositiveExclusiveOption.IsSet && formatTest.Int64PositiveExclusive == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64PositiveExclusive to non-nullable JSON property 'int64PositiveExclusive'.");
+
+            if (formatTest.IntegerOption.IsSet && formatTest.Integer == null)
+                throw new JsonException("Cannot write null property FormatTest.Integer to non-nullable JSON property 'integer'.");
 
             if (formatTest.PatternWithBackslashOption.IsSet && formatTest.PatternWithBackslash == null)
                 throw new JsonException("Cannot write null property FormatTest.PatternWithBackslash to non-nullable JSON property 'pattern_with_backslash'.");
@@ -971,6 +1007,18 @@ namespace Org.OpenAPITools.Model
 
             if (formatTest.StringOption.IsSet && formatTest.String == null)
                 throw new JsonException("Cannot write null property FormatTest.String to non-nullable JSON property 'string'.");
+
+            if (formatTest.StringFormattedAsDecimalOption.IsSet && formatTest.StringFormattedAsDecimal == null)
+                throw new JsonException("Cannot write null property FormatTest.StringFormattedAsDecimal to non-nullable JSON property 'string_formatted_as_decimal'.");
+
+            if (formatTest.UnsignedIntegerOption.IsSet && formatTest.UnsignedInteger == null)
+                throw new JsonException("Cannot write null property FormatTest.UnsignedInteger to non-nullable JSON property 'unsigned_integer'.");
+
+            if (formatTest.UnsignedLongOption.IsSet && formatTest.UnsignedLong == null)
+                throw new JsonException("Cannot write null property FormatTest.UnsignedLong to non-nullable JSON property 'unsigned_long'.");
+
+            if (formatTest.UuidOption.IsSet && formatTest.Uuid == null)
+                throw new JsonException("Cannot write null property FormatTest.Uuid to non-nullable JSON property 'uuid'.");
 
             writer.WritePropertyName("byte");
             JsonSerializer.Serialize(writer, formatTest.Byte, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -951,32 +951,26 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, FormatTest formatTest, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (formatTest.Byte == null)
-                throw new ArgumentNullException(nameof(formatTest.Byte), "Property is required for class FormatTest.");
-
-            if (formatTest.Password == null)
-                throw new ArgumentNullException(nameof(formatTest.Password), "Property is required for class FormatTest.");
-
             if (formatTest.BinaryOption.IsSet && formatTest.Binary == null)
-                throw new ArgumentNullException(nameof(formatTest.Binary), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.Binary to non-nullable JSON property 'binary'.");
 
             if (formatTest.DuplicatePropertyName2Option.IsSet && formatTest.DuplicatePropertyName2 == null)
-                throw new ArgumentNullException(nameof(formatTest.DuplicatePropertyName2), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName2 to non-nullable JSON property 'duplicate_property_name'.");
 
             if (formatTest.DuplicatePropertyNameOption.IsSet && formatTest.DuplicatePropertyName == null)
-                throw new ArgumentNullException(nameof(formatTest.DuplicatePropertyName), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName to non-nullable JSON property '@duplicate_property_name'.");
 
             if (formatTest.PatternWithBackslashOption.IsSet && formatTest.PatternWithBackslash == null)
-                throw new ArgumentNullException(nameof(formatTest.PatternWithBackslash), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.PatternWithBackslash to non-nullable JSON property 'pattern_with_backslash'.");
 
             if (formatTest.PatternWithDigitsOption.IsSet && formatTest.PatternWithDigits == null)
-                throw new ArgumentNullException(nameof(formatTest.PatternWithDigits), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.PatternWithDigits to non-nullable JSON property 'pattern_with_digits'.");
 
             if (formatTest.PatternWithDigitsAndDelimiterOption.IsSet && formatTest.PatternWithDigitsAndDelimiter == null)
-                throw new ArgumentNullException(nameof(formatTest.PatternWithDigitsAndDelimiter), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.PatternWithDigitsAndDelimiter to non-nullable JSON property 'pattern_with_digits_and_delimiter'.");
 
             if (formatTest.StringOption.IsSet && formatTest.String == null)
-                throw new ArgumentNullException(nameof(formatTest.String), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.String to non-nullable JSON property 'string'.");
 
             writer.WritePropertyName("byte");
             JsonSerializer.Serialize(writer, formatTest.Byte, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
@@ -219,7 +219,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Fruit fruit, JsonSerializerOptions jsonSerializerOptions)
         {
             if (fruit.ColorOption.IsSet && fruit.Color == null)
-                throw new ArgumentNullException(nameof(fruit.Color), "Property is required for class Fruit.");
+                throw new JsonException("Cannot write null property Fruit.Color to non-nullable JSON property 'color'.");
 
             if (fruit.ColorOption.IsSet)
                 writer.WriteString("color", fruit.Color);

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -236,7 +236,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, GmFruit gmFruit, JsonSerializerOptions jsonSerializerOptions)
         {
             if (gmFruit.ColorOption.IsSet && gmFruit.Color == null)
-                throw new ArgumentNullException(nameof(gmFruit.Color), "Property is required for class GmFruit.");
+                throw new JsonException("Cannot write null property GmFruit.Color to non-nullable JSON property 'color'.");
 
             if (gmFruit.ColorOption.IsSet)
                 writer.WriteString("color", gmFruit.Color);

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -239,10 +239,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, HasOnlyReadOnly hasOnlyReadOnly, JsonSerializerOptions jsonSerializerOptions)
         {
             if (hasOnlyReadOnly.BarOption.IsSet && hasOnlyReadOnly.Bar == null)
-                throw new ArgumentNullException(nameof(hasOnlyReadOnly.Bar), "Property is required for class HasOnlyReadOnly.");
+                throw new JsonException("Cannot write null property HasOnlyReadOnly.Bar to non-nullable JSON property 'bar'.");
 
             if (hasOnlyReadOnly.FooOption.IsSet && hasOnlyReadOnly.Foo == null)
-                throw new ArgumentNullException(nameof(hasOnlyReadOnly.Foo), "Property is required for class HasOnlyReadOnly.");
+                throw new JsonException("Cannot write null property HasOnlyReadOnly.Foo to non-nullable JSON property 'foo'.");
 
             if (hasOnlyReadOnly.BarOption.IsSet)
                 writer.WriteString("bar", hasOnlyReadOnly.Bar);

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
@@ -337,22 +337,22 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, InjectedVendorExtensionsTest injectedVendorExtensionsTest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessorOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor to non-nullable JSON property 'potentiallyOverriddenPropertyAccessor'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternalOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternal == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternal), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternal to non-nullable JSON property 'potentiallyOverriddenPropertyToInternal'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivateOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivate == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivate), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivate to non-nullable JSON property 'potentiallyOverriddenPropertyToPrivate'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublicOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublic == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublic), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublic to non-nullable JSON property 'potentiallyOverriddenPropertyToPublic'.");
 
             if (injectedVendorExtensionsTest.UnalteredPropertyOption.IsSet && injectedVendorExtensionsTest.UnalteredProperty == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.UnalteredProperty), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.UnalteredProperty to non-nullable JSON property 'unalteredProperty'.");
 
             if (injectedVendorExtensionsTest.UnalteredPropertyAccessorOption.IsSet && injectedVendorExtensionsTest.UnalteredPropertyAccessor == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.UnalteredPropertyAccessor), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.UnalteredPropertyAccessor to non-nullable JSON property 'unalteredPropertyAccessor'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessorOption.IsSet)
                 writer.WriteString("potentiallyOverriddenPropertyAccessor", injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor);

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
@@ -182,12 +182,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, IsoscelesTriangle isoscelesTriangle, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (isoscelesTriangle.ShapeType == null)
-                throw new ArgumentNullException(nameof(isoscelesTriangle.ShapeType), "Property is required for class IsoscelesTriangle.");
-
-            if (isoscelesTriangle.TriangleType == null)
-                throw new ArgumentNullException(nameof(isoscelesTriangle.TriangleType), "Property is required for class IsoscelesTriangle.");
-
             writer.WriteString("shapeType", isoscelesTriangle.ShapeType);
 
             writer.WriteString("triangleType", isoscelesTriangle.TriangleType);

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/List.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, List list, JsonSerializerOptions jsonSerializerOptions)
         {
             if (list.Var123ListOption.IsSet && list.Var123List == null)
-                throw new ArgumentNullException(nameof(list.Var123List), "Property is required for class List.");
+                throw new JsonException("Cannot write null property List.Var123List to non-nullable JSON property '123-list'.");
 
             if (list.Var123ListOption.IsSet)
                 writer.WriteString("123-list", list.Var123List);

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -198,10 +198,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, LiteralStringClass literalStringClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (literalStringClass.EscapedLiteralStringOption.IsSet && literalStringClass.EscapedLiteralString == null)
-                throw new ArgumentNullException(nameof(literalStringClass.EscapedLiteralString), "Property is required for class LiteralStringClass.");
+                throw new JsonException("Cannot write null property LiteralStringClass.EscapedLiteralString to non-nullable JSON property 'escapedLiteralString'.");
 
             if (literalStringClass.UnescapedLiteralStringOption.IsSet && literalStringClass.UnescapedLiteralString == null)
-                throw new ArgumentNullException(nameof(literalStringClass.UnescapedLiteralString), "Property is required for class LiteralStringClass.");
+                throw new JsonException("Cannot write null property LiteralStringClass.UnescapedLiteralString to non-nullable JSON property 'unescapedLiteralString'.");
 
             if (literalStringClass.EscapedLiteralStringOption.IsSet)
                 writer.WriteString("escapedLiteralString", literalStringClass.EscapedLiteralString);

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/MapTest.cs
@@ -310,16 +310,16 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MapTest mapTest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mapTest.DirectMapOption.IsSet && mapTest.DirectMap == null)
-                throw new ArgumentNullException(nameof(mapTest.DirectMap), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.DirectMap to non-nullable JSON property 'direct_map'.");
 
             if (mapTest.IndirectMapOption.IsSet && mapTest.IndirectMap == null)
-                throw new ArgumentNullException(nameof(mapTest.IndirectMap), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.IndirectMap to non-nullable JSON property 'indirect_map'.");
 
             if (mapTest.MapMapOfStringOption.IsSet && mapTest.MapMapOfString == null)
-                throw new ArgumentNullException(nameof(mapTest.MapMapOfString), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.MapMapOfString to non-nullable JSON property 'map_map_of_string'.");
 
             if (mapTest.MapOfEnumStringOption.IsSet && mapTest.MapOfEnumString == null)
-                throw new ArgumentNullException(nameof(mapTest.MapOfEnumString), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.MapOfEnumString to non-nullable JSON property 'map_of_enum_string'.");
 
             if (mapTest.DirectMapOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/MixedAnyOf.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/MixedAnyOf.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedAnyOf mixedAnyOf, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedAnyOf.ContentOption.IsSet && mixedAnyOf.Content == null)
-                throw new ArgumentNullException(nameof(mixedAnyOf.Content), "Property is required for class MixedAnyOf.");
+                throw new JsonException("Cannot write null property MixedAnyOf.Content to non-nullable JSON property 'content'.");
 
             if (mixedAnyOf.ContentOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/MixedOneOf.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/MixedOneOf.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedOneOf mixedOneOf, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedOneOf.ContentOption.IsSet && mixedOneOf.Content == null)
-                throw new ArgumentNullException(nameof(mixedOneOf.Content), "Property is required for class MixedOneOf.");
+                throw new JsonException("Cannot write null property MixedOneOf.Content to non-nullable JSON property 'content'.");
 
             if (mixedOneOf.ContentOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -255,8 +255,17 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, MixedPropertiesAndAdditionalPropertiesClass mixedPropertiesAndAdditionalPropertiesClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.DateTime == null)
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.DateTime to non-nullable JSON property 'dateTime'.");
+
             if (mixedPropertiesAndAdditionalPropertiesClass.MapOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.Map == null)
                 throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.Map to non-nullable JSON property 'map'.");
+
+            if (mixedPropertiesAndAdditionalPropertiesClass.UuidOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.Uuid == null)
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.Uuid to non-nullable JSON property 'uuid'.");
+
+            if (mixedPropertiesAndAdditionalPropertiesClass.UuidWithPatternOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.UuidWithPattern == null)
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.UuidWithPattern to non-nullable JSON property 'uuid_with_pattern'.");
 
             if (mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.IsSet)
                 writer.WriteString("dateTime", mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.Value.Value.ToString(DateTimeFormat));

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -256,7 +256,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedPropertiesAndAdditionalPropertiesClass mixedPropertiesAndAdditionalPropertiesClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedPropertiesAndAdditionalPropertiesClass.MapOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.Map == null)
-                throw new ArgumentNullException(nameof(mixedPropertiesAndAdditionalPropertiesClass.Map), "Property is required for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.Map to non-nullable JSON property 'map'.");
 
             if (mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.IsSet)
                 writer.WriteString("dateTime", mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.Value.Value.ToString(DateTimeFormat));

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/MixedSubId.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/MixedSubId.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedSubId mixedSubId, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedSubId.IdOption.IsSet && mixedSubId.Id == null)
-                throw new ArgumentNullException(nameof(mixedSubId.Id), "Property is required for class MixedSubId.");
+                throw new JsonException("Cannot write null property MixedSubId.Id to non-nullable JSON property 'id'.");
 
             if (mixedSubId.IdOption.IsSet)
                 writer.WriteString("id", mixedSubId.Id);

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -198,7 +198,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Model200Response model200Response, JsonSerializerOptions jsonSerializerOptions)
         {
             if (model200Response.ClassOption.IsSet && model200Response.Class == null)
-                throw new ArgumentNullException(nameof(model200Response.Class), "Property is required for class Model200Response.");
+                throw new JsonException("Cannot write null property Model200Response.Class to non-nullable JSON property 'class'.");
 
             if (model200Response.ClassOption.IsSet)
                 writer.WriteString("class", model200Response.Class);

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -200,6 +200,9 @@ namespace Org.OpenAPITools.Model
             if (model200Response.ClassOption.IsSet && model200Response.Class == null)
                 throw new JsonException("Cannot write null property Model200Response.Class to non-nullable JSON property 'class'.");
 
+            if (model200Response.NameOption.IsSet && model200Response.Name == null)
+                throw new JsonException("Cannot write null property Model200Response.Name to non-nullable JSON property 'name'.");
+
             if (model200Response.ClassOption.IsSet)
                 writer.WriteString("class", model200Response.Class);
 

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ModelClient modelClient, JsonSerializerOptions jsonSerializerOptions)
         {
             if (modelClient.VarClientOption.IsSet && modelClient.VarClient == null)
-                throw new ArgumentNullException(nameof(modelClient.VarClient), "Property is required for class ModelClient.");
+                throw new JsonException("Cannot write null property ModelClient.VarClient to non-nullable JSON property 'client'.");
 
             if (modelClient.VarClientOption.IsSet)
                 writer.WriteString("client", modelClient.VarClient);

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Name.cs
@@ -281,7 +281,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Name name, JsonSerializerOptions jsonSerializerOptions)
         {
             if (name.PropertyOption.IsSet && name.Property == null)
-                throw new ArgumentNullException(nameof(name.Property), "Property is required for class Name.");
+                throw new JsonException("Cannot write null property Name.Property to non-nullable JSON property 'property'.");
 
             writer.WriteNumber("name", name.VarName);
 

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Name.cs
@@ -283,6 +283,12 @@ namespace Org.OpenAPITools.Model
             if (name.PropertyOption.IsSet && name.Property == null)
                 throw new JsonException("Cannot write null property Name.Property to non-nullable JSON property 'property'.");
 
+            if (name.SnakeCaseOption.IsSet && name.SnakeCase == null)
+                throw new JsonException("Cannot write null property Name.SnakeCase to non-nullable JSON property 'snake_case'.");
+
+            if (name.Var123NumberOption.IsSet && name.Var123Number == null)
+                throw new JsonException("Cannot write null property Name.Var123Number to non-nullable JSON property '123Number'.");
+
             writer.WriteNumber("name", name.VarName);
 
             if (name.PropertyOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
@@ -189,9 +189,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, NotificationtestGetElementsV1ResponseMPayload notificationtestGetElementsV1ResponseMPayload, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (notificationtestGetElementsV1ResponseMPayload.AObjVariableobject == null)
-                throw new ArgumentNullException(nameof(notificationtestGetElementsV1ResponseMPayload.AObjVariableobject), "Property is required for class NotificationtestGetElementsV1ResponseMPayload.");
-
             writer.WritePropertyName("a_objVariableobject");
             JsonSerializer.Serialize(writer, notificationtestGetElementsV1ResponseMPayload.AObjVariableobject, jsonSerializerOptions);
             writer.WriteNumber("pkiNotificationtestID", notificationtestGetElementsV1ResponseMPayload.PkiNotificationtestID);

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -408,10 +408,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, NullableClass nullableClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (nullableClass.ArrayItemsNullableOption.IsSet && nullableClass.ArrayItemsNullable == null)
-                throw new ArgumentNullException(nameof(nullableClass.ArrayItemsNullable), "Property is required for class NullableClass.");
+                throw new JsonException("Cannot write null property NullableClass.ArrayItemsNullable to non-nullable JSON property 'array_items_nullable'.");
 
             if (nullableClass.ObjectItemsNullableOption.IsSet && nullableClass.ObjectItemsNullable == null)
-                throw new ArgumentNullException(nameof(nullableClass.ObjectItemsNullable), "Property is required for class NullableClass.");
+                throw new JsonException("Cannot write null property NullableClass.ObjectItemsNullable to non-nullable JSON property 'object_items_nullable'.");
 
             if (nullableClass.ArrayAndItemsNullablePropOption.IsSet)
                 if (nullableClass.ArrayAndItemsNullablePropOption.Value != null)

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -174,6 +174,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, NumberOnly numberOnly, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (numberOnly.JustNumberOption.IsSet && numberOnly.JustNumber == null)
+                throw new JsonException("Cannot write null property NumberOnly.JustNumber to non-nullable JSON property 'JustNumber'.");
+
             if (numberOnly.JustNumberOption.IsSet)
                 writer.WriteNumber("JustNumber", numberOnly.JustNumberOption.Value.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -247,13 +247,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ObjectWithDeprecatedFields objectWithDeprecatedFields, JsonSerializerOptions jsonSerializerOptions)
         {
             if (objectWithDeprecatedFields.BarsOption.IsSet && objectWithDeprecatedFields.Bars == null)
-                throw new ArgumentNullException(nameof(objectWithDeprecatedFields.Bars), "Property is required for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Bars to non-nullable JSON property 'bars'.");
 
             if (objectWithDeprecatedFields.DeprecatedRefOption.IsSet && objectWithDeprecatedFields.DeprecatedRef == null)
-                throw new ArgumentNullException(nameof(objectWithDeprecatedFields.DeprecatedRef), "Property is required for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.DeprecatedRef to non-nullable JSON property 'deprecatedRef'.");
 
             if (objectWithDeprecatedFields.UuidOption.IsSet && objectWithDeprecatedFields.Uuid == null)
-                throw new ArgumentNullException(nameof(objectWithDeprecatedFields.Uuid), "Property is required for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Uuid to non-nullable JSON property 'uuid'.");
 
             if (objectWithDeprecatedFields.BarsOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -252,6 +252,9 @@ namespace Org.OpenAPITools.Model
             if (objectWithDeprecatedFields.DeprecatedRefOption.IsSet && objectWithDeprecatedFields.DeprecatedRef == null)
                 throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.DeprecatedRef to non-nullable JSON property 'deprecatedRef'.");
 
+            if (objectWithDeprecatedFields.IdOption.IsSet && objectWithDeprecatedFields.Id == null)
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Id to non-nullable JSON property 'id'.");
+
             if (objectWithDeprecatedFields.UuidOption.IsSet && objectWithDeprecatedFields.Uuid == null)
                 throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Uuid to non-nullable JSON property 'uuid'.");
 

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Order.cs
@@ -384,6 +384,24 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Order order, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (order.CompleteOption.IsSet && order.Complete == null)
+                throw new JsonException("Cannot write null property Order.Complete to non-nullable JSON property 'complete'.");
+
+            if (order.IdOption.IsSet && order.Id == null)
+                throw new JsonException("Cannot write null property Order.Id to non-nullable JSON property 'id'.");
+
+            if (order.PetIdOption.IsSet && order.PetId == null)
+                throw new JsonException("Cannot write null property Order.PetId to non-nullable JSON property 'petId'.");
+
+            if (order.QuantityOption.IsSet && order.Quantity == null)
+                throw new JsonException("Cannot write null property Order.Quantity to non-nullable JSON property 'quantity'.");
+
+            if (order.ShipDateOption.IsSet && order.ShipDate == null)
+                throw new JsonException("Cannot write null property Order.ShipDate to non-nullable JSON property 'shipDate'.");
+
+            if (order.StatusOption.IsSet && order.Status == null)
+                throw new JsonException("Cannot write null property Order.Status to non-nullable JSON property 'status'.");
+
             if (order.CompleteOption.IsSet)
                 writer.WriteBoolean("complete", order.CompleteOption.Value.Value);
 

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -220,6 +220,12 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, OuterComposite outerComposite, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (outerComposite.MyBooleanOption.IsSet && outerComposite.MyBoolean == null)
+                throw new JsonException("Cannot write null property OuterComposite.MyBoolean to non-nullable JSON property 'my_boolean'.");
+
+            if (outerComposite.MyNumberOption.IsSet && outerComposite.MyNumber == null)
+                throw new JsonException("Cannot write null property OuterComposite.MyNumber to non-nullable JSON property 'my_number'.");
+
             if (outerComposite.MyStringOption.IsSet && outerComposite.MyString == null)
                 throw new JsonException("Cannot write null property OuterComposite.MyString to non-nullable JSON property 'my_string'.");
 

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -221,7 +221,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, OuterComposite outerComposite, JsonSerializerOptions jsonSerializerOptions)
         {
             if (outerComposite.MyStringOption.IsSet && outerComposite.MyString == null)
-                throw new ArgumentNullException(nameof(outerComposite.MyString), "Property is required for class OuterComposite.");
+                throw new JsonException("Cannot write null property OuterComposite.MyString to non-nullable JSON property 'my_string'.");
 
             if (outerComposite.MyBooleanOption.IsSet)
                 writer.WriteBoolean("my_boolean", outerComposite.MyBooleanOption.Value.Value);

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Pet.cs
@@ -371,17 +371,11 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Pet pet, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (pet.Name == null)
-                throw new ArgumentNullException(nameof(pet.Name), "Property is required for class Pet.");
-
-            if (pet.PhotoUrls == null)
-                throw new ArgumentNullException(nameof(pet.PhotoUrls), "Property is required for class Pet.");
-
             if (pet.CategoryOption.IsSet && pet.Category == null)
-                throw new ArgumentNullException(nameof(pet.Category), "Property is required for class Pet.");
+                throw new JsonException("Cannot write null property Pet.Category to non-nullable JSON property 'category'.");
 
             if (pet.TagsOption.IsSet && pet.Tags == null)
-                throw new ArgumentNullException(nameof(pet.Tags), "Property is required for class Pet.");
+                throw new JsonException("Cannot write null property Pet.Tags to non-nullable JSON property 'tags'.");
 
             writer.WriteString("name", pet.Name);
 

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Pet.cs
@@ -374,6 +374,12 @@ namespace Org.OpenAPITools.Model
             if (pet.CategoryOption.IsSet && pet.Category == null)
                 throw new JsonException("Cannot write null property Pet.Category to non-nullable JSON property 'category'.");
 
+            if (pet.IdOption.IsSet && pet.Id == null)
+                throw new JsonException("Cannot write null property Pet.Id to non-nullable JSON property 'id'.");
+
+            if (pet.StatusOption.IsSet && pet.Status == null)
+                throw new JsonException("Cannot write null property Pet.Status to non-nullable JSON property 'status'.");
+
             if (pet.TagsOption.IsSet && pet.Tags == null)
                 throw new JsonException("Cannot write null property Pet.Tags to non-nullable JSON property 'tags'.");
 

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
@@ -170,9 +170,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, QuadrilateralInterface quadrilateralInterface, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (quadrilateralInterface.QuadrilateralType == null)
-                throw new ArgumentNullException(nameof(quadrilateralInterface.QuadrilateralType), "Property is required for class QuadrilateralInterface.");
-
             writer.WriteString("quadrilateralType", quadrilateralInterface.QuadrilateralType);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -236,10 +236,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ReadOnlyFirst readOnlyFirst, JsonSerializerOptions jsonSerializerOptions)
         {
             if (readOnlyFirst.BarOption.IsSet && readOnlyFirst.Bar == null)
-                throw new ArgumentNullException(nameof(readOnlyFirst.Bar), "Property is required for class ReadOnlyFirst.");
+                throw new JsonException("Cannot write null property ReadOnlyFirst.Bar to non-nullable JSON property 'bar'.");
 
             if (readOnlyFirst.BazOption.IsSet && readOnlyFirst.Baz == null)
-                throw new ArgumentNullException(nameof(readOnlyFirst.Baz), "Property is required for class ReadOnlyFirst.");
+                throw new JsonException("Cannot write null property ReadOnlyFirst.Baz to non-nullable JSON property 'baz'.");
 
             if (readOnlyFirst.BarOption.IsSet)
                 writer.WriteString("bar", readOnlyFirst.Bar);

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -2235,17 +2235,11 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, RequiredClass requiredClass, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (requiredClass.RequiredNotnullableArrayOfString == null)
-                throw new ArgumentNullException(nameof(requiredClass.RequiredNotnullableArrayOfString), "Property is required for class RequiredClass.");
-
-            if (requiredClass.RequiredNotnullableStringProp == null)
-                throw new ArgumentNullException(nameof(requiredClass.RequiredNotnullableStringProp), "Property is required for class RequiredClass.");
-
             if (requiredClass.NotrequiredNotnullableArrayOfStringOption.IsSet && requiredClass.NotrequiredNotnullableArrayOfString == null)
-                throw new ArgumentNullException(nameof(requiredClass.NotrequiredNotnullableArrayOfString), "Property is required for class RequiredClass.");
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableArrayOfString to non-nullable JSON property 'notrequired_notnullable_array_of_string'.");
 
             if (requiredClass.NotrequiredNotnullableStringPropOption.IsSet && requiredClass.NotrequiredNotnullableStringProp == null)
-                throw new ArgumentNullException(nameof(requiredClass.NotrequiredNotnullableStringProp), "Property is required for class RequiredClass.");
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableStringProp to non-nullable JSON property 'notrequired_notnullable_string_prop'.");
 
             writer.WriteString("required_not_nullable_date_prop", requiredClass.RequiredNotNullableDateProp.ToString(RequiredNotNullableDatePropFormat));
 

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -2235,11 +2235,38 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, RequiredClass requiredClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (requiredClass.NotRequiredNotnullableDatePropOption.IsSet && requiredClass.NotRequiredNotnullableDateProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotRequiredNotnullableDateProp to non-nullable JSON property 'not_required_notnullable_date_prop'.");
+
+            if (requiredClass.NotRequiredNotnullableintegerPropOption.IsSet && requiredClass.NotRequiredNotnullableintegerProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotRequiredNotnullableintegerProp to non-nullable JSON property 'not_required_notnullableinteger_prop'.");
+
             if (requiredClass.NotrequiredNotnullableArrayOfStringOption.IsSet && requiredClass.NotrequiredNotnullableArrayOfString == null)
                 throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableArrayOfString to non-nullable JSON property 'notrequired_notnullable_array_of_string'.");
 
+            if (requiredClass.NotrequiredNotnullableBooleanPropOption.IsSet && requiredClass.NotrequiredNotnullableBooleanProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableBooleanProp to non-nullable JSON property 'notrequired_notnullable_boolean_prop'.");
+
+            if (requiredClass.NotrequiredNotnullableDatetimePropOption.IsSet && requiredClass.NotrequiredNotnullableDatetimeProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableDatetimeProp to non-nullable JSON property 'notrequired_notnullable_datetime_prop'.");
+
+            if (requiredClass.NotrequiredNotnullableEnumIntegerOption.IsSet && requiredClass.NotrequiredNotnullableEnumInteger == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableEnumInteger to non-nullable JSON property 'notrequired_notnullable_enum_integer'.");
+
+            if (requiredClass.NotrequiredNotnullableEnumIntegerOnlyOption.IsSet && requiredClass.NotrequiredNotnullableEnumIntegerOnly == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableEnumIntegerOnly to non-nullable JSON property 'notrequired_notnullable_enum_integer_only'.");
+
+            if (requiredClass.NotrequiredNotnullableEnumStringOption.IsSet && requiredClass.NotrequiredNotnullableEnumString == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableEnumString to non-nullable JSON property 'notrequired_notnullable_enum_string'.");
+
+            if (requiredClass.NotrequiredNotnullableOuterEnumDefaultValueOption.IsSet && requiredClass.NotrequiredNotnullableOuterEnumDefaultValue == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableOuterEnumDefaultValue to non-nullable JSON property 'notrequired_notnullable_outerEnumDefaultValue'.");
+
             if (requiredClass.NotrequiredNotnullableStringPropOption.IsSet && requiredClass.NotrequiredNotnullableStringProp == null)
                 throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableStringProp to non-nullable JSON property 'notrequired_notnullable_string_prop'.");
+
+            if (requiredClass.NotrequiredNotnullableUuidOption.IsSet && requiredClass.NotrequiredNotnullableUuid == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableUuid to non-nullable JSON property 'notrequired_notnullable_uuid'.");
 
             writer.WriteString("required_not_nullable_date_prop", requiredClass.RequiredNotNullableDateProp.ToString(RequiredNotNullableDatePropFormat));
 

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Result.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Result.cs
@@ -224,13 +224,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Result result, JsonSerializerOptions jsonSerializerOptions)
         {
             if (result.CodeOption.IsSet && result.Code == null)
-                throw new ArgumentNullException(nameof(result.Code), "Property is required for class Result.");
+                throw new JsonException("Cannot write null property Result.Code to non-nullable JSON property 'code'.");
 
             if (result.DataOption.IsSet && result.Data == null)
-                throw new ArgumentNullException(nameof(result.Data), "Property is required for class Result.");
+                throw new JsonException("Cannot write null property Result.Data to non-nullable JSON property 'data'.");
 
             if (result.UuidOption.IsSet && result.Uuid == null)
-                throw new ArgumentNullException(nameof(result.Uuid), "Property is required for class Result.");
+                throw new JsonException("Cannot write null property Result.Uuid to non-nullable JSON property 'uuid'.");
 
             if (result.CodeOption.IsSet)
                 writer.WriteString("code", result.Code);

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Return.cs
@@ -232,11 +232,8 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Return varReturn, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (varReturn.Lock == null)
-                throw new ArgumentNullException(nameof(varReturn.Lock), "Property is required for class Return.");
-
             if (varReturn.UnsafeOption.IsSet && varReturn.Unsafe == null)
-                throw new ArgumentNullException(nameof(varReturn.Unsafe), "Property is required for class Return.");
+                throw new JsonException("Cannot write null property Return.Unsafe to non-nullable JSON property 'unsafe'.");
 
             writer.WriteString("lock", varReturn.Lock);
 

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Return.cs
@@ -232,6 +232,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Return varReturn, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (varReturn.VarReturnOption.IsSet && varReturn.VarReturn == null)
+                throw new JsonException("Cannot write null property Return.VarReturn to non-nullable JSON property 'return'.");
+
             if (varReturn.UnsafeOption.IsSet && varReturn.Unsafe == null)
                 throw new JsonException("Cannot write null property Return.Unsafe to non-nullable JSON property 'unsafe'.");
 

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -198,7 +198,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, RolesReportsHash rolesReportsHash, JsonSerializerOptions jsonSerializerOptions)
         {
             if (rolesReportsHash.RoleOption.IsSet && rolesReportsHash.Role == null)
-                throw new ArgumentNullException(nameof(rolesReportsHash.Role), "Property is required for class RolesReportsHash.");
+                throw new JsonException("Cannot write null property RolesReportsHash.Role to non-nullable JSON property 'role'.");
 
             if (rolesReportsHash.RoleOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -200,6 +200,9 @@ namespace Org.OpenAPITools.Model
             if (rolesReportsHash.RoleOption.IsSet && rolesReportsHash.Role == null)
                 throw new JsonException("Cannot write null property RolesReportsHash.Role to non-nullable JSON property 'role'.");
 
+            if (rolesReportsHash.RoleUuidOption.IsSet && rolesReportsHash.RoleUuid == null)
+                throw new JsonException("Cannot write null property RolesReportsHash.RoleUuid to non-nullable JSON property 'role_uuid'.");
+
             if (rolesReportsHash.RoleOption.IsSet)
             {
                 writer.WritePropertyName("role");

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, RolesReportsHashRole rolesReportsHashRole, JsonSerializerOptions jsonSerializerOptions)
         {
             if (rolesReportsHashRole.NameOption.IsSet && rolesReportsHashRole.Name == null)
-                throw new ArgumentNullException(nameof(rolesReportsHashRole.Name), "Property is required for class RolesReportsHashRole.");
+                throw new JsonException("Cannot write null property RolesReportsHashRole.Name to non-nullable JSON property 'name'.");
 
             if (rolesReportsHashRole.NameOption.IsSet)
                 writer.WriteString("name", rolesReportsHashRole.Name);

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
@@ -189,12 +189,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ScaleneTriangle scaleneTriangle, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (scaleneTriangle.ShapeType == null)
-                throw new ArgumentNullException(nameof(scaleneTriangle.ShapeType), "Property is required for class ScaleneTriangle.");
-
-            if (scaleneTriangle.TriangleType == null)
-                throw new ArgumentNullException(nameof(scaleneTriangle.TriangleType), "Property is required for class ScaleneTriangle.");
-
             writer.WriteString("shapeType", scaleneTriangle.ShapeType);
 
             writer.WriteString("triangleType", scaleneTriangle.TriangleType);

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ShapeInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ShapeInterface.cs
@@ -170,9 +170,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ShapeInterface shapeInterface, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (shapeInterface.ShapeType == null)
-                throw new ArgumentNullException(nameof(shapeInterface.ShapeType), "Property is required for class ShapeInterface.");
-
             writer.WriteString("shapeType", shapeInterface.ShapeType);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
@@ -189,12 +189,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, SimpleQuadrilateral simpleQuadrilateral, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (simpleQuadrilateral.QuadrilateralType == null)
-                throw new ArgumentNullException(nameof(simpleQuadrilateral.QuadrilateralType), "Property is required for class SimpleQuadrilateral.");
-
-            if (simpleQuadrilateral.ShapeType == null)
-                throw new ArgumentNullException(nameof(simpleQuadrilateral.ShapeType), "Property is required for class SimpleQuadrilateral.");
-
             writer.WriteString("quadrilateralType", simpleQuadrilateral.QuadrilateralType);
 
             writer.WriteString("shapeType", simpleQuadrilateral.ShapeType);

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -200,6 +200,9 @@ namespace Org.OpenAPITools.Model
             if (specialModelName.VarSpecialModelNameOption.IsSet && specialModelName.VarSpecialModelName == null)
                 throw new JsonException("Cannot write null property SpecialModelName.VarSpecialModelName to non-nullable JSON property '_special_model.name_'.");
 
+            if (specialModelName.SpecialPropertyNameOption.IsSet && specialModelName.SpecialPropertyName == null)
+                throw new JsonException("Cannot write null property SpecialModelName.SpecialPropertyName to non-nullable JSON property '$special[property.name]'.");
+
             if (specialModelName.VarSpecialModelNameOption.IsSet)
                 writer.WriteString("_special_model.name_", specialModelName.VarSpecialModelName);
 

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -198,7 +198,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, SpecialModelName specialModelName, JsonSerializerOptions jsonSerializerOptions)
         {
             if (specialModelName.VarSpecialModelNameOption.IsSet && specialModelName.VarSpecialModelName == null)
-                throw new ArgumentNullException(nameof(specialModelName.VarSpecialModelName), "Property is required for class SpecialModelName.");
+                throw new JsonException("Cannot write null property SpecialModelName.VarSpecialModelName to non-nullable JSON property '_special_model.name_'.");
 
             if (specialModelName.VarSpecialModelNameOption.IsSet)
                 writer.WriteString("_special_model.name_", specialModelName.VarSpecialModelName);

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Tag.cs
@@ -198,7 +198,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Tag tag, JsonSerializerOptions jsonSerializerOptions)
         {
             if (tag.NameOption.IsSet && tag.Name == null)
-                throw new ArgumentNullException(nameof(tag.Name), "Property is required for class Tag.");
+                throw new JsonException("Cannot write null property Tag.Name to non-nullable JSON property 'name'.");
 
             if (tag.IdOption.IsSet)
                 writer.WriteNumber("id", tag.IdOption.Value.Value);

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Tag.cs
@@ -197,6 +197,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Tag tag, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (tag.IdOption.IsSet && tag.Id == null)
+                throw new JsonException("Cannot write null property Tag.Id to non-nullable JSON property 'id'.");
+
             if (tag.NameOption.IsSet && tag.Name == null)
                 throw new JsonException("Cannot write null property Tag.Name to non-nullable JSON property 'name'.");
 

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestCollectionEndingWithWordList testCollectionEndingWithWordList, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testCollectionEndingWithWordList.ValueOption.IsSet && testCollectionEndingWithWordList.Value == null)
-                throw new ArgumentNullException(nameof(testCollectionEndingWithWordList.Value), "Property is required for class TestCollectionEndingWithWordList.");
+                throw new JsonException("Cannot write null property TestCollectionEndingWithWordList.Value to non-nullable JSON property 'value'.");
 
             if (testCollectionEndingWithWordList.ValueOption.IsSet)
                 writer.WriteString("value", testCollectionEndingWithWordList.Value);

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestCollectionEndingWithWordListObject testCollectionEndingWithWordListObject, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testCollectionEndingWithWordListObject.TestCollectionEndingWithWordListOption.IsSet && testCollectionEndingWithWordListObject.TestCollectionEndingWithWordList == null)
-                throw new ArgumentNullException(nameof(testCollectionEndingWithWordListObject.TestCollectionEndingWithWordList), "Property is required for class TestCollectionEndingWithWordListObject.");
+                throw new JsonException("Cannot write null property TestCollectionEndingWithWordListObject.TestCollectionEndingWithWordList to non-nullable JSON property 'TestCollectionEndingWithWordList'.");
 
             if (testCollectionEndingWithWordListObject.TestCollectionEndingWithWordListOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/TestDescendants.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/TestDescendants.cs
@@ -289,9 +289,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, TestDescendants testDescendants, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (testDescendants.AlternativeName == null)
-                throw new ArgumentNullException(nameof(testDescendants.AlternativeName), "Property is required for class TestDescendants.");
-
             writer.WriteString("alternativeName", testDescendants.AlternativeName);
 
             writer.WriteString("objectType", TestDescendants.ObjectTypeEnumToJsonValue(testDescendants.ObjectType));

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestInlineFreeformAdditionalPropertiesRequest testInlineFreeformAdditionalPropertiesRequest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testInlineFreeformAdditionalPropertiesRequest.SomePropertyOption.IsSet && testInlineFreeformAdditionalPropertiesRequest.SomeProperty == null)
-                throw new ArgumentNullException(nameof(testInlineFreeformAdditionalPropertiesRequest.SomeProperty), "Property is required for class TestInlineFreeformAdditionalPropertiesRequest.");
+                throw new JsonException("Cannot write null property TestInlineFreeformAdditionalPropertiesRequest.SomeProperty to non-nullable JSON property 'someProperty'.");
 
             if (testInlineFreeformAdditionalPropertiesRequest.SomePropertyOption.IsSet)
                 writer.WriteString("someProperty", testInlineFreeformAdditionalPropertiesRequest.SomeProperty);

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/TestResult.cs
@@ -222,6 +222,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, TestResult testResult, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (testResult.CodeOption.IsSet && testResult.Code == null)
+                throw new JsonException("Cannot write null property TestResult.Code to non-nullable JSON property 'code'.");
+
             if (testResult.DataOption.IsSet && testResult.Data == null)
                 throw new JsonException("Cannot write null property TestResult.Data to non-nullable JSON property 'data'.");
 

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/TestResult.cs
@@ -223,10 +223,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestResult testResult, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testResult.DataOption.IsSet && testResult.Data == null)
-                throw new ArgumentNullException(nameof(testResult.Data), "Property is required for class TestResult.");
+                throw new JsonException("Cannot write null property TestResult.Data to non-nullable JSON property 'data'.");
 
             if (testResult.UuidOption.IsSet && testResult.Uuid == null)
-                throw new ArgumentNullException(nameof(testResult.Uuid), "Property is required for class TestResult.");
+                throw new JsonException("Cannot write null property TestResult.Uuid to non-nullable JSON property 'uuid'.");
 
             if (testResult.CodeOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/TriangleInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/TriangleInterface.cs
@@ -170,9 +170,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, TriangleInterface triangleInterface, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (triangleInterface.TriangleType == null)
-                throw new ArgumentNullException(nameof(triangleInterface.TriangleType), "Property is required for class TriangleInterface.");
-
             writer.WriteString("triangleType", triangleInterface.TriangleType);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/User.cs
@@ -429,6 +429,9 @@ namespace Org.OpenAPITools.Model
             if (user.FirstNameOption.IsSet && user.FirstName == null)
                 throw new JsonException("Cannot write null property User.FirstName to non-nullable JSON property 'firstName'.");
 
+            if (user.IdOption.IsSet && user.Id == null)
+                throw new JsonException("Cannot write null property User.Id to non-nullable JSON property 'id'.");
+
             if (user.LastNameOption.IsSet && user.LastName == null)
                 throw new JsonException("Cannot write null property User.LastName to non-nullable JSON property 'lastName'.");
 
@@ -440,6 +443,9 @@ namespace Org.OpenAPITools.Model
 
             if (user.PhoneOption.IsSet && user.Phone == null)
                 throw new JsonException("Cannot write null property User.Phone to non-nullable JSON property 'phone'.");
+
+            if (user.UserStatusOption.IsSet && user.UserStatus == null)
+                throw new JsonException("Cannot write null property User.UserStatus to non-nullable JSON property 'userStatus'.");
 
             if (user.UsernameOption.IsSet && user.Username == null)
                 throw new JsonException("Cannot write null property User.Username to non-nullable JSON property 'username'.");

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/User.cs
@@ -424,25 +424,25 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, User user, JsonSerializerOptions jsonSerializerOptions)
         {
             if (user.EmailOption.IsSet && user.Email == null)
-                throw new ArgumentNullException(nameof(user.Email), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Email to non-nullable JSON property 'email'.");
 
             if (user.FirstNameOption.IsSet && user.FirstName == null)
-                throw new ArgumentNullException(nameof(user.FirstName), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.FirstName to non-nullable JSON property 'firstName'.");
 
             if (user.LastNameOption.IsSet && user.LastName == null)
-                throw new ArgumentNullException(nameof(user.LastName), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.LastName to non-nullable JSON property 'lastName'.");
 
             if (user.ObjectWithNoDeclaredPropsOption.IsSet && user.ObjectWithNoDeclaredProps == null)
-                throw new ArgumentNullException(nameof(user.ObjectWithNoDeclaredProps), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.ObjectWithNoDeclaredProps to non-nullable JSON property 'objectWithNoDeclaredProps'.");
 
             if (user.PasswordOption.IsSet && user.Password == null)
-                throw new ArgumentNullException(nameof(user.Password), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Password to non-nullable JSON property 'password'.");
 
             if (user.PhoneOption.IsSet && user.Phone == null)
-                throw new ArgumentNullException(nameof(user.Phone), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Phone to non-nullable JSON property 'phone'.");
 
             if (user.UsernameOption.IsSet && user.Username == null)
-                throw new ArgumentNullException(nameof(user.Username), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Username to non-nullable JSON property 'username'.");
 
             if (user.AnyTypePropOption.IsSet)
                 if (user.AnyTypePropOption.Value != null)

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Whale.cs
@@ -216,9 +216,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Whale whale, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (whale.ClassName == null)
-                throw new ArgumentNullException(nameof(whale.ClassName), "Property is required for class Whale.");
-
             writer.WriteString("className", whale.ClassName);
 
             if (whale.HasBaleenOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Whale.cs
@@ -216,6 +216,12 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Whale whale, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (whale.HasBaleenOption.IsSet && whale.HasBaleen == null)
+                throw new JsonException("Cannot write null property Whale.HasBaleen to non-nullable JSON property 'hasBaleen'.");
+
+            if (whale.HasTeethOption.IsSet && whale.HasTeeth == null)
+                throw new JsonException("Cannot write null property Whale.HasTeeth to non-nullable JSON property 'hasTeeth'.");
+
             writer.WriteString("className", whale.ClassName);
 
             if (whale.HasBaleenOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Zebra.cs
@@ -280,6 +280,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Zebra zebra, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (zebra.TypeOption.IsSet && zebra.Type == null)
+                throw new JsonException("Cannot write null property Zebra.Type to non-nullable JSON property 'type'.");
+
             writer.WriteString("className", zebra.ClassName);
 
             var typeRawValue = Zebra.TypeEnumToJsonValue(zebra.TypeOption.Value.Value);

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Zebra.cs
@@ -280,9 +280,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Zebra zebra, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (zebra.ClassName == null)
-                throw new ArgumentNullException(nameof(zebra.ClassName), "Property is required for class Zebra.");
-
             writer.WriteString("className", zebra.ClassName);
 
             var typeRawValue = Zebra.TypeEnumToJsonValue(zebra.TypeOption.Value.Value);

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
@@ -247,6 +247,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ZeroBasedEnumClass zeroBasedEnumClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (zeroBasedEnumClass.ZeroBasedEnumOption.IsSet && zeroBasedEnumClass.ZeroBasedEnum == null)
+                throw new JsonException("Cannot write null property ZeroBasedEnumClass.ZeroBasedEnum to non-nullable JSON property 'ZeroBasedEnum'.");
+
             var zeroBasedEnumRawValue = ZeroBasedEnumClass.ZeroBasedEnumEnumToJsonValue(zeroBasedEnumClass.ZeroBasedEnumOption.Value.Value);
             writer.WriteString("ZeroBasedEnum", zeroBasedEnumRawValue);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Activity.cs
@@ -178,7 +178,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Activity activity, JsonSerializerOptions jsonSerializerOptions)
         {
             if (activity.ActivityOutputsOption.IsSet && activity.ActivityOutputs == null)
-                throw new ArgumentNullException(nameof(activity.ActivityOutputs), "Property is required for class Activity.");
+                throw new JsonException("Cannot write null property Activity.ActivityOutputs to non-nullable JSON property 'activity_outputs'.");
 
             if (activity.ActivityOutputsOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -201,10 +201,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ActivityOutputElementRepresentation activityOutputElementRepresentation, JsonSerializerOptions jsonSerializerOptions)
         {
             if (activityOutputElementRepresentation.Prop1Option.IsSet && activityOutputElementRepresentation.Prop1 == null)
-                throw new ArgumentNullException(nameof(activityOutputElementRepresentation.Prop1), "Property is required for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Cannot write null property ActivityOutputElementRepresentation.Prop1 to non-nullable JSON property 'prop1'.");
 
             if (activityOutputElementRepresentation.Prop2Option.IsSet && activityOutputElementRepresentation.Prop2 == null)
-                throw new ArgumentNullException(nameof(activityOutputElementRepresentation.Prop2), "Property is required for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Cannot write null property ActivityOutputElementRepresentation.Prop2 to non-nullable JSON property 'prop2'.");
 
             if (activityOutputElementRepresentation.Prop1Option.IsSet)
                 writer.WriteString("prop1", activityOutputElementRepresentation.Prop1);

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -337,25 +337,25 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, AdditionalPropertiesClass additionalPropertiesClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (additionalPropertiesClass.EmptyMapOption.IsSet && additionalPropertiesClass.EmptyMap == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.EmptyMap), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.EmptyMap to non-nullable JSON property 'empty_map'.");
 
             if (additionalPropertiesClass.MapOfMapPropertyOption.IsSet && additionalPropertiesClass.MapOfMapProperty == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapOfMapProperty), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapOfMapProperty to non-nullable JSON property 'map_of_map_property'.");
 
             if (additionalPropertiesClass.MapPropertyOption.IsSet && additionalPropertiesClass.MapProperty == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapProperty), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapProperty to non-nullable JSON property 'map_property'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1Option.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1 == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1 to non-nullable JSON property 'map_with_undeclared_properties_anytype_1'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2Option.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2 == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2 to non-nullable JSON property 'map_with_undeclared_properties_anytype_2'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3Option.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3 == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3 to non-nullable JSON property 'map_with_undeclared_properties_anytype_3'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesStringOption.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesString == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesString), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesString to non-nullable JSON property 'map_with_undeclared_properties_string'.");
 
             if (additionalPropertiesClass.Anytype1Option.IsSet)
                 if (additionalPropertiesClass.Anytype1Option.Value != null)

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Animal.cs
@@ -224,7 +224,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Animal animal, JsonSerializerOptions jsonSerializerOptions)
         {
             if (animal.ColorOption.IsSet && animal.Color == null)
-                throw new ArgumentNullException(nameof(animal.Color), "Property is required for class Animal.");
+                throw new JsonException("Cannot write null property Animal.Color to non-nullable JSON property 'color'.");
 
             writer.WriteString("className", animal.ClassName);
 

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -224,10 +224,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ApiResponse apiResponse, JsonSerializerOptions jsonSerializerOptions)
         {
             if (apiResponse.MessageOption.IsSet && apiResponse.Message == null)
-                throw new ArgumentNullException(nameof(apiResponse.Message), "Property is required for class ApiResponse.");
+                throw new JsonException("Cannot write null property ApiResponse.Message to non-nullable JSON property 'message'.");
 
             if (apiResponse.TypeOption.IsSet && apiResponse.Type == null)
-                throw new ArgumentNullException(nameof(apiResponse.Type), "Property is required for class ApiResponse.");
+                throw new JsonException("Cannot write null property ApiResponse.Type to non-nullable JSON property 'type'.");
 
             if (apiResponse.CodeOption.IsSet)
                 writer.WriteNumber("code", apiResponse.CodeOption.Value!.Value);

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -223,6 +223,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ApiResponse apiResponse, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (apiResponse.CodeOption.IsSet && apiResponse.Code == null)
+                throw new JsonException("Cannot write null property ApiResponse.Code to non-nullable JSON property 'code'.");
+
             if (apiResponse.MessageOption.IsSet && apiResponse.Message == null)
                 throw new JsonException("Cannot write null property ApiResponse.Message to non-nullable JSON property 'message'.");
 

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Apple.cs
@@ -254,13 +254,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Apple apple, JsonSerializerOptions jsonSerializerOptions)
         {
             if (apple.ColorCodeOption.IsSet && apple.ColorCode == null)
-                throw new ArgumentNullException(nameof(apple.ColorCode), "Property is required for class Apple.");
+                throw new JsonException("Cannot write null property Apple.ColorCode to non-nullable JSON property 'color_code'.");
 
             if (apple.CultivarOption.IsSet && apple.Cultivar == null)
-                throw new ArgumentNullException(nameof(apple.Cultivar), "Property is required for class Apple.");
+                throw new JsonException("Cannot write null property Apple.Cultivar to non-nullable JSON property 'cultivar'.");
 
             if (apple.OriginOption.IsSet && apple.Origin == null)
-                throw new ArgumentNullException(nameof(apple.Origin), "Property is required for class Apple.");
+                throw new JsonException("Cannot write null property Apple.Origin to non-nullable JSON property 'origin'.");
 
             if (apple.ColorCodeOption.IsSet)
                 writer.WriteString("color_code", apple.ColorCode);

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -189,9 +189,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, AppleReq appleReq, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (appleReq.Cultivar == null)
-                throw new ArgumentNullException(nameof(appleReq.Cultivar), "Property is required for class AppleReq.");
-
             writer.WriteString("cultivar", appleReq.Cultivar);
 
             if (appleReq.MealyOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -189,6 +189,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, AppleReq appleReq, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (appleReq.MealyOption.IsSet && appleReq.Mealy == null)
+                throw new JsonException("Cannot write null property AppleReq.Mealy to non-nullable JSON property 'mealy'.");
+
             writer.WriteString("cultivar", appleReq.Cultivar);
 
             if (appleReq.MealyOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -178,7 +178,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ArrayOfArrayOfNumberOnly arrayOfArrayOfNumberOnly, JsonSerializerOptions jsonSerializerOptions)
         {
             if (arrayOfArrayOfNumberOnly.ArrayArrayNumberOption.IsSet && arrayOfArrayOfNumberOnly.ArrayArrayNumber == null)
-                throw new ArgumentNullException(nameof(arrayOfArrayOfNumberOnly.ArrayArrayNumber), "Property is required for class ArrayOfArrayOfNumberOnly.");
+                throw new JsonException("Cannot write null property ArrayOfArrayOfNumberOnly.ArrayArrayNumber to non-nullable JSON property 'ArrayArrayNumber'.");
 
             if (arrayOfArrayOfNumberOnly.ArrayArrayNumberOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -178,7 +178,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ArrayOfNumberOnly arrayOfNumberOnly, JsonSerializerOptions jsonSerializerOptions)
         {
             if (arrayOfNumberOnly.ArrayNumberOption.IsSet && arrayOfNumberOnly.ArrayNumber == null)
-                throw new ArgumentNullException(nameof(arrayOfNumberOnly.ArrayNumber), "Property is required for class ArrayOfNumberOnly.");
+                throw new JsonException("Cannot write null property ArrayOfNumberOnly.ArrayNumber to non-nullable JSON property 'ArrayNumber'.");
 
             if (arrayOfNumberOnly.ArrayNumberOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -224,13 +224,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ArrayTest arrayTest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (arrayTest.ArrayArrayOfIntegerOption.IsSet && arrayTest.ArrayArrayOfInteger == null)
-                throw new ArgumentNullException(nameof(arrayTest.ArrayArrayOfInteger), "Property is required for class ArrayTest.");
+                throw new JsonException("Cannot write null property ArrayTest.ArrayArrayOfInteger to non-nullable JSON property 'array_array_of_integer'.");
 
             if (arrayTest.ArrayArrayOfModelOption.IsSet && arrayTest.ArrayArrayOfModel == null)
-                throw new ArgumentNullException(nameof(arrayTest.ArrayArrayOfModel), "Property is required for class ArrayTest.");
+                throw new JsonException("Cannot write null property ArrayTest.ArrayArrayOfModel to non-nullable JSON property 'array_array_of_model'.");
 
             if (arrayTest.ArrayOfStringOption.IsSet && arrayTest.ArrayOfString == null)
-                throw new ArgumentNullException(nameof(arrayTest.ArrayOfString), "Property is required for class ArrayTest.");
+                throw new JsonException("Cannot write null property ArrayTest.ArrayOfString to non-nullable JSON property 'array_of_string'.");
 
             if (arrayTest.ArrayArrayOfIntegerOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Banana.cs
@@ -177,6 +177,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Banana banana, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (banana.LengthCmOption.IsSet && banana.LengthCm == null)
+                throw new JsonException("Cannot write null property Banana.LengthCm to non-nullable JSON property 'lengthCm'.");
+
             if (banana.LengthCmOption.IsSet)
                 writer.WriteNumber("lengthCm", banana.LengthCmOption.Value!.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -189,6 +189,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, BananaReq bananaReq, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (bananaReq.SweetOption.IsSet && bananaReq.Sweet == null)
+                throw new JsonException("Cannot write null property BananaReq.Sweet to non-nullable JSON property 'sweet'.");
+
             writer.WriteNumber("lengthCm", bananaReq.LengthCm);
 
             if (bananaReq.SweetOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/BasquePig.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/BasquePig.cs
@@ -173,9 +173,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, BasquePig basquePig, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (basquePig.ClassName == null)
-                throw new ArgumentNullException(nameof(basquePig.ClassName), "Property is required for class BasquePig.");
-
             writer.WriteString("className", basquePig.ClassName);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -294,22 +294,22 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Capitalization capitalization, JsonSerializerOptions jsonSerializerOptions)
         {
             if (capitalization.ATT_NAMEOption.IsSet && capitalization.ATT_NAME == null)
-                throw new ArgumentNullException(nameof(capitalization.ATT_NAME), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.ATT_NAME to non-nullable JSON property 'ATT_NAME'.");
 
             if (capitalization.CapitalCamelOption.IsSet && capitalization.CapitalCamel == null)
-                throw new ArgumentNullException(nameof(capitalization.CapitalCamel), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.CapitalCamel to non-nullable JSON property 'CapitalCamel'.");
 
             if (capitalization.CapitalSnakeOption.IsSet && capitalization.CapitalSnake == null)
-                throw new ArgumentNullException(nameof(capitalization.CapitalSnake), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.CapitalSnake to non-nullable JSON property 'Capital_Snake'.");
 
             if (capitalization.SCAETHFlowPointsOption.IsSet && capitalization.SCAETHFlowPoints == null)
-                throw new ArgumentNullException(nameof(capitalization.SCAETHFlowPoints), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.SCAETHFlowPoints to non-nullable JSON property 'SCA_ETH_Flow_Points'.");
 
             if (capitalization.SmallCamelOption.IsSet && capitalization.SmallCamel == null)
-                throw new ArgumentNullException(nameof(capitalization.SmallCamel), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.SmallCamel to non-nullable JSON property 'smallCamel'.");
 
             if (capitalization.SmallSnakeOption.IsSet && capitalization.SmallSnake == null)
-                throw new ArgumentNullException(nameof(capitalization.SmallSnake), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.SmallSnake to non-nullable JSON property 'small_Snake'.");
 
             if (capitalization.ATT_NAMEOption.IsSet)
                 writer.WriteString("ATT_NAME", capitalization.ATT_NAME);

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Cat.cs
@@ -182,6 +182,9 @@ namespace Org.OpenAPITools.Model
             if (cat.ColorOption.IsSet && cat.Color == null)
                 throw new JsonException("Cannot write null property Cat.Color to non-nullable JSON property 'color'.");
 
+            if (cat.DeclawedOption.IsSet && cat.Declawed == null)
+                throw new JsonException("Cannot write null property Cat.Declawed to non-nullable JSON property 'declawed'.");
+
             writer.WriteString("className", cat.ClassName);
 
             if (cat.ColorOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Cat.cs
@@ -180,7 +180,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Cat cat, JsonSerializerOptions jsonSerializerOptions)
         {
             if (cat.ColorOption.IsSet && cat.Color == null)
-                throw new ArgumentNullException(nameof(cat.Color), "Property is required for class Cat.");
+                throw new JsonException("Cannot write null property Cat.Color to non-nullable JSON property 'color'.");
 
             writer.WriteString("className", cat.ClassName);
 

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Category.cs
@@ -196,6 +196,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Category category, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (category.IdOption.IsSet && category.Id == null)
+                throw new JsonException("Cannot write null property Category.Id to non-nullable JSON property 'id'.");
+
             if (category.IdOption.IsSet)
                 writer.WriteNumber("id", category.IdOption.Value!.Value);
 

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Category.cs
@@ -196,9 +196,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Category category, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (category.Name == null)
-                throw new ArgumentNullException(nameof(category.Name), "Property is required for class Category.");
-
             if (category.IdOption.IsSet)
                 writer.WriteNumber("id", category.IdOption.Value!.Value);
 

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -239,7 +239,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ChildCat childCat, JsonSerializerOptions jsonSerializerOptions)
         {
             if (childCat.NameOption.IsSet && childCat.Name == null)
-                throw new ArgumentNullException(nameof(childCat.Name), "Property is required for class ChildCat.");
+                throw new JsonException("Cannot write null property ChildCat.Name to non-nullable JSON property 'name'.");
 
             if (childCat.NameOption.IsSet)
                 writer.WriteString("name", childCat.Name);

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -178,7 +178,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ClassModel classModel, JsonSerializerOptions jsonSerializerOptions)
         {
             if (classModel.ClassOption.IsSet && classModel.Class == null)
-                throw new ArgumentNullException(nameof(classModel.Class), "Property is required for class ClassModel.");
+                throw new JsonException("Cannot write null property ClassModel.Class to non-nullable JSON property '_class'.");
 
             if (classModel.ClassOption.IsSet)
                 writer.WriteString("_class", classModel.Class);

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
@@ -192,12 +192,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ComplexQuadrilateral complexQuadrilateral, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (complexQuadrilateral.QuadrilateralType == null)
-                throw new ArgumentNullException(nameof(complexQuadrilateral.QuadrilateralType), "Property is required for class ComplexQuadrilateral.");
-
-            if (complexQuadrilateral.ShapeType == null)
-                throw new ArgumentNullException(nameof(complexQuadrilateral.ShapeType), "Property is required for class ComplexQuadrilateral.");
-
             writer.WriteString("quadrilateralType", complexQuadrilateral.QuadrilateralType);
 
             writer.WriteString("shapeType", complexQuadrilateral.ShapeType);

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/CopyActivity.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/CopyActivity.cs
@@ -234,9 +234,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, CopyActivity copyActivity, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (copyActivity.CopyActivitytt == null)
-                throw new ArgumentNullException(nameof(copyActivity.CopyActivitytt), "Property is required for class CopyActivity.");
-
             writer.WriteString("copyActivitytt", copyActivity.CopyActivitytt);
 
             writer.WriteString("$schema", CopyActivity.SchemaEnumToJsonValue(copyActivity.Schema));

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/DanishPig.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/DanishPig.cs
@@ -173,9 +173,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, DanishPig danishPig, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (danishPig.ClassName == null)
-                throw new ArgumentNullException(nameof(danishPig.ClassName), "Property is required for class DanishPig.");
-
             writer.WriteString("className", danishPig.ClassName);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -183,6 +183,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, DateOnlyClass dateOnlyClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (dateOnlyClass.DateOnlyPropertyOption.IsSet && dateOnlyClass.DateOnlyProperty == null)
+                throw new JsonException("Cannot write null property DateOnlyClass.DateOnlyProperty to non-nullable JSON property 'dateOnlyProperty'.");
+
             if (dateOnlyClass.DateOnlyPropertyOption.IsSet)
                 writer.WriteString("dateOnlyProperty", dateOnlyClass.DateOnlyPropertyOption.Value!.Value.ToString(DateOnlyPropertyFormat));
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -178,7 +178,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, DeprecatedObject deprecatedObject, JsonSerializerOptions jsonSerializerOptions)
         {
             if (deprecatedObject.NameOption.IsSet && deprecatedObject.Name == null)
-                throw new ArgumentNullException(nameof(deprecatedObject.Name), "Property is required for class DeprecatedObject.");
+                throw new JsonException("Cannot write null property DeprecatedObject.Name to non-nullable JSON property 'name'.");
 
             if (deprecatedObject.NameOption.IsSet)
                 writer.WriteString("name", deprecatedObject.Name);

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Descendant1.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Descendant1.cs
@@ -185,12 +185,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Descendant1 descendant1, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (descendant1.AlternativeName == null)
-                throw new ArgumentNullException(nameof(descendant1.AlternativeName), "Property is required for class Descendant1.");
-
-            if (descendant1.DescendantName == null)
-                throw new ArgumentNullException(nameof(descendant1.DescendantName), "Property is required for class Descendant1.");
-
             writer.WriteString("alternativeName", descendant1.AlternativeName);
 
             writer.WriteString("descendantName", descendant1.DescendantName);

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Descendant2.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Descendant2.cs
@@ -185,12 +185,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Descendant2 descendant2, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (descendant2.AlternativeName == null)
-                throw new ArgumentNullException(nameof(descendant2.AlternativeName), "Property is required for class Descendant2.");
-
-            if (descendant2.Confidentiality == null)
-                throw new ArgumentNullException(nameof(descendant2.Confidentiality), "Property is required for class Descendant2.");
-
             writer.WriteString("alternativeName", descendant2.AlternativeName);
 
             writer.WriteString("confidentiality", descendant2.Confidentiality);

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Dog.cs
@@ -180,10 +180,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Dog dog, JsonSerializerOptions jsonSerializerOptions)
         {
             if (dog.BreedOption.IsSet && dog.Breed == null)
-                throw new ArgumentNullException(nameof(dog.Breed), "Property is required for class Dog.");
+                throw new JsonException("Cannot write null property Dog.Breed to non-nullable JSON property 'breed'.");
 
             if (dog.ColorOption.IsSet && dog.Color == null)
-                throw new ArgumentNullException(nameof(dog.Color), "Property is required for class Dog.");
+                throw new JsonException("Cannot write null property Dog.Color to non-nullable JSON property 'color'.");
 
             writer.WriteString("className", dog.ClassName);
 

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Drawing.cs
@@ -241,10 +241,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Drawing drawing, JsonSerializerOptions jsonSerializerOptions)
         {
             if (drawing.MainShapeOption.IsSet && drawing.MainShape == null)
-                throw new ArgumentNullException(nameof(drawing.MainShape), "Property is required for class Drawing.");
+                throw new JsonException("Cannot write null property Drawing.MainShape to non-nullable JSON property 'mainShape'.");
 
             if (drawing.ShapesOption.IsSet && drawing.Shapes == null)
-                throw new ArgumentNullException(nameof(drawing.Shapes), "Property is required for class Drawing.");
+                throw new JsonException("Cannot write null property Drawing.Shapes to non-nullable JSON property 'shapes'.");
 
             if (drawing.MainShapeOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -342,6 +342,9 @@ namespace Org.OpenAPITools.Model
             if (enumArrays.ArrayEnumOption.IsSet && enumArrays.ArrayEnum == null)
                 throw new JsonException("Cannot write null property EnumArrays.ArrayEnum to non-nullable JSON property 'array_enum'.");
 
+            if (enumArrays.JustSymbolOption.IsSet && enumArrays.JustSymbol == null)
+                throw new JsonException("Cannot write null property EnumArrays.JustSymbol to non-nullable JSON property 'just_symbol'.");
+
             if (enumArrays.ArrayEnumOption.IsSet)
             {
                 writer.WritePropertyName("array_enum");

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -340,7 +340,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, EnumArrays enumArrays, JsonSerializerOptions jsonSerializerOptions)
         {
             if (enumArrays.ArrayEnumOption.IsSet && enumArrays.ArrayEnum == null)
-                throw new ArgumentNullException(nameof(enumArrays.ArrayEnum), "Property is required for class EnumArrays.");
+                throw new JsonException("Cannot write null property EnumArrays.ArrayEnum to non-nullable JSON property 'array_enum'.");
 
             if (enumArrays.ArrayEnumOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -878,6 +878,27 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, EnumTest enumTest, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (enumTest.EnumIntegerOption.IsSet && enumTest.EnumInteger == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumInteger to non-nullable JSON property 'enum_integer'.");
+
+            if (enumTest.EnumIntegerOnlyOption.IsSet && enumTest.EnumIntegerOnly == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumIntegerOnly to non-nullable JSON property 'enum_integer_only'.");
+
+            if (enumTest.EnumNumberOption.IsSet && enumTest.EnumNumber == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumNumber to non-nullable JSON property 'enum_number'.");
+
+            if (enumTest.EnumStringOption.IsSet && enumTest.EnumString == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumString to non-nullable JSON property 'enum_string'.");
+
+            if (enumTest.OuterEnumDefaultValueOption.IsSet && enumTest.OuterEnumDefaultValue == null)
+                throw new JsonException("Cannot write null property EnumTest.OuterEnumDefaultValue to non-nullable JSON property 'outerEnumDefaultValue'.");
+
+            if (enumTest.OuterEnumIntegerOption.IsSet && enumTest.OuterEnumInteger == null)
+                throw new JsonException("Cannot write null property EnumTest.OuterEnumInteger to non-nullable JSON property 'outerEnumInteger'.");
+
+            if (enumTest.OuterEnumIntegerDefaultValueOption.IsSet && enumTest.OuterEnumIntegerDefaultValue == null)
+                throw new JsonException("Cannot write null property EnumTest.OuterEnumIntegerDefaultValue to non-nullable JSON property 'outerEnumIntegerDefaultValue'.");
+
             var enumStringRequiredRawValue = EnumTest.EnumStringRequiredEnumToJsonValue(enumTest.EnumStringRequired);
             writer.WriteString("enum_string_required", enumStringRequiredRawValue);
             if (enumTest.EnumIntegerOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
@@ -192,12 +192,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, EquilateralTriangle equilateralTriangle, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (equilateralTriangle.ShapeType == null)
-                throw new ArgumentNullException(nameof(equilateralTriangle.ShapeType), "Property is required for class EquilateralTriangle.");
-
-            if (equilateralTriangle.TriangleType == null)
-                throw new ArgumentNullException(nameof(equilateralTriangle.TriangleType), "Property is required for class EquilateralTriangle.");
-
             writer.WriteString("shapeType", equilateralTriangle.ShapeType);
 
             writer.WriteString("triangleType", equilateralTriangle.TriangleType);

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/File.cs
@@ -179,7 +179,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, File file, JsonSerializerOptions jsonSerializerOptions)
         {
             if (file.SourceURIOption.IsSet && file.SourceURI == null)
-                throw new ArgumentNullException(nameof(file.SourceURI), "Property is required for class File.");
+                throw new JsonException("Cannot write null property File.SourceURI to non-nullable JSON property 'sourceURI'.");
 
             if (file.SourceURIOption.IsSet)
                 writer.WriteString("sourceURI", file.SourceURI);

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -201,10 +201,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, FileSchemaTestClass fileSchemaTestClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (fileSchemaTestClass.FileOption.IsSet && fileSchemaTestClass.File == null)
-                throw new ArgumentNullException(nameof(fileSchemaTestClass.File), "Property is required for class FileSchemaTestClass.");
+                throw new JsonException("Cannot write null property FileSchemaTestClass.File to non-nullable JSON property 'file'.");
 
             if (fileSchemaTestClass.FilesOption.IsSet && fileSchemaTestClass.Files == null)
-                throw new ArgumentNullException(nameof(fileSchemaTestClass.Files), "Property is required for class FileSchemaTestClass.");
+                throw new JsonException("Cannot write null property FileSchemaTestClass.Files to non-nullable JSON property 'files'.");
 
             if (fileSchemaTestClass.FileOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Foo.cs
@@ -178,7 +178,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Foo foo, JsonSerializerOptions jsonSerializerOptions)
         {
             if (foo.BarOption.IsSet && foo.Bar == null)
-                throw new ArgumentNullException(nameof(foo.Bar), "Property is required for class Foo.");
+                throw new JsonException("Cannot write null property Foo.Bar to non-nullable JSON property 'bar'.");
 
             if (foo.BarOption.IsSet)
                 writer.WriteString("bar", foo.Bar);

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -178,7 +178,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, FooGetDefaultResponse fooGetDefaultResponse, JsonSerializerOptions jsonSerializerOptions)
         {
             if (fooGetDefaultResponse.StringOption.IsSet && fooGetDefaultResponse.String == null)
-                throw new ArgumentNullException(nameof(fooGetDefaultResponse.String), "Property is required for class FooGetDefaultResponse.");
+                throw new JsonException("Cannot write null property FooGetDefaultResponse.String to non-nullable JSON property 'string'.");
 
             if (fooGetDefaultResponse.StringOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -957,11 +957,47 @@ namespace Org.OpenAPITools.Model
             if (formatTest.BinaryOption.IsSet && formatTest.Binary == null)
                 throw new JsonException("Cannot write null property FormatTest.Binary to non-nullable JSON property 'binary'.");
 
+            if (formatTest.DateTimeOption.IsSet && formatTest.DateTime == null)
+                throw new JsonException("Cannot write null property FormatTest.DateTime to non-nullable JSON property 'dateTime'.");
+
+            if (formatTest.DecimalOption.IsSet && formatTest.Decimal == null)
+                throw new JsonException("Cannot write null property FormatTest.Decimal to non-nullable JSON property 'decimal'.");
+
+            if (formatTest.DoubleOption.IsSet && formatTest.Double == null)
+                throw new JsonException("Cannot write null property FormatTest.Double to non-nullable JSON property 'double'.");
+
             if (formatTest.DuplicatePropertyName2Option.IsSet && formatTest.DuplicatePropertyName2 == null)
                 throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName2 to non-nullable JSON property 'duplicate_property_name'.");
 
             if (formatTest.DuplicatePropertyNameOption.IsSet && formatTest.DuplicatePropertyName == null)
                 throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName to non-nullable JSON property '@duplicate_property_name'.");
+
+            if (formatTest.FloatOption.IsSet && formatTest.Float == null)
+                throw new JsonException("Cannot write null property FormatTest.Float to non-nullable JSON property 'float'.");
+
+            if (formatTest.Int32Option.IsSet && formatTest.Int32 == null)
+                throw new JsonException("Cannot write null property FormatTest.Int32 to non-nullable JSON property 'int32'.");
+
+            if (formatTest.Int32RangeOption.IsSet && formatTest.Int32Range == null)
+                throw new JsonException("Cannot write null property FormatTest.Int32Range to non-nullable JSON property 'int32Range'.");
+
+            if (formatTest.Int64Option.IsSet && formatTest.Int64 == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64 to non-nullable JSON property 'int64'.");
+
+            if (formatTest.Int64NegativeOption.IsSet && formatTest.Int64Negative == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64Negative to non-nullable JSON property 'int64Negative'.");
+
+            if (formatTest.Int64NegativeExclusiveOption.IsSet && formatTest.Int64NegativeExclusive == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64NegativeExclusive to non-nullable JSON property 'int64NegativeExclusive'.");
+
+            if (formatTest.Int64PositiveOption.IsSet && formatTest.Int64Positive == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64Positive to non-nullable JSON property 'int64Positive'.");
+
+            if (formatTest.Int64PositiveExclusiveOption.IsSet && formatTest.Int64PositiveExclusive == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64PositiveExclusive to non-nullable JSON property 'int64PositiveExclusive'.");
+
+            if (formatTest.IntegerOption.IsSet && formatTest.Integer == null)
+                throw new JsonException("Cannot write null property FormatTest.Integer to non-nullable JSON property 'integer'.");
 
             if (formatTest.PatternWithBackslashOption.IsSet && formatTest.PatternWithBackslash == null)
                 throw new JsonException("Cannot write null property FormatTest.PatternWithBackslash to non-nullable JSON property 'pattern_with_backslash'.");
@@ -974,6 +1010,18 @@ namespace Org.OpenAPITools.Model
 
             if (formatTest.StringOption.IsSet && formatTest.String == null)
                 throw new JsonException("Cannot write null property FormatTest.String to non-nullable JSON property 'string'.");
+
+            if (formatTest.StringFormattedAsDecimalOption.IsSet && formatTest.StringFormattedAsDecimal == null)
+                throw new JsonException("Cannot write null property FormatTest.StringFormattedAsDecimal to non-nullable JSON property 'string_formatted_as_decimal'.");
+
+            if (formatTest.UnsignedIntegerOption.IsSet && formatTest.UnsignedInteger == null)
+                throw new JsonException("Cannot write null property FormatTest.UnsignedInteger to non-nullable JSON property 'unsigned_integer'.");
+
+            if (formatTest.UnsignedLongOption.IsSet && formatTest.UnsignedLong == null)
+                throw new JsonException("Cannot write null property FormatTest.UnsignedLong to non-nullable JSON property 'unsigned_long'.");
+
+            if (formatTest.UuidOption.IsSet && formatTest.Uuid == null)
+                throw new JsonException("Cannot write null property FormatTest.Uuid to non-nullable JSON property 'uuid'.");
 
             writer.WritePropertyName("byte");
             JsonSerializer.Serialize(writer, formatTest.Byte, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -954,32 +954,26 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, FormatTest formatTest, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (formatTest.Byte == null)
-                throw new ArgumentNullException(nameof(formatTest.Byte), "Property is required for class FormatTest.");
-
-            if (formatTest.Password == null)
-                throw new ArgumentNullException(nameof(formatTest.Password), "Property is required for class FormatTest.");
-
             if (formatTest.BinaryOption.IsSet && formatTest.Binary == null)
-                throw new ArgumentNullException(nameof(formatTest.Binary), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.Binary to non-nullable JSON property 'binary'.");
 
             if (formatTest.DuplicatePropertyName2Option.IsSet && formatTest.DuplicatePropertyName2 == null)
-                throw new ArgumentNullException(nameof(formatTest.DuplicatePropertyName2), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName2 to non-nullable JSON property 'duplicate_property_name'.");
 
             if (formatTest.DuplicatePropertyNameOption.IsSet && formatTest.DuplicatePropertyName == null)
-                throw new ArgumentNullException(nameof(formatTest.DuplicatePropertyName), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName to non-nullable JSON property '@duplicate_property_name'.");
 
             if (formatTest.PatternWithBackslashOption.IsSet && formatTest.PatternWithBackslash == null)
-                throw new ArgumentNullException(nameof(formatTest.PatternWithBackslash), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.PatternWithBackslash to non-nullable JSON property 'pattern_with_backslash'.");
 
             if (formatTest.PatternWithDigitsOption.IsSet && formatTest.PatternWithDigits == null)
-                throw new ArgumentNullException(nameof(formatTest.PatternWithDigits), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.PatternWithDigits to non-nullable JSON property 'pattern_with_digits'.");
 
             if (formatTest.PatternWithDigitsAndDelimiterOption.IsSet && formatTest.PatternWithDigitsAndDelimiter == null)
-                throw new ArgumentNullException(nameof(formatTest.PatternWithDigitsAndDelimiter), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.PatternWithDigitsAndDelimiter to non-nullable JSON property 'pattern_with_digits_and_delimiter'.");
 
             if (formatTest.StringOption.IsSet && formatTest.String == null)
-                throw new ArgumentNullException(nameof(formatTest.String), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.String to non-nullable JSON property 'string'.");
 
             writer.WritePropertyName("byte");
             JsonSerializer.Serialize(writer, formatTest.Byte, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Fruit.cs
@@ -222,7 +222,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Fruit fruit, JsonSerializerOptions jsonSerializerOptions)
         {
             if (fruit.ColorOption.IsSet && fruit.Color == null)
-                throw new ArgumentNullException(nameof(fruit.Color), "Property is required for class Fruit.");
+                throw new JsonException("Cannot write null property Fruit.Color to non-nullable JSON property 'color'.");
 
             if (fruit.ColorOption.IsSet)
                 writer.WriteString("color", fruit.Color);

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -239,7 +239,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, GmFruit gmFruit, JsonSerializerOptions jsonSerializerOptions)
         {
             if (gmFruit.ColorOption.IsSet && gmFruit.Color == null)
-                throw new ArgumentNullException(nameof(gmFruit.Color), "Property is required for class GmFruit.");
+                throw new JsonException("Cannot write null property GmFruit.Color to non-nullable JSON property 'color'.");
 
             if (gmFruit.ColorOption.IsSet)
                 writer.WriteString("color", gmFruit.Color);

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -242,10 +242,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, HasOnlyReadOnly hasOnlyReadOnly, JsonSerializerOptions jsonSerializerOptions)
         {
             if (hasOnlyReadOnly.BarOption.IsSet && hasOnlyReadOnly.Bar == null)
-                throw new ArgumentNullException(nameof(hasOnlyReadOnly.Bar), "Property is required for class HasOnlyReadOnly.");
+                throw new JsonException("Cannot write null property HasOnlyReadOnly.Bar to non-nullable JSON property 'bar'.");
 
             if (hasOnlyReadOnly.FooOption.IsSet && hasOnlyReadOnly.Foo == null)
-                throw new ArgumentNullException(nameof(hasOnlyReadOnly.Foo), "Property is required for class HasOnlyReadOnly.");
+                throw new JsonException("Cannot write null property HasOnlyReadOnly.Foo to non-nullable JSON property 'foo'.");
 
             if (hasOnlyReadOnly.BarOption.IsSet)
                 writer.WriteString("bar", hasOnlyReadOnly.Bar);

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
@@ -340,22 +340,22 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, InjectedVendorExtensionsTest injectedVendorExtensionsTest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessorOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor to non-nullable JSON property 'potentiallyOverriddenPropertyAccessor'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternalOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternal == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternal), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternal to non-nullable JSON property 'potentiallyOverriddenPropertyToInternal'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivateOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivate == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivate), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivate to non-nullable JSON property 'potentiallyOverriddenPropertyToPrivate'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublicOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublic == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublic), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublic to non-nullable JSON property 'potentiallyOverriddenPropertyToPublic'.");
 
             if (injectedVendorExtensionsTest.UnalteredPropertyOption.IsSet && injectedVendorExtensionsTest.UnalteredProperty == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.UnalteredProperty), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.UnalteredProperty to non-nullable JSON property 'unalteredProperty'.");
 
             if (injectedVendorExtensionsTest.UnalteredPropertyAccessorOption.IsSet && injectedVendorExtensionsTest.UnalteredPropertyAccessor == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.UnalteredPropertyAccessor), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.UnalteredPropertyAccessor to non-nullable JSON property 'unalteredPropertyAccessor'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessorOption.IsSet)
                 writer.WriteString("potentiallyOverriddenPropertyAccessor", injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor);

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
@@ -185,12 +185,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, IsoscelesTriangle isoscelesTriangle, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (isoscelesTriangle.ShapeType == null)
-                throw new ArgumentNullException(nameof(isoscelesTriangle.ShapeType), "Property is required for class IsoscelesTriangle.");
-
-            if (isoscelesTriangle.TriangleType == null)
-                throw new ArgumentNullException(nameof(isoscelesTriangle.TriangleType), "Property is required for class IsoscelesTriangle.");
-
             writer.WriteString("shapeType", isoscelesTriangle.ShapeType);
 
             writer.WriteString("triangleType", isoscelesTriangle.TriangleType);

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/List.cs
@@ -178,7 +178,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, List list, JsonSerializerOptions jsonSerializerOptions)
         {
             if (list.Var123ListOption.IsSet && list.Var123List == null)
-                throw new ArgumentNullException(nameof(list.Var123List), "Property is required for class List.");
+                throw new JsonException("Cannot write null property List.Var123List to non-nullable JSON property '123-list'.");
 
             if (list.Var123ListOption.IsSet)
                 writer.WriteString("123-list", list.Var123List);

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -201,10 +201,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, LiteralStringClass literalStringClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (literalStringClass.EscapedLiteralStringOption.IsSet && literalStringClass.EscapedLiteralString == null)
-                throw new ArgumentNullException(nameof(literalStringClass.EscapedLiteralString), "Property is required for class LiteralStringClass.");
+                throw new JsonException("Cannot write null property LiteralStringClass.EscapedLiteralString to non-nullable JSON property 'escapedLiteralString'.");
 
             if (literalStringClass.UnescapedLiteralStringOption.IsSet && literalStringClass.UnescapedLiteralString == null)
-                throw new ArgumentNullException(nameof(literalStringClass.UnescapedLiteralString), "Property is required for class LiteralStringClass.");
+                throw new JsonException("Cannot write null property LiteralStringClass.UnescapedLiteralString to non-nullable JSON property 'unescapedLiteralString'.");
 
             if (literalStringClass.EscapedLiteralStringOption.IsSet)
                 writer.WriteString("escapedLiteralString", literalStringClass.EscapedLiteralString);

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/MapTest.cs
@@ -313,16 +313,16 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MapTest mapTest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mapTest.DirectMapOption.IsSet && mapTest.DirectMap == null)
-                throw new ArgumentNullException(nameof(mapTest.DirectMap), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.DirectMap to non-nullable JSON property 'direct_map'.");
 
             if (mapTest.IndirectMapOption.IsSet && mapTest.IndirectMap == null)
-                throw new ArgumentNullException(nameof(mapTest.IndirectMap), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.IndirectMap to non-nullable JSON property 'indirect_map'.");
 
             if (mapTest.MapMapOfStringOption.IsSet && mapTest.MapMapOfString == null)
-                throw new ArgumentNullException(nameof(mapTest.MapMapOfString), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.MapMapOfString to non-nullable JSON property 'map_map_of_string'.");
 
             if (mapTest.MapOfEnumStringOption.IsSet && mapTest.MapOfEnumString == null)
-                throw new ArgumentNullException(nameof(mapTest.MapOfEnumString), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.MapOfEnumString to non-nullable JSON property 'map_of_enum_string'.");
 
             if (mapTest.DirectMapOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/MixedAnyOf.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/MixedAnyOf.cs
@@ -178,7 +178,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedAnyOf mixedAnyOf, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedAnyOf.ContentOption.IsSet && mixedAnyOf.Content == null)
-                throw new ArgumentNullException(nameof(mixedAnyOf.Content), "Property is required for class MixedAnyOf.");
+                throw new JsonException("Cannot write null property MixedAnyOf.Content to non-nullable JSON property 'content'.");
 
             if (mixedAnyOf.ContentOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/MixedOneOf.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/MixedOneOf.cs
@@ -178,7 +178,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedOneOf mixedOneOf, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedOneOf.ContentOption.IsSet && mixedOneOf.Content == null)
-                throw new ArgumentNullException(nameof(mixedOneOf.Content), "Property is required for class MixedOneOf.");
+                throw new JsonException("Cannot write null property MixedOneOf.Content to non-nullable JSON property 'content'.");
 
             if (mixedOneOf.ContentOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -258,8 +258,17 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, MixedPropertiesAndAdditionalPropertiesClass mixedPropertiesAndAdditionalPropertiesClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.DateTime == null)
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.DateTime to non-nullable JSON property 'dateTime'.");
+
             if (mixedPropertiesAndAdditionalPropertiesClass.MapOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.Map == null)
                 throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.Map to non-nullable JSON property 'map'.");
+
+            if (mixedPropertiesAndAdditionalPropertiesClass.UuidOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.Uuid == null)
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.Uuid to non-nullable JSON property 'uuid'.");
+
+            if (mixedPropertiesAndAdditionalPropertiesClass.UuidWithPatternOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.UuidWithPattern == null)
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.UuidWithPattern to non-nullable JSON property 'uuid_with_pattern'.");
 
             if (mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.IsSet)
                 writer.WriteString("dateTime", mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.Value!.Value.ToString(DateTimeFormat));

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -259,7 +259,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedPropertiesAndAdditionalPropertiesClass mixedPropertiesAndAdditionalPropertiesClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedPropertiesAndAdditionalPropertiesClass.MapOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.Map == null)
-                throw new ArgumentNullException(nameof(mixedPropertiesAndAdditionalPropertiesClass.Map), "Property is required for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.Map to non-nullable JSON property 'map'.");
 
             if (mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.IsSet)
                 writer.WriteString("dateTime", mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.Value!.Value.ToString(DateTimeFormat));

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/MixedSubId.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/MixedSubId.cs
@@ -178,7 +178,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedSubId mixedSubId, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedSubId.IdOption.IsSet && mixedSubId.Id == null)
-                throw new ArgumentNullException(nameof(mixedSubId.Id), "Property is required for class MixedSubId.");
+                throw new JsonException("Cannot write null property MixedSubId.Id to non-nullable JSON property 'id'.");
 
             if (mixedSubId.IdOption.IsSet)
                 writer.WriteString("id", mixedSubId.Id);

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -201,7 +201,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Model200Response model200Response, JsonSerializerOptions jsonSerializerOptions)
         {
             if (model200Response.ClassOption.IsSet && model200Response.Class == null)
-                throw new ArgumentNullException(nameof(model200Response.Class), "Property is required for class Model200Response.");
+                throw new JsonException("Cannot write null property Model200Response.Class to non-nullable JSON property 'class'.");
 
             if (model200Response.ClassOption.IsSet)
                 writer.WriteString("class", model200Response.Class);

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -203,6 +203,9 @@ namespace Org.OpenAPITools.Model
             if (model200Response.ClassOption.IsSet && model200Response.Class == null)
                 throw new JsonException("Cannot write null property Model200Response.Class to non-nullable JSON property 'class'.");
 
+            if (model200Response.NameOption.IsSet && model200Response.Name == null)
+                throw new JsonException("Cannot write null property Model200Response.Name to non-nullable JSON property 'name'.");
+
             if (model200Response.ClassOption.IsSet)
                 writer.WriteString("class", model200Response.Class);
 

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -178,7 +178,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ModelClient modelClient, JsonSerializerOptions jsonSerializerOptions)
         {
             if (modelClient.VarClientOption.IsSet && modelClient.VarClient == null)
-                throw new ArgumentNullException(nameof(modelClient.VarClient), "Property is required for class ModelClient.");
+                throw new JsonException("Cannot write null property ModelClient.VarClient to non-nullable JSON property 'client'.");
 
             if (modelClient.VarClientOption.IsSet)
                 writer.WriteString("client", modelClient.VarClient);

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Name.cs
@@ -284,7 +284,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Name name, JsonSerializerOptions jsonSerializerOptions)
         {
             if (name.PropertyOption.IsSet && name.Property == null)
-                throw new ArgumentNullException(nameof(name.Property), "Property is required for class Name.");
+                throw new JsonException("Cannot write null property Name.Property to non-nullable JSON property 'property'.");
 
             writer.WriteNumber("name", name.VarName);
 

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Name.cs
@@ -286,6 +286,12 @@ namespace Org.OpenAPITools.Model
             if (name.PropertyOption.IsSet && name.Property == null)
                 throw new JsonException("Cannot write null property Name.Property to non-nullable JSON property 'property'.");
 
+            if (name.SnakeCaseOption.IsSet && name.SnakeCase == null)
+                throw new JsonException("Cannot write null property Name.SnakeCase to non-nullable JSON property 'snake_case'.");
+
+            if (name.Var123NumberOption.IsSet && name.Var123Number == null)
+                throw new JsonException("Cannot write null property Name.Var123Number to non-nullable JSON property '123Number'.");
+
             writer.WriteNumber("name", name.VarName);
 
             if (name.PropertyOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
@@ -192,9 +192,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, NotificationtestGetElementsV1ResponseMPayload notificationtestGetElementsV1ResponseMPayload, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (notificationtestGetElementsV1ResponseMPayload.AObjVariableobject == null)
-                throw new ArgumentNullException(nameof(notificationtestGetElementsV1ResponseMPayload.AObjVariableobject), "Property is required for class NotificationtestGetElementsV1ResponseMPayload.");
-
             writer.WritePropertyName("a_objVariableobject");
             JsonSerializer.Serialize(writer, notificationtestGetElementsV1ResponseMPayload.AObjVariableobject, jsonSerializerOptions);
             writer.WriteNumber("pkiNotificationtestID", notificationtestGetElementsV1ResponseMPayload.PkiNotificationtestID);

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -411,10 +411,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, NullableClass nullableClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (nullableClass.ArrayItemsNullableOption.IsSet && nullableClass.ArrayItemsNullable == null)
-                throw new ArgumentNullException(nameof(nullableClass.ArrayItemsNullable), "Property is required for class NullableClass.");
+                throw new JsonException("Cannot write null property NullableClass.ArrayItemsNullable to non-nullable JSON property 'array_items_nullable'.");
 
             if (nullableClass.ObjectItemsNullableOption.IsSet && nullableClass.ObjectItemsNullable == null)
-                throw new ArgumentNullException(nameof(nullableClass.ObjectItemsNullable), "Property is required for class NullableClass.");
+                throw new JsonException("Cannot write null property NullableClass.ObjectItemsNullable to non-nullable JSON property 'object_items_nullable'.");
 
             if (nullableClass.ArrayAndItemsNullablePropOption.IsSet)
                 if (nullableClass.ArrayAndItemsNullablePropOption.Value != null)

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -177,6 +177,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, NumberOnly numberOnly, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (numberOnly.JustNumberOption.IsSet && numberOnly.JustNumber == null)
+                throw new JsonException("Cannot write null property NumberOnly.JustNumber to non-nullable JSON property 'JustNumber'.");
+
             if (numberOnly.JustNumberOption.IsSet)
                 writer.WriteNumber("JustNumber", numberOnly.JustNumberOption.Value!.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -250,13 +250,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ObjectWithDeprecatedFields objectWithDeprecatedFields, JsonSerializerOptions jsonSerializerOptions)
         {
             if (objectWithDeprecatedFields.BarsOption.IsSet && objectWithDeprecatedFields.Bars == null)
-                throw new ArgumentNullException(nameof(objectWithDeprecatedFields.Bars), "Property is required for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Bars to non-nullable JSON property 'bars'.");
 
             if (objectWithDeprecatedFields.DeprecatedRefOption.IsSet && objectWithDeprecatedFields.DeprecatedRef == null)
-                throw new ArgumentNullException(nameof(objectWithDeprecatedFields.DeprecatedRef), "Property is required for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.DeprecatedRef to non-nullable JSON property 'deprecatedRef'.");
 
             if (objectWithDeprecatedFields.UuidOption.IsSet && objectWithDeprecatedFields.Uuid == null)
-                throw new ArgumentNullException(nameof(objectWithDeprecatedFields.Uuid), "Property is required for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Uuid to non-nullable JSON property 'uuid'.");
 
             if (objectWithDeprecatedFields.BarsOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -255,6 +255,9 @@ namespace Org.OpenAPITools.Model
             if (objectWithDeprecatedFields.DeprecatedRefOption.IsSet && objectWithDeprecatedFields.DeprecatedRef == null)
                 throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.DeprecatedRef to non-nullable JSON property 'deprecatedRef'.");
 
+            if (objectWithDeprecatedFields.IdOption.IsSet && objectWithDeprecatedFields.Id == null)
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Id to non-nullable JSON property 'id'.");
+
             if (objectWithDeprecatedFields.UuidOption.IsSet && objectWithDeprecatedFields.Uuid == null)
                 throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Uuid to non-nullable JSON property 'uuid'.");
 

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Order.cs
@@ -387,6 +387,24 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Order order, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (order.CompleteOption.IsSet && order.Complete == null)
+                throw new JsonException("Cannot write null property Order.Complete to non-nullable JSON property 'complete'.");
+
+            if (order.IdOption.IsSet && order.Id == null)
+                throw new JsonException("Cannot write null property Order.Id to non-nullable JSON property 'id'.");
+
+            if (order.PetIdOption.IsSet && order.PetId == null)
+                throw new JsonException("Cannot write null property Order.PetId to non-nullable JSON property 'petId'.");
+
+            if (order.QuantityOption.IsSet && order.Quantity == null)
+                throw new JsonException("Cannot write null property Order.Quantity to non-nullable JSON property 'quantity'.");
+
+            if (order.ShipDateOption.IsSet && order.ShipDate == null)
+                throw new JsonException("Cannot write null property Order.ShipDate to non-nullable JSON property 'shipDate'.");
+
+            if (order.StatusOption.IsSet && order.Status == null)
+                throw new JsonException("Cannot write null property Order.Status to non-nullable JSON property 'status'.");
+
             if (order.CompleteOption.IsSet)
                 writer.WriteBoolean("complete", order.CompleteOption.Value!.Value);
 

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -224,7 +224,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, OuterComposite outerComposite, JsonSerializerOptions jsonSerializerOptions)
         {
             if (outerComposite.MyStringOption.IsSet && outerComposite.MyString == null)
-                throw new ArgumentNullException(nameof(outerComposite.MyString), "Property is required for class OuterComposite.");
+                throw new JsonException("Cannot write null property OuterComposite.MyString to non-nullable JSON property 'my_string'.");
 
             if (outerComposite.MyBooleanOption.IsSet)
                 writer.WriteBoolean("my_boolean", outerComposite.MyBooleanOption.Value!.Value);

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -223,6 +223,12 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, OuterComposite outerComposite, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (outerComposite.MyBooleanOption.IsSet && outerComposite.MyBoolean == null)
+                throw new JsonException("Cannot write null property OuterComposite.MyBoolean to non-nullable JSON property 'my_boolean'.");
+
+            if (outerComposite.MyNumberOption.IsSet && outerComposite.MyNumber == null)
+                throw new JsonException("Cannot write null property OuterComposite.MyNumber to non-nullable JSON property 'my_number'.");
+
             if (outerComposite.MyStringOption.IsSet && outerComposite.MyString == null)
                 throw new JsonException("Cannot write null property OuterComposite.MyString to non-nullable JSON property 'my_string'.");
 

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Pet.cs
@@ -374,17 +374,11 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Pet pet, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (pet.Name == null)
-                throw new ArgumentNullException(nameof(pet.Name), "Property is required for class Pet.");
-
-            if (pet.PhotoUrls == null)
-                throw new ArgumentNullException(nameof(pet.PhotoUrls), "Property is required for class Pet.");
-
             if (pet.CategoryOption.IsSet && pet.Category == null)
-                throw new ArgumentNullException(nameof(pet.Category), "Property is required for class Pet.");
+                throw new JsonException("Cannot write null property Pet.Category to non-nullable JSON property 'category'.");
 
             if (pet.TagsOption.IsSet && pet.Tags == null)
-                throw new ArgumentNullException(nameof(pet.Tags), "Property is required for class Pet.");
+                throw new JsonException("Cannot write null property Pet.Tags to non-nullable JSON property 'tags'.");
 
             writer.WriteString("name", pet.Name);
 

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Pet.cs
@@ -377,6 +377,12 @@ namespace Org.OpenAPITools.Model
             if (pet.CategoryOption.IsSet && pet.Category == null)
                 throw new JsonException("Cannot write null property Pet.Category to non-nullable JSON property 'category'.");
 
+            if (pet.IdOption.IsSet && pet.Id == null)
+                throw new JsonException("Cannot write null property Pet.Id to non-nullable JSON property 'id'.");
+
+            if (pet.StatusOption.IsSet && pet.Status == null)
+                throw new JsonException("Cannot write null property Pet.Status to non-nullable JSON property 'status'.");
+
             if (pet.TagsOption.IsSet && pet.Tags == null)
                 throw new JsonException("Cannot write null property Pet.Tags to non-nullable JSON property 'tags'.");
 

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
@@ -173,9 +173,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, QuadrilateralInterface quadrilateralInterface, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (quadrilateralInterface.QuadrilateralType == null)
-                throw new ArgumentNullException(nameof(quadrilateralInterface.QuadrilateralType), "Property is required for class QuadrilateralInterface.");
-
             writer.WriteString("quadrilateralType", quadrilateralInterface.QuadrilateralType);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -239,10 +239,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ReadOnlyFirst readOnlyFirst, JsonSerializerOptions jsonSerializerOptions)
         {
             if (readOnlyFirst.BarOption.IsSet && readOnlyFirst.Bar == null)
-                throw new ArgumentNullException(nameof(readOnlyFirst.Bar), "Property is required for class ReadOnlyFirst.");
+                throw new JsonException("Cannot write null property ReadOnlyFirst.Bar to non-nullable JSON property 'bar'.");
 
             if (readOnlyFirst.BazOption.IsSet && readOnlyFirst.Baz == null)
-                throw new ArgumentNullException(nameof(readOnlyFirst.Baz), "Property is required for class ReadOnlyFirst.");
+                throw new JsonException("Cannot write null property ReadOnlyFirst.Baz to non-nullable JSON property 'baz'.");
 
             if (readOnlyFirst.BarOption.IsSet)
                 writer.WriteString("bar", readOnlyFirst.Bar);

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -2238,11 +2238,38 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, RequiredClass requiredClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (requiredClass.NotRequiredNotnullableDatePropOption.IsSet && requiredClass.NotRequiredNotnullableDateProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotRequiredNotnullableDateProp to non-nullable JSON property 'not_required_notnullable_date_prop'.");
+
+            if (requiredClass.NotRequiredNotnullableintegerPropOption.IsSet && requiredClass.NotRequiredNotnullableintegerProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotRequiredNotnullableintegerProp to non-nullable JSON property 'not_required_notnullableinteger_prop'.");
+
             if (requiredClass.NotrequiredNotnullableArrayOfStringOption.IsSet && requiredClass.NotrequiredNotnullableArrayOfString == null)
                 throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableArrayOfString to non-nullable JSON property 'notrequired_notnullable_array_of_string'.");
 
+            if (requiredClass.NotrequiredNotnullableBooleanPropOption.IsSet && requiredClass.NotrequiredNotnullableBooleanProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableBooleanProp to non-nullable JSON property 'notrequired_notnullable_boolean_prop'.");
+
+            if (requiredClass.NotrequiredNotnullableDatetimePropOption.IsSet && requiredClass.NotrequiredNotnullableDatetimeProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableDatetimeProp to non-nullable JSON property 'notrequired_notnullable_datetime_prop'.");
+
+            if (requiredClass.NotrequiredNotnullableEnumIntegerOption.IsSet && requiredClass.NotrequiredNotnullableEnumInteger == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableEnumInteger to non-nullable JSON property 'notrequired_notnullable_enum_integer'.");
+
+            if (requiredClass.NotrequiredNotnullableEnumIntegerOnlyOption.IsSet && requiredClass.NotrequiredNotnullableEnumIntegerOnly == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableEnumIntegerOnly to non-nullable JSON property 'notrequired_notnullable_enum_integer_only'.");
+
+            if (requiredClass.NotrequiredNotnullableEnumStringOption.IsSet && requiredClass.NotrequiredNotnullableEnumString == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableEnumString to non-nullable JSON property 'notrequired_notnullable_enum_string'.");
+
+            if (requiredClass.NotrequiredNotnullableOuterEnumDefaultValueOption.IsSet && requiredClass.NotrequiredNotnullableOuterEnumDefaultValue == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableOuterEnumDefaultValue to non-nullable JSON property 'notrequired_notnullable_outerEnumDefaultValue'.");
+
             if (requiredClass.NotrequiredNotnullableStringPropOption.IsSet && requiredClass.NotrequiredNotnullableStringProp == null)
                 throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableStringProp to non-nullable JSON property 'notrequired_notnullable_string_prop'.");
+
+            if (requiredClass.NotrequiredNotnullableUuidOption.IsSet && requiredClass.NotrequiredNotnullableUuid == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableUuid to non-nullable JSON property 'notrequired_notnullable_uuid'.");
 
             writer.WriteString("required_not_nullable_date_prop", requiredClass.RequiredNotNullableDateProp.ToString(RequiredNotNullableDatePropFormat));
 

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -2238,17 +2238,11 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, RequiredClass requiredClass, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (requiredClass.RequiredNotnullableArrayOfString == null)
-                throw new ArgumentNullException(nameof(requiredClass.RequiredNotnullableArrayOfString), "Property is required for class RequiredClass.");
-
-            if (requiredClass.RequiredNotnullableStringProp == null)
-                throw new ArgumentNullException(nameof(requiredClass.RequiredNotnullableStringProp), "Property is required for class RequiredClass.");
-
             if (requiredClass.NotrequiredNotnullableArrayOfStringOption.IsSet && requiredClass.NotrequiredNotnullableArrayOfString == null)
-                throw new ArgumentNullException(nameof(requiredClass.NotrequiredNotnullableArrayOfString), "Property is required for class RequiredClass.");
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableArrayOfString to non-nullable JSON property 'notrequired_notnullable_array_of_string'.");
 
             if (requiredClass.NotrequiredNotnullableStringPropOption.IsSet && requiredClass.NotrequiredNotnullableStringProp == null)
-                throw new ArgumentNullException(nameof(requiredClass.NotrequiredNotnullableStringProp), "Property is required for class RequiredClass.");
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableStringProp to non-nullable JSON property 'notrequired_notnullable_string_prop'.");
 
             writer.WriteString("required_not_nullable_date_prop", requiredClass.RequiredNotNullableDateProp.ToString(RequiredNotNullableDatePropFormat));
 

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Result.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Result.cs
@@ -227,13 +227,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Result result, JsonSerializerOptions jsonSerializerOptions)
         {
             if (result.CodeOption.IsSet && result.Code == null)
-                throw new ArgumentNullException(nameof(result.Code), "Property is required for class Result.");
+                throw new JsonException("Cannot write null property Result.Code to non-nullable JSON property 'code'.");
 
             if (result.DataOption.IsSet && result.Data == null)
-                throw new ArgumentNullException(nameof(result.Data), "Property is required for class Result.");
+                throw new JsonException("Cannot write null property Result.Data to non-nullable JSON property 'data'.");
 
             if (result.UuidOption.IsSet && result.Uuid == null)
-                throw new ArgumentNullException(nameof(result.Uuid), "Property is required for class Result.");
+                throw new JsonException("Cannot write null property Result.Uuid to non-nullable JSON property 'uuid'.");
 
             if (result.CodeOption.IsSet)
                 writer.WriteString("code", result.Code);

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Return.cs
@@ -235,11 +235,8 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Return varReturn, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (varReturn.Lock == null)
-                throw new ArgumentNullException(nameof(varReturn.Lock), "Property is required for class Return.");
-
             if (varReturn.UnsafeOption.IsSet && varReturn.Unsafe == null)
-                throw new ArgumentNullException(nameof(varReturn.Unsafe), "Property is required for class Return.");
+                throw new JsonException("Cannot write null property Return.Unsafe to non-nullable JSON property 'unsafe'.");
 
             writer.WriteString("lock", varReturn.Lock);
 

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Return.cs
@@ -235,6 +235,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Return varReturn, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (varReturn.VarReturnOption.IsSet && varReturn.VarReturn == null)
+                throw new JsonException("Cannot write null property Return.VarReturn to non-nullable JSON property 'return'.");
+
             if (varReturn.UnsafeOption.IsSet && varReturn.Unsafe == null)
                 throw new JsonException("Cannot write null property Return.Unsafe to non-nullable JSON property 'unsafe'.");
 

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -203,6 +203,9 @@ namespace Org.OpenAPITools.Model
             if (rolesReportsHash.RoleOption.IsSet && rolesReportsHash.Role == null)
                 throw new JsonException("Cannot write null property RolesReportsHash.Role to non-nullable JSON property 'role'.");
 
+            if (rolesReportsHash.RoleUuidOption.IsSet && rolesReportsHash.RoleUuid == null)
+                throw new JsonException("Cannot write null property RolesReportsHash.RoleUuid to non-nullable JSON property 'role_uuid'.");
+
             if (rolesReportsHash.RoleOption.IsSet)
             {
                 writer.WritePropertyName("role");

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -201,7 +201,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, RolesReportsHash rolesReportsHash, JsonSerializerOptions jsonSerializerOptions)
         {
             if (rolesReportsHash.RoleOption.IsSet && rolesReportsHash.Role == null)
-                throw new ArgumentNullException(nameof(rolesReportsHash.Role), "Property is required for class RolesReportsHash.");
+                throw new JsonException("Cannot write null property RolesReportsHash.Role to non-nullable JSON property 'role'.");
 
             if (rolesReportsHash.RoleOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
@@ -178,7 +178,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, RolesReportsHashRole rolesReportsHashRole, JsonSerializerOptions jsonSerializerOptions)
         {
             if (rolesReportsHashRole.NameOption.IsSet && rolesReportsHashRole.Name == null)
-                throw new ArgumentNullException(nameof(rolesReportsHashRole.Name), "Property is required for class RolesReportsHashRole.");
+                throw new JsonException("Cannot write null property RolesReportsHashRole.Name to non-nullable JSON property 'name'.");
 
             if (rolesReportsHashRole.NameOption.IsSet)
                 writer.WriteString("name", rolesReportsHashRole.Name);

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
@@ -192,12 +192,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ScaleneTriangle scaleneTriangle, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (scaleneTriangle.ShapeType == null)
-                throw new ArgumentNullException(nameof(scaleneTriangle.ShapeType), "Property is required for class ScaleneTriangle.");
-
-            if (scaleneTriangle.TriangleType == null)
-                throw new ArgumentNullException(nameof(scaleneTriangle.TriangleType), "Property is required for class ScaleneTriangle.");
-
             writer.WriteString("shapeType", scaleneTriangle.ShapeType);
 
             writer.WriteString("triangleType", scaleneTriangle.TriangleType);

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ShapeInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ShapeInterface.cs
@@ -173,9 +173,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ShapeInterface shapeInterface, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (shapeInterface.ShapeType == null)
-                throw new ArgumentNullException(nameof(shapeInterface.ShapeType), "Property is required for class ShapeInterface.");
-
             writer.WriteString("shapeType", shapeInterface.ShapeType);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
@@ -192,12 +192,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, SimpleQuadrilateral simpleQuadrilateral, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (simpleQuadrilateral.QuadrilateralType == null)
-                throw new ArgumentNullException(nameof(simpleQuadrilateral.QuadrilateralType), "Property is required for class SimpleQuadrilateral.");
-
-            if (simpleQuadrilateral.ShapeType == null)
-                throw new ArgumentNullException(nameof(simpleQuadrilateral.ShapeType), "Property is required for class SimpleQuadrilateral.");
-
             writer.WriteString("quadrilateralType", simpleQuadrilateral.QuadrilateralType);
 
             writer.WriteString("shapeType", simpleQuadrilateral.ShapeType);

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -203,6 +203,9 @@ namespace Org.OpenAPITools.Model
             if (specialModelName.VarSpecialModelNameOption.IsSet && specialModelName.VarSpecialModelName == null)
                 throw new JsonException("Cannot write null property SpecialModelName.VarSpecialModelName to non-nullable JSON property '_special_model.name_'.");
 
+            if (specialModelName.SpecialPropertyNameOption.IsSet && specialModelName.SpecialPropertyName == null)
+                throw new JsonException("Cannot write null property SpecialModelName.SpecialPropertyName to non-nullable JSON property '$special[property.name]'.");
+
             if (specialModelName.VarSpecialModelNameOption.IsSet)
                 writer.WriteString("_special_model.name_", specialModelName.VarSpecialModelName);
 

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -201,7 +201,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, SpecialModelName specialModelName, JsonSerializerOptions jsonSerializerOptions)
         {
             if (specialModelName.VarSpecialModelNameOption.IsSet && specialModelName.VarSpecialModelName == null)
-                throw new ArgumentNullException(nameof(specialModelName.VarSpecialModelName), "Property is required for class SpecialModelName.");
+                throw new JsonException("Cannot write null property SpecialModelName.VarSpecialModelName to non-nullable JSON property '_special_model.name_'.");
 
             if (specialModelName.VarSpecialModelNameOption.IsSet)
                 writer.WriteString("_special_model.name_", specialModelName.VarSpecialModelName);

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Tag.cs
@@ -200,6 +200,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Tag tag, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (tag.IdOption.IsSet && tag.Id == null)
+                throw new JsonException("Cannot write null property Tag.Id to non-nullable JSON property 'id'.");
+
             if (tag.NameOption.IsSet && tag.Name == null)
                 throw new JsonException("Cannot write null property Tag.Name to non-nullable JSON property 'name'.");
 

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Tag.cs
@@ -201,7 +201,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Tag tag, JsonSerializerOptions jsonSerializerOptions)
         {
             if (tag.NameOption.IsSet && tag.Name == null)
-                throw new ArgumentNullException(nameof(tag.Name), "Property is required for class Tag.");
+                throw new JsonException("Cannot write null property Tag.Name to non-nullable JSON property 'name'.");
 
             if (tag.IdOption.IsSet)
                 writer.WriteNumber("id", tag.IdOption.Value!.Value);

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -178,7 +178,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestCollectionEndingWithWordList testCollectionEndingWithWordList, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testCollectionEndingWithWordList.ValueOption.IsSet && testCollectionEndingWithWordList.Value == null)
-                throw new ArgumentNullException(nameof(testCollectionEndingWithWordList.Value), "Property is required for class TestCollectionEndingWithWordList.");
+                throw new JsonException("Cannot write null property TestCollectionEndingWithWordList.Value to non-nullable JSON property 'value'.");
 
             if (testCollectionEndingWithWordList.ValueOption.IsSet)
                 writer.WriteString("value", testCollectionEndingWithWordList.Value);

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -178,7 +178,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestCollectionEndingWithWordListObject testCollectionEndingWithWordListObject, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testCollectionEndingWithWordListObject.TestCollectionEndingWithWordListOption.IsSet && testCollectionEndingWithWordListObject.TestCollectionEndingWithWordList == null)
-                throw new ArgumentNullException(nameof(testCollectionEndingWithWordListObject.TestCollectionEndingWithWordList), "Property is required for class TestCollectionEndingWithWordListObject.");
+                throw new JsonException("Cannot write null property TestCollectionEndingWithWordListObject.TestCollectionEndingWithWordList to non-nullable JSON property 'TestCollectionEndingWithWordList'.");
 
             if (testCollectionEndingWithWordListObject.TestCollectionEndingWithWordListOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/TestDescendants.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/TestDescendants.cs
@@ -292,9 +292,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, TestDescendants testDescendants, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (testDescendants.AlternativeName == null)
-                throw new ArgumentNullException(nameof(testDescendants.AlternativeName), "Property is required for class TestDescendants.");
-
             writer.WriteString("alternativeName", testDescendants.AlternativeName);
 
             writer.WriteString("objectType", TestDescendants.ObjectTypeEnumToJsonValue(testDescendants.ObjectType));

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
@@ -178,7 +178,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestInlineFreeformAdditionalPropertiesRequest testInlineFreeformAdditionalPropertiesRequest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testInlineFreeformAdditionalPropertiesRequest.SomePropertyOption.IsSet && testInlineFreeformAdditionalPropertiesRequest.SomeProperty == null)
-                throw new ArgumentNullException(nameof(testInlineFreeformAdditionalPropertiesRequest.SomeProperty), "Property is required for class TestInlineFreeformAdditionalPropertiesRequest.");
+                throw new JsonException("Cannot write null property TestInlineFreeformAdditionalPropertiesRequest.SomeProperty to non-nullable JSON property 'someProperty'.");
 
             if (testInlineFreeformAdditionalPropertiesRequest.SomePropertyOption.IsSet)
                 writer.WriteString("someProperty", testInlineFreeformAdditionalPropertiesRequest.SomeProperty);

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/TestResult.cs
@@ -225,6 +225,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, TestResult testResult, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (testResult.CodeOption.IsSet && testResult.Code == null)
+                throw new JsonException("Cannot write null property TestResult.Code to non-nullable JSON property 'code'.");
+
             if (testResult.DataOption.IsSet && testResult.Data == null)
                 throw new JsonException("Cannot write null property TestResult.Data to non-nullable JSON property 'data'.");
 

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/TestResult.cs
@@ -226,10 +226,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestResult testResult, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testResult.DataOption.IsSet && testResult.Data == null)
-                throw new ArgumentNullException(nameof(testResult.Data), "Property is required for class TestResult.");
+                throw new JsonException("Cannot write null property TestResult.Data to non-nullable JSON property 'data'.");
 
             if (testResult.UuidOption.IsSet && testResult.Uuid == null)
-                throw new ArgumentNullException(nameof(testResult.Uuid), "Property is required for class TestResult.");
+                throw new JsonException("Cannot write null property TestResult.Uuid to non-nullable JSON property 'uuid'.");
 
             if (testResult.CodeOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/TriangleInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/TriangleInterface.cs
@@ -173,9 +173,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, TriangleInterface triangleInterface, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (triangleInterface.TriangleType == null)
-                throw new ArgumentNullException(nameof(triangleInterface.TriangleType), "Property is required for class TriangleInterface.");
-
             writer.WriteString("triangleType", triangleInterface.TriangleType);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/User.cs
@@ -427,25 +427,25 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, User user, JsonSerializerOptions jsonSerializerOptions)
         {
             if (user.EmailOption.IsSet && user.Email == null)
-                throw new ArgumentNullException(nameof(user.Email), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Email to non-nullable JSON property 'email'.");
 
             if (user.FirstNameOption.IsSet && user.FirstName == null)
-                throw new ArgumentNullException(nameof(user.FirstName), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.FirstName to non-nullable JSON property 'firstName'.");
 
             if (user.LastNameOption.IsSet && user.LastName == null)
-                throw new ArgumentNullException(nameof(user.LastName), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.LastName to non-nullable JSON property 'lastName'.");
 
             if (user.ObjectWithNoDeclaredPropsOption.IsSet && user.ObjectWithNoDeclaredProps == null)
-                throw new ArgumentNullException(nameof(user.ObjectWithNoDeclaredProps), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.ObjectWithNoDeclaredProps to non-nullable JSON property 'objectWithNoDeclaredProps'.");
 
             if (user.PasswordOption.IsSet && user.Password == null)
-                throw new ArgumentNullException(nameof(user.Password), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Password to non-nullable JSON property 'password'.");
 
             if (user.PhoneOption.IsSet && user.Phone == null)
-                throw new ArgumentNullException(nameof(user.Phone), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Phone to non-nullable JSON property 'phone'.");
 
             if (user.UsernameOption.IsSet && user.Username == null)
-                throw new ArgumentNullException(nameof(user.Username), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Username to non-nullable JSON property 'username'.");
 
             if (user.AnyTypePropOption.IsSet)
                 if (user.AnyTypePropOption.Value != null)

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/User.cs
@@ -432,6 +432,9 @@ namespace Org.OpenAPITools.Model
             if (user.FirstNameOption.IsSet && user.FirstName == null)
                 throw new JsonException("Cannot write null property User.FirstName to non-nullable JSON property 'firstName'.");
 
+            if (user.IdOption.IsSet && user.Id == null)
+                throw new JsonException("Cannot write null property User.Id to non-nullable JSON property 'id'.");
+
             if (user.LastNameOption.IsSet && user.LastName == null)
                 throw new JsonException("Cannot write null property User.LastName to non-nullable JSON property 'lastName'.");
 
@@ -443,6 +446,9 @@ namespace Org.OpenAPITools.Model
 
             if (user.PhoneOption.IsSet && user.Phone == null)
                 throw new JsonException("Cannot write null property User.Phone to non-nullable JSON property 'phone'.");
+
+            if (user.UserStatusOption.IsSet && user.UserStatus == null)
+                throw new JsonException("Cannot write null property User.UserStatus to non-nullable JSON property 'userStatus'.");
 
             if (user.UsernameOption.IsSet && user.Username == null)
                 throw new JsonException("Cannot write null property User.Username to non-nullable JSON property 'username'.");

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Whale.cs
@@ -219,9 +219,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Whale whale, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (whale.ClassName == null)
-                throw new ArgumentNullException(nameof(whale.ClassName), "Property is required for class Whale.");
-
             writer.WriteString("className", whale.ClassName);
 
             if (whale.HasBaleenOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Whale.cs
@@ -219,6 +219,12 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Whale whale, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (whale.HasBaleenOption.IsSet && whale.HasBaleen == null)
+                throw new JsonException("Cannot write null property Whale.HasBaleen to non-nullable JSON property 'hasBaleen'.");
+
+            if (whale.HasTeethOption.IsSet && whale.HasTeeth == null)
+                throw new JsonException("Cannot write null property Whale.HasTeeth to non-nullable JSON property 'hasTeeth'.");
+
             writer.WriteString("className", whale.ClassName);
 
             if (whale.HasBaleenOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Zebra.cs
@@ -283,9 +283,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Zebra zebra, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (zebra.ClassName == null)
-                throw new ArgumentNullException(nameof(zebra.ClassName), "Property is required for class Zebra.");
-
             writer.WriteString("className", zebra.ClassName);
 
             var typeRawValue = Zebra.TypeEnumToJsonValue(zebra.TypeOption.Value!.Value);

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Zebra.cs
@@ -283,6 +283,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Zebra zebra, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (zebra.TypeOption.IsSet && zebra.Type == null)
+                throw new JsonException("Cannot write null property Zebra.Type to non-nullable JSON property 'type'.");
+
             writer.WriteString("className", zebra.ClassName);
 
             var typeRawValue = Zebra.TypeEnumToJsonValue(zebra.TypeOption.Value!.Value);

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
@@ -250,6 +250,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ZeroBasedEnumClass zeroBasedEnumClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (zeroBasedEnumClass.ZeroBasedEnumOption.IsSet && zeroBasedEnumClass.ZeroBasedEnum == null)
+                throw new JsonException("Cannot write null property ZeroBasedEnumClass.ZeroBasedEnum to non-nullable JSON property 'ZeroBasedEnum'.");
+
             var zeroBasedEnumRawValue = ZeroBasedEnumClass.ZeroBasedEnumEnumToJsonValue(zeroBasedEnumClass.ZeroBasedEnumOption.Value!.Value);
             writer.WriteString("ZeroBasedEnum", zeroBasedEnumRawValue);
         }

--- a/samples/client/petstore/csharp/generichost/net10/UseDateTimeForDate/src/Org.OpenAPITools/Model/NowGet200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net10/UseDateTimeForDate/src/Org.OpenAPITools/Model/NowGet200Response.cs
@@ -201,6 +201,12 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, NowGet200Response nowGet200Response, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (nowGet200Response.NowOption.IsSet && nowGet200Response.Now == null)
+                throw new JsonException("Cannot write null property NowGet200Response.Now to non-nullable JSON property 'now'.");
+
+            if (nowGet200Response.TodayOption.IsSet && nowGet200Response.Today == null)
+                throw new JsonException("Cannot write null property NowGet200Response.Today to non-nullable JSON property 'today'.");
+
             if (nowGet200Response.NowOption.IsSet)
                 writer.WriteString("now", nowGet200Response.NowOption.Value!.Value.ToString(NowFormat));
 

--- a/samples/client/petstore/csharp/generichost/net4.7/AllOf/src/Org.OpenAPITools/Model/Adult.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/AllOf/src/Org.OpenAPITools/Model/Adult.cs
@@ -182,13 +182,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Adult adult, JsonSerializerOptions jsonSerializerOptions)
         {
             if (adult.ChildrenOption.IsSet && adult.Children == null)
-                throw new ArgumentNullException(nameof(adult.Children), "Property is required for class Adult.");
+                throw new JsonException("Cannot write null property Adult.Children to non-nullable JSON property 'children'.");
 
             if (adult.FirstNameOption.IsSet && adult.FirstName == null)
-                throw new ArgumentNullException(nameof(adult.FirstName), "Property is required for class Adult.");
+                throw new JsonException("Cannot write null property Adult.FirstName to non-nullable JSON property 'firstName'.");
 
             if (adult.LastNameOption.IsSet && adult.LastName == null)
-                throw new ArgumentNullException(nameof(adult.LastName), "Property is required for class Adult.");
+                throw new JsonException("Cannot write null property Adult.LastName to non-nullable JSON property 'lastName'.");
 
             if (adult.ChildrenOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net4.7/AllOf/src/Org.OpenAPITools/Model/Child.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/AllOf/src/Org.OpenAPITools/Model/Child.cs
@@ -205,10 +205,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Child child, JsonSerializerOptions jsonSerializerOptions)
         {
             if (child.FirstNameOption.IsSet && child.FirstName == null)
-                throw new ArgumentNullException(nameof(child.FirstName), "Property is required for class Child.");
+                throw new JsonException("Cannot write null property Child.FirstName to non-nullable JSON property 'firstName'.");
 
             if (child.LastNameOption.IsSet && child.LastName == null)
-                throw new ArgumentNullException(nameof(child.LastName), "Property is required for class Child.");
+                throw new JsonException("Cannot write null property Child.LastName to non-nullable JSON property 'lastName'.");
 
             if (child.AgeOption.IsSet)
                 writer.WriteNumber("age", child.AgeOption.Value.Value);

--- a/samples/client/petstore/csharp/generichost/net4.7/AllOf/src/Org.OpenAPITools/Model/Child.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/AllOf/src/Org.OpenAPITools/Model/Child.cs
@@ -204,6 +204,12 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Child child, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (child.AgeOption.IsSet && child.Age == null)
+                throw new JsonException("Cannot write null property Child.Age to non-nullable JSON property 'age'.");
+
+            if (child.BoosterSeatOption.IsSet && child.BoosterSeat == null)
+                throw new JsonException("Cannot write null property Child.BoosterSeat to non-nullable JSON property 'boosterSeat'.");
+
             if (child.FirstNameOption.IsSet && child.FirstName == null)
                 throw new JsonException("Cannot write null property Child.FirstName to non-nullable JSON property 'firstName'.");
 

--- a/samples/client/petstore/csharp/generichost/net4.7/AllOf/src/Org.OpenAPITools/Model/Person.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/AllOf/src/Org.OpenAPITools/Model/Person.cs
@@ -241,10 +241,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Person person, JsonSerializerOptions jsonSerializerOptions)
         {
             if (person.FirstNameOption.IsSet && person.FirstName == null)
-                throw new ArgumentNullException(nameof(person.FirstName), "Property is required for class Person.");
+                throw new JsonException("Cannot write null property Person.FirstName to non-nullable JSON property 'firstName'.");
 
             if (person.LastNameOption.IsSet && person.LastName == null)
-                throw new ArgumentNullException(nameof(person.LastName), "Property is required for class Person.");
+                throw new JsonException("Cannot write null property Person.LastName to non-nullable JSON property 'lastName'.");
 
             if (person.FirstNameOption.IsSet)
                 writer.WriteString("firstName", person.FirstName);

--- a/samples/client/petstore/csharp/generichost/net4.7/AnyOf/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/AnyOf/src/Org.OpenAPITools/Model/Apple.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Apple apple, JsonSerializerOptions jsonSerializerOptions)
         {
             if (apple.KindOption.IsSet && apple.Kind == null)
-                throw new ArgumentNullException(nameof(apple.Kind), "Property is required for class Apple.");
+                throw new JsonException("Cannot write null property Apple.Kind to non-nullable JSON property 'kind'.");
 
             if (apple.KindOption.IsSet)
                 writer.WriteString("kind", apple.Kind);

--- a/samples/client/petstore/csharp/generichost/net4.7/AnyOf/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/AnyOf/src/Org.OpenAPITools/Model/Banana.cs
@@ -174,6 +174,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Banana banana, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (banana.CountOption.IsSet && banana.Count == null)
+                throw new JsonException("Cannot write null property Banana.Count to non-nullable JSON property 'count'.");
+
             if (banana.CountOption.IsSet)
                 writer.WriteNumber("count", banana.CountOption.Value.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/AnyOf/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/AnyOf/src/Org.OpenAPITools/Model/Fruit.cs
@@ -243,7 +243,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Fruit fruit, JsonSerializerOptions jsonSerializerOptions)
         {
             if (fruit.ColorOption.IsSet && fruit.Color == null)
-                throw new ArgumentNullException(nameof(fruit.Color), "Property is required for class Fruit.");
+                throw new JsonException("Cannot write null property Fruit.Color to non-nullable JSON property 'color'.");
 
             if (fruit.ColorOption.IsSet)
                 writer.WriteString("color", fruit.Color);

--- a/samples/client/petstore/csharp/generichost/net4.7/AnyOfNoCompare/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/AnyOfNoCompare/src/Org.OpenAPITools/Model/Apple.cs
@@ -174,7 +174,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Apple apple, JsonSerializerOptions jsonSerializerOptions)
         {
             if (apple.KindOption.IsSet && apple.Kind == null)
-                throw new ArgumentNullException(nameof(apple.Kind), "Property is required for class Apple.");
+                throw new JsonException("Cannot write null property Apple.Kind to non-nullable JSON property 'kind'.");
 
             if (apple.KindOption.IsSet)
                 writer.WriteString("kind", apple.Kind);

--- a/samples/client/petstore/csharp/generichost/net4.7/AnyOfNoCompare/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/AnyOfNoCompare/src/Org.OpenAPITools/Model/Banana.cs
@@ -173,6 +173,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Banana banana, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (banana.CountOption.IsSet && banana.Count == null)
+                throw new JsonException("Cannot write null property Banana.Count to non-nullable JSON property 'count'.");
+
             if (banana.CountOption.IsSet)
                 writer.WriteNumber("count", banana.CountOption.Value.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/AnyOfNoCompare/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/AnyOfNoCompare/src/Org.OpenAPITools/Model/Fruit.cs
@@ -242,7 +242,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Fruit fruit, JsonSerializerOptions jsonSerializerOptions)
         {
             if (fruit.ColorOption.IsSet && fruit.Color == null)
-                throw new ArgumentNullException(nameof(fruit.Color), "Property is required for class Fruit.");
+                throw new JsonException("Cannot write null property Fruit.Color to non-nullable JSON property 'color'.");
 
             if (fruit.ColorOption.IsSet)
                 writer.WriteString("color", fruit.Color);

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Activity.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Activity activity, JsonSerializerOptions jsonSerializerOptions)
         {
             if (activity.ActivityOutputsOption.IsSet && activity.ActivityOutputs == null)
-                throw new ArgumentNullException(nameof(activity.ActivityOutputs), "Property is required for class Activity.");
+                throw new JsonException("Cannot write null property Activity.ActivityOutputs to non-nullable JSON property 'activity_outputs'.");
 
             if (activity.ActivityOutputsOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -198,10 +198,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ActivityOutputElementRepresentation activityOutputElementRepresentation, JsonSerializerOptions jsonSerializerOptions)
         {
             if (activityOutputElementRepresentation.Prop1Option.IsSet && activityOutputElementRepresentation.Prop1 == null)
-                throw new ArgumentNullException(nameof(activityOutputElementRepresentation.Prop1), "Property is required for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Cannot write null property ActivityOutputElementRepresentation.Prop1 to non-nullable JSON property 'prop1'.");
 
             if (activityOutputElementRepresentation.Prop2Option.IsSet && activityOutputElementRepresentation.Prop2 == null)
-                throw new ArgumentNullException(nameof(activityOutputElementRepresentation.Prop2), "Property is required for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Cannot write null property ActivityOutputElementRepresentation.Prop2 to non-nullable JSON property 'prop2'.");
 
             if (activityOutputElementRepresentation.Prop1Option.IsSet)
                 writer.WriteString("prop1", activityOutputElementRepresentation.Prop1);

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -334,25 +334,25 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, AdditionalPropertiesClass additionalPropertiesClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (additionalPropertiesClass.EmptyMapOption.IsSet && additionalPropertiesClass.EmptyMap == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.EmptyMap), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.EmptyMap to non-nullable JSON property 'empty_map'.");
 
             if (additionalPropertiesClass.MapOfMapPropertyOption.IsSet && additionalPropertiesClass.MapOfMapProperty == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapOfMapProperty), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapOfMapProperty to non-nullable JSON property 'map_of_map_property'.");
 
             if (additionalPropertiesClass.MapPropertyOption.IsSet && additionalPropertiesClass.MapProperty == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapProperty), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapProperty to non-nullable JSON property 'map_property'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1Option.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1 == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1 to non-nullable JSON property 'map_with_undeclared_properties_anytype_1'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2Option.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2 == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2 to non-nullable JSON property 'map_with_undeclared_properties_anytype_2'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3Option.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3 == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3 to non-nullable JSON property 'map_with_undeclared_properties_anytype_3'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesStringOption.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesString == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesString), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesString to non-nullable JSON property 'map_with_undeclared_properties_string'.");
 
             if (additionalPropertiesClass.Anytype1Option.IsSet)
                 if (additionalPropertiesClass.Anytype1Option.Value != null)

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Animal.cs
@@ -221,7 +221,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Animal animal, JsonSerializerOptions jsonSerializerOptions)
         {
             if (animal.ColorOption.IsSet && animal.Color == null)
-                throw new ArgumentNullException(nameof(animal.Color), "Property is required for class Animal.");
+                throw new JsonException("Cannot write null property Animal.Color to non-nullable JSON property 'color'.");
 
             writer.WriteString("className", animal.ClassName);
 

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -221,10 +221,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ApiResponse apiResponse, JsonSerializerOptions jsonSerializerOptions)
         {
             if (apiResponse.MessageOption.IsSet && apiResponse.Message == null)
-                throw new ArgumentNullException(nameof(apiResponse.Message), "Property is required for class ApiResponse.");
+                throw new JsonException("Cannot write null property ApiResponse.Message to non-nullable JSON property 'message'.");
 
             if (apiResponse.TypeOption.IsSet && apiResponse.Type == null)
-                throw new ArgumentNullException(nameof(apiResponse.Type), "Property is required for class ApiResponse.");
+                throw new JsonException("Cannot write null property ApiResponse.Type to non-nullable JSON property 'type'.");
 
             if (apiResponse.CodeOption.IsSet)
                 writer.WriteNumber("code", apiResponse.CodeOption.Value.Value);

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -220,6 +220,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ApiResponse apiResponse, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (apiResponse.CodeOption.IsSet && apiResponse.Code == null)
+                throw new JsonException("Cannot write null property ApiResponse.Code to non-nullable JSON property 'code'.");
+
             if (apiResponse.MessageOption.IsSet && apiResponse.Message == null)
                 throw new JsonException("Cannot write null property ApiResponse.Message to non-nullable JSON property 'message'.");
 

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Apple.cs
@@ -251,13 +251,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Apple apple, JsonSerializerOptions jsonSerializerOptions)
         {
             if (apple.ColorCodeOption.IsSet && apple.ColorCode == null)
-                throw new ArgumentNullException(nameof(apple.ColorCode), "Property is required for class Apple.");
+                throw new JsonException("Cannot write null property Apple.ColorCode to non-nullable JSON property 'color_code'.");
 
             if (apple.CultivarOption.IsSet && apple.Cultivar == null)
-                throw new ArgumentNullException(nameof(apple.Cultivar), "Property is required for class Apple.");
+                throw new JsonException("Cannot write null property Apple.Cultivar to non-nullable JSON property 'cultivar'.");
 
             if (apple.OriginOption.IsSet && apple.Origin == null)
-                throw new ArgumentNullException(nameof(apple.Origin), "Property is required for class Apple.");
+                throw new JsonException("Cannot write null property Apple.Origin to non-nullable JSON property 'origin'.");
 
             if (apple.ColorCodeOption.IsSet)
                 writer.WriteString("color_code", apple.ColorCode);

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -186,9 +186,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, AppleReq appleReq, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (appleReq.Cultivar == null)
-                throw new ArgumentNullException(nameof(appleReq.Cultivar), "Property is required for class AppleReq.");
-
             writer.WriteString("cultivar", appleReq.Cultivar);
 
             if (appleReq.MealyOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -186,6 +186,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, AppleReq appleReq, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (appleReq.MealyOption.IsSet && appleReq.Mealy == null)
+                throw new JsonException("Cannot write null property AppleReq.Mealy to non-nullable JSON property 'mealy'.");
+
             writer.WriteString("cultivar", appleReq.Cultivar);
 
             if (appleReq.MealyOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ArrayOfArrayOfNumberOnly arrayOfArrayOfNumberOnly, JsonSerializerOptions jsonSerializerOptions)
         {
             if (arrayOfArrayOfNumberOnly.ArrayArrayNumberOption.IsSet && arrayOfArrayOfNumberOnly.ArrayArrayNumber == null)
-                throw new ArgumentNullException(nameof(arrayOfArrayOfNumberOnly.ArrayArrayNumber), "Property is required for class ArrayOfArrayOfNumberOnly.");
+                throw new JsonException("Cannot write null property ArrayOfArrayOfNumberOnly.ArrayArrayNumber to non-nullable JSON property 'ArrayArrayNumber'.");
 
             if (arrayOfArrayOfNumberOnly.ArrayArrayNumberOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ArrayOfNumberOnly arrayOfNumberOnly, JsonSerializerOptions jsonSerializerOptions)
         {
             if (arrayOfNumberOnly.ArrayNumberOption.IsSet && arrayOfNumberOnly.ArrayNumber == null)
-                throw new ArgumentNullException(nameof(arrayOfNumberOnly.ArrayNumber), "Property is required for class ArrayOfNumberOnly.");
+                throw new JsonException("Cannot write null property ArrayOfNumberOnly.ArrayNumber to non-nullable JSON property 'ArrayNumber'.");
 
             if (arrayOfNumberOnly.ArrayNumberOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -221,13 +221,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ArrayTest arrayTest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (arrayTest.ArrayArrayOfIntegerOption.IsSet && arrayTest.ArrayArrayOfInteger == null)
-                throw new ArgumentNullException(nameof(arrayTest.ArrayArrayOfInteger), "Property is required for class ArrayTest.");
+                throw new JsonException("Cannot write null property ArrayTest.ArrayArrayOfInteger to non-nullable JSON property 'array_array_of_integer'.");
 
             if (arrayTest.ArrayArrayOfModelOption.IsSet && arrayTest.ArrayArrayOfModel == null)
-                throw new ArgumentNullException(nameof(arrayTest.ArrayArrayOfModel), "Property is required for class ArrayTest.");
+                throw new JsonException("Cannot write null property ArrayTest.ArrayArrayOfModel to non-nullable JSON property 'array_array_of_model'.");
 
             if (arrayTest.ArrayOfStringOption.IsSet && arrayTest.ArrayOfString == null)
-                throw new ArgumentNullException(nameof(arrayTest.ArrayOfString), "Property is required for class ArrayTest.");
+                throw new JsonException("Cannot write null property ArrayTest.ArrayOfString to non-nullable JSON property 'array_of_string'.");
 
             if (arrayTest.ArrayArrayOfIntegerOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Banana.cs
@@ -174,6 +174,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Banana banana, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (banana.LengthCmOption.IsSet && banana.LengthCm == null)
+                throw new JsonException("Cannot write null property Banana.LengthCm to non-nullable JSON property 'lengthCm'.");
+
             if (banana.LengthCmOption.IsSet)
                 writer.WriteNumber("lengthCm", banana.LengthCmOption.Value.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -186,6 +186,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, BananaReq bananaReq, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (bananaReq.SweetOption.IsSet && bananaReq.Sweet == null)
+                throw new JsonException("Cannot write null property BananaReq.Sweet to non-nullable JSON property 'sweet'.");
+
             writer.WriteNumber("lengthCm", bananaReq.LengthCm);
 
             if (bananaReq.SweetOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/BasquePig.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/BasquePig.cs
@@ -170,9 +170,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, BasquePig basquePig, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (basquePig.ClassName == null)
-                throw new ArgumentNullException(nameof(basquePig.ClassName), "Property is required for class BasquePig.");
-
             writer.WriteString("className", basquePig.ClassName);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -291,22 +291,22 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Capitalization capitalization, JsonSerializerOptions jsonSerializerOptions)
         {
             if (capitalization.ATT_NAMEOption.IsSet && capitalization.ATT_NAME == null)
-                throw new ArgumentNullException(nameof(capitalization.ATT_NAME), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.ATT_NAME to non-nullable JSON property 'ATT_NAME'.");
 
             if (capitalization.CapitalCamelOption.IsSet && capitalization.CapitalCamel == null)
-                throw new ArgumentNullException(nameof(capitalization.CapitalCamel), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.CapitalCamel to non-nullable JSON property 'CapitalCamel'.");
 
             if (capitalization.CapitalSnakeOption.IsSet && capitalization.CapitalSnake == null)
-                throw new ArgumentNullException(nameof(capitalization.CapitalSnake), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.CapitalSnake to non-nullable JSON property 'Capital_Snake'.");
 
             if (capitalization.SCAETHFlowPointsOption.IsSet && capitalization.SCAETHFlowPoints == null)
-                throw new ArgumentNullException(nameof(capitalization.SCAETHFlowPoints), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.SCAETHFlowPoints to non-nullable JSON property 'SCA_ETH_Flow_Points'.");
 
             if (capitalization.SmallCamelOption.IsSet && capitalization.SmallCamel == null)
-                throw new ArgumentNullException(nameof(capitalization.SmallCamel), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.SmallCamel to non-nullable JSON property 'smallCamel'.");
 
             if (capitalization.SmallSnakeOption.IsSet && capitalization.SmallSnake == null)
-                throw new ArgumentNullException(nameof(capitalization.SmallSnake), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.SmallSnake to non-nullable JSON property 'small_Snake'.");
 
             if (capitalization.ATT_NAMEOption.IsSet)
                 writer.WriteString("ATT_NAME", capitalization.ATT_NAME);

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Cat.cs
@@ -179,6 +179,9 @@ namespace Org.OpenAPITools.Model
             if (cat.ColorOption.IsSet && cat.Color == null)
                 throw new JsonException("Cannot write null property Cat.Color to non-nullable JSON property 'color'.");
 
+            if (cat.DeclawedOption.IsSet && cat.Declawed == null)
+                throw new JsonException("Cannot write null property Cat.Declawed to non-nullable JSON property 'declawed'.");
+
             writer.WriteString("className", cat.ClassName);
 
             if (cat.ColorOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Cat.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Cat cat, JsonSerializerOptions jsonSerializerOptions)
         {
             if (cat.ColorOption.IsSet && cat.Color == null)
-                throw new ArgumentNullException(nameof(cat.Color), "Property is required for class Cat.");
+                throw new JsonException("Cannot write null property Cat.Color to non-nullable JSON property 'color'.");
 
             writer.WriteString("className", cat.ClassName);
 

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Category.cs
@@ -193,9 +193,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Category category, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (category.Name == null)
-                throw new ArgumentNullException(nameof(category.Name), "Property is required for class Category.");
-
             if (category.IdOption.IsSet)
                 writer.WriteNumber("id", category.IdOption.Value.Value);
 

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Category.cs
@@ -193,6 +193,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Category category, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (category.IdOption.IsSet && category.Id == null)
+                throw new JsonException("Cannot write null property Category.Id to non-nullable JSON property 'id'.");
+
             if (category.IdOption.IsSet)
                 writer.WriteNumber("id", category.IdOption.Value.Value);
 

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ChildCat childCat, JsonSerializerOptions jsonSerializerOptions)
         {
             if (childCat.NameOption.IsSet && childCat.Name == null)
-                throw new ArgumentNullException(nameof(childCat.Name), "Property is required for class ChildCat.");
+                throw new JsonException("Cannot write null property ChildCat.Name to non-nullable JSON property 'name'.");
 
             writer.WriteString("pet_type", ChildCatAllOfPetTypeValueConverter.ToJsonValue(childCat.PetType));
 

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ClassModel classModel, JsonSerializerOptions jsonSerializerOptions)
         {
             if (classModel.ClassOption.IsSet && classModel.Class == null)
-                throw new ArgumentNullException(nameof(classModel.Class), "Property is required for class ClassModel.");
+                throw new JsonException("Cannot write null property ClassModel.Class to non-nullable JSON property '_class'.");
 
             if (classModel.ClassOption.IsSet)
                 writer.WriteString("_class", classModel.Class);

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
@@ -189,12 +189,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ComplexQuadrilateral complexQuadrilateral, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (complexQuadrilateral.QuadrilateralType == null)
-                throw new ArgumentNullException(nameof(complexQuadrilateral.QuadrilateralType), "Property is required for class ComplexQuadrilateral.");
-
-            if (complexQuadrilateral.ShapeType == null)
-                throw new ArgumentNullException(nameof(complexQuadrilateral.ShapeType), "Property is required for class ComplexQuadrilateral.");
-
             writer.WriteString("quadrilateralType", complexQuadrilateral.QuadrilateralType);
 
             writer.WriteString("shapeType", complexQuadrilateral.ShapeType);

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/CopyActivity.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/CopyActivity.cs
@@ -172,9 +172,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, CopyActivity copyActivity, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (copyActivity.CopyActivitytt == null)
-                throw new ArgumentNullException(nameof(copyActivity.CopyActivitytt), "Property is required for class CopyActivity.");
-
             writer.WriteString("copyActivitytt", copyActivity.CopyActivitytt);
 
             writer.WriteString("$schema", CopyActivityAllOfSchemaValueConverter.ToJsonValue(copyActivity.Schema));

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/DanishPig.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/DanishPig.cs
@@ -170,9 +170,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, DanishPig danishPig, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (danishPig.ClassName == null)
-                throw new ArgumentNullException(nameof(danishPig.ClassName), "Property is required for class DanishPig.");
-
             writer.WriteString("className", danishPig.ClassName);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -180,6 +180,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, DateOnlyClass dateOnlyClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (dateOnlyClass.DateOnlyPropertyOption.IsSet && dateOnlyClass.DateOnlyProperty == null)
+                throw new JsonException("Cannot write null property DateOnlyClass.DateOnlyProperty to non-nullable JSON property 'dateOnlyProperty'.");
+
             if (dateOnlyClass.DateOnlyPropertyOption.IsSet)
                 writer.WriteString("dateOnlyProperty", dateOnlyClass.DateOnlyPropertyOption.Value.Value.ToString(DateOnlyPropertyFormat));
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, DeprecatedObject deprecatedObject, JsonSerializerOptions jsonSerializerOptions)
         {
             if (deprecatedObject.NameOption.IsSet && deprecatedObject.Name == null)
-                throw new ArgumentNullException(nameof(deprecatedObject.Name), "Property is required for class DeprecatedObject.");
+                throw new JsonException("Cannot write null property DeprecatedObject.Name to non-nullable JSON property 'name'.");
 
             if (deprecatedObject.NameOption.IsSet)
                 writer.WriteString("name", deprecatedObject.Name);

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Descendant1.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Descendant1.cs
@@ -175,12 +175,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Descendant1 descendant1, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (descendant1.AlternativeName == null)
-                throw new ArgumentNullException(nameof(descendant1.AlternativeName), "Property is required for class Descendant1.");
-
-            if (descendant1.DescendantName == null)
-                throw new ArgumentNullException(nameof(descendant1.DescendantName), "Property is required for class Descendant1.");
-
             writer.WriteString("alternativeName", descendant1.AlternativeName);
 
             writer.WriteString("descendantName", descendant1.DescendantName);

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Descendant2.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Descendant2.cs
@@ -175,12 +175,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Descendant2 descendant2, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (descendant2.AlternativeName == null)
-                throw new ArgumentNullException(nameof(descendant2.AlternativeName), "Property is required for class Descendant2.");
-
-            if (descendant2.Confidentiality == null)
-                throw new ArgumentNullException(nameof(descendant2.Confidentiality), "Property is required for class Descendant2.");
-
             writer.WriteString("alternativeName", descendant2.AlternativeName);
 
             writer.WriteString("confidentiality", descendant2.Confidentiality);

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Dog.cs
@@ -177,10 +177,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Dog dog, JsonSerializerOptions jsonSerializerOptions)
         {
             if (dog.BreedOption.IsSet && dog.Breed == null)
-                throw new ArgumentNullException(nameof(dog.Breed), "Property is required for class Dog.");
+                throw new JsonException("Cannot write null property Dog.Breed to non-nullable JSON property 'breed'.");
 
             if (dog.ColorOption.IsSet && dog.Color == null)
-                throw new ArgumentNullException(nameof(dog.Color), "Property is required for class Dog.");
+                throw new JsonException("Cannot write null property Dog.Color to non-nullable JSON property 'color'.");
 
             writer.WriteString("className", dog.ClassName);
 

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Drawing.cs
@@ -238,10 +238,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Drawing drawing, JsonSerializerOptions jsonSerializerOptions)
         {
             if (drawing.MainShapeOption.IsSet && drawing.MainShape == null)
-                throw new ArgumentNullException(nameof(drawing.MainShape), "Property is required for class Drawing.");
+                throw new JsonException("Cannot write null property Drawing.MainShape to non-nullable JSON property 'mainShape'.");
 
             if (drawing.ShapesOption.IsSet && drawing.Shapes == null)
-                throw new ArgumentNullException(nameof(drawing.Shapes), "Property is required for class Drawing.");
+                throw new JsonException("Cannot write null property Drawing.Shapes to non-nullable JSON property 'shapes'.");
 
             if (drawing.MainShapeOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -200,6 +200,9 @@ namespace Org.OpenAPITools.Model
             if (enumArrays.ArrayEnumOption.IsSet && enumArrays.ArrayEnum == null)
                 throw new JsonException("Cannot write null property EnumArrays.ArrayEnum to non-nullable JSON property 'array_enum'.");
 
+            if (enumArrays.JustSymbolOption.IsSet && enumArrays.JustSymbol == null)
+                throw new JsonException("Cannot write null property EnumArrays.JustSymbol to non-nullable JSON property 'just_symbol'.");
+
             if (enumArrays.ArrayEnumOption.IsSet)
             {
                 writer.WritePropertyName("array_enum");

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -198,7 +198,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, EnumArrays enumArrays, JsonSerializerOptions jsonSerializerOptions)
         {
             if (enumArrays.ArrayEnumOption.IsSet && enumArrays.ArrayEnum == null)
-                throw new ArgumentNullException(nameof(enumArrays.ArrayEnum), "Property is required for class EnumArrays.");
+                throw new JsonException("Cannot write null property EnumArrays.ArrayEnum to non-nullable JSON property 'array_enum'.");
 
             if (enumArrays.ArrayEnumOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -351,6 +351,27 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, EnumTest enumTest, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (enumTest.EnumIntegerOption.IsSet && enumTest.EnumInteger == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumInteger to non-nullable JSON property 'enum_integer'.");
+
+            if (enumTest.EnumIntegerOnlyOption.IsSet && enumTest.EnumIntegerOnly == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumIntegerOnly to non-nullable JSON property 'enum_integer_only'.");
+
+            if (enumTest.EnumNumberOption.IsSet && enumTest.EnumNumber == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumNumber to non-nullable JSON property 'enum_number'.");
+
+            if (enumTest.EnumStringOption.IsSet && enumTest.EnumString == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumString to non-nullable JSON property 'enum_string'.");
+
+            if (enumTest.OuterEnumDefaultValueOption.IsSet && enumTest.OuterEnumDefaultValue == null)
+                throw new JsonException("Cannot write null property EnumTest.OuterEnumDefaultValue to non-nullable JSON property 'outerEnumDefaultValue'.");
+
+            if (enumTest.OuterEnumIntegerOption.IsSet && enumTest.OuterEnumInteger == null)
+                throw new JsonException("Cannot write null property EnumTest.OuterEnumInteger to non-nullable JSON property 'outerEnumInteger'.");
+
+            if (enumTest.OuterEnumIntegerDefaultValueOption.IsSet && enumTest.OuterEnumIntegerDefaultValue == null)
+                throw new JsonException("Cannot write null property EnumTest.OuterEnumIntegerDefaultValue to non-nullable JSON property 'outerEnumIntegerDefaultValue'.");
+
             var enumStringRequiredRawValue = EnumTestEnumStringValueConverter.ToJsonValue(enumTest.EnumStringRequired);
             writer.WriteString("enum_string_required", enumStringRequiredRawValue);
 

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
@@ -189,12 +189,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, EquilateralTriangle equilateralTriangle, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (equilateralTriangle.ShapeType == null)
-                throw new ArgumentNullException(nameof(equilateralTriangle.ShapeType), "Property is required for class EquilateralTriangle.");
-
-            if (equilateralTriangle.TriangleType == null)
-                throw new ArgumentNullException(nameof(equilateralTriangle.TriangleType), "Property is required for class EquilateralTriangle.");
-
             writer.WriteString("shapeType", equilateralTriangle.ShapeType);
 
             writer.WriteString("triangleType", equilateralTriangle.TriangleType);

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/File.cs
@@ -176,7 +176,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, File file, JsonSerializerOptions jsonSerializerOptions)
         {
             if (file.SourceURIOption.IsSet && file.SourceURI == null)
-                throw new ArgumentNullException(nameof(file.SourceURI), "Property is required for class File.");
+                throw new JsonException("Cannot write null property File.SourceURI to non-nullable JSON property 'sourceURI'.");
 
             if (file.SourceURIOption.IsSet)
                 writer.WriteString("sourceURI", file.SourceURI);

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -198,10 +198,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, FileSchemaTestClass fileSchemaTestClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (fileSchemaTestClass.FileOption.IsSet && fileSchemaTestClass.File == null)
-                throw new ArgumentNullException(nameof(fileSchemaTestClass.File), "Property is required for class FileSchemaTestClass.");
+                throw new JsonException("Cannot write null property FileSchemaTestClass.File to non-nullable JSON property 'file'.");
 
             if (fileSchemaTestClass.FilesOption.IsSet && fileSchemaTestClass.Files == null)
-                throw new ArgumentNullException(nameof(fileSchemaTestClass.Files), "Property is required for class FileSchemaTestClass.");
+                throw new JsonException("Cannot write null property FileSchemaTestClass.Files to non-nullable JSON property 'files'.");
 
             if (fileSchemaTestClass.FileOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Foo.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Foo foo, JsonSerializerOptions jsonSerializerOptions)
         {
             if (foo.BarOption.IsSet && foo.Bar == null)
-                throw new ArgumentNullException(nameof(foo.Bar), "Property is required for class Foo.");
+                throw new JsonException("Cannot write null property Foo.Bar to non-nullable JSON property 'bar'.");
 
             if (foo.BarOption.IsSet)
                 writer.WriteString("bar", foo.Bar);

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, FooGetDefaultResponse fooGetDefaultResponse, JsonSerializerOptions jsonSerializerOptions)
         {
             if (fooGetDefaultResponse.StringOption.IsSet && fooGetDefaultResponse.String == null)
-                throw new ArgumentNullException(nameof(fooGetDefaultResponse.String), "Property is required for class FooGetDefaultResponse.");
+                throw new JsonException("Cannot write null property FooGetDefaultResponse.String to non-nullable JSON property 'string'.");
 
             if (fooGetDefaultResponse.StringOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -954,11 +954,47 @@ namespace Org.OpenAPITools.Model
             if (formatTest.BinaryOption.IsSet && formatTest.Binary == null)
                 throw new JsonException("Cannot write null property FormatTest.Binary to non-nullable JSON property 'binary'.");
 
+            if (formatTest.DateTimeOption.IsSet && formatTest.DateTime == null)
+                throw new JsonException("Cannot write null property FormatTest.DateTime to non-nullable JSON property 'dateTime'.");
+
+            if (formatTest.DecimalOption.IsSet && formatTest.Decimal == null)
+                throw new JsonException("Cannot write null property FormatTest.Decimal to non-nullable JSON property 'decimal'.");
+
+            if (formatTest.DoubleOption.IsSet && formatTest.Double == null)
+                throw new JsonException("Cannot write null property FormatTest.Double to non-nullable JSON property 'double'.");
+
             if (formatTest.DuplicatePropertyName2Option.IsSet && formatTest.DuplicatePropertyName2 == null)
                 throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName2 to non-nullable JSON property 'duplicate_property_name'.");
 
             if (formatTest.DuplicatePropertyNameOption.IsSet && formatTest.DuplicatePropertyName == null)
                 throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName to non-nullable JSON property '@duplicate_property_name'.");
+
+            if (formatTest.FloatOption.IsSet && formatTest.Float == null)
+                throw new JsonException("Cannot write null property FormatTest.Float to non-nullable JSON property 'float'.");
+
+            if (formatTest.Int32Option.IsSet && formatTest.Int32 == null)
+                throw new JsonException("Cannot write null property FormatTest.Int32 to non-nullable JSON property 'int32'.");
+
+            if (formatTest.Int32RangeOption.IsSet && formatTest.Int32Range == null)
+                throw new JsonException("Cannot write null property FormatTest.Int32Range to non-nullable JSON property 'int32Range'.");
+
+            if (formatTest.Int64Option.IsSet && formatTest.Int64 == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64 to non-nullable JSON property 'int64'.");
+
+            if (formatTest.Int64NegativeOption.IsSet && formatTest.Int64Negative == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64Negative to non-nullable JSON property 'int64Negative'.");
+
+            if (formatTest.Int64NegativeExclusiveOption.IsSet && formatTest.Int64NegativeExclusive == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64NegativeExclusive to non-nullable JSON property 'int64NegativeExclusive'.");
+
+            if (formatTest.Int64PositiveOption.IsSet && formatTest.Int64Positive == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64Positive to non-nullable JSON property 'int64Positive'.");
+
+            if (formatTest.Int64PositiveExclusiveOption.IsSet && formatTest.Int64PositiveExclusive == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64PositiveExclusive to non-nullable JSON property 'int64PositiveExclusive'.");
+
+            if (formatTest.IntegerOption.IsSet && formatTest.Integer == null)
+                throw new JsonException("Cannot write null property FormatTest.Integer to non-nullable JSON property 'integer'.");
 
             if (formatTest.PatternWithBackslashOption.IsSet && formatTest.PatternWithBackslash == null)
                 throw new JsonException("Cannot write null property FormatTest.PatternWithBackslash to non-nullable JSON property 'pattern_with_backslash'.");
@@ -971,6 +1007,18 @@ namespace Org.OpenAPITools.Model
 
             if (formatTest.StringOption.IsSet && formatTest.String == null)
                 throw new JsonException("Cannot write null property FormatTest.String to non-nullable JSON property 'string'.");
+
+            if (formatTest.StringFormattedAsDecimalOption.IsSet && formatTest.StringFormattedAsDecimal == null)
+                throw new JsonException("Cannot write null property FormatTest.StringFormattedAsDecimal to non-nullable JSON property 'string_formatted_as_decimal'.");
+
+            if (formatTest.UnsignedIntegerOption.IsSet && formatTest.UnsignedInteger == null)
+                throw new JsonException("Cannot write null property FormatTest.UnsignedInteger to non-nullable JSON property 'unsigned_integer'.");
+
+            if (formatTest.UnsignedLongOption.IsSet && formatTest.UnsignedLong == null)
+                throw new JsonException("Cannot write null property FormatTest.UnsignedLong to non-nullable JSON property 'unsigned_long'.");
+
+            if (formatTest.UuidOption.IsSet && formatTest.Uuid == null)
+                throw new JsonException("Cannot write null property FormatTest.Uuid to non-nullable JSON property 'uuid'.");
 
             writer.WritePropertyName("byte");
             JsonSerializer.Serialize(writer, formatTest.Byte, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -951,32 +951,26 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, FormatTest formatTest, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (formatTest.Byte == null)
-                throw new ArgumentNullException(nameof(formatTest.Byte), "Property is required for class FormatTest.");
-
-            if (formatTest.Password == null)
-                throw new ArgumentNullException(nameof(formatTest.Password), "Property is required for class FormatTest.");
-
             if (formatTest.BinaryOption.IsSet && formatTest.Binary == null)
-                throw new ArgumentNullException(nameof(formatTest.Binary), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.Binary to non-nullable JSON property 'binary'.");
 
             if (formatTest.DuplicatePropertyName2Option.IsSet && formatTest.DuplicatePropertyName2 == null)
-                throw new ArgumentNullException(nameof(formatTest.DuplicatePropertyName2), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName2 to non-nullable JSON property 'duplicate_property_name'.");
 
             if (formatTest.DuplicatePropertyNameOption.IsSet && formatTest.DuplicatePropertyName == null)
-                throw new ArgumentNullException(nameof(formatTest.DuplicatePropertyName), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName to non-nullable JSON property '@duplicate_property_name'.");
 
             if (formatTest.PatternWithBackslashOption.IsSet && formatTest.PatternWithBackslash == null)
-                throw new ArgumentNullException(nameof(formatTest.PatternWithBackslash), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.PatternWithBackslash to non-nullable JSON property 'pattern_with_backslash'.");
 
             if (formatTest.PatternWithDigitsOption.IsSet && formatTest.PatternWithDigits == null)
-                throw new ArgumentNullException(nameof(formatTest.PatternWithDigits), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.PatternWithDigits to non-nullable JSON property 'pattern_with_digits'.");
 
             if (formatTest.PatternWithDigitsAndDelimiterOption.IsSet && formatTest.PatternWithDigitsAndDelimiter == null)
-                throw new ArgumentNullException(nameof(formatTest.PatternWithDigitsAndDelimiter), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.PatternWithDigitsAndDelimiter to non-nullable JSON property 'pattern_with_digits_and_delimiter'.");
 
             if (formatTest.StringOption.IsSet && formatTest.String == null)
-                throw new ArgumentNullException(nameof(formatTest.String), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.String to non-nullable JSON property 'string'.");
 
             writer.WritePropertyName("byte");
             JsonSerializer.Serialize(writer, formatTest.Byte, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Fruit.cs
@@ -219,7 +219,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Fruit fruit, JsonSerializerOptions jsonSerializerOptions)
         {
             if (fruit.ColorOption.IsSet && fruit.Color == null)
-                throw new ArgumentNullException(nameof(fruit.Color), "Property is required for class Fruit.");
+                throw new JsonException("Cannot write null property Fruit.Color to non-nullable JSON property 'color'.");
 
             if (fruit.ColorOption.IsSet)
                 writer.WriteString("color", fruit.Color);

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -236,7 +236,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, GmFruit gmFruit, JsonSerializerOptions jsonSerializerOptions)
         {
             if (gmFruit.ColorOption.IsSet && gmFruit.Color == null)
-                throw new ArgumentNullException(nameof(gmFruit.Color), "Property is required for class GmFruit.");
+                throw new JsonException("Cannot write null property GmFruit.Color to non-nullable JSON property 'color'.");
 
             if (gmFruit.ColorOption.IsSet)
                 writer.WriteString("color", gmFruit.Color);

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -239,10 +239,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, HasOnlyReadOnly hasOnlyReadOnly, JsonSerializerOptions jsonSerializerOptions)
         {
             if (hasOnlyReadOnly.BarOption.IsSet && hasOnlyReadOnly.Bar == null)
-                throw new ArgumentNullException(nameof(hasOnlyReadOnly.Bar), "Property is required for class HasOnlyReadOnly.");
+                throw new JsonException("Cannot write null property HasOnlyReadOnly.Bar to non-nullable JSON property 'bar'.");
 
             if (hasOnlyReadOnly.FooOption.IsSet && hasOnlyReadOnly.Foo == null)
-                throw new ArgumentNullException(nameof(hasOnlyReadOnly.Foo), "Property is required for class HasOnlyReadOnly.");
+                throw new JsonException("Cannot write null property HasOnlyReadOnly.Foo to non-nullable JSON property 'foo'.");
 
             if (hasOnlyReadOnly.BarOption.IsSet)
                 writer.WriteString("bar", hasOnlyReadOnly.Bar);

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
@@ -337,22 +337,22 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, InjectedVendorExtensionsTest injectedVendorExtensionsTest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessorOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor to non-nullable JSON property 'potentiallyOverriddenPropertyAccessor'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternalOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternal == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternal), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternal to non-nullable JSON property 'potentiallyOverriddenPropertyToInternal'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivateOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivate == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivate), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivate to non-nullable JSON property 'potentiallyOverriddenPropertyToPrivate'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublicOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublic == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublic), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublic to non-nullable JSON property 'potentiallyOverriddenPropertyToPublic'.");
 
             if (injectedVendorExtensionsTest.UnalteredPropertyOption.IsSet && injectedVendorExtensionsTest.UnalteredProperty == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.UnalteredProperty), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.UnalteredProperty to non-nullable JSON property 'unalteredProperty'.");
 
             if (injectedVendorExtensionsTest.UnalteredPropertyAccessorOption.IsSet && injectedVendorExtensionsTest.UnalteredPropertyAccessor == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.UnalteredPropertyAccessor), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.UnalteredPropertyAccessor to non-nullable JSON property 'unalteredPropertyAccessor'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessorOption.IsSet)
                 writer.WriteString("potentiallyOverriddenPropertyAccessor", injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor);

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
@@ -182,12 +182,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, IsoscelesTriangle isoscelesTriangle, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (isoscelesTriangle.ShapeType == null)
-                throw new ArgumentNullException(nameof(isoscelesTriangle.ShapeType), "Property is required for class IsoscelesTriangle.");
-
-            if (isoscelesTriangle.TriangleType == null)
-                throw new ArgumentNullException(nameof(isoscelesTriangle.TriangleType), "Property is required for class IsoscelesTriangle.");
-
             writer.WriteString("shapeType", isoscelesTriangle.ShapeType);
 
             writer.WriteString("triangleType", isoscelesTriangle.TriangleType);

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/List.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, List list, JsonSerializerOptions jsonSerializerOptions)
         {
             if (list.Var123ListOption.IsSet && list.Var123List == null)
-                throw new ArgumentNullException(nameof(list.Var123List), "Property is required for class List.");
+                throw new JsonException("Cannot write null property List.Var123List to non-nullable JSON property '123-list'.");
 
             if (list.Var123ListOption.IsSet)
                 writer.WriteString("123-list", list.Var123List);

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -198,10 +198,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, LiteralStringClass literalStringClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (literalStringClass.EscapedLiteralStringOption.IsSet && literalStringClass.EscapedLiteralString == null)
-                throw new ArgumentNullException(nameof(literalStringClass.EscapedLiteralString), "Property is required for class LiteralStringClass.");
+                throw new JsonException("Cannot write null property LiteralStringClass.EscapedLiteralString to non-nullable JSON property 'escapedLiteralString'.");
 
             if (literalStringClass.UnescapedLiteralStringOption.IsSet && literalStringClass.UnescapedLiteralString == null)
-                throw new ArgumentNullException(nameof(literalStringClass.UnescapedLiteralString), "Property is required for class LiteralStringClass.");
+                throw new JsonException("Cannot write null property LiteralStringClass.UnescapedLiteralString to non-nullable JSON property 'unescapedLiteralString'.");
 
             if (literalStringClass.EscapedLiteralStringOption.IsSet)
                 writer.WriteString("escapedLiteralString", literalStringClass.EscapedLiteralString);

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/MapTest.cs
@@ -244,16 +244,16 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MapTest mapTest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mapTest.DirectMapOption.IsSet && mapTest.DirectMap == null)
-                throw new ArgumentNullException(nameof(mapTest.DirectMap), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.DirectMap to non-nullable JSON property 'direct_map'.");
 
             if (mapTest.IndirectMapOption.IsSet && mapTest.IndirectMap == null)
-                throw new ArgumentNullException(nameof(mapTest.IndirectMap), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.IndirectMap to non-nullable JSON property 'indirect_map'.");
 
             if (mapTest.MapMapOfStringOption.IsSet && mapTest.MapMapOfString == null)
-                throw new ArgumentNullException(nameof(mapTest.MapMapOfString), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.MapMapOfString to non-nullable JSON property 'map_map_of_string'.");
 
             if (mapTest.MapOfEnumStringOption.IsSet && mapTest.MapOfEnumString == null)
-                throw new ArgumentNullException(nameof(mapTest.MapOfEnumString), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.MapOfEnumString to non-nullable JSON property 'map_of_enum_string'.");
 
             if (mapTest.DirectMapOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/MixedAnyOf.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/MixedAnyOf.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedAnyOf mixedAnyOf, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedAnyOf.ContentOption.IsSet && mixedAnyOf.Content == null)
-                throw new ArgumentNullException(nameof(mixedAnyOf.Content), "Property is required for class MixedAnyOf.");
+                throw new JsonException("Cannot write null property MixedAnyOf.Content to non-nullable JSON property 'content'.");
 
             if (mixedAnyOf.ContentOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/MixedOneOf.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/MixedOneOf.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedOneOf mixedOneOf, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedOneOf.ContentOption.IsSet && mixedOneOf.Content == null)
-                throw new ArgumentNullException(nameof(mixedOneOf.Content), "Property is required for class MixedOneOf.");
+                throw new JsonException("Cannot write null property MixedOneOf.Content to non-nullable JSON property 'content'.");
 
             if (mixedOneOf.ContentOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -255,8 +255,17 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, MixedPropertiesAndAdditionalPropertiesClass mixedPropertiesAndAdditionalPropertiesClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.DateTime == null)
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.DateTime to non-nullable JSON property 'dateTime'.");
+
             if (mixedPropertiesAndAdditionalPropertiesClass.MapOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.Map == null)
                 throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.Map to non-nullable JSON property 'map'.");
+
+            if (mixedPropertiesAndAdditionalPropertiesClass.UuidOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.Uuid == null)
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.Uuid to non-nullable JSON property 'uuid'.");
+
+            if (mixedPropertiesAndAdditionalPropertiesClass.UuidWithPatternOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.UuidWithPattern == null)
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.UuidWithPattern to non-nullable JSON property 'uuid_with_pattern'.");
 
             if (mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.IsSet)
                 writer.WriteString("dateTime", mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.Value.Value.ToString(DateTimeFormat));

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -256,7 +256,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedPropertiesAndAdditionalPropertiesClass mixedPropertiesAndAdditionalPropertiesClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedPropertiesAndAdditionalPropertiesClass.MapOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.Map == null)
-                throw new ArgumentNullException(nameof(mixedPropertiesAndAdditionalPropertiesClass.Map), "Property is required for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.Map to non-nullable JSON property 'map'.");
 
             if (mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.IsSet)
                 writer.WriteString("dateTime", mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.Value.Value.ToString(DateTimeFormat));

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/MixedSubId.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/MixedSubId.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedSubId mixedSubId, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedSubId.IdOption.IsSet && mixedSubId.Id == null)
-                throw new ArgumentNullException(nameof(mixedSubId.Id), "Property is required for class MixedSubId.");
+                throw new JsonException("Cannot write null property MixedSubId.Id to non-nullable JSON property 'id'.");
 
             if (mixedSubId.IdOption.IsSet)
                 writer.WriteString("id", mixedSubId.Id);

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -198,7 +198,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Model200Response model200Response, JsonSerializerOptions jsonSerializerOptions)
         {
             if (model200Response.ClassOption.IsSet && model200Response.Class == null)
-                throw new ArgumentNullException(nameof(model200Response.Class), "Property is required for class Model200Response.");
+                throw new JsonException("Cannot write null property Model200Response.Class to non-nullable JSON property 'class'.");
 
             if (model200Response.ClassOption.IsSet)
                 writer.WriteString("class", model200Response.Class);

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -200,6 +200,9 @@ namespace Org.OpenAPITools.Model
             if (model200Response.ClassOption.IsSet && model200Response.Class == null)
                 throw new JsonException("Cannot write null property Model200Response.Class to non-nullable JSON property 'class'.");
 
+            if (model200Response.NameOption.IsSet && model200Response.Name == null)
+                throw new JsonException("Cannot write null property Model200Response.Name to non-nullable JSON property 'name'.");
+
             if (model200Response.ClassOption.IsSet)
                 writer.WriteString("class", model200Response.Class);
 

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ModelClient modelClient, JsonSerializerOptions jsonSerializerOptions)
         {
             if (modelClient.VarClientOption.IsSet && modelClient.VarClient == null)
-                throw new ArgumentNullException(nameof(modelClient.VarClient), "Property is required for class ModelClient.");
+                throw new JsonException("Cannot write null property ModelClient.VarClient to non-nullable JSON property 'client'.");
 
             if (modelClient.VarClientOption.IsSet)
                 writer.WriteString("client", modelClient.VarClient);

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Name.cs
@@ -281,7 +281,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Name name, JsonSerializerOptions jsonSerializerOptions)
         {
             if (name.PropertyOption.IsSet && name.Property == null)
-                throw new ArgumentNullException(nameof(name.Property), "Property is required for class Name.");
+                throw new JsonException("Cannot write null property Name.Property to non-nullable JSON property 'property'.");
 
             writer.WriteNumber("name", name.VarName);
 

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Name.cs
@@ -283,6 +283,12 @@ namespace Org.OpenAPITools.Model
             if (name.PropertyOption.IsSet && name.Property == null)
                 throw new JsonException("Cannot write null property Name.Property to non-nullable JSON property 'property'.");
 
+            if (name.SnakeCaseOption.IsSet && name.SnakeCase == null)
+                throw new JsonException("Cannot write null property Name.SnakeCase to non-nullable JSON property 'snake_case'.");
+
+            if (name.Var123NumberOption.IsSet && name.Var123Number == null)
+                throw new JsonException("Cannot write null property Name.Var123Number to non-nullable JSON property '123Number'.");
+
             writer.WriteNumber("name", name.VarName);
 
             if (name.PropertyOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
@@ -189,9 +189,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, NotificationtestGetElementsV1ResponseMPayload notificationtestGetElementsV1ResponseMPayload, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (notificationtestGetElementsV1ResponseMPayload.AObjVariableobject == null)
-                throw new ArgumentNullException(nameof(notificationtestGetElementsV1ResponseMPayload.AObjVariableobject), "Property is required for class NotificationtestGetElementsV1ResponseMPayload.");
-
             writer.WritePropertyName("a_objVariableobject");
             JsonSerializer.Serialize(writer, notificationtestGetElementsV1ResponseMPayload.AObjVariableobject, jsonSerializerOptions);
             writer.WriteNumber("pkiNotificationtestID", notificationtestGetElementsV1ResponseMPayload.PkiNotificationtestID);

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -408,10 +408,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, NullableClass nullableClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (nullableClass.ArrayItemsNullableOption.IsSet && nullableClass.ArrayItemsNullable == null)
-                throw new ArgumentNullException(nameof(nullableClass.ArrayItemsNullable), "Property is required for class NullableClass.");
+                throw new JsonException("Cannot write null property NullableClass.ArrayItemsNullable to non-nullable JSON property 'array_items_nullable'.");
 
             if (nullableClass.ObjectItemsNullableOption.IsSet && nullableClass.ObjectItemsNullable == null)
-                throw new ArgumentNullException(nameof(nullableClass.ObjectItemsNullable), "Property is required for class NullableClass.");
+                throw new JsonException("Cannot write null property NullableClass.ObjectItemsNullable to non-nullable JSON property 'object_items_nullable'.");
 
             if (nullableClass.ArrayAndItemsNullablePropOption.IsSet)
                 if (nullableClass.ArrayAndItemsNullablePropOption.Value != null)

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -174,6 +174,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, NumberOnly numberOnly, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (numberOnly.JustNumberOption.IsSet && numberOnly.JustNumber == null)
+                throw new JsonException("Cannot write null property NumberOnly.JustNumber to non-nullable JSON property 'JustNumber'.");
+
             if (numberOnly.JustNumberOption.IsSet)
                 writer.WriteNumber("JustNumber", numberOnly.JustNumberOption.Value.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -247,13 +247,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ObjectWithDeprecatedFields objectWithDeprecatedFields, JsonSerializerOptions jsonSerializerOptions)
         {
             if (objectWithDeprecatedFields.BarsOption.IsSet && objectWithDeprecatedFields.Bars == null)
-                throw new ArgumentNullException(nameof(objectWithDeprecatedFields.Bars), "Property is required for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Bars to non-nullable JSON property 'bars'.");
 
             if (objectWithDeprecatedFields.DeprecatedRefOption.IsSet && objectWithDeprecatedFields.DeprecatedRef == null)
-                throw new ArgumentNullException(nameof(objectWithDeprecatedFields.DeprecatedRef), "Property is required for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.DeprecatedRef to non-nullable JSON property 'deprecatedRef'.");
 
             if (objectWithDeprecatedFields.UuidOption.IsSet && objectWithDeprecatedFields.Uuid == null)
-                throw new ArgumentNullException(nameof(objectWithDeprecatedFields.Uuid), "Property is required for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Uuid to non-nullable JSON property 'uuid'.");
 
             if (objectWithDeprecatedFields.BarsOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -252,6 +252,9 @@ namespace Org.OpenAPITools.Model
             if (objectWithDeprecatedFields.DeprecatedRefOption.IsSet && objectWithDeprecatedFields.DeprecatedRef == null)
                 throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.DeprecatedRef to non-nullable JSON property 'deprecatedRef'.");
 
+            if (objectWithDeprecatedFields.IdOption.IsSet && objectWithDeprecatedFields.Id == null)
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Id to non-nullable JSON property 'id'.");
+
             if (objectWithDeprecatedFields.UuidOption.IsSet && objectWithDeprecatedFields.Uuid == null)
                 throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Uuid to non-nullable JSON property 'uuid'.");
 

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Order.cs
@@ -295,6 +295,24 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Order order, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (order.CompleteOption.IsSet && order.Complete == null)
+                throw new JsonException("Cannot write null property Order.Complete to non-nullable JSON property 'complete'.");
+
+            if (order.IdOption.IsSet && order.Id == null)
+                throw new JsonException("Cannot write null property Order.Id to non-nullable JSON property 'id'.");
+
+            if (order.PetIdOption.IsSet && order.PetId == null)
+                throw new JsonException("Cannot write null property Order.PetId to non-nullable JSON property 'petId'.");
+
+            if (order.QuantityOption.IsSet && order.Quantity == null)
+                throw new JsonException("Cannot write null property Order.Quantity to non-nullable JSON property 'quantity'.");
+
+            if (order.ShipDateOption.IsSet && order.ShipDate == null)
+                throw new JsonException("Cannot write null property Order.ShipDate to non-nullable JSON property 'shipDate'.");
+
+            if (order.StatusOption.IsSet && order.Status == null)
+                throw new JsonException("Cannot write null property Order.Status to non-nullable JSON property 'status'.");
+
             if (order.CompleteOption.IsSet)
                 writer.WriteBoolean("complete", order.CompleteOption.Value.Value);
 

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -220,6 +220,12 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, OuterComposite outerComposite, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (outerComposite.MyBooleanOption.IsSet && outerComposite.MyBoolean == null)
+                throw new JsonException("Cannot write null property OuterComposite.MyBoolean to non-nullable JSON property 'my_boolean'.");
+
+            if (outerComposite.MyNumberOption.IsSet && outerComposite.MyNumber == null)
+                throw new JsonException("Cannot write null property OuterComposite.MyNumber to non-nullable JSON property 'my_number'.");
+
             if (outerComposite.MyStringOption.IsSet && outerComposite.MyString == null)
                 throw new JsonException("Cannot write null property OuterComposite.MyString to non-nullable JSON property 'my_string'.");
 

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -221,7 +221,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, OuterComposite outerComposite, JsonSerializerOptions jsonSerializerOptions)
         {
             if (outerComposite.MyStringOption.IsSet && outerComposite.MyString == null)
-                throw new ArgumentNullException(nameof(outerComposite.MyString), "Property is required for class OuterComposite.");
+                throw new JsonException("Cannot write null property OuterComposite.MyString to non-nullable JSON property 'my_string'.");
 
             if (outerComposite.MyBooleanOption.IsSet)
                 writer.WriteBoolean("my_boolean", outerComposite.MyBooleanOption.Value.Value);

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Pet.cs
@@ -282,17 +282,11 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Pet pet, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (pet.Name == null)
-                throw new ArgumentNullException(nameof(pet.Name), "Property is required for class Pet.");
-
-            if (pet.PhotoUrls == null)
-                throw new ArgumentNullException(nameof(pet.PhotoUrls), "Property is required for class Pet.");
-
             if (pet.CategoryOption.IsSet && pet.Category == null)
-                throw new ArgumentNullException(nameof(pet.Category), "Property is required for class Pet.");
+                throw new JsonException("Cannot write null property Pet.Category to non-nullable JSON property 'category'.");
 
             if (pet.TagsOption.IsSet && pet.Tags == null)
-                throw new ArgumentNullException(nameof(pet.Tags), "Property is required for class Pet.");
+                throw new JsonException("Cannot write null property Pet.Tags to non-nullable JSON property 'tags'.");
 
             writer.WriteString("name", pet.Name);
 

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Pet.cs
@@ -285,6 +285,12 @@ namespace Org.OpenAPITools.Model
             if (pet.CategoryOption.IsSet && pet.Category == null)
                 throw new JsonException("Cannot write null property Pet.Category to non-nullable JSON property 'category'.");
 
+            if (pet.IdOption.IsSet && pet.Id == null)
+                throw new JsonException("Cannot write null property Pet.Id to non-nullable JSON property 'id'.");
+
+            if (pet.StatusOption.IsSet && pet.Status == null)
+                throw new JsonException("Cannot write null property Pet.Status to non-nullable JSON property 'status'.");
+
             if (pet.TagsOption.IsSet && pet.Tags == null)
                 throw new JsonException("Cannot write null property Pet.Tags to non-nullable JSON property 'tags'.");
 

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
@@ -170,9 +170,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, QuadrilateralInterface quadrilateralInterface, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (quadrilateralInterface.QuadrilateralType == null)
-                throw new ArgumentNullException(nameof(quadrilateralInterface.QuadrilateralType), "Property is required for class QuadrilateralInterface.");
-
             writer.WriteString("quadrilateralType", quadrilateralInterface.QuadrilateralType);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -236,10 +236,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ReadOnlyFirst readOnlyFirst, JsonSerializerOptions jsonSerializerOptions)
         {
             if (readOnlyFirst.BarOption.IsSet && readOnlyFirst.Bar == null)
-                throw new ArgumentNullException(nameof(readOnlyFirst.Bar), "Property is required for class ReadOnlyFirst.");
+                throw new JsonException("Cannot write null property ReadOnlyFirst.Bar to non-nullable JSON property 'bar'.");
 
             if (readOnlyFirst.BazOption.IsSet && readOnlyFirst.Baz == null)
-                throw new ArgumentNullException(nameof(readOnlyFirst.Baz), "Property is required for class ReadOnlyFirst.");
+                throw new JsonException("Cannot write null property ReadOnlyFirst.Baz to non-nullable JSON property 'baz'.");
 
             if (readOnlyFirst.BarOption.IsSet)
                 writer.WriteString("bar", readOnlyFirst.Bar);

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -1053,11 +1053,38 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, RequiredClass requiredClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (requiredClass.NotRequiredNotnullableDatePropOption.IsSet && requiredClass.NotRequiredNotnullableDateProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotRequiredNotnullableDateProp to non-nullable JSON property 'not_required_notnullable_date_prop'.");
+
+            if (requiredClass.NotRequiredNotnullableintegerPropOption.IsSet && requiredClass.NotRequiredNotnullableintegerProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotRequiredNotnullableintegerProp to non-nullable JSON property 'not_required_notnullableinteger_prop'.");
+
             if (requiredClass.NotrequiredNotnullableArrayOfStringOption.IsSet && requiredClass.NotrequiredNotnullableArrayOfString == null)
                 throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableArrayOfString to non-nullable JSON property 'notrequired_notnullable_array_of_string'.");
 
+            if (requiredClass.NotrequiredNotnullableBooleanPropOption.IsSet && requiredClass.NotrequiredNotnullableBooleanProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableBooleanProp to non-nullable JSON property 'notrequired_notnullable_boolean_prop'.");
+
+            if (requiredClass.NotrequiredNotnullableDatetimePropOption.IsSet && requiredClass.NotrequiredNotnullableDatetimeProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableDatetimeProp to non-nullable JSON property 'notrequired_notnullable_datetime_prop'.");
+
+            if (requiredClass.NotrequiredNotnullableEnumIntegerOption.IsSet && requiredClass.NotrequiredNotnullableEnumInteger == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableEnumInteger to non-nullable JSON property 'notrequired_notnullable_enum_integer'.");
+
+            if (requiredClass.NotrequiredNotnullableEnumIntegerOnlyOption.IsSet && requiredClass.NotrequiredNotnullableEnumIntegerOnly == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableEnumIntegerOnly to non-nullable JSON property 'notrequired_notnullable_enum_integer_only'.");
+
+            if (requiredClass.NotrequiredNotnullableEnumStringOption.IsSet && requiredClass.NotrequiredNotnullableEnumString == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableEnumString to non-nullable JSON property 'notrequired_notnullable_enum_string'.");
+
+            if (requiredClass.NotrequiredNotnullableOuterEnumDefaultValueOption.IsSet && requiredClass.NotrequiredNotnullableOuterEnumDefaultValue == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableOuterEnumDefaultValue to non-nullable JSON property 'notrequired_notnullable_outerEnumDefaultValue'.");
+
             if (requiredClass.NotrequiredNotnullableStringPropOption.IsSet && requiredClass.NotrequiredNotnullableStringProp == null)
                 throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableStringProp to non-nullable JSON property 'notrequired_notnullable_string_prop'.");
+
+            if (requiredClass.NotrequiredNotnullableUuidOption.IsSet && requiredClass.NotrequiredNotnullableUuid == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableUuid to non-nullable JSON property 'notrequired_notnullable_uuid'.");
 
             writer.WriteString("required_not_nullable_date_prop", requiredClass.RequiredNotNullableDateProp.ToString(RequiredNotNullableDatePropFormat));
 

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -1053,17 +1053,11 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, RequiredClass requiredClass, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (requiredClass.RequiredNotnullableArrayOfString == null)
-                throw new ArgumentNullException(nameof(requiredClass.RequiredNotnullableArrayOfString), "Property is required for class RequiredClass.");
-
-            if (requiredClass.RequiredNotnullableStringProp == null)
-                throw new ArgumentNullException(nameof(requiredClass.RequiredNotnullableStringProp), "Property is required for class RequiredClass.");
-
             if (requiredClass.NotrequiredNotnullableArrayOfStringOption.IsSet && requiredClass.NotrequiredNotnullableArrayOfString == null)
-                throw new ArgumentNullException(nameof(requiredClass.NotrequiredNotnullableArrayOfString), "Property is required for class RequiredClass.");
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableArrayOfString to non-nullable JSON property 'notrequired_notnullable_array_of_string'.");
 
             if (requiredClass.NotrequiredNotnullableStringPropOption.IsSet && requiredClass.NotrequiredNotnullableStringProp == null)
-                throw new ArgumentNullException(nameof(requiredClass.NotrequiredNotnullableStringProp), "Property is required for class RequiredClass.");
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableStringProp to non-nullable JSON property 'notrequired_notnullable_string_prop'.");
 
             writer.WriteString("required_not_nullable_date_prop", requiredClass.RequiredNotNullableDateProp.ToString(RequiredNotNullableDatePropFormat));
 

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Result.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Result.cs
@@ -224,13 +224,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Result result, JsonSerializerOptions jsonSerializerOptions)
         {
             if (result.CodeOption.IsSet && result.Code == null)
-                throw new ArgumentNullException(nameof(result.Code), "Property is required for class Result.");
+                throw new JsonException("Cannot write null property Result.Code to non-nullable JSON property 'code'.");
 
             if (result.DataOption.IsSet && result.Data == null)
-                throw new ArgumentNullException(nameof(result.Data), "Property is required for class Result.");
+                throw new JsonException("Cannot write null property Result.Data to non-nullable JSON property 'data'.");
 
             if (result.UuidOption.IsSet && result.Uuid == null)
-                throw new ArgumentNullException(nameof(result.Uuid), "Property is required for class Result.");
+                throw new JsonException("Cannot write null property Result.Uuid to non-nullable JSON property 'uuid'.");
 
             if (result.CodeOption.IsSet)
                 writer.WriteString("code", result.Code);

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Return.cs
@@ -232,11 +232,8 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Return varReturn, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (varReturn.Lock == null)
-                throw new ArgumentNullException(nameof(varReturn.Lock), "Property is required for class Return.");
-
             if (varReturn.UnsafeOption.IsSet && varReturn.Unsafe == null)
-                throw new ArgumentNullException(nameof(varReturn.Unsafe), "Property is required for class Return.");
+                throw new JsonException("Cannot write null property Return.Unsafe to non-nullable JSON property 'unsafe'.");
 
             writer.WriteString("lock", varReturn.Lock);
 

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Return.cs
@@ -232,6 +232,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Return varReturn, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (varReturn.VarReturnOption.IsSet && varReturn.VarReturn == null)
+                throw new JsonException("Cannot write null property Return.VarReturn to non-nullable JSON property 'return'.");
+
             if (varReturn.UnsafeOption.IsSet && varReturn.Unsafe == null)
                 throw new JsonException("Cannot write null property Return.Unsafe to non-nullable JSON property 'unsafe'.");
 

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -198,7 +198,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, RolesReportsHash rolesReportsHash, JsonSerializerOptions jsonSerializerOptions)
         {
             if (rolesReportsHash.RoleOption.IsSet && rolesReportsHash.Role == null)
-                throw new ArgumentNullException(nameof(rolesReportsHash.Role), "Property is required for class RolesReportsHash.");
+                throw new JsonException("Cannot write null property RolesReportsHash.Role to non-nullable JSON property 'role'.");
 
             if (rolesReportsHash.RoleOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -200,6 +200,9 @@ namespace Org.OpenAPITools.Model
             if (rolesReportsHash.RoleOption.IsSet && rolesReportsHash.Role == null)
                 throw new JsonException("Cannot write null property RolesReportsHash.Role to non-nullable JSON property 'role'.");
 
+            if (rolesReportsHash.RoleUuidOption.IsSet && rolesReportsHash.RoleUuid == null)
+                throw new JsonException("Cannot write null property RolesReportsHash.RoleUuid to non-nullable JSON property 'role_uuid'.");
+
             if (rolesReportsHash.RoleOption.IsSet)
             {
                 writer.WritePropertyName("role");

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, RolesReportsHashRole rolesReportsHashRole, JsonSerializerOptions jsonSerializerOptions)
         {
             if (rolesReportsHashRole.NameOption.IsSet && rolesReportsHashRole.Name == null)
-                throw new ArgumentNullException(nameof(rolesReportsHashRole.Name), "Property is required for class RolesReportsHashRole.");
+                throw new JsonException("Cannot write null property RolesReportsHashRole.Name to non-nullable JSON property 'name'.");
 
             if (rolesReportsHashRole.NameOption.IsSet)
                 writer.WriteString("name", rolesReportsHashRole.Name);

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
@@ -189,12 +189,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ScaleneTriangle scaleneTriangle, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (scaleneTriangle.ShapeType == null)
-                throw new ArgumentNullException(nameof(scaleneTriangle.ShapeType), "Property is required for class ScaleneTriangle.");
-
-            if (scaleneTriangle.TriangleType == null)
-                throw new ArgumentNullException(nameof(scaleneTriangle.TriangleType), "Property is required for class ScaleneTriangle.");
-
             writer.WriteString("shapeType", scaleneTriangle.ShapeType);
 
             writer.WriteString("triangleType", scaleneTriangle.TriangleType);

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ShapeInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ShapeInterface.cs
@@ -170,9 +170,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ShapeInterface shapeInterface, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (shapeInterface.ShapeType == null)
-                throw new ArgumentNullException(nameof(shapeInterface.ShapeType), "Property is required for class ShapeInterface.");
-
             writer.WriteString("shapeType", shapeInterface.ShapeType);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
@@ -189,12 +189,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, SimpleQuadrilateral simpleQuadrilateral, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (simpleQuadrilateral.QuadrilateralType == null)
-                throw new ArgumentNullException(nameof(simpleQuadrilateral.QuadrilateralType), "Property is required for class SimpleQuadrilateral.");
-
-            if (simpleQuadrilateral.ShapeType == null)
-                throw new ArgumentNullException(nameof(simpleQuadrilateral.ShapeType), "Property is required for class SimpleQuadrilateral.");
-
             writer.WriteString("quadrilateralType", simpleQuadrilateral.QuadrilateralType);
 
             writer.WriteString("shapeType", simpleQuadrilateral.ShapeType);

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -200,6 +200,9 @@ namespace Org.OpenAPITools.Model
             if (specialModelName.VarSpecialModelNameOption.IsSet && specialModelName.VarSpecialModelName == null)
                 throw new JsonException("Cannot write null property SpecialModelName.VarSpecialModelName to non-nullable JSON property '_special_model.name_'.");
 
+            if (specialModelName.SpecialPropertyNameOption.IsSet && specialModelName.SpecialPropertyName == null)
+                throw new JsonException("Cannot write null property SpecialModelName.SpecialPropertyName to non-nullable JSON property '$special[property.name]'.");
+
             if (specialModelName.VarSpecialModelNameOption.IsSet)
                 writer.WriteString("_special_model.name_", specialModelName.VarSpecialModelName);
 

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -198,7 +198,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, SpecialModelName specialModelName, JsonSerializerOptions jsonSerializerOptions)
         {
             if (specialModelName.VarSpecialModelNameOption.IsSet && specialModelName.VarSpecialModelName == null)
-                throw new ArgumentNullException(nameof(specialModelName.VarSpecialModelName), "Property is required for class SpecialModelName.");
+                throw new JsonException("Cannot write null property SpecialModelName.VarSpecialModelName to non-nullable JSON property '_special_model.name_'.");
 
             if (specialModelName.VarSpecialModelNameOption.IsSet)
                 writer.WriteString("_special_model.name_", specialModelName.VarSpecialModelName);

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Tag.cs
@@ -198,7 +198,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Tag tag, JsonSerializerOptions jsonSerializerOptions)
         {
             if (tag.NameOption.IsSet && tag.Name == null)
-                throw new ArgumentNullException(nameof(tag.Name), "Property is required for class Tag.");
+                throw new JsonException("Cannot write null property Tag.Name to non-nullable JSON property 'name'.");
 
             if (tag.IdOption.IsSet)
                 writer.WriteNumber("id", tag.IdOption.Value.Value);

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Tag.cs
@@ -197,6 +197,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Tag tag, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (tag.IdOption.IsSet && tag.Id == null)
+                throw new JsonException("Cannot write null property Tag.Id to non-nullable JSON property 'id'.");
+
             if (tag.NameOption.IsSet && tag.Name == null)
                 throw new JsonException("Cannot write null property Tag.Name to non-nullable JSON property 'name'.");
 

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestCollectionEndingWithWordList testCollectionEndingWithWordList, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testCollectionEndingWithWordList.ValueOption.IsSet && testCollectionEndingWithWordList.Value == null)
-                throw new ArgumentNullException(nameof(testCollectionEndingWithWordList.Value), "Property is required for class TestCollectionEndingWithWordList.");
+                throw new JsonException("Cannot write null property TestCollectionEndingWithWordList.Value to non-nullable JSON property 'value'.");
 
             if (testCollectionEndingWithWordList.ValueOption.IsSet)
                 writer.WriteString("value", testCollectionEndingWithWordList.Value);

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestCollectionEndingWithWordListObject testCollectionEndingWithWordListObject, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testCollectionEndingWithWordListObject.TestCollectionEndingWithWordListOption.IsSet && testCollectionEndingWithWordListObject.TestCollectionEndingWithWordList == null)
-                throw new ArgumentNullException(nameof(testCollectionEndingWithWordListObject.TestCollectionEndingWithWordList), "Property is required for class TestCollectionEndingWithWordListObject.");
+                throw new JsonException("Cannot write null property TestCollectionEndingWithWordListObject.TestCollectionEndingWithWordList to non-nullable JSON property 'TestCollectionEndingWithWordList'.");
 
             if (testCollectionEndingWithWordListObject.TestCollectionEndingWithWordListOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/TestDescendants.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/TestDescendants.cs
@@ -216,9 +216,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, TestDescendants testDescendants, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (testDescendants.AlternativeName == null)
-                throw new ArgumentNullException(nameof(testDescendants.AlternativeName), "Property is required for class TestDescendants.");
-
             writer.WriteString("alternativeName", testDescendants.AlternativeName);
 
             writer.WriteString("objectType", TestDescendantsObjectTypeValueConverter.ToJsonValue(testDescendants.ObjectType));

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestInlineFreeformAdditionalPropertiesRequest testInlineFreeformAdditionalPropertiesRequest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testInlineFreeformAdditionalPropertiesRequest.SomePropertyOption.IsSet && testInlineFreeformAdditionalPropertiesRequest.SomeProperty == null)
-                throw new ArgumentNullException(nameof(testInlineFreeformAdditionalPropertiesRequest.SomeProperty), "Property is required for class TestInlineFreeformAdditionalPropertiesRequest.");
+                throw new JsonException("Cannot write null property TestInlineFreeformAdditionalPropertiesRequest.SomeProperty to non-nullable JSON property 'someProperty'.");
 
             if (testInlineFreeformAdditionalPropertiesRequest.SomePropertyOption.IsSet)
                 writer.WriteString("someProperty", testInlineFreeformAdditionalPropertiesRequest.SomeProperty);

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/TestResult.cs
@@ -222,6 +222,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, TestResult testResult, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (testResult.CodeOption.IsSet && testResult.Code == null)
+                throw new JsonException("Cannot write null property TestResult.Code to non-nullable JSON property 'code'.");
+
             if (testResult.DataOption.IsSet && testResult.Data == null)
                 throw new JsonException("Cannot write null property TestResult.Data to non-nullable JSON property 'data'.");
 

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/TestResult.cs
@@ -223,10 +223,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestResult testResult, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testResult.DataOption.IsSet && testResult.Data == null)
-                throw new ArgumentNullException(nameof(testResult.Data), "Property is required for class TestResult.");
+                throw new JsonException("Cannot write null property TestResult.Data to non-nullable JSON property 'data'.");
 
             if (testResult.UuidOption.IsSet && testResult.Uuid == null)
-                throw new ArgumentNullException(nameof(testResult.Uuid), "Property is required for class TestResult.");
+                throw new JsonException("Cannot write null property TestResult.Uuid to non-nullable JSON property 'uuid'.");
 
             if (testResult.CodeOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/TriangleInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/TriangleInterface.cs
@@ -170,9 +170,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, TriangleInterface triangleInterface, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (triangleInterface.TriangleType == null)
-                throw new ArgumentNullException(nameof(triangleInterface.TriangleType), "Property is required for class TriangleInterface.");
-
             writer.WriteString("triangleType", triangleInterface.TriangleType);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/User.cs
@@ -429,6 +429,9 @@ namespace Org.OpenAPITools.Model
             if (user.FirstNameOption.IsSet && user.FirstName == null)
                 throw new JsonException("Cannot write null property User.FirstName to non-nullable JSON property 'firstName'.");
 
+            if (user.IdOption.IsSet && user.Id == null)
+                throw new JsonException("Cannot write null property User.Id to non-nullable JSON property 'id'.");
+
             if (user.LastNameOption.IsSet && user.LastName == null)
                 throw new JsonException("Cannot write null property User.LastName to non-nullable JSON property 'lastName'.");
 
@@ -440,6 +443,9 @@ namespace Org.OpenAPITools.Model
 
             if (user.PhoneOption.IsSet && user.Phone == null)
                 throw new JsonException("Cannot write null property User.Phone to non-nullable JSON property 'phone'.");
+
+            if (user.UserStatusOption.IsSet && user.UserStatus == null)
+                throw new JsonException("Cannot write null property User.UserStatus to non-nullable JSON property 'userStatus'.");
 
             if (user.UsernameOption.IsSet && user.Username == null)
                 throw new JsonException("Cannot write null property User.Username to non-nullable JSON property 'username'.");

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/User.cs
@@ -424,25 +424,25 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, User user, JsonSerializerOptions jsonSerializerOptions)
         {
             if (user.EmailOption.IsSet && user.Email == null)
-                throw new ArgumentNullException(nameof(user.Email), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Email to non-nullable JSON property 'email'.");
 
             if (user.FirstNameOption.IsSet && user.FirstName == null)
-                throw new ArgumentNullException(nameof(user.FirstName), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.FirstName to non-nullable JSON property 'firstName'.");
 
             if (user.LastNameOption.IsSet && user.LastName == null)
-                throw new ArgumentNullException(nameof(user.LastName), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.LastName to non-nullable JSON property 'lastName'.");
 
             if (user.ObjectWithNoDeclaredPropsOption.IsSet && user.ObjectWithNoDeclaredProps == null)
-                throw new ArgumentNullException(nameof(user.ObjectWithNoDeclaredProps), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.ObjectWithNoDeclaredProps to non-nullable JSON property 'objectWithNoDeclaredProps'.");
 
             if (user.PasswordOption.IsSet && user.Password == null)
-                throw new ArgumentNullException(nameof(user.Password), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Password to non-nullable JSON property 'password'.");
 
             if (user.PhoneOption.IsSet && user.Phone == null)
-                throw new ArgumentNullException(nameof(user.Phone), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Phone to non-nullable JSON property 'phone'.");
 
             if (user.UsernameOption.IsSet && user.Username == null)
-                throw new ArgumentNullException(nameof(user.Username), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Username to non-nullable JSON property 'username'.");
 
             if (user.AnyTypePropOption.IsSet)
                 if (user.AnyTypePropOption.Value != null)

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Whale.cs
@@ -216,9 +216,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Whale whale, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (whale.ClassName == null)
-                throw new ArgumentNullException(nameof(whale.ClassName), "Property is required for class Whale.");
-
             writer.WriteString("className", whale.ClassName);
 
             if (whale.HasBaleenOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Whale.cs
@@ -216,6 +216,12 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Whale whale, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (whale.HasBaleenOption.IsSet && whale.HasBaleen == null)
+                throw new JsonException("Cannot write null property Whale.HasBaleen to non-nullable JSON property 'hasBaleen'.");
+
+            if (whale.HasTeethOption.IsSet && whale.HasTeeth == null)
+                throw new JsonException("Cannot write null property Whale.HasTeeth to non-nullable JSON property 'hasTeeth'.");
+
             writer.WriteString("className", whale.ClassName);
 
             if (whale.HasBaleenOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Zebra.cs
@@ -193,6 +193,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Zebra zebra, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (zebra.TypeOption.IsSet && zebra.Type == null)
+                throw new JsonException("Cannot write null property Zebra.Type to non-nullable JSON property 'type'.");
+
             writer.WriteString("className", zebra.ClassName);
 
             if (zebra.TypeOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Zebra.cs
@@ -193,9 +193,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Zebra zebra, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (zebra.ClassName == null)
-                throw new ArgumentNullException(nameof(zebra.ClassName), "Property is required for class Zebra.");
-
             writer.WriteString("className", zebra.ClassName);
 
             if (zebra.TypeOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
@@ -174,6 +174,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ZeroBasedEnumClass zeroBasedEnumClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (zeroBasedEnumClass.ZeroBasedEnumOption.IsSet && zeroBasedEnumClass.ZeroBasedEnum == null)
+                throw new JsonException("Cannot write null property ZeroBasedEnumClass.ZeroBasedEnum to non-nullable JSON property 'ZeroBasedEnum'.");
+
             if (zeroBasedEnumClass.ZeroBasedEnumOption.IsSet)
             {
                 var zeroBasedEnumRawValue = ZeroBasedEnumClassZeroBasedEnumValueConverter.ToJsonValue(zeroBasedEnumClass.ZeroBasedEnum.Value);

--- a/samples/client/petstore/csharp/generichost/net4.7/OneOf/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/OneOf/src/Org.OpenAPITools/Model/Apple.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Apple apple, JsonSerializerOptions jsonSerializerOptions)
         {
             if (apple.KindOption.IsSet && apple.Kind == null)
-                throw new ArgumentNullException(nameof(apple.Kind), "Property is required for class Apple.");
+                throw new JsonException("Cannot write null property Apple.Kind to non-nullable JSON property 'kind'.");
 
             if (apple.KindOption.IsSet)
                 writer.WriteString("kind", apple.Kind);

--- a/samples/client/petstore/csharp/generichost/net4.7/OneOf/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/OneOf/src/Org.OpenAPITools/Model/Banana.cs
@@ -174,6 +174,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Banana banana, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (banana.CountOption.IsSet && banana.Count == null)
+                throw new JsonException("Cannot write null property Banana.Count to non-nullable JSON property 'count'.");
+
             if (banana.CountOption.IsSet)
                 writer.WriteNumber("count", banana.CountOption.Value.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/OneOf/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/OneOf/src/Org.OpenAPITools/Model/Fruit.cs
@@ -250,7 +250,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Fruit fruit, JsonSerializerOptions jsonSerializerOptions)
         {
             if (fruit.ColorOption.IsSet && fruit.Color == null)
-                throw new ArgumentNullException(nameof(fruit.Color), "Property is required for class Fruit.");
+                throw new JsonException("Cannot write null property Fruit.Color to non-nullable JSON property 'color'.");
 
             if (fruit.ColorOption.IsSet)
                 writer.WriteString("color", fruit.Color);

--- a/samples/client/petstore/csharp/generichost/net4.7/OneOf/src/Org.OpenAPITools/Model/Orange.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/OneOf/src/Org.OpenAPITools/Model/Orange.cs
@@ -174,6 +174,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Orange orange, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (orange.SweetOption.IsSet && orange.Sweet == null)
+                throw new JsonException("Cannot write null property Orange.Sweet to non-nullable JSON property 'sweet'.");
+
             if (orange.SweetOption.IsSet)
                 writer.WriteBoolean("sweet", orange.SweetOption.Value.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Activity.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Activity activity, JsonSerializerOptions jsonSerializerOptions)
         {
             if (activity.ActivityOutputsOption.IsSet && activity.ActivityOutputs == null)
-                throw new ArgumentNullException(nameof(activity.ActivityOutputs), "Property is required for class Activity.");
+                throw new JsonException("Cannot write null property Activity.ActivityOutputs to non-nullable JSON property 'activity_outputs'.");
 
             if (activity.ActivityOutputsOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -198,10 +198,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ActivityOutputElementRepresentation activityOutputElementRepresentation, JsonSerializerOptions jsonSerializerOptions)
         {
             if (activityOutputElementRepresentation.Prop1Option.IsSet && activityOutputElementRepresentation.Prop1 == null)
-                throw new ArgumentNullException(nameof(activityOutputElementRepresentation.Prop1), "Property is required for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Cannot write null property ActivityOutputElementRepresentation.Prop1 to non-nullable JSON property 'prop1'.");
 
             if (activityOutputElementRepresentation.Prop2Option.IsSet && activityOutputElementRepresentation.Prop2 == null)
-                throw new ArgumentNullException(nameof(activityOutputElementRepresentation.Prop2), "Property is required for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Cannot write null property ActivityOutputElementRepresentation.Prop2 to non-nullable JSON property 'prop2'.");
 
             if (activityOutputElementRepresentation.Prop1Option.IsSet)
                 writer.WriteString("prop1", activityOutputElementRepresentation.Prop1);

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -334,25 +334,25 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, AdditionalPropertiesClass additionalPropertiesClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (additionalPropertiesClass.EmptyMapOption.IsSet && additionalPropertiesClass.EmptyMap == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.EmptyMap), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.EmptyMap to non-nullable JSON property 'empty_map'.");
 
             if (additionalPropertiesClass.MapOfMapPropertyOption.IsSet && additionalPropertiesClass.MapOfMapProperty == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapOfMapProperty), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapOfMapProperty to non-nullable JSON property 'map_of_map_property'.");
 
             if (additionalPropertiesClass.MapPropertyOption.IsSet && additionalPropertiesClass.MapProperty == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapProperty), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapProperty to non-nullable JSON property 'map_property'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1Option.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1 == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1 to non-nullable JSON property 'map_with_undeclared_properties_anytype_1'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2Option.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2 == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2 to non-nullable JSON property 'map_with_undeclared_properties_anytype_2'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3Option.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3 == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3 to non-nullable JSON property 'map_with_undeclared_properties_anytype_3'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesStringOption.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesString == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesString), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesString to non-nullable JSON property 'map_with_undeclared_properties_string'.");
 
             if (additionalPropertiesClass.Anytype1Option.IsSet)
                 if (additionalPropertiesClass.Anytype1Option.Value != null)

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Animal.cs
@@ -221,7 +221,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Animal animal, JsonSerializerOptions jsonSerializerOptions)
         {
             if (animal.ColorOption.IsSet && animal.Color == null)
-                throw new ArgumentNullException(nameof(animal.Color), "Property is required for class Animal.");
+                throw new JsonException("Cannot write null property Animal.Color to non-nullable JSON property 'color'.");
 
             writer.WriteString("className", animal.ClassName);
 

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -221,10 +221,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ApiResponse apiResponse, JsonSerializerOptions jsonSerializerOptions)
         {
             if (apiResponse.MessageOption.IsSet && apiResponse.Message == null)
-                throw new ArgumentNullException(nameof(apiResponse.Message), "Property is required for class ApiResponse.");
+                throw new JsonException("Cannot write null property ApiResponse.Message to non-nullable JSON property 'message'.");
 
             if (apiResponse.TypeOption.IsSet && apiResponse.Type == null)
-                throw new ArgumentNullException(nameof(apiResponse.Type), "Property is required for class ApiResponse.");
+                throw new JsonException("Cannot write null property ApiResponse.Type to non-nullable JSON property 'type'.");
 
             if (apiResponse.CodeOption.IsSet)
                 writer.WriteNumber("code", apiResponse.CodeOption.Value.Value);

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -220,6 +220,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ApiResponse apiResponse, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (apiResponse.CodeOption.IsSet && apiResponse.Code == null)
+                throw new JsonException("Cannot write null property ApiResponse.Code to non-nullable JSON property 'code'.");
+
             if (apiResponse.MessageOption.IsSet && apiResponse.Message == null)
                 throw new JsonException("Cannot write null property ApiResponse.Message to non-nullable JSON property 'message'.");
 

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Apple.cs
@@ -251,13 +251,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Apple apple, JsonSerializerOptions jsonSerializerOptions)
         {
             if (apple.ColorCodeOption.IsSet && apple.ColorCode == null)
-                throw new ArgumentNullException(nameof(apple.ColorCode), "Property is required for class Apple.");
+                throw new JsonException("Cannot write null property Apple.ColorCode to non-nullable JSON property 'color_code'.");
 
             if (apple.CultivarOption.IsSet && apple.Cultivar == null)
-                throw new ArgumentNullException(nameof(apple.Cultivar), "Property is required for class Apple.");
+                throw new JsonException("Cannot write null property Apple.Cultivar to non-nullable JSON property 'cultivar'.");
 
             if (apple.OriginOption.IsSet && apple.Origin == null)
-                throw new ArgumentNullException(nameof(apple.Origin), "Property is required for class Apple.");
+                throw new JsonException("Cannot write null property Apple.Origin to non-nullable JSON property 'origin'.");
 
             if (apple.ColorCodeOption.IsSet)
                 writer.WriteString("color_code", apple.ColorCode);

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -186,9 +186,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, AppleReq appleReq, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (appleReq.Cultivar == null)
-                throw new ArgumentNullException(nameof(appleReq.Cultivar), "Property is required for class AppleReq.");
-
             writer.WriteString("cultivar", appleReq.Cultivar);
 
             if (appleReq.MealyOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -186,6 +186,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, AppleReq appleReq, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (appleReq.MealyOption.IsSet && appleReq.Mealy == null)
+                throw new JsonException("Cannot write null property AppleReq.Mealy to non-nullable JSON property 'mealy'.");
+
             writer.WriteString("cultivar", appleReq.Cultivar);
 
             if (appleReq.MealyOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ArrayOfArrayOfNumberOnly arrayOfArrayOfNumberOnly, JsonSerializerOptions jsonSerializerOptions)
         {
             if (arrayOfArrayOfNumberOnly.ArrayArrayNumberOption.IsSet && arrayOfArrayOfNumberOnly.ArrayArrayNumber == null)
-                throw new ArgumentNullException(nameof(arrayOfArrayOfNumberOnly.ArrayArrayNumber), "Property is required for class ArrayOfArrayOfNumberOnly.");
+                throw new JsonException("Cannot write null property ArrayOfArrayOfNumberOnly.ArrayArrayNumber to non-nullable JSON property 'ArrayArrayNumber'.");
 
             if (arrayOfArrayOfNumberOnly.ArrayArrayNumberOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ArrayOfNumberOnly arrayOfNumberOnly, JsonSerializerOptions jsonSerializerOptions)
         {
             if (arrayOfNumberOnly.ArrayNumberOption.IsSet && arrayOfNumberOnly.ArrayNumber == null)
-                throw new ArgumentNullException(nameof(arrayOfNumberOnly.ArrayNumber), "Property is required for class ArrayOfNumberOnly.");
+                throw new JsonException("Cannot write null property ArrayOfNumberOnly.ArrayNumber to non-nullable JSON property 'ArrayNumber'.");
 
             if (arrayOfNumberOnly.ArrayNumberOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -221,13 +221,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ArrayTest arrayTest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (arrayTest.ArrayArrayOfIntegerOption.IsSet && arrayTest.ArrayArrayOfInteger == null)
-                throw new ArgumentNullException(nameof(arrayTest.ArrayArrayOfInteger), "Property is required for class ArrayTest.");
+                throw new JsonException("Cannot write null property ArrayTest.ArrayArrayOfInteger to non-nullable JSON property 'array_array_of_integer'.");
 
             if (arrayTest.ArrayArrayOfModelOption.IsSet && arrayTest.ArrayArrayOfModel == null)
-                throw new ArgumentNullException(nameof(arrayTest.ArrayArrayOfModel), "Property is required for class ArrayTest.");
+                throw new JsonException("Cannot write null property ArrayTest.ArrayArrayOfModel to non-nullable JSON property 'array_array_of_model'.");
 
             if (arrayTest.ArrayOfStringOption.IsSet && arrayTest.ArrayOfString == null)
-                throw new ArgumentNullException(nameof(arrayTest.ArrayOfString), "Property is required for class ArrayTest.");
+                throw new JsonException("Cannot write null property ArrayTest.ArrayOfString to non-nullable JSON property 'array_of_string'.");
 
             if (arrayTest.ArrayArrayOfIntegerOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Banana.cs
@@ -174,6 +174,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Banana banana, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (banana.LengthCmOption.IsSet && banana.LengthCm == null)
+                throw new JsonException("Cannot write null property Banana.LengthCm to non-nullable JSON property 'lengthCm'.");
+
             if (banana.LengthCmOption.IsSet)
                 writer.WriteNumber("lengthCm", banana.LengthCmOption.Value.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -186,6 +186,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, BananaReq bananaReq, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (bananaReq.SweetOption.IsSet && bananaReq.Sweet == null)
+                throw new JsonException("Cannot write null property BananaReq.Sweet to non-nullable JSON property 'sweet'.");
+
             writer.WriteNumber("lengthCm", bananaReq.LengthCm);
 
             if (bananaReq.SweetOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/BasquePig.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/BasquePig.cs
@@ -170,9 +170,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, BasquePig basquePig, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (basquePig.ClassName == null)
-                throw new ArgumentNullException(nameof(basquePig.ClassName), "Property is required for class BasquePig.");
-
             writer.WriteString("className", basquePig.ClassName);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -291,22 +291,22 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Capitalization capitalization, JsonSerializerOptions jsonSerializerOptions)
         {
             if (capitalization.ATT_NAMEOption.IsSet && capitalization.ATT_NAME == null)
-                throw new ArgumentNullException(nameof(capitalization.ATT_NAME), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.ATT_NAME to non-nullable JSON property 'ATT_NAME'.");
 
             if (capitalization.CapitalCamelOption.IsSet && capitalization.CapitalCamel == null)
-                throw new ArgumentNullException(nameof(capitalization.CapitalCamel), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.CapitalCamel to non-nullable JSON property 'CapitalCamel'.");
 
             if (capitalization.CapitalSnakeOption.IsSet && capitalization.CapitalSnake == null)
-                throw new ArgumentNullException(nameof(capitalization.CapitalSnake), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.CapitalSnake to non-nullable JSON property 'Capital_Snake'.");
 
             if (capitalization.SCAETHFlowPointsOption.IsSet && capitalization.SCAETHFlowPoints == null)
-                throw new ArgumentNullException(nameof(capitalization.SCAETHFlowPoints), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.SCAETHFlowPoints to non-nullable JSON property 'SCA_ETH_Flow_Points'.");
 
             if (capitalization.SmallCamelOption.IsSet && capitalization.SmallCamel == null)
-                throw new ArgumentNullException(nameof(capitalization.SmallCamel), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.SmallCamel to non-nullable JSON property 'smallCamel'.");
 
             if (capitalization.SmallSnakeOption.IsSet && capitalization.SmallSnake == null)
-                throw new ArgumentNullException(nameof(capitalization.SmallSnake), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.SmallSnake to non-nullable JSON property 'small_Snake'.");
 
             if (capitalization.ATT_NAMEOption.IsSet)
                 writer.WriteString("ATT_NAME", capitalization.ATT_NAME);

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Cat.cs
@@ -179,6 +179,9 @@ namespace Org.OpenAPITools.Model
             if (cat.ColorOption.IsSet && cat.Color == null)
                 throw new JsonException("Cannot write null property Cat.Color to non-nullable JSON property 'color'.");
 
+            if (cat.DeclawedOption.IsSet && cat.Declawed == null)
+                throw new JsonException("Cannot write null property Cat.Declawed to non-nullable JSON property 'declawed'.");
+
             writer.WriteString("className", cat.ClassName);
 
             if (cat.ColorOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Cat.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Cat cat, JsonSerializerOptions jsonSerializerOptions)
         {
             if (cat.ColorOption.IsSet && cat.Color == null)
-                throw new ArgumentNullException(nameof(cat.Color), "Property is required for class Cat.");
+                throw new JsonException("Cannot write null property Cat.Color to non-nullable JSON property 'color'.");
 
             writer.WriteString("className", cat.ClassName);
 

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Category.cs
@@ -193,9 +193,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Category category, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (category.Name == null)
-                throw new ArgumentNullException(nameof(category.Name), "Property is required for class Category.");
-
             if (category.IdOption.IsSet)
                 writer.WriteNumber("id", category.IdOption.Value.Value);
 

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Category.cs
@@ -193,6 +193,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Category category, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (category.IdOption.IsSet && category.Id == null)
+                throw new JsonException("Cannot write null property Category.Id to non-nullable JSON property 'id'.");
+
             if (category.IdOption.IsSet)
                 writer.WriteNumber("id", category.IdOption.Value.Value);
 

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -236,7 +236,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ChildCat childCat, JsonSerializerOptions jsonSerializerOptions)
         {
             if (childCat.NameOption.IsSet && childCat.Name == null)
-                throw new ArgumentNullException(nameof(childCat.Name), "Property is required for class ChildCat.");
+                throw new JsonException("Cannot write null property ChildCat.Name to non-nullable JSON property 'name'.");
 
             if (childCat.NameOption.IsSet)
                 writer.WriteString("name", childCat.Name);

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ClassModel classModel, JsonSerializerOptions jsonSerializerOptions)
         {
             if (classModel.ClassOption.IsSet && classModel.Class == null)
-                throw new ArgumentNullException(nameof(classModel.Class), "Property is required for class ClassModel.");
+                throw new JsonException("Cannot write null property ClassModel.Class to non-nullable JSON property '_class'.");
 
             if (classModel.ClassOption.IsSet)
                 writer.WriteString("_class", classModel.Class);

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
@@ -189,12 +189,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ComplexQuadrilateral complexQuadrilateral, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (complexQuadrilateral.QuadrilateralType == null)
-                throw new ArgumentNullException(nameof(complexQuadrilateral.QuadrilateralType), "Property is required for class ComplexQuadrilateral.");
-
-            if (complexQuadrilateral.ShapeType == null)
-                throw new ArgumentNullException(nameof(complexQuadrilateral.ShapeType), "Property is required for class ComplexQuadrilateral.");
-
             writer.WriteString("quadrilateralType", complexQuadrilateral.QuadrilateralType);
 
             writer.WriteString("shapeType", complexQuadrilateral.ShapeType);

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/CopyActivity.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/CopyActivity.cs
@@ -231,9 +231,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, CopyActivity copyActivity, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (copyActivity.CopyActivitytt == null)
-                throw new ArgumentNullException(nameof(copyActivity.CopyActivitytt), "Property is required for class CopyActivity.");
-
             writer.WriteString("copyActivitytt", copyActivity.CopyActivitytt);
 
             writer.WriteString("$schema", CopyActivity.SchemaEnumToJsonValue(copyActivity.Schema));

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/DanishPig.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/DanishPig.cs
@@ -170,9 +170,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, DanishPig danishPig, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (danishPig.ClassName == null)
-                throw new ArgumentNullException(nameof(danishPig.ClassName), "Property is required for class DanishPig.");
-
             writer.WriteString("className", danishPig.ClassName);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -180,6 +180,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, DateOnlyClass dateOnlyClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (dateOnlyClass.DateOnlyPropertyOption.IsSet && dateOnlyClass.DateOnlyProperty == null)
+                throw new JsonException("Cannot write null property DateOnlyClass.DateOnlyProperty to non-nullable JSON property 'dateOnlyProperty'.");
+
             if (dateOnlyClass.DateOnlyPropertyOption.IsSet)
                 writer.WriteString("dateOnlyProperty", dateOnlyClass.DateOnlyPropertyOption.Value.Value.ToString(DateOnlyPropertyFormat));
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, DeprecatedObject deprecatedObject, JsonSerializerOptions jsonSerializerOptions)
         {
             if (deprecatedObject.NameOption.IsSet && deprecatedObject.Name == null)
-                throw new ArgumentNullException(nameof(deprecatedObject.Name), "Property is required for class DeprecatedObject.");
+                throw new JsonException("Cannot write null property DeprecatedObject.Name to non-nullable JSON property 'name'.");
 
             if (deprecatedObject.NameOption.IsSet)
                 writer.WriteString("name", deprecatedObject.Name);

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Descendant1.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Descendant1.cs
@@ -182,12 +182,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Descendant1 descendant1, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (descendant1.AlternativeName == null)
-                throw new ArgumentNullException(nameof(descendant1.AlternativeName), "Property is required for class Descendant1.");
-
-            if (descendant1.DescendantName == null)
-                throw new ArgumentNullException(nameof(descendant1.DescendantName), "Property is required for class Descendant1.");
-
             writer.WriteString("alternativeName", descendant1.AlternativeName);
 
             writer.WriteString("descendantName", descendant1.DescendantName);

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Descendant2.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Descendant2.cs
@@ -182,12 +182,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Descendant2 descendant2, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (descendant2.AlternativeName == null)
-                throw new ArgumentNullException(nameof(descendant2.AlternativeName), "Property is required for class Descendant2.");
-
-            if (descendant2.Confidentiality == null)
-                throw new ArgumentNullException(nameof(descendant2.Confidentiality), "Property is required for class Descendant2.");
-
             writer.WriteString("alternativeName", descendant2.AlternativeName);
 
             writer.WriteString("confidentiality", descendant2.Confidentiality);

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Dog.cs
@@ -177,10 +177,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Dog dog, JsonSerializerOptions jsonSerializerOptions)
         {
             if (dog.BreedOption.IsSet && dog.Breed == null)
-                throw new ArgumentNullException(nameof(dog.Breed), "Property is required for class Dog.");
+                throw new JsonException("Cannot write null property Dog.Breed to non-nullable JSON property 'breed'.");
 
             if (dog.ColorOption.IsSet && dog.Color == null)
-                throw new ArgumentNullException(nameof(dog.Color), "Property is required for class Dog.");
+                throw new JsonException("Cannot write null property Dog.Color to non-nullable JSON property 'color'.");
 
             writer.WriteString("className", dog.ClassName);
 

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Drawing.cs
@@ -238,10 +238,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Drawing drawing, JsonSerializerOptions jsonSerializerOptions)
         {
             if (drawing.MainShapeOption.IsSet && drawing.MainShape == null)
-                throw new ArgumentNullException(nameof(drawing.MainShape), "Property is required for class Drawing.");
+                throw new JsonException("Cannot write null property Drawing.MainShape to non-nullable JSON property 'mainShape'.");
 
             if (drawing.ShapesOption.IsSet && drawing.Shapes == null)
-                throw new ArgumentNullException(nameof(drawing.Shapes), "Property is required for class Drawing.");
+                throw new JsonException("Cannot write null property Drawing.Shapes to non-nullable JSON property 'shapes'.");
 
             if (drawing.MainShapeOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -337,7 +337,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, EnumArrays enumArrays, JsonSerializerOptions jsonSerializerOptions)
         {
             if (enumArrays.ArrayEnumOption.IsSet && enumArrays.ArrayEnum == null)
-                throw new ArgumentNullException(nameof(enumArrays.ArrayEnum), "Property is required for class EnumArrays.");
+                throw new JsonException("Cannot write null property EnumArrays.ArrayEnum to non-nullable JSON property 'array_enum'.");
 
             if (enumArrays.ArrayEnumOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -339,6 +339,9 @@ namespace Org.OpenAPITools.Model
             if (enumArrays.ArrayEnumOption.IsSet && enumArrays.ArrayEnum == null)
                 throw new JsonException("Cannot write null property EnumArrays.ArrayEnum to non-nullable JSON property 'array_enum'.");
 
+            if (enumArrays.JustSymbolOption.IsSet && enumArrays.JustSymbol == null)
+                throw new JsonException("Cannot write null property EnumArrays.JustSymbol to non-nullable JSON property 'just_symbol'.");
+
             if (enumArrays.ArrayEnumOption.IsSet)
             {
                 writer.WritePropertyName("array_enum");

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -875,6 +875,27 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, EnumTest enumTest, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (enumTest.EnumIntegerOption.IsSet && enumTest.EnumInteger == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumInteger to non-nullable JSON property 'enum_integer'.");
+
+            if (enumTest.EnumIntegerOnlyOption.IsSet && enumTest.EnumIntegerOnly == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumIntegerOnly to non-nullable JSON property 'enum_integer_only'.");
+
+            if (enumTest.EnumNumberOption.IsSet && enumTest.EnumNumber == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumNumber to non-nullable JSON property 'enum_number'.");
+
+            if (enumTest.EnumStringOption.IsSet && enumTest.EnumString == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumString to non-nullable JSON property 'enum_string'.");
+
+            if (enumTest.OuterEnumDefaultValueOption.IsSet && enumTest.OuterEnumDefaultValue == null)
+                throw new JsonException("Cannot write null property EnumTest.OuterEnumDefaultValue to non-nullable JSON property 'outerEnumDefaultValue'.");
+
+            if (enumTest.OuterEnumIntegerOption.IsSet && enumTest.OuterEnumInteger == null)
+                throw new JsonException("Cannot write null property EnumTest.OuterEnumInteger to non-nullable JSON property 'outerEnumInteger'.");
+
+            if (enumTest.OuterEnumIntegerDefaultValueOption.IsSet && enumTest.OuterEnumIntegerDefaultValue == null)
+                throw new JsonException("Cannot write null property EnumTest.OuterEnumIntegerDefaultValue to non-nullable JSON property 'outerEnumIntegerDefaultValue'.");
+
             var enumStringRequiredRawValue = EnumTest.EnumStringRequiredEnumToJsonValue(enumTest.EnumStringRequired);
             writer.WriteString("enum_string_required", enumStringRequiredRawValue);
             if (enumTest.EnumIntegerOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
@@ -189,12 +189,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, EquilateralTriangle equilateralTriangle, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (equilateralTriangle.ShapeType == null)
-                throw new ArgumentNullException(nameof(equilateralTriangle.ShapeType), "Property is required for class EquilateralTriangle.");
-
-            if (equilateralTriangle.TriangleType == null)
-                throw new ArgumentNullException(nameof(equilateralTriangle.TriangleType), "Property is required for class EquilateralTriangle.");
-
             writer.WriteString("shapeType", equilateralTriangle.ShapeType);
 
             writer.WriteString("triangleType", equilateralTriangle.TriangleType);

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/File.cs
@@ -176,7 +176,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, File file, JsonSerializerOptions jsonSerializerOptions)
         {
             if (file.SourceURIOption.IsSet && file.SourceURI == null)
-                throw new ArgumentNullException(nameof(file.SourceURI), "Property is required for class File.");
+                throw new JsonException("Cannot write null property File.SourceURI to non-nullable JSON property 'sourceURI'.");
 
             if (file.SourceURIOption.IsSet)
                 writer.WriteString("sourceURI", file.SourceURI);

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -198,10 +198,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, FileSchemaTestClass fileSchemaTestClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (fileSchemaTestClass.FileOption.IsSet && fileSchemaTestClass.File == null)
-                throw new ArgumentNullException(nameof(fileSchemaTestClass.File), "Property is required for class FileSchemaTestClass.");
+                throw new JsonException("Cannot write null property FileSchemaTestClass.File to non-nullable JSON property 'file'.");
 
             if (fileSchemaTestClass.FilesOption.IsSet && fileSchemaTestClass.Files == null)
-                throw new ArgumentNullException(nameof(fileSchemaTestClass.Files), "Property is required for class FileSchemaTestClass.");
+                throw new JsonException("Cannot write null property FileSchemaTestClass.Files to non-nullable JSON property 'files'.");
 
             if (fileSchemaTestClass.FileOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Foo.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Foo foo, JsonSerializerOptions jsonSerializerOptions)
         {
             if (foo.BarOption.IsSet && foo.Bar == null)
-                throw new ArgumentNullException(nameof(foo.Bar), "Property is required for class Foo.");
+                throw new JsonException("Cannot write null property Foo.Bar to non-nullable JSON property 'bar'.");
 
             if (foo.BarOption.IsSet)
                 writer.WriteString("bar", foo.Bar);

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, FooGetDefaultResponse fooGetDefaultResponse, JsonSerializerOptions jsonSerializerOptions)
         {
             if (fooGetDefaultResponse.StringOption.IsSet && fooGetDefaultResponse.String == null)
-                throw new ArgumentNullException(nameof(fooGetDefaultResponse.String), "Property is required for class FooGetDefaultResponse.");
+                throw new JsonException("Cannot write null property FooGetDefaultResponse.String to non-nullable JSON property 'string'.");
 
             if (fooGetDefaultResponse.StringOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -954,11 +954,47 @@ namespace Org.OpenAPITools.Model
             if (formatTest.BinaryOption.IsSet && formatTest.Binary == null)
                 throw new JsonException("Cannot write null property FormatTest.Binary to non-nullable JSON property 'binary'.");
 
+            if (formatTest.DateTimeOption.IsSet && formatTest.DateTime == null)
+                throw new JsonException("Cannot write null property FormatTest.DateTime to non-nullable JSON property 'dateTime'.");
+
+            if (formatTest.DecimalOption.IsSet && formatTest.Decimal == null)
+                throw new JsonException("Cannot write null property FormatTest.Decimal to non-nullable JSON property 'decimal'.");
+
+            if (formatTest.DoubleOption.IsSet && formatTest.Double == null)
+                throw new JsonException("Cannot write null property FormatTest.Double to non-nullable JSON property 'double'.");
+
             if (formatTest.DuplicatePropertyName2Option.IsSet && formatTest.DuplicatePropertyName2 == null)
                 throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName2 to non-nullable JSON property 'duplicate_property_name'.");
 
             if (formatTest.DuplicatePropertyNameOption.IsSet && formatTest.DuplicatePropertyName == null)
                 throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName to non-nullable JSON property '@duplicate_property_name'.");
+
+            if (formatTest.FloatOption.IsSet && formatTest.Float == null)
+                throw new JsonException("Cannot write null property FormatTest.Float to non-nullable JSON property 'float'.");
+
+            if (formatTest.Int32Option.IsSet && formatTest.Int32 == null)
+                throw new JsonException("Cannot write null property FormatTest.Int32 to non-nullable JSON property 'int32'.");
+
+            if (formatTest.Int32RangeOption.IsSet && formatTest.Int32Range == null)
+                throw new JsonException("Cannot write null property FormatTest.Int32Range to non-nullable JSON property 'int32Range'.");
+
+            if (formatTest.Int64Option.IsSet && formatTest.Int64 == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64 to non-nullable JSON property 'int64'.");
+
+            if (formatTest.Int64NegativeOption.IsSet && formatTest.Int64Negative == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64Negative to non-nullable JSON property 'int64Negative'.");
+
+            if (formatTest.Int64NegativeExclusiveOption.IsSet && formatTest.Int64NegativeExclusive == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64NegativeExclusive to non-nullable JSON property 'int64NegativeExclusive'.");
+
+            if (formatTest.Int64PositiveOption.IsSet && formatTest.Int64Positive == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64Positive to non-nullable JSON property 'int64Positive'.");
+
+            if (formatTest.Int64PositiveExclusiveOption.IsSet && formatTest.Int64PositiveExclusive == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64PositiveExclusive to non-nullable JSON property 'int64PositiveExclusive'.");
+
+            if (formatTest.IntegerOption.IsSet && formatTest.Integer == null)
+                throw new JsonException("Cannot write null property FormatTest.Integer to non-nullable JSON property 'integer'.");
 
             if (formatTest.PatternWithBackslashOption.IsSet && formatTest.PatternWithBackslash == null)
                 throw new JsonException("Cannot write null property FormatTest.PatternWithBackslash to non-nullable JSON property 'pattern_with_backslash'.");
@@ -971,6 +1007,18 @@ namespace Org.OpenAPITools.Model
 
             if (formatTest.StringOption.IsSet && formatTest.String == null)
                 throw new JsonException("Cannot write null property FormatTest.String to non-nullable JSON property 'string'.");
+
+            if (formatTest.StringFormattedAsDecimalOption.IsSet && formatTest.StringFormattedAsDecimal == null)
+                throw new JsonException("Cannot write null property FormatTest.StringFormattedAsDecimal to non-nullable JSON property 'string_formatted_as_decimal'.");
+
+            if (formatTest.UnsignedIntegerOption.IsSet && formatTest.UnsignedInteger == null)
+                throw new JsonException("Cannot write null property FormatTest.UnsignedInteger to non-nullable JSON property 'unsigned_integer'.");
+
+            if (formatTest.UnsignedLongOption.IsSet && formatTest.UnsignedLong == null)
+                throw new JsonException("Cannot write null property FormatTest.UnsignedLong to non-nullable JSON property 'unsigned_long'.");
+
+            if (formatTest.UuidOption.IsSet && formatTest.Uuid == null)
+                throw new JsonException("Cannot write null property FormatTest.Uuid to non-nullable JSON property 'uuid'.");
 
             writer.WritePropertyName("byte");
             JsonSerializer.Serialize(writer, formatTest.Byte, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -951,32 +951,26 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, FormatTest formatTest, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (formatTest.Byte == null)
-                throw new ArgumentNullException(nameof(formatTest.Byte), "Property is required for class FormatTest.");
-
-            if (formatTest.Password == null)
-                throw new ArgumentNullException(nameof(formatTest.Password), "Property is required for class FormatTest.");
-
             if (formatTest.BinaryOption.IsSet && formatTest.Binary == null)
-                throw new ArgumentNullException(nameof(formatTest.Binary), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.Binary to non-nullable JSON property 'binary'.");
 
             if (formatTest.DuplicatePropertyName2Option.IsSet && formatTest.DuplicatePropertyName2 == null)
-                throw new ArgumentNullException(nameof(formatTest.DuplicatePropertyName2), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName2 to non-nullable JSON property 'duplicate_property_name'.");
 
             if (formatTest.DuplicatePropertyNameOption.IsSet && formatTest.DuplicatePropertyName == null)
-                throw new ArgumentNullException(nameof(formatTest.DuplicatePropertyName), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName to non-nullable JSON property '@duplicate_property_name'.");
 
             if (formatTest.PatternWithBackslashOption.IsSet && formatTest.PatternWithBackslash == null)
-                throw new ArgumentNullException(nameof(formatTest.PatternWithBackslash), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.PatternWithBackslash to non-nullable JSON property 'pattern_with_backslash'.");
 
             if (formatTest.PatternWithDigitsOption.IsSet && formatTest.PatternWithDigits == null)
-                throw new ArgumentNullException(nameof(formatTest.PatternWithDigits), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.PatternWithDigits to non-nullable JSON property 'pattern_with_digits'.");
 
             if (formatTest.PatternWithDigitsAndDelimiterOption.IsSet && formatTest.PatternWithDigitsAndDelimiter == null)
-                throw new ArgumentNullException(nameof(formatTest.PatternWithDigitsAndDelimiter), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.PatternWithDigitsAndDelimiter to non-nullable JSON property 'pattern_with_digits_and_delimiter'.");
 
             if (formatTest.StringOption.IsSet && formatTest.String == null)
-                throw new ArgumentNullException(nameof(formatTest.String), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.String to non-nullable JSON property 'string'.");
 
             writer.WritePropertyName("byte");
             JsonSerializer.Serialize(writer, formatTest.Byte, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
@@ -219,7 +219,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Fruit fruit, JsonSerializerOptions jsonSerializerOptions)
         {
             if (fruit.ColorOption.IsSet && fruit.Color == null)
-                throw new ArgumentNullException(nameof(fruit.Color), "Property is required for class Fruit.");
+                throw new JsonException("Cannot write null property Fruit.Color to non-nullable JSON property 'color'.");
 
             if (fruit.ColorOption.IsSet)
                 writer.WriteString("color", fruit.Color);

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -236,7 +236,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, GmFruit gmFruit, JsonSerializerOptions jsonSerializerOptions)
         {
             if (gmFruit.ColorOption.IsSet && gmFruit.Color == null)
-                throw new ArgumentNullException(nameof(gmFruit.Color), "Property is required for class GmFruit.");
+                throw new JsonException("Cannot write null property GmFruit.Color to non-nullable JSON property 'color'.");
 
             if (gmFruit.ColorOption.IsSet)
                 writer.WriteString("color", gmFruit.Color);

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -239,10 +239,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, HasOnlyReadOnly hasOnlyReadOnly, JsonSerializerOptions jsonSerializerOptions)
         {
             if (hasOnlyReadOnly.BarOption.IsSet && hasOnlyReadOnly.Bar == null)
-                throw new ArgumentNullException(nameof(hasOnlyReadOnly.Bar), "Property is required for class HasOnlyReadOnly.");
+                throw new JsonException("Cannot write null property HasOnlyReadOnly.Bar to non-nullable JSON property 'bar'.");
 
             if (hasOnlyReadOnly.FooOption.IsSet && hasOnlyReadOnly.Foo == null)
-                throw new ArgumentNullException(nameof(hasOnlyReadOnly.Foo), "Property is required for class HasOnlyReadOnly.");
+                throw new JsonException("Cannot write null property HasOnlyReadOnly.Foo to non-nullable JSON property 'foo'.");
 
             if (hasOnlyReadOnly.BarOption.IsSet)
                 writer.WriteString("bar", hasOnlyReadOnly.Bar);

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
@@ -337,22 +337,22 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, InjectedVendorExtensionsTest injectedVendorExtensionsTest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessorOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor to non-nullable JSON property 'potentiallyOverriddenPropertyAccessor'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternalOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternal == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternal), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternal to non-nullable JSON property 'potentiallyOverriddenPropertyToInternal'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivateOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivate == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivate), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivate to non-nullable JSON property 'potentiallyOverriddenPropertyToPrivate'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublicOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublic == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublic), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublic to non-nullable JSON property 'potentiallyOverriddenPropertyToPublic'.");
 
             if (injectedVendorExtensionsTest.UnalteredPropertyOption.IsSet && injectedVendorExtensionsTest.UnalteredProperty == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.UnalteredProperty), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.UnalteredProperty to non-nullable JSON property 'unalteredProperty'.");
 
             if (injectedVendorExtensionsTest.UnalteredPropertyAccessorOption.IsSet && injectedVendorExtensionsTest.UnalteredPropertyAccessor == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.UnalteredPropertyAccessor), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.UnalteredPropertyAccessor to non-nullable JSON property 'unalteredPropertyAccessor'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessorOption.IsSet)
                 writer.WriteString("potentiallyOverriddenPropertyAccessor", injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor);

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
@@ -182,12 +182,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, IsoscelesTriangle isoscelesTriangle, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (isoscelesTriangle.ShapeType == null)
-                throw new ArgumentNullException(nameof(isoscelesTriangle.ShapeType), "Property is required for class IsoscelesTriangle.");
-
-            if (isoscelesTriangle.TriangleType == null)
-                throw new ArgumentNullException(nameof(isoscelesTriangle.TriangleType), "Property is required for class IsoscelesTriangle.");
-
             writer.WriteString("shapeType", isoscelesTriangle.ShapeType);
 
             writer.WriteString("triangleType", isoscelesTriangle.TriangleType);

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/List.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, List list, JsonSerializerOptions jsonSerializerOptions)
         {
             if (list.Var123ListOption.IsSet && list.Var123List == null)
-                throw new ArgumentNullException(nameof(list.Var123List), "Property is required for class List.");
+                throw new JsonException("Cannot write null property List.Var123List to non-nullable JSON property '123-list'.");
 
             if (list.Var123ListOption.IsSet)
                 writer.WriteString("123-list", list.Var123List);

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -198,10 +198,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, LiteralStringClass literalStringClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (literalStringClass.EscapedLiteralStringOption.IsSet && literalStringClass.EscapedLiteralString == null)
-                throw new ArgumentNullException(nameof(literalStringClass.EscapedLiteralString), "Property is required for class LiteralStringClass.");
+                throw new JsonException("Cannot write null property LiteralStringClass.EscapedLiteralString to non-nullable JSON property 'escapedLiteralString'.");
 
             if (literalStringClass.UnescapedLiteralStringOption.IsSet && literalStringClass.UnescapedLiteralString == null)
-                throw new ArgumentNullException(nameof(literalStringClass.UnescapedLiteralString), "Property is required for class LiteralStringClass.");
+                throw new JsonException("Cannot write null property LiteralStringClass.UnescapedLiteralString to non-nullable JSON property 'unescapedLiteralString'.");
 
             if (literalStringClass.EscapedLiteralStringOption.IsSet)
                 writer.WriteString("escapedLiteralString", literalStringClass.EscapedLiteralString);

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/MapTest.cs
@@ -310,16 +310,16 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MapTest mapTest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mapTest.DirectMapOption.IsSet && mapTest.DirectMap == null)
-                throw new ArgumentNullException(nameof(mapTest.DirectMap), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.DirectMap to non-nullable JSON property 'direct_map'.");
 
             if (mapTest.IndirectMapOption.IsSet && mapTest.IndirectMap == null)
-                throw new ArgumentNullException(nameof(mapTest.IndirectMap), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.IndirectMap to non-nullable JSON property 'indirect_map'.");
 
             if (mapTest.MapMapOfStringOption.IsSet && mapTest.MapMapOfString == null)
-                throw new ArgumentNullException(nameof(mapTest.MapMapOfString), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.MapMapOfString to non-nullable JSON property 'map_map_of_string'.");
 
             if (mapTest.MapOfEnumStringOption.IsSet && mapTest.MapOfEnumString == null)
-                throw new ArgumentNullException(nameof(mapTest.MapOfEnumString), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.MapOfEnumString to non-nullable JSON property 'map_of_enum_string'.");
 
             if (mapTest.DirectMapOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/MixedAnyOf.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/MixedAnyOf.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedAnyOf mixedAnyOf, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedAnyOf.ContentOption.IsSet && mixedAnyOf.Content == null)
-                throw new ArgumentNullException(nameof(mixedAnyOf.Content), "Property is required for class MixedAnyOf.");
+                throw new JsonException("Cannot write null property MixedAnyOf.Content to non-nullable JSON property 'content'.");
 
             if (mixedAnyOf.ContentOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/MixedOneOf.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/MixedOneOf.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedOneOf mixedOneOf, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedOneOf.ContentOption.IsSet && mixedOneOf.Content == null)
-                throw new ArgumentNullException(nameof(mixedOneOf.Content), "Property is required for class MixedOneOf.");
+                throw new JsonException("Cannot write null property MixedOneOf.Content to non-nullable JSON property 'content'.");
 
             if (mixedOneOf.ContentOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -255,8 +255,17 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, MixedPropertiesAndAdditionalPropertiesClass mixedPropertiesAndAdditionalPropertiesClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.DateTime == null)
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.DateTime to non-nullable JSON property 'dateTime'.");
+
             if (mixedPropertiesAndAdditionalPropertiesClass.MapOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.Map == null)
                 throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.Map to non-nullable JSON property 'map'.");
+
+            if (mixedPropertiesAndAdditionalPropertiesClass.UuidOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.Uuid == null)
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.Uuid to non-nullable JSON property 'uuid'.");
+
+            if (mixedPropertiesAndAdditionalPropertiesClass.UuidWithPatternOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.UuidWithPattern == null)
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.UuidWithPattern to non-nullable JSON property 'uuid_with_pattern'.");
 
             if (mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.IsSet)
                 writer.WriteString("dateTime", mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.Value.Value.ToString(DateTimeFormat));

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -256,7 +256,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedPropertiesAndAdditionalPropertiesClass mixedPropertiesAndAdditionalPropertiesClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedPropertiesAndAdditionalPropertiesClass.MapOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.Map == null)
-                throw new ArgumentNullException(nameof(mixedPropertiesAndAdditionalPropertiesClass.Map), "Property is required for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.Map to non-nullable JSON property 'map'.");
 
             if (mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.IsSet)
                 writer.WriteString("dateTime", mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.Value.Value.ToString(DateTimeFormat));

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/MixedSubId.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/MixedSubId.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedSubId mixedSubId, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedSubId.IdOption.IsSet && mixedSubId.Id == null)
-                throw new ArgumentNullException(nameof(mixedSubId.Id), "Property is required for class MixedSubId.");
+                throw new JsonException("Cannot write null property MixedSubId.Id to non-nullable JSON property 'id'.");
 
             if (mixedSubId.IdOption.IsSet)
                 writer.WriteString("id", mixedSubId.Id);

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -198,7 +198,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Model200Response model200Response, JsonSerializerOptions jsonSerializerOptions)
         {
             if (model200Response.ClassOption.IsSet && model200Response.Class == null)
-                throw new ArgumentNullException(nameof(model200Response.Class), "Property is required for class Model200Response.");
+                throw new JsonException("Cannot write null property Model200Response.Class to non-nullable JSON property 'class'.");
 
             if (model200Response.ClassOption.IsSet)
                 writer.WriteString("class", model200Response.Class);

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -200,6 +200,9 @@ namespace Org.OpenAPITools.Model
             if (model200Response.ClassOption.IsSet && model200Response.Class == null)
                 throw new JsonException("Cannot write null property Model200Response.Class to non-nullable JSON property 'class'.");
 
+            if (model200Response.NameOption.IsSet && model200Response.Name == null)
+                throw new JsonException("Cannot write null property Model200Response.Name to non-nullable JSON property 'name'.");
+
             if (model200Response.ClassOption.IsSet)
                 writer.WriteString("class", model200Response.Class);
 

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ModelClient modelClient, JsonSerializerOptions jsonSerializerOptions)
         {
             if (modelClient.VarClientOption.IsSet && modelClient.VarClient == null)
-                throw new ArgumentNullException(nameof(modelClient.VarClient), "Property is required for class ModelClient.");
+                throw new JsonException("Cannot write null property ModelClient.VarClient to non-nullable JSON property 'client'.");
 
             if (modelClient.VarClientOption.IsSet)
                 writer.WriteString("client", modelClient.VarClient);

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Name.cs
@@ -281,7 +281,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Name name, JsonSerializerOptions jsonSerializerOptions)
         {
             if (name.PropertyOption.IsSet && name.Property == null)
-                throw new ArgumentNullException(nameof(name.Property), "Property is required for class Name.");
+                throw new JsonException("Cannot write null property Name.Property to non-nullable JSON property 'property'.");
 
             writer.WriteNumber("name", name.VarName);
 

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Name.cs
@@ -283,6 +283,12 @@ namespace Org.OpenAPITools.Model
             if (name.PropertyOption.IsSet && name.Property == null)
                 throw new JsonException("Cannot write null property Name.Property to non-nullable JSON property 'property'.");
 
+            if (name.SnakeCaseOption.IsSet && name.SnakeCase == null)
+                throw new JsonException("Cannot write null property Name.SnakeCase to non-nullable JSON property 'snake_case'.");
+
+            if (name.Var123NumberOption.IsSet && name.Var123Number == null)
+                throw new JsonException("Cannot write null property Name.Var123Number to non-nullable JSON property '123Number'.");
+
             writer.WriteNumber("name", name.VarName);
 
             if (name.PropertyOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
@@ -189,9 +189,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, NotificationtestGetElementsV1ResponseMPayload notificationtestGetElementsV1ResponseMPayload, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (notificationtestGetElementsV1ResponseMPayload.AObjVariableobject == null)
-                throw new ArgumentNullException(nameof(notificationtestGetElementsV1ResponseMPayload.AObjVariableobject), "Property is required for class NotificationtestGetElementsV1ResponseMPayload.");
-
             writer.WritePropertyName("a_objVariableobject");
             JsonSerializer.Serialize(writer, notificationtestGetElementsV1ResponseMPayload.AObjVariableobject, jsonSerializerOptions);
             writer.WriteNumber("pkiNotificationtestID", notificationtestGetElementsV1ResponseMPayload.PkiNotificationtestID);

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -408,10 +408,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, NullableClass nullableClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (nullableClass.ArrayItemsNullableOption.IsSet && nullableClass.ArrayItemsNullable == null)
-                throw new ArgumentNullException(nameof(nullableClass.ArrayItemsNullable), "Property is required for class NullableClass.");
+                throw new JsonException("Cannot write null property NullableClass.ArrayItemsNullable to non-nullable JSON property 'array_items_nullable'.");
 
             if (nullableClass.ObjectItemsNullableOption.IsSet && nullableClass.ObjectItemsNullable == null)
-                throw new ArgumentNullException(nameof(nullableClass.ObjectItemsNullable), "Property is required for class NullableClass.");
+                throw new JsonException("Cannot write null property NullableClass.ObjectItemsNullable to non-nullable JSON property 'object_items_nullable'.");
 
             if (nullableClass.ArrayAndItemsNullablePropOption.IsSet)
                 if (nullableClass.ArrayAndItemsNullablePropOption.Value != null)

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -174,6 +174,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, NumberOnly numberOnly, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (numberOnly.JustNumberOption.IsSet && numberOnly.JustNumber == null)
+                throw new JsonException("Cannot write null property NumberOnly.JustNumber to non-nullable JSON property 'JustNumber'.");
+
             if (numberOnly.JustNumberOption.IsSet)
                 writer.WriteNumber("JustNumber", numberOnly.JustNumberOption.Value.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -247,13 +247,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ObjectWithDeprecatedFields objectWithDeprecatedFields, JsonSerializerOptions jsonSerializerOptions)
         {
             if (objectWithDeprecatedFields.BarsOption.IsSet && objectWithDeprecatedFields.Bars == null)
-                throw new ArgumentNullException(nameof(objectWithDeprecatedFields.Bars), "Property is required for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Bars to non-nullable JSON property 'bars'.");
 
             if (objectWithDeprecatedFields.DeprecatedRefOption.IsSet && objectWithDeprecatedFields.DeprecatedRef == null)
-                throw new ArgumentNullException(nameof(objectWithDeprecatedFields.DeprecatedRef), "Property is required for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.DeprecatedRef to non-nullable JSON property 'deprecatedRef'.");
 
             if (objectWithDeprecatedFields.UuidOption.IsSet && objectWithDeprecatedFields.Uuid == null)
-                throw new ArgumentNullException(nameof(objectWithDeprecatedFields.Uuid), "Property is required for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Uuid to non-nullable JSON property 'uuid'.");
 
             if (objectWithDeprecatedFields.BarsOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -252,6 +252,9 @@ namespace Org.OpenAPITools.Model
             if (objectWithDeprecatedFields.DeprecatedRefOption.IsSet && objectWithDeprecatedFields.DeprecatedRef == null)
                 throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.DeprecatedRef to non-nullable JSON property 'deprecatedRef'.");
 
+            if (objectWithDeprecatedFields.IdOption.IsSet && objectWithDeprecatedFields.Id == null)
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Id to non-nullable JSON property 'id'.");
+
             if (objectWithDeprecatedFields.UuidOption.IsSet && objectWithDeprecatedFields.Uuid == null)
                 throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Uuid to non-nullable JSON property 'uuid'.");
 

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Order.cs
@@ -384,6 +384,24 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Order order, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (order.CompleteOption.IsSet && order.Complete == null)
+                throw new JsonException("Cannot write null property Order.Complete to non-nullable JSON property 'complete'.");
+
+            if (order.IdOption.IsSet && order.Id == null)
+                throw new JsonException("Cannot write null property Order.Id to non-nullable JSON property 'id'.");
+
+            if (order.PetIdOption.IsSet && order.PetId == null)
+                throw new JsonException("Cannot write null property Order.PetId to non-nullable JSON property 'petId'.");
+
+            if (order.QuantityOption.IsSet && order.Quantity == null)
+                throw new JsonException("Cannot write null property Order.Quantity to non-nullable JSON property 'quantity'.");
+
+            if (order.ShipDateOption.IsSet && order.ShipDate == null)
+                throw new JsonException("Cannot write null property Order.ShipDate to non-nullable JSON property 'shipDate'.");
+
+            if (order.StatusOption.IsSet && order.Status == null)
+                throw new JsonException("Cannot write null property Order.Status to non-nullable JSON property 'status'.");
+
             if (order.CompleteOption.IsSet)
                 writer.WriteBoolean("complete", order.CompleteOption.Value.Value);
 

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -220,6 +220,12 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, OuterComposite outerComposite, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (outerComposite.MyBooleanOption.IsSet && outerComposite.MyBoolean == null)
+                throw new JsonException("Cannot write null property OuterComposite.MyBoolean to non-nullable JSON property 'my_boolean'.");
+
+            if (outerComposite.MyNumberOption.IsSet && outerComposite.MyNumber == null)
+                throw new JsonException("Cannot write null property OuterComposite.MyNumber to non-nullable JSON property 'my_number'.");
+
             if (outerComposite.MyStringOption.IsSet && outerComposite.MyString == null)
                 throw new JsonException("Cannot write null property OuterComposite.MyString to non-nullable JSON property 'my_string'.");
 

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -221,7 +221,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, OuterComposite outerComposite, JsonSerializerOptions jsonSerializerOptions)
         {
             if (outerComposite.MyStringOption.IsSet && outerComposite.MyString == null)
-                throw new ArgumentNullException(nameof(outerComposite.MyString), "Property is required for class OuterComposite.");
+                throw new JsonException("Cannot write null property OuterComposite.MyString to non-nullable JSON property 'my_string'.");
 
             if (outerComposite.MyBooleanOption.IsSet)
                 writer.WriteBoolean("my_boolean", outerComposite.MyBooleanOption.Value.Value);

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Pet.cs
@@ -371,17 +371,11 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Pet pet, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (pet.Name == null)
-                throw new ArgumentNullException(nameof(pet.Name), "Property is required for class Pet.");
-
-            if (pet.PhotoUrls == null)
-                throw new ArgumentNullException(nameof(pet.PhotoUrls), "Property is required for class Pet.");
-
             if (pet.CategoryOption.IsSet && pet.Category == null)
-                throw new ArgumentNullException(nameof(pet.Category), "Property is required for class Pet.");
+                throw new JsonException("Cannot write null property Pet.Category to non-nullable JSON property 'category'.");
 
             if (pet.TagsOption.IsSet && pet.Tags == null)
-                throw new ArgumentNullException(nameof(pet.Tags), "Property is required for class Pet.");
+                throw new JsonException("Cannot write null property Pet.Tags to non-nullable JSON property 'tags'.");
 
             writer.WriteString("name", pet.Name);
 

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Pet.cs
@@ -374,6 +374,12 @@ namespace Org.OpenAPITools.Model
             if (pet.CategoryOption.IsSet && pet.Category == null)
                 throw new JsonException("Cannot write null property Pet.Category to non-nullable JSON property 'category'.");
 
+            if (pet.IdOption.IsSet && pet.Id == null)
+                throw new JsonException("Cannot write null property Pet.Id to non-nullable JSON property 'id'.");
+
+            if (pet.StatusOption.IsSet && pet.Status == null)
+                throw new JsonException("Cannot write null property Pet.Status to non-nullable JSON property 'status'.");
+
             if (pet.TagsOption.IsSet && pet.Tags == null)
                 throw new JsonException("Cannot write null property Pet.Tags to non-nullable JSON property 'tags'.");
 

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
@@ -170,9 +170,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, QuadrilateralInterface quadrilateralInterface, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (quadrilateralInterface.QuadrilateralType == null)
-                throw new ArgumentNullException(nameof(quadrilateralInterface.QuadrilateralType), "Property is required for class QuadrilateralInterface.");
-
             writer.WriteString("quadrilateralType", quadrilateralInterface.QuadrilateralType);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -236,10 +236,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ReadOnlyFirst readOnlyFirst, JsonSerializerOptions jsonSerializerOptions)
         {
             if (readOnlyFirst.BarOption.IsSet && readOnlyFirst.Bar == null)
-                throw new ArgumentNullException(nameof(readOnlyFirst.Bar), "Property is required for class ReadOnlyFirst.");
+                throw new JsonException("Cannot write null property ReadOnlyFirst.Bar to non-nullable JSON property 'bar'.");
 
             if (readOnlyFirst.BazOption.IsSet && readOnlyFirst.Baz == null)
-                throw new ArgumentNullException(nameof(readOnlyFirst.Baz), "Property is required for class ReadOnlyFirst.");
+                throw new JsonException("Cannot write null property ReadOnlyFirst.Baz to non-nullable JSON property 'baz'.");
 
             if (readOnlyFirst.BarOption.IsSet)
                 writer.WriteString("bar", readOnlyFirst.Bar);

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -2235,17 +2235,11 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, RequiredClass requiredClass, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (requiredClass.RequiredNotnullableArrayOfString == null)
-                throw new ArgumentNullException(nameof(requiredClass.RequiredNotnullableArrayOfString), "Property is required for class RequiredClass.");
-
-            if (requiredClass.RequiredNotnullableStringProp == null)
-                throw new ArgumentNullException(nameof(requiredClass.RequiredNotnullableStringProp), "Property is required for class RequiredClass.");
-
             if (requiredClass.NotrequiredNotnullableArrayOfStringOption.IsSet && requiredClass.NotrequiredNotnullableArrayOfString == null)
-                throw new ArgumentNullException(nameof(requiredClass.NotrequiredNotnullableArrayOfString), "Property is required for class RequiredClass.");
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableArrayOfString to non-nullable JSON property 'notrequired_notnullable_array_of_string'.");
 
             if (requiredClass.NotrequiredNotnullableStringPropOption.IsSet && requiredClass.NotrequiredNotnullableStringProp == null)
-                throw new ArgumentNullException(nameof(requiredClass.NotrequiredNotnullableStringProp), "Property is required for class RequiredClass.");
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableStringProp to non-nullable JSON property 'notrequired_notnullable_string_prop'.");
 
             writer.WriteString("required_not_nullable_date_prop", requiredClass.RequiredNotNullableDateProp.ToString(RequiredNotNullableDatePropFormat));
 

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -2235,11 +2235,38 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, RequiredClass requiredClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (requiredClass.NotRequiredNotnullableDatePropOption.IsSet && requiredClass.NotRequiredNotnullableDateProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotRequiredNotnullableDateProp to non-nullable JSON property 'not_required_notnullable_date_prop'.");
+
+            if (requiredClass.NotRequiredNotnullableintegerPropOption.IsSet && requiredClass.NotRequiredNotnullableintegerProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotRequiredNotnullableintegerProp to non-nullable JSON property 'not_required_notnullableinteger_prop'.");
+
             if (requiredClass.NotrequiredNotnullableArrayOfStringOption.IsSet && requiredClass.NotrequiredNotnullableArrayOfString == null)
                 throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableArrayOfString to non-nullable JSON property 'notrequired_notnullable_array_of_string'.");
 
+            if (requiredClass.NotrequiredNotnullableBooleanPropOption.IsSet && requiredClass.NotrequiredNotnullableBooleanProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableBooleanProp to non-nullable JSON property 'notrequired_notnullable_boolean_prop'.");
+
+            if (requiredClass.NotrequiredNotnullableDatetimePropOption.IsSet && requiredClass.NotrequiredNotnullableDatetimeProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableDatetimeProp to non-nullable JSON property 'notrequired_notnullable_datetime_prop'.");
+
+            if (requiredClass.NotrequiredNotnullableEnumIntegerOption.IsSet && requiredClass.NotrequiredNotnullableEnumInteger == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableEnumInteger to non-nullable JSON property 'notrequired_notnullable_enum_integer'.");
+
+            if (requiredClass.NotrequiredNotnullableEnumIntegerOnlyOption.IsSet && requiredClass.NotrequiredNotnullableEnumIntegerOnly == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableEnumIntegerOnly to non-nullable JSON property 'notrequired_notnullable_enum_integer_only'.");
+
+            if (requiredClass.NotrequiredNotnullableEnumStringOption.IsSet && requiredClass.NotrequiredNotnullableEnumString == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableEnumString to non-nullable JSON property 'notrequired_notnullable_enum_string'.");
+
+            if (requiredClass.NotrequiredNotnullableOuterEnumDefaultValueOption.IsSet && requiredClass.NotrequiredNotnullableOuterEnumDefaultValue == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableOuterEnumDefaultValue to non-nullable JSON property 'notrequired_notnullable_outerEnumDefaultValue'.");
+
             if (requiredClass.NotrequiredNotnullableStringPropOption.IsSet && requiredClass.NotrequiredNotnullableStringProp == null)
                 throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableStringProp to non-nullable JSON property 'notrequired_notnullable_string_prop'.");
+
+            if (requiredClass.NotrequiredNotnullableUuidOption.IsSet && requiredClass.NotrequiredNotnullableUuid == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableUuid to non-nullable JSON property 'notrequired_notnullable_uuid'.");
 
             writer.WriteString("required_not_nullable_date_prop", requiredClass.RequiredNotNullableDateProp.ToString(RequiredNotNullableDatePropFormat));
 

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Result.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Result.cs
@@ -224,13 +224,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Result result, JsonSerializerOptions jsonSerializerOptions)
         {
             if (result.CodeOption.IsSet && result.Code == null)
-                throw new ArgumentNullException(nameof(result.Code), "Property is required for class Result.");
+                throw new JsonException("Cannot write null property Result.Code to non-nullable JSON property 'code'.");
 
             if (result.DataOption.IsSet && result.Data == null)
-                throw new ArgumentNullException(nameof(result.Data), "Property is required for class Result.");
+                throw new JsonException("Cannot write null property Result.Data to non-nullable JSON property 'data'.");
 
             if (result.UuidOption.IsSet && result.Uuid == null)
-                throw new ArgumentNullException(nameof(result.Uuid), "Property is required for class Result.");
+                throw new JsonException("Cannot write null property Result.Uuid to non-nullable JSON property 'uuid'.");
 
             if (result.CodeOption.IsSet)
                 writer.WriteString("code", result.Code);

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Return.cs
@@ -232,11 +232,8 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Return varReturn, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (varReturn.Lock == null)
-                throw new ArgumentNullException(nameof(varReturn.Lock), "Property is required for class Return.");
-
             if (varReturn.UnsafeOption.IsSet && varReturn.Unsafe == null)
-                throw new ArgumentNullException(nameof(varReturn.Unsafe), "Property is required for class Return.");
+                throw new JsonException("Cannot write null property Return.Unsafe to non-nullable JSON property 'unsafe'.");
 
             writer.WriteString("lock", varReturn.Lock);
 

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Return.cs
@@ -232,6 +232,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Return varReturn, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (varReturn.VarReturnOption.IsSet && varReturn.VarReturn == null)
+                throw new JsonException("Cannot write null property Return.VarReturn to non-nullable JSON property 'return'.");
+
             if (varReturn.UnsafeOption.IsSet && varReturn.Unsafe == null)
                 throw new JsonException("Cannot write null property Return.Unsafe to non-nullable JSON property 'unsafe'.");
 

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -198,7 +198,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, RolesReportsHash rolesReportsHash, JsonSerializerOptions jsonSerializerOptions)
         {
             if (rolesReportsHash.RoleOption.IsSet && rolesReportsHash.Role == null)
-                throw new ArgumentNullException(nameof(rolesReportsHash.Role), "Property is required for class RolesReportsHash.");
+                throw new JsonException("Cannot write null property RolesReportsHash.Role to non-nullable JSON property 'role'.");
 
             if (rolesReportsHash.RoleOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -200,6 +200,9 @@ namespace Org.OpenAPITools.Model
             if (rolesReportsHash.RoleOption.IsSet && rolesReportsHash.Role == null)
                 throw new JsonException("Cannot write null property RolesReportsHash.Role to non-nullable JSON property 'role'.");
 
+            if (rolesReportsHash.RoleUuidOption.IsSet && rolesReportsHash.RoleUuid == null)
+                throw new JsonException("Cannot write null property RolesReportsHash.RoleUuid to non-nullable JSON property 'role_uuid'.");
+
             if (rolesReportsHash.RoleOption.IsSet)
             {
                 writer.WritePropertyName("role");

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, RolesReportsHashRole rolesReportsHashRole, JsonSerializerOptions jsonSerializerOptions)
         {
             if (rolesReportsHashRole.NameOption.IsSet && rolesReportsHashRole.Name == null)
-                throw new ArgumentNullException(nameof(rolesReportsHashRole.Name), "Property is required for class RolesReportsHashRole.");
+                throw new JsonException("Cannot write null property RolesReportsHashRole.Name to non-nullable JSON property 'name'.");
 
             if (rolesReportsHashRole.NameOption.IsSet)
                 writer.WriteString("name", rolesReportsHashRole.Name);

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
@@ -189,12 +189,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ScaleneTriangle scaleneTriangle, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (scaleneTriangle.ShapeType == null)
-                throw new ArgumentNullException(nameof(scaleneTriangle.ShapeType), "Property is required for class ScaleneTriangle.");
-
-            if (scaleneTriangle.TriangleType == null)
-                throw new ArgumentNullException(nameof(scaleneTriangle.TriangleType), "Property is required for class ScaleneTriangle.");
-
             writer.WriteString("shapeType", scaleneTriangle.ShapeType);
 
             writer.WriteString("triangleType", scaleneTriangle.TriangleType);

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ShapeInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ShapeInterface.cs
@@ -170,9 +170,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ShapeInterface shapeInterface, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (shapeInterface.ShapeType == null)
-                throw new ArgumentNullException(nameof(shapeInterface.ShapeType), "Property is required for class ShapeInterface.");
-
             writer.WriteString("shapeType", shapeInterface.ShapeType);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
@@ -189,12 +189,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, SimpleQuadrilateral simpleQuadrilateral, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (simpleQuadrilateral.QuadrilateralType == null)
-                throw new ArgumentNullException(nameof(simpleQuadrilateral.QuadrilateralType), "Property is required for class SimpleQuadrilateral.");
-
-            if (simpleQuadrilateral.ShapeType == null)
-                throw new ArgumentNullException(nameof(simpleQuadrilateral.ShapeType), "Property is required for class SimpleQuadrilateral.");
-
             writer.WriteString("quadrilateralType", simpleQuadrilateral.QuadrilateralType);
 
             writer.WriteString("shapeType", simpleQuadrilateral.ShapeType);

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -200,6 +200,9 @@ namespace Org.OpenAPITools.Model
             if (specialModelName.VarSpecialModelNameOption.IsSet && specialModelName.VarSpecialModelName == null)
                 throw new JsonException("Cannot write null property SpecialModelName.VarSpecialModelName to non-nullable JSON property '_special_model.name_'.");
 
+            if (specialModelName.SpecialPropertyNameOption.IsSet && specialModelName.SpecialPropertyName == null)
+                throw new JsonException("Cannot write null property SpecialModelName.SpecialPropertyName to non-nullable JSON property '$special[property.name]'.");
+
             if (specialModelName.VarSpecialModelNameOption.IsSet)
                 writer.WriteString("_special_model.name_", specialModelName.VarSpecialModelName);
 

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -198,7 +198,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, SpecialModelName specialModelName, JsonSerializerOptions jsonSerializerOptions)
         {
             if (specialModelName.VarSpecialModelNameOption.IsSet && specialModelName.VarSpecialModelName == null)
-                throw new ArgumentNullException(nameof(specialModelName.VarSpecialModelName), "Property is required for class SpecialModelName.");
+                throw new JsonException("Cannot write null property SpecialModelName.VarSpecialModelName to non-nullable JSON property '_special_model.name_'.");
 
             if (specialModelName.VarSpecialModelNameOption.IsSet)
                 writer.WriteString("_special_model.name_", specialModelName.VarSpecialModelName);

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Tag.cs
@@ -198,7 +198,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Tag tag, JsonSerializerOptions jsonSerializerOptions)
         {
             if (tag.NameOption.IsSet && tag.Name == null)
-                throw new ArgumentNullException(nameof(tag.Name), "Property is required for class Tag.");
+                throw new JsonException("Cannot write null property Tag.Name to non-nullable JSON property 'name'.");
 
             if (tag.IdOption.IsSet)
                 writer.WriteNumber("id", tag.IdOption.Value.Value);

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Tag.cs
@@ -197,6 +197,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Tag tag, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (tag.IdOption.IsSet && tag.Id == null)
+                throw new JsonException("Cannot write null property Tag.Id to non-nullable JSON property 'id'.");
+
             if (tag.NameOption.IsSet && tag.Name == null)
                 throw new JsonException("Cannot write null property Tag.Name to non-nullable JSON property 'name'.");
 

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestCollectionEndingWithWordList testCollectionEndingWithWordList, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testCollectionEndingWithWordList.ValueOption.IsSet && testCollectionEndingWithWordList.Value == null)
-                throw new ArgumentNullException(nameof(testCollectionEndingWithWordList.Value), "Property is required for class TestCollectionEndingWithWordList.");
+                throw new JsonException("Cannot write null property TestCollectionEndingWithWordList.Value to non-nullable JSON property 'value'.");
 
             if (testCollectionEndingWithWordList.ValueOption.IsSet)
                 writer.WriteString("value", testCollectionEndingWithWordList.Value);

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestCollectionEndingWithWordListObject testCollectionEndingWithWordListObject, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testCollectionEndingWithWordListObject.TestCollectionEndingWithWordListOption.IsSet && testCollectionEndingWithWordListObject.TestCollectionEndingWithWordList == null)
-                throw new ArgumentNullException(nameof(testCollectionEndingWithWordListObject.TestCollectionEndingWithWordList), "Property is required for class TestCollectionEndingWithWordListObject.");
+                throw new JsonException("Cannot write null property TestCollectionEndingWithWordListObject.TestCollectionEndingWithWordList to non-nullable JSON property 'TestCollectionEndingWithWordList'.");
 
             if (testCollectionEndingWithWordListObject.TestCollectionEndingWithWordListOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/TestDescendants.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/TestDescendants.cs
@@ -289,9 +289,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, TestDescendants testDescendants, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (testDescendants.AlternativeName == null)
-                throw new ArgumentNullException(nameof(testDescendants.AlternativeName), "Property is required for class TestDescendants.");
-
             writer.WriteString("alternativeName", testDescendants.AlternativeName);
 
             writer.WriteString("objectType", TestDescendants.ObjectTypeEnumToJsonValue(testDescendants.ObjectType));

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestInlineFreeformAdditionalPropertiesRequest testInlineFreeformAdditionalPropertiesRequest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testInlineFreeformAdditionalPropertiesRequest.SomePropertyOption.IsSet && testInlineFreeformAdditionalPropertiesRequest.SomeProperty == null)
-                throw new ArgumentNullException(nameof(testInlineFreeformAdditionalPropertiesRequest.SomeProperty), "Property is required for class TestInlineFreeformAdditionalPropertiesRequest.");
+                throw new JsonException("Cannot write null property TestInlineFreeformAdditionalPropertiesRequest.SomeProperty to non-nullable JSON property 'someProperty'.");
 
             if (testInlineFreeformAdditionalPropertiesRequest.SomePropertyOption.IsSet)
                 writer.WriteString("someProperty", testInlineFreeformAdditionalPropertiesRequest.SomeProperty);

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/TestResult.cs
@@ -222,6 +222,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, TestResult testResult, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (testResult.CodeOption.IsSet && testResult.Code == null)
+                throw new JsonException("Cannot write null property TestResult.Code to non-nullable JSON property 'code'.");
+
             if (testResult.DataOption.IsSet && testResult.Data == null)
                 throw new JsonException("Cannot write null property TestResult.Data to non-nullable JSON property 'data'.");
 

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/TestResult.cs
@@ -223,10 +223,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestResult testResult, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testResult.DataOption.IsSet && testResult.Data == null)
-                throw new ArgumentNullException(nameof(testResult.Data), "Property is required for class TestResult.");
+                throw new JsonException("Cannot write null property TestResult.Data to non-nullable JSON property 'data'.");
 
             if (testResult.UuidOption.IsSet && testResult.Uuid == null)
-                throw new ArgumentNullException(nameof(testResult.Uuid), "Property is required for class TestResult.");
+                throw new JsonException("Cannot write null property TestResult.Uuid to non-nullable JSON property 'uuid'.");
 
             if (testResult.CodeOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/TriangleInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/TriangleInterface.cs
@@ -170,9 +170,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, TriangleInterface triangleInterface, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (triangleInterface.TriangleType == null)
-                throw new ArgumentNullException(nameof(triangleInterface.TriangleType), "Property is required for class TriangleInterface.");
-
             writer.WriteString("triangleType", triangleInterface.TriangleType);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/User.cs
@@ -429,6 +429,9 @@ namespace Org.OpenAPITools.Model
             if (user.FirstNameOption.IsSet && user.FirstName == null)
                 throw new JsonException("Cannot write null property User.FirstName to non-nullable JSON property 'firstName'.");
 
+            if (user.IdOption.IsSet && user.Id == null)
+                throw new JsonException("Cannot write null property User.Id to non-nullable JSON property 'id'.");
+
             if (user.LastNameOption.IsSet && user.LastName == null)
                 throw new JsonException("Cannot write null property User.LastName to non-nullable JSON property 'lastName'.");
 
@@ -440,6 +443,9 @@ namespace Org.OpenAPITools.Model
 
             if (user.PhoneOption.IsSet && user.Phone == null)
                 throw new JsonException("Cannot write null property User.Phone to non-nullable JSON property 'phone'.");
+
+            if (user.UserStatusOption.IsSet && user.UserStatus == null)
+                throw new JsonException("Cannot write null property User.UserStatus to non-nullable JSON property 'userStatus'.");
 
             if (user.UsernameOption.IsSet && user.Username == null)
                 throw new JsonException("Cannot write null property User.Username to non-nullable JSON property 'username'.");

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/User.cs
@@ -424,25 +424,25 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, User user, JsonSerializerOptions jsonSerializerOptions)
         {
             if (user.EmailOption.IsSet && user.Email == null)
-                throw new ArgumentNullException(nameof(user.Email), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Email to non-nullable JSON property 'email'.");
 
             if (user.FirstNameOption.IsSet && user.FirstName == null)
-                throw new ArgumentNullException(nameof(user.FirstName), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.FirstName to non-nullable JSON property 'firstName'.");
 
             if (user.LastNameOption.IsSet && user.LastName == null)
-                throw new ArgumentNullException(nameof(user.LastName), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.LastName to non-nullable JSON property 'lastName'.");
 
             if (user.ObjectWithNoDeclaredPropsOption.IsSet && user.ObjectWithNoDeclaredProps == null)
-                throw new ArgumentNullException(nameof(user.ObjectWithNoDeclaredProps), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.ObjectWithNoDeclaredProps to non-nullable JSON property 'objectWithNoDeclaredProps'.");
 
             if (user.PasswordOption.IsSet && user.Password == null)
-                throw new ArgumentNullException(nameof(user.Password), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Password to non-nullable JSON property 'password'.");
 
             if (user.PhoneOption.IsSet && user.Phone == null)
-                throw new ArgumentNullException(nameof(user.Phone), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Phone to non-nullable JSON property 'phone'.");
 
             if (user.UsernameOption.IsSet && user.Username == null)
-                throw new ArgumentNullException(nameof(user.Username), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Username to non-nullable JSON property 'username'.");
 
             if (user.AnyTypePropOption.IsSet)
                 if (user.AnyTypePropOption.Value != null)

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Whale.cs
@@ -216,9 +216,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Whale whale, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (whale.ClassName == null)
-                throw new ArgumentNullException(nameof(whale.ClassName), "Property is required for class Whale.");
-
             writer.WriteString("className", whale.ClassName);
 
             if (whale.HasBaleenOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Whale.cs
@@ -216,6 +216,12 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Whale whale, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (whale.HasBaleenOption.IsSet && whale.HasBaleen == null)
+                throw new JsonException("Cannot write null property Whale.HasBaleen to non-nullable JSON property 'hasBaleen'.");
+
+            if (whale.HasTeethOption.IsSet && whale.HasTeeth == null)
+                throw new JsonException("Cannot write null property Whale.HasTeeth to non-nullable JSON property 'hasTeeth'.");
+
             writer.WriteString("className", whale.ClassName);
 
             if (whale.HasBaleenOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Zebra.cs
@@ -280,6 +280,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Zebra zebra, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (zebra.TypeOption.IsSet && zebra.Type == null)
+                throw new JsonException("Cannot write null property Zebra.Type to non-nullable JSON property 'type'.");
+
             writer.WriteString("className", zebra.ClassName);
 
             var typeRawValue = Zebra.TypeEnumToJsonValue(zebra.TypeOption.Value.Value);

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Zebra.cs
@@ -280,9 +280,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Zebra zebra, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (zebra.ClassName == null)
-                throw new ArgumentNullException(nameof(zebra.ClassName), "Property is required for class Zebra.");
-
             writer.WriteString("className", zebra.ClassName);
 
             var typeRawValue = Zebra.TypeEnumToJsonValue(zebra.TypeOption.Value.Value);

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
@@ -247,6 +247,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ZeroBasedEnumClass zeroBasedEnumClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (zeroBasedEnumClass.ZeroBasedEnumOption.IsSet && zeroBasedEnumClass.ZeroBasedEnum == null)
+                throw new JsonException("Cannot write null property ZeroBasedEnumClass.ZeroBasedEnum to non-nullable JSON property 'ZeroBasedEnum'.");
+
             var zeroBasedEnumRawValue = ZeroBasedEnumClass.ZeroBasedEnumEnumToJsonValue(zeroBasedEnumClass.ZeroBasedEnumOption.Value.Value);
             writer.WriteString("ZeroBasedEnum", zeroBasedEnumRawValue);
         }

--- a/samples/client/petstore/csharp/generichost/net4.7/UseDateTimeForDate/src/Org.OpenAPITools/Model/NowGet200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/UseDateTimeForDate/src/Org.OpenAPITools/Model/NowGet200Response.cs
@@ -199,6 +199,12 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, NowGet200Response nowGet200Response, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (nowGet200Response.NowOption.IsSet && nowGet200Response.Now == null)
+                throw new JsonException("Cannot write null property NowGet200Response.Now to non-nullable JSON property 'now'.");
+
+            if (nowGet200Response.TodayOption.IsSet && nowGet200Response.Today == null)
+                throw new JsonException("Cannot write null property NowGet200Response.Today to non-nullable JSON property 'today'.");
+
             if (nowGet200Response.NowOption.IsSet)
                 writer.WriteString("now", nowGet200Response.NowOption.Value.Value.ToString(NowFormat));
 

--- a/samples/client/petstore/csharp/generichost/net4.8/AllOf/src/Org.OpenAPITools/Model/Adult.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/AllOf/src/Org.OpenAPITools/Model/Adult.cs
@@ -182,13 +182,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Adult adult, JsonSerializerOptions jsonSerializerOptions)
         {
             if (adult.ChildrenOption.IsSet && adult.Children == null)
-                throw new ArgumentNullException(nameof(adult.Children), "Property is required for class Adult.");
+                throw new JsonException("Cannot write null property Adult.Children to non-nullable JSON property 'children'.");
 
             if (adult.FirstNameOption.IsSet && adult.FirstName == null)
-                throw new ArgumentNullException(nameof(adult.FirstName), "Property is required for class Adult.");
+                throw new JsonException("Cannot write null property Adult.FirstName to non-nullable JSON property 'firstName'.");
 
             if (adult.LastNameOption.IsSet && adult.LastName == null)
-                throw new ArgumentNullException(nameof(adult.LastName), "Property is required for class Adult.");
+                throw new JsonException("Cannot write null property Adult.LastName to non-nullable JSON property 'lastName'.");
 
             if (adult.ChildrenOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net4.8/AllOf/src/Org.OpenAPITools/Model/Child.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/AllOf/src/Org.OpenAPITools/Model/Child.cs
@@ -205,10 +205,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Child child, JsonSerializerOptions jsonSerializerOptions)
         {
             if (child.FirstNameOption.IsSet && child.FirstName == null)
-                throw new ArgumentNullException(nameof(child.FirstName), "Property is required for class Child.");
+                throw new JsonException("Cannot write null property Child.FirstName to non-nullable JSON property 'firstName'.");
 
             if (child.LastNameOption.IsSet && child.LastName == null)
-                throw new ArgumentNullException(nameof(child.LastName), "Property is required for class Child.");
+                throw new JsonException("Cannot write null property Child.LastName to non-nullable JSON property 'lastName'.");
 
             if (child.AgeOption.IsSet)
                 writer.WriteNumber("age", child.AgeOption.Value.Value);

--- a/samples/client/petstore/csharp/generichost/net4.8/AllOf/src/Org.OpenAPITools/Model/Child.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/AllOf/src/Org.OpenAPITools/Model/Child.cs
@@ -204,6 +204,12 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Child child, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (child.AgeOption.IsSet && child.Age == null)
+                throw new JsonException("Cannot write null property Child.Age to non-nullable JSON property 'age'.");
+
+            if (child.BoosterSeatOption.IsSet && child.BoosterSeat == null)
+                throw new JsonException("Cannot write null property Child.BoosterSeat to non-nullable JSON property 'boosterSeat'.");
+
             if (child.FirstNameOption.IsSet && child.FirstName == null)
                 throw new JsonException("Cannot write null property Child.FirstName to non-nullable JSON property 'firstName'.");
 

--- a/samples/client/petstore/csharp/generichost/net4.8/AllOf/src/Org.OpenAPITools/Model/Person.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/AllOf/src/Org.OpenAPITools/Model/Person.cs
@@ -241,10 +241,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Person person, JsonSerializerOptions jsonSerializerOptions)
         {
             if (person.FirstNameOption.IsSet && person.FirstName == null)
-                throw new ArgumentNullException(nameof(person.FirstName), "Property is required for class Person.");
+                throw new JsonException("Cannot write null property Person.FirstName to non-nullable JSON property 'firstName'.");
 
             if (person.LastNameOption.IsSet && person.LastName == null)
-                throw new ArgumentNullException(nameof(person.LastName), "Property is required for class Person.");
+                throw new JsonException("Cannot write null property Person.LastName to non-nullable JSON property 'lastName'.");
 
             if (person.FirstNameOption.IsSet)
                 writer.WriteString("firstName", person.FirstName);

--- a/samples/client/petstore/csharp/generichost/net4.8/AnyOf/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/AnyOf/src/Org.OpenAPITools/Model/Apple.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Apple apple, JsonSerializerOptions jsonSerializerOptions)
         {
             if (apple.KindOption.IsSet && apple.Kind == null)
-                throw new ArgumentNullException(nameof(apple.Kind), "Property is required for class Apple.");
+                throw new JsonException("Cannot write null property Apple.Kind to non-nullable JSON property 'kind'.");
 
             if (apple.KindOption.IsSet)
                 writer.WriteString("kind", apple.Kind);

--- a/samples/client/petstore/csharp/generichost/net4.8/AnyOf/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/AnyOf/src/Org.OpenAPITools/Model/Banana.cs
@@ -174,6 +174,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Banana banana, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (banana.CountOption.IsSet && banana.Count == null)
+                throw new JsonException("Cannot write null property Banana.Count to non-nullable JSON property 'count'.");
+
             if (banana.CountOption.IsSet)
                 writer.WriteNumber("count", banana.CountOption.Value.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/AnyOf/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/AnyOf/src/Org.OpenAPITools/Model/Fruit.cs
@@ -243,7 +243,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Fruit fruit, JsonSerializerOptions jsonSerializerOptions)
         {
             if (fruit.ColorOption.IsSet && fruit.Color == null)
-                throw new ArgumentNullException(nameof(fruit.Color), "Property is required for class Fruit.");
+                throw new JsonException("Cannot write null property Fruit.Color to non-nullable JSON property 'color'.");
 
             if (fruit.ColorOption.IsSet)
                 writer.WriteString("color", fruit.Color);

--- a/samples/client/petstore/csharp/generichost/net4.8/AnyOfNoCompare/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/AnyOfNoCompare/src/Org.OpenAPITools/Model/Apple.cs
@@ -174,7 +174,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Apple apple, JsonSerializerOptions jsonSerializerOptions)
         {
             if (apple.KindOption.IsSet && apple.Kind == null)
-                throw new ArgumentNullException(nameof(apple.Kind), "Property is required for class Apple.");
+                throw new JsonException("Cannot write null property Apple.Kind to non-nullable JSON property 'kind'.");
 
             if (apple.KindOption.IsSet)
                 writer.WriteString("kind", apple.Kind);

--- a/samples/client/petstore/csharp/generichost/net4.8/AnyOfNoCompare/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/AnyOfNoCompare/src/Org.OpenAPITools/Model/Banana.cs
@@ -173,6 +173,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Banana banana, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (banana.CountOption.IsSet && banana.Count == null)
+                throw new JsonException("Cannot write null property Banana.Count to non-nullable JSON property 'count'.");
+
             if (banana.CountOption.IsSet)
                 writer.WriteNumber("count", banana.CountOption.Value.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/AnyOfNoCompare/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/AnyOfNoCompare/src/Org.OpenAPITools/Model/Fruit.cs
@@ -242,7 +242,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Fruit fruit, JsonSerializerOptions jsonSerializerOptions)
         {
             if (fruit.ColorOption.IsSet && fruit.Color == null)
-                throw new ArgumentNullException(nameof(fruit.Color), "Property is required for class Fruit.");
+                throw new JsonException("Cannot write null property Fruit.Color to non-nullable JSON property 'color'.");
 
             if (fruit.ColorOption.IsSet)
                 writer.WriteString("color", fruit.Color);

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Activity.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Activity activity, JsonSerializerOptions jsonSerializerOptions)
         {
             if (activity.ActivityOutputsOption.IsSet && activity.ActivityOutputs == null)
-                throw new ArgumentNullException(nameof(activity.ActivityOutputs), "Property is required for class Activity.");
+                throw new JsonException("Cannot write null property Activity.ActivityOutputs to non-nullable JSON property 'activity_outputs'.");
 
             if (activity.ActivityOutputsOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -198,10 +198,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ActivityOutputElementRepresentation activityOutputElementRepresentation, JsonSerializerOptions jsonSerializerOptions)
         {
             if (activityOutputElementRepresentation.Prop1Option.IsSet && activityOutputElementRepresentation.Prop1 == null)
-                throw new ArgumentNullException(nameof(activityOutputElementRepresentation.Prop1), "Property is required for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Cannot write null property ActivityOutputElementRepresentation.Prop1 to non-nullable JSON property 'prop1'.");
 
             if (activityOutputElementRepresentation.Prop2Option.IsSet && activityOutputElementRepresentation.Prop2 == null)
-                throw new ArgumentNullException(nameof(activityOutputElementRepresentation.Prop2), "Property is required for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Cannot write null property ActivityOutputElementRepresentation.Prop2 to non-nullable JSON property 'prop2'.");
 
             if (activityOutputElementRepresentation.Prop1Option.IsSet)
                 writer.WriteString("prop1", activityOutputElementRepresentation.Prop1);

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -334,25 +334,25 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, AdditionalPropertiesClass additionalPropertiesClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (additionalPropertiesClass.EmptyMapOption.IsSet && additionalPropertiesClass.EmptyMap == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.EmptyMap), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.EmptyMap to non-nullable JSON property 'empty_map'.");
 
             if (additionalPropertiesClass.MapOfMapPropertyOption.IsSet && additionalPropertiesClass.MapOfMapProperty == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapOfMapProperty), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapOfMapProperty to non-nullable JSON property 'map_of_map_property'.");
 
             if (additionalPropertiesClass.MapPropertyOption.IsSet && additionalPropertiesClass.MapProperty == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapProperty), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapProperty to non-nullable JSON property 'map_property'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1Option.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1 == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1 to non-nullable JSON property 'map_with_undeclared_properties_anytype_1'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2Option.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2 == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2 to non-nullable JSON property 'map_with_undeclared_properties_anytype_2'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3Option.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3 == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3 to non-nullable JSON property 'map_with_undeclared_properties_anytype_3'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesStringOption.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesString == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesString), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesString to non-nullable JSON property 'map_with_undeclared_properties_string'.");
 
             if (additionalPropertiesClass.Anytype1Option.IsSet)
                 if (additionalPropertiesClass.Anytype1Option.Value != null)

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Animal.cs
@@ -221,7 +221,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Animal animal, JsonSerializerOptions jsonSerializerOptions)
         {
             if (animal.ColorOption.IsSet && animal.Color == null)
-                throw new ArgumentNullException(nameof(animal.Color), "Property is required for class Animal.");
+                throw new JsonException("Cannot write null property Animal.Color to non-nullable JSON property 'color'.");
 
             writer.WriteString("className", animal.ClassName);
 

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -221,10 +221,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ApiResponse apiResponse, JsonSerializerOptions jsonSerializerOptions)
         {
             if (apiResponse.MessageOption.IsSet && apiResponse.Message == null)
-                throw new ArgumentNullException(nameof(apiResponse.Message), "Property is required for class ApiResponse.");
+                throw new JsonException("Cannot write null property ApiResponse.Message to non-nullable JSON property 'message'.");
 
             if (apiResponse.TypeOption.IsSet && apiResponse.Type == null)
-                throw new ArgumentNullException(nameof(apiResponse.Type), "Property is required for class ApiResponse.");
+                throw new JsonException("Cannot write null property ApiResponse.Type to non-nullable JSON property 'type'.");
 
             if (apiResponse.CodeOption.IsSet)
                 writer.WriteNumber("code", apiResponse.CodeOption.Value.Value);

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -220,6 +220,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ApiResponse apiResponse, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (apiResponse.CodeOption.IsSet && apiResponse.Code == null)
+                throw new JsonException("Cannot write null property ApiResponse.Code to non-nullable JSON property 'code'.");
+
             if (apiResponse.MessageOption.IsSet && apiResponse.Message == null)
                 throw new JsonException("Cannot write null property ApiResponse.Message to non-nullable JSON property 'message'.");
 

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Apple.cs
@@ -251,13 +251,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Apple apple, JsonSerializerOptions jsonSerializerOptions)
         {
             if (apple.ColorCodeOption.IsSet && apple.ColorCode == null)
-                throw new ArgumentNullException(nameof(apple.ColorCode), "Property is required for class Apple.");
+                throw new JsonException("Cannot write null property Apple.ColorCode to non-nullable JSON property 'color_code'.");
 
             if (apple.CultivarOption.IsSet && apple.Cultivar == null)
-                throw new ArgumentNullException(nameof(apple.Cultivar), "Property is required for class Apple.");
+                throw new JsonException("Cannot write null property Apple.Cultivar to non-nullable JSON property 'cultivar'.");
 
             if (apple.OriginOption.IsSet && apple.Origin == null)
-                throw new ArgumentNullException(nameof(apple.Origin), "Property is required for class Apple.");
+                throw new JsonException("Cannot write null property Apple.Origin to non-nullable JSON property 'origin'.");
 
             if (apple.ColorCodeOption.IsSet)
                 writer.WriteString("color_code", apple.ColorCode);

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -186,9 +186,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, AppleReq appleReq, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (appleReq.Cultivar == null)
-                throw new ArgumentNullException(nameof(appleReq.Cultivar), "Property is required for class AppleReq.");
-
             writer.WriteString("cultivar", appleReq.Cultivar);
 
             if (appleReq.MealyOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -186,6 +186,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, AppleReq appleReq, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (appleReq.MealyOption.IsSet && appleReq.Mealy == null)
+                throw new JsonException("Cannot write null property AppleReq.Mealy to non-nullable JSON property 'mealy'.");
+
             writer.WriteString("cultivar", appleReq.Cultivar);
 
             if (appleReq.MealyOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ArrayOfArrayOfNumberOnly arrayOfArrayOfNumberOnly, JsonSerializerOptions jsonSerializerOptions)
         {
             if (arrayOfArrayOfNumberOnly.ArrayArrayNumberOption.IsSet && arrayOfArrayOfNumberOnly.ArrayArrayNumber == null)
-                throw new ArgumentNullException(nameof(arrayOfArrayOfNumberOnly.ArrayArrayNumber), "Property is required for class ArrayOfArrayOfNumberOnly.");
+                throw new JsonException("Cannot write null property ArrayOfArrayOfNumberOnly.ArrayArrayNumber to non-nullable JSON property 'ArrayArrayNumber'.");
 
             if (arrayOfArrayOfNumberOnly.ArrayArrayNumberOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ArrayOfNumberOnly arrayOfNumberOnly, JsonSerializerOptions jsonSerializerOptions)
         {
             if (arrayOfNumberOnly.ArrayNumberOption.IsSet && arrayOfNumberOnly.ArrayNumber == null)
-                throw new ArgumentNullException(nameof(arrayOfNumberOnly.ArrayNumber), "Property is required for class ArrayOfNumberOnly.");
+                throw new JsonException("Cannot write null property ArrayOfNumberOnly.ArrayNumber to non-nullable JSON property 'ArrayNumber'.");
 
             if (arrayOfNumberOnly.ArrayNumberOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -221,13 +221,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ArrayTest arrayTest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (arrayTest.ArrayArrayOfIntegerOption.IsSet && arrayTest.ArrayArrayOfInteger == null)
-                throw new ArgumentNullException(nameof(arrayTest.ArrayArrayOfInteger), "Property is required for class ArrayTest.");
+                throw new JsonException("Cannot write null property ArrayTest.ArrayArrayOfInteger to non-nullable JSON property 'array_array_of_integer'.");
 
             if (arrayTest.ArrayArrayOfModelOption.IsSet && arrayTest.ArrayArrayOfModel == null)
-                throw new ArgumentNullException(nameof(arrayTest.ArrayArrayOfModel), "Property is required for class ArrayTest.");
+                throw new JsonException("Cannot write null property ArrayTest.ArrayArrayOfModel to non-nullable JSON property 'array_array_of_model'.");
 
             if (arrayTest.ArrayOfStringOption.IsSet && arrayTest.ArrayOfString == null)
-                throw new ArgumentNullException(nameof(arrayTest.ArrayOfString), "Property is required for class ArrayTest.");
+                throw new JsonException("Cannot write null property ArrayTest.ArrayOfString to non-nullable JSON property 'array_of_string'.");
 
             if (arrayTest.ArrayArrayOfIntegerOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Banana.cs
@@ -174,6 +174,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Banana banana, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (banana.LengthCmOption.IsSet && banana.LengthCm == null)
+                throw new JsonException("Cannot write null property Banana.LengthCm to non-nullable JSON property 'lengthCm'.");
+
             if (banana.LengthCmOption.IsSet)
                 writer.WriteNumber("lengthCm", banana.LengthCmOption.Value.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -186,6 +186,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, BananaReq bananaReq, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (bananaReq.SweetOption.IsSet && bananaReq.Sweet == null)
+                throw new JsonException("Cannot write null property BananaReq.Sweet to non-nullable JSON property 'sweet'.");
+
             writer.WriteNumber("lengthCm", bananaReq.LengthCm);
 
             if (bananaReq.SweetOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/BasquePig.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/BasquePig.cs
@@ -170,9 +170,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, BasquePig basquePig, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (basquePig.ClassName == null)
-                throw new ArgumentNullException(nameof(basquePig.ClassName), "Property is required for class BasquePig.");
-
             writer.WriteString("className", basquePig.ClassName);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -291,22 +291,22 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Capitalization capitalization, JsonSerializerOptions jsonSerializerOptions)
         {
             if (capitalization.ATT_NAMEOption.IsSet && capitalization.ATT_NAME == null)
-                throw new ArgumentNullException(nameof(capitalization.ATT_NAME), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.ATT_NAME to non-nullable JSON property 'ATT_NAME'.");
 
             if (capitalization.CapitalCamelOption.IsSet && capitalization.CapitalCamel == null)
-                throw new ArgumentNullException(nameof(capitalization.CapitalCamel), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.CapitalCamel to non-nullable JSON property 'CapitalCamel'.");
 
             if (capitalization.CapitalSnakeOption.IsSet && capitalization.CapitalSnake == null)
-                throw new ArgumentNullException(nameof(capitalization.CapitalSnake), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.CapitalSnake to non-nullable JSON property 'Capital_Snake'.");
 
             if (capitalization.SCAETHFlowPointsOption.IsSet && capitalization.SCAETHFlowPoints == null)
-                throw new ArgumentNullException(nameof(capitalization.SCAETHFlowPoints), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.SCAETHFlowPoints to non-nullable JSON property 'SCA_ETH_Flow_Points'.");
 
             if (capitalization.SmallCamelOption.IsSet && capitalization.SmallCamel == null)
-                throw new ArgumentNullException(nameof(capitalization.SmallCamel), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.SmallCamel to non-nullable JSON property 'smallCamel'.");
 
             if (capitalization.SmallSnakeOption.IsSet && capitalization.SmallSnake == null)
-                throw new ArgumentNullException(nameof(capitalization.SmallSnake), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.SmallSnake to non-nullable JSON property 'small_Snake'.");
 
             if (capitalization.ATT_NAMEOption.IsSet)
                 writer.WriteString("ATT_NAME", capitalization.ATT_NAME);

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Cat.cs
@@ -179,6 +179,9 @@ namespace Org.OpenAPITools.Model
             if (cat.ColorOption.IsSet && cat.Color == null)
                 throw new JsonException("Cannot write null property Cat.Color to non-nullable JSON property 'color'.");
 
+            if (cat.DeclawedOption.IsSet && cat.Declawed == null)
+                throw new JsonException("Cannot write null property Cat.Declawed to non-nullable JSON property 'declawed'.");
+
             writer.WriteString("className", cat.ClassName);
 
             if (cat.ColorOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Cat.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Cat cat, JsonSerializerOptions jsonSerializerOptions)
         {
             if (cat.ColorOption.IsSet && cat.Color == null)
-                throw new ArgumentNullException(nameof(cat.Color), "Property is required for class Cat.");
+                throw new JsonException("Cannot write null property Cat.Color to non-nullable JSON property 'color'.");
 
             writer.WriteString("className", cat.ClassName);
 

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Category.cs
@@ -193,9 +193,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Category category, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (category.Name == null)
-                throw new ArgumentNullException(nameof(category.Name), "Property is required for class Category.");
-
             if (category.IdOption.IsSet)
                 writer.WriteNumber("id", category.IdOption.Value.Value);
 

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Category.cs
@@ -193,6 +193,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Category category, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (category.IdOption.IsSet && category.Id == null)
+                throw new JsonException("Cannot write null property Category.Id to non-nullable JSON property 'id'.");
+
             if (category.IdOption.IsSet)
                 writer.WriteNumber("id", category.IdOption.Value.Value);
 

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ChildCat childCat, JsonSerializerOptions jsonSerializerOptions)
         {
             if (childCat.NameOption.IsSet && childCat.Name == null)
-                throw new ArgumentNullException(nameof(childCat.Name), "Property is required for class ChildCat.");
+                throw new JsonException("Cannot write null property ChildCat.Name to non-nullable JSON property 'name'.");
 
             writer.WriteString("pet_type", ChildCatAllOfPetTypeValueConverter.ToJsonValue(childCat.PetType));
 

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ClassModel classModel, JsonSerializerOptions jsonSerializerOptions)
         {
             if (classModel.ClassOption.IsSet && classModel.Class == null)
-                throw new ArgumentNullException(nameof(classModel.Class), "Property is required for class ClassModel.");
+                throw new JsonException("Cannot write null property ClassModel.Class to non-nullable JSON property '_class'.");
 
             if (classModel.ClassOption.IsSet)
                 writer.WriteString("_class", classModel.Class);

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
@@ -189,12 +189,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ComplexQuadrilateral complexQuadrilateral, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (complexQuadrilateral.QuadrilateralType == null)
-                throw new ArgumentNullException(nameof(complexQuadrilateral.QuadrilateralType), "Property is required for class ComplexQuadrilateral.");
-
-            if (complexQuadrilateral.ShapeType == null)
-                throw new ArgumentNullException(nameof(complexQuadrilateral.ShapeType), "Property is required for class ComplexQuadrilateral.");
-
             writer.WriteString("quadrilateralType", complexQuadrilateral.QuadrilateralType);
 
             writer.WriteString("shapeType", complexQuadrilateral.ShapeType);

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/CopyActivity.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/CopyActivity.cs
@@ -172,9 +172,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, CopyActivity copyActivity, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (copyActivity.CopyActivitytt == null)
-                throw new ArgumentNullException(nameof(copyActivity.CopyActivitytt), "Property is required for class CopyActivity.");
-
             writer.WriteString("copyActivitytt", copyActivity.CopyActivitytt);
 
             writer.WriteString("$schema", CopyActivityAllOfSchemaValueConverter.ToJsonValue(copyActivity.Schema));

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/DanishPig.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/DanishPig.cs
@@ -170,9 +170,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, DanishPig danishPig, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (danishPig.ClassName == null)
-                throw new ArgumentNullException(nameof(danishPig.ClassName), "Property is required for class DanishPig.");
-
             writer.WriteString("className", danishPig.ClassName);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -180,6 +180,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, DateOnlyClass dateOnlyClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (dateOnlyClass.DateOnlyPropertyOption.IsSet && dateOnlyClass.DateOnlyProperty == null)
+                throw new JsonException("Cannot write null property DateOnlyClass.DateOnlyProperty to non-nullable JSON property 'dateOnlyProperty'.");
+
             if (dateOnlyClass.DateOnlyPropertyOption.IsSet)
                 writer.WriteString("dateOnlyProperty", dateOnlyClass.DateOnlyPropertyOption.Value.Value.ToString(DateOnlyPropertyFormat));
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, DeprecatedObject deprecatedObject, JsonSerializerOptions jsonSerializerOptions)
         {
             if (deprecatedObject.NameOption.IsSet && deprecatedObject.Name == null)
-                throw new ArgumentNullException(nameof(deprecatedObject.Name), "Property is required for class DeprecatedObject.");
+                throw new JsonException("Cannot write null property DeprecatedObject.Name to non-nullable JSON property 'name'.");
 
             if (deprecatedObject.NameOption.IsSet)
                 writer.WriteString("name", deprecatedObject.Name);

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Descendant1.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Descendant1.cs
@@ -175,12 +175,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Descendant1 descendant1, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (descendant1.AlternativeName == null)
-                throw new ArgumentNullException(nameof(descendant1.AlternativeName), "Property is required for class Descendant1.");
-
-            if (descendant1.DescendantName == null)
-                throw new ArgumentNullException(nameof(descendant1.DescendantName), "Property is required for class Descendant1.");
-
             writer.WriteString("alternativeName", descendant1.AlternativeName);
 
             writer.WriteString("descendantName", descendant1.DescendantName);

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Descendant2.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Descendant2.cs
@@ -175,12 +175,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Descendant2 descendant2, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (descendant2.AlternativeName == null)
-                throw new ArgumentNullException(nameof(descendant2.AlternativeName), "Property is required for class Descendant2.");
-
-            if (descendant2.Confidentiality == null)
-                throw new ArgumentNullException(nameof(descendant2.Confidentiality), "Property is required for class Descendant2.");
-
             writer.WriteString("alternativeName", descendant2.AlternativeName);
 
             writer.WriteString("confidentiality", descendant2.Confidentiality);

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Dog.cs
@@ -177,10 +177,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Dog dog, JsonSerializerOptions jsonSerializerOptions)
         {
             if (dog.BreedOption.IsSet && dog.Breed == null)
-                throw new ArgumentNullException(nameof(dog.Breed), "Property is required for class Dog.");
+                throw new JsonException("Cannot write null property Dog.Breed to non-nullable JSON property 'breed'.");
 
             if (dog.ColorOption.IsSet && dog.Color == null)
-                throw new ArgumentNullException(nameof(dog.Color), "Property is required for class Dog.");
+                throw new JsonException("Cannot write null property Dog.Color to non-nullable JSON property 'color'.");
 
             writer.WriteString("className", dog.ClassName);
 

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Drawing.cs
@@ -238,10 +238,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Drawing drawing, JsonSerializerOptions jsonSerializerOptions)
         {
             if (drawing.MainShapeOption.IsSet && drawing.MainShape == null)
-                throw new ArgumentNullException(nameof(drawing.MainShape), "Property is required for class Drawing.");
+                throw new JsonException("Cannot write null property Drawing.MainShape to non-nullable JSON property 'mainShape'.");
 
             if (drawing.ShapesOption.IsSet && drawing.Shapes == null)
-                throw new ArgumentNullException(nameof(drawing.Shapes), "Property is required for class Drawing.");
+                throw new JsonException("Cannot write null property Drawing.Shapes to non-nullable JSON property 'shapes'.");
 
             if (drawing.MainShapeOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -200,6 +200,9 @@ namespace Org.OpenAPITools.Model
             if (enumArrays.ArrayEnumOption.IsSet && enumArrays.ArrayEnum == null)
                 throw new JsonException("Cannot write null property EnumArrays.ArrayEnum to non-nullable JSON property 'array_enum'.");
 
+            if (enumArrays.JustSymbolOption.IsSet && enumArrays.JustSymbol == null)
+                throw new JsonException("Cannot write null property EnumArrays.JustSymbol to non-nullable JSON property 'just_symbol'.");
+
             if (enumArrays.ArrayEnumOption.IsSet)
             {
                 writer.WritePropertyName("array_enum");

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -198,7 +198,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, EnumArrays enumArrays, JsonSerializerOptions jsonSerializerOptions)
         {
             if (enumArrays.ArrayEnumOption.IsSet && enumArrays.ArrayEnum == null)
-                throw new ArgumentNullException(nameof(enumArrays.ArrayEnum), "Property is required for class EnumArrays.");
+                throw new JsonException("Cannot write null property EnumArrays.ArrayEnum to non-nullable JSON property 'array_enum'.");
 
             if (enumArrays.ArrayEnumOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -351,6 +351,27 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, EnumTest enumTest, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (enumTest.EnumIntegerOption.IsSet && enumTest.EnumInteger == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumInteger to non-nullable JSON property 'enum_integer'.");
+
+            if (enumTest.EnumIntegerOnlyOption.IsSet && enumTest.EnumIntegerOnly == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumIntegerOnly to non-nullable JSON property 'enum_integer_only'.");
+
+            if (enumTest.EnumNumberOption.IsSet && enumTest.EnumNumber == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumNumber to non-nullable JSON property 'enum_number'.");
+
+            if (enumTest.EnumStringOption.IsSet && enumTest.EnumString == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumString to non-nullable JSON property 'enum_string'.");
+
+            if (enumTest.OuterEnumDefaultValueOption.IsSet && enumTest.OuterEnumDefaultValue == null)
+                throw new JsonException("Cannot write null property EnumTest.OuterEnumDefaultValue to non-nullable JSON property 'outerEnumDefaultValue'.");
+
+            if (enumTest.OuterEnumIntegerOption.IsSet && enumTest.OuterEnumInteger == null)
+                throw new JsonException("Cannot write null property EnumTest.OuterEnumInteger to non-nullable JSON property 'outerEnumInteger'.");
+
+            if (enumTest.OuterEnumIntegerDefaultValueOption.IsSet && enumTest.OuterEnumIntegerDefaultValue == null)
+                throw new JsonException("Cannot write null property EnumTest.OuterEnumIntegerDefaultValue to non-nullable JSON property 'outerEnumIntegerDefaultValue'.");
+
             var enumStringRequiredRawValue = EnumTestEnumStringValueConverter.ToJsonValue(enumTest.EnumStringRequired);
             writer.WriteString("enum_string_required", enumStringRequiredRawValue);
 

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
@@ -189,12 +189,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, EquilateralTriangle equilateralTriangle, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (equilateralTriangle.ShapeType == null)
-                throw new ArgumentNullException(nameof(equilateralTriangle.ShapeType), "Property is required for class EquilateralTriangle.");
-
-            if (equilateralTriangle.TriangleType == null)
-                throw new ArgumentNullException(nameof(equilateralTriangle.TriangleType), "Property is required for class EquilateralTriangle.");
-
             writer.WriteString("shapeType", equilateralTriangle.ShapeType);
 
             writer.WriteString("triangleType", equilateralTriangle.TriangleType);

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/File.cs
@@ -176,7 +176,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, File file, JsonSerializerOptions jsonSerializerOptions)
         {
             if (file.SourceURIOption.IsSet && file.SourceURI == null)
-                throw new ArgumentNullException(nameof(file.SourceURI), "Property is required for class File.");
+                throw new JsonException("Cannot write null property File.SourceURI to non-nullable JSON property 'sourceURI'.");
 
             if (file.SourceURIOption.IsSet)
                 writer.WriteString("sourceURI", file.SourceURI);

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -198,10 +198,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, FileSchemaTestClass fileSchemaTestClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (fileSchemaTestClass.FileOption.IsSet && fileSchemaTestClass.File == null)
-                throw new ArgumentNullException(nameof(fileSchemaTestClass.File), "Property is required for class FileSchemaTestClass.");
+                throw new JsonException("Cannot write null property FileSchemaTestClass.File to non-nullable JSON property 'file'.");
 
             if (fileSchemaTestClass.FilesOption.IsSet && fileSchemaTestClass.Files == null)
-                throw new ArgumentNullException(nameof(fileSchemaTestClass.Files), "Property is required for class FileSchemaTestClass.");
+                throw new JsonException("Cannot write null property FileSchemaTestClass.Files to non-nullable JSON property 'files'.");
 
             if (fileSchemaTestClass.FileOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Foo.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Foo foo, JsonSerializerOptions jsonSerializerOptions)
         {
             if (foo.BarOption.IsSet && foo.Bar == null)
-                throw new ArgumentNullException(nameof(foo.Bar), "Property is required for class Foo.");
+                throw new JsonException("Cannot write null property Foo.Bar to non-nullable JSON property 'bar'.");
 
             if (foo.BarOption.IsSet)
                 writer.WriteString("bar", foo.Bar);

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, FooGetDefaultResponse fooGetDefaultResponse, JsonSerializerOptions jsonSerializerOptions)
         {
             if (fooGetDefaultResponse.StringOption.IsSet && fooGetDefaultResponse.String == null)
-                throw new ArgumentNullException(nameof(fooGetDefaultResponse.String), "Property is required for class FooGetDefaultResponse.");
+                throw new JsonException("Cannot write null property FooGetDefaultResponse.String to non-nullable JSON property 'string'.");
 
             if (fooGetDefaultResponse.StringOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -954,11 +954,47 @@ namespace Org.OpenAPITools.Model
             if (formatTest.BinaryOption.IsSet && formatTest.Binary == null)
                 throw new JsonException("Cannot write null property FormatTest.Binary to non-nullable JSON property 'binary'.");
 
+            if (formatTest.DateTimeOption.IsSet && formatTest.DateTime == null)
+                throw new JsonException("Cannot write null property FormatTest.DateTime to non-nullable JSON property 'dateTime'.");
+
+            if (formatTest.DecimalOption.IsSet && formatTest.Decimal == null)
+                throw new JsonException("Cannot write null property FormatTest.Decimal to non-nullable JSON property 'decimal'.");
+
+            if (formatTest.DoubleOption.IsSet && formatTest.Double == null)
+                throw new JsonException("Cannot write null property FormatTest.Double to non-nullable JSON property 'double'.");
+
             if (formatTest.DuplicatePropertyName2Option.IsSet && formatTest.DuplicatePropertyName2 == null)
                 throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName2 to non-nullable JSON property 'duplicate_property_name'.");
 
             if (formatTest.DuplicatePropertyNameOption.IsSet && formatTest.DuplicatePropertyName == null)
                 throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName to non-nullable JSON property '@duplicate_property_name'.");
+
+            if (formatTest.FloatOption.IsSet && formatTest.Float == null)
+                throw new JsonException("Cannot write null property FormatTest.Float to non-nullable JSON property 'float'.");
+
+            if (formatTest.Int32Option.IsSet && formatTest.Int32 == null)
+                throw new JsonException("Cannot write null property FormatTest.Int32 to non-nullable JSON property 'int32'.");
+
+            if (formatTest.Int32RangeOption.IsSet && formatTest.Int32Range == null)
+                throw new JsonException("Cannot write null property FormatTest.Int32Range to non-nullable JSON property 'int32Range'.");
+
+            if (formatTest.Int64Option.IsSet && formatTest.Int64 == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64 to non-nullable JSON property 'int64'.");
+
+            if (formatTest.Int64NegativeOption.IsSet && formatTest.Int64Negative == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64Negative to non-nullable JSON property 'int64Negative'.");
+
+            if (formatTest.Int64NegativeExclusiveOption.IsSet && formatTest.Int64NegativeExclusive == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64NegativeExclusive to non-nullable JSON property 'int64NegativeExclusive'.");
+
+            if (formatTest.Int64PositiveOption.IsSet && formatTest.Int64Positive == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64Positive to non-nullable JSON property 'int64Positive'.");
+
+            if (formatTest.Int64PositiveExclusiveOption.IsSet && formatTest.Int64PositiveExclusive == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64PositiveExclusive to non-nullable JSON property 'int64PositiveExclusive'.");
+
+            if (formatTest.IntegerOption.IsSet && formatTest.Integer == null)
+                throw new JsonException("Cannot write null property FormatTest.Integer to non-nullable JSON property 'integer'.");
 
             if (formatTest.PatternWithBackslashOption.IsSet && formatTest.PatternWithBackslash == null)
                 throw new JsonException("Cannot write null property FormatTest.PatternWithBackslash to non-nullable JSON property 'pattern_with_backslash'.");
@@ -971,6 +1007,18 @@ namespace Org.OpenAPITools.Model
 
             if (formatTest.StringOption.IsSet && formatTest.String == null)
                 throw new JsonException("Cannot write null property FormatTest.String to non-nullable JSON property 'string'.");
+
+            if (formatTest.StringFormattedAsDecimalOption.IsSet && formatTest.StringFormattedAsDecimal == null)
+                throw new JsonException("Cannot write null property FormatTest.StringFormattedAsDecimal to non-nullable JSON property 'string_formatted_as_decimal'.");
+
+            if (formatTest.UnsignedIntegerOption.IsSet && formatTest.UnsignedInteger == null)
+                throw new JsonException("Cannot write null property FormatTest.UnsignedInteger to non-nullable JSON property 'unsigned_integer'.");
+
+            if (formatTest.UnsignedLongOption.IsSet && formatTest.UnsignedLong == null)
+                throw new JsonException("Cannot write null property FormatTest.UnsignedLong to non-nullable JSON property 'unsigned_long'.");
+
+            if (formatTest.UuidOption.IsSet && formatTest.Uuid == null)
+                throw new JsonException("Cannot write null property FormatTest.Uuid to non-nullable JSON property 'uuid'.");
 
             writer.WritePropertyName("byte");
             JsonSerializer.Serialize(writer, formatTest.Byte, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -951,32 +951,26 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, FormatTest formatTest, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (formatTest.Byte == null)
-                throw new ArgumentNullException(nameof(formatTest.Byte), "Property is required for class FormatTest.");
-
-            if (formatTest.Password == null)
-                throw new ArgumentNullException(nameof(formatTest.Password), "Property is required for class FormatTest.");
-
             if (formatTest.BinaryOption.IsSet && formatTest.Binary == null)
-                throw new ArgumentNullException(nameof(formatTest.Binary), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.Binary to non-nullable JSON property 'binary'.");
 
             if (formatTest.DuplicatePropertyName2Option.IsSet && formatTest.DuplicatePropertyName2 == null)
-                throw new ArgumentNullException(nameof(formatTest.DuplicatePropertyName2), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName2 to non-nullable JSON property 'duplicate_property_name'.");
 
             if (formatTest.DuplicatePropertyNameOption.IsSet && formatTest.DuplicatePropertyName == null)
-                throw new ArgumentNullException(nameof(formatTest.DuplicatePropertyName), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName to non-nullable JSON property '@duplicate_property_name'.");
 
             if (formatTest.PatternWithBackslashOption.IsSet && formatTest.PatternWithBackslash == null)
-                throw new ArgumentNullException(nameof(formatTest.PatternWithBackslash), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.PatternWithBackslash to non-nullable JSON property 'pattern_with_backslash'.");
 
             if (formatTest.PatternWithDigitsOption.IsSet && formatTest.PatternWithDigits == null)
-                throw new ArgumentNullException(nameof(formatTest.PatternWithDigits), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.PatternWithDigits to non-nullable JSON property 'pattern_with_digits'.");
 
             if (formatTest.PatternWithDigitsAndDelimiterOption.IsSet && formatTest.PatternWithDigitsAndDelimiter == null)
-                throw new ArgumentNullException(nameof(formatTest.PatternWithDigitsAndDelimiter), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.PatternWithDigitsAndDelimiter to non-nullable JSON property 'pattern_with_digits_and_delimiter'.");
 
             if (formatTest.StringOption.IsSet && formatTest.String == null)
-                throw new ArgumentNullException(nameof(formatTest.String), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.String to non-nullable JSON property 'string'.");
 
             writer.WritePropertyName("byte");
             JsonSerializer.Serialize(writer, formatTest.Byte, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Fruit.cs
@@ -219,7 +219,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Fruit fruit, JsonSerializerOptions jsonSerializerOptions)
         {
             if (fruit.ColorOption.IsSet && fruit.Color == null)
-                throw new ArgumentNullException(nameof(fruit.Color), "Property is required for class Fruit.");
+                throw new JsonException("Cannot write null property Fruit.Color to non-nullable JSON property 'color'.");
 
             if (fruit.ColorOption.IsSet)
                 writer.WriteString("color", fruit.Color);

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -236,7 +236,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, GmFruit gmFruit, JsonSerializerOptions jsonSerializerOptions)
         {
             if (gmFruit.ColorOption.IsSet && gmFruit.Color == null)
-                throw new ArgumentNullException(nameof(gmFruit.Color), "Property is required for class GmFruit.");
+                throw new JsonException("Cannot write null property GmFruit.Color to non-nullable JSON property 'color'.");
 
             if (gmFruit.ColorOption.IsSet)
                 writer.WriteString("color", gmFruit.Color);

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -239,10 +239,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, HasOnlyReadOnly hasOnlyReadOnly, JsonSerializerOptions jsonSerializerOptions)
         {
             if (hasOnlyReadOnly.BarOption.IsSet && hasOnlyReadOnly.Bar == null)
-                throw new ArgumentNullException(nameof(hasOnlyReadOnly.Bar), "Property is required for class HasOnlyReadOnly.");
+                throw new JsonException("Cannot write null property HasOnlyReadOnly.Bar to non-nullable JSON property 'bar'.");
 
             if (hasOnlyReadOnly.FooOption.IsSet && hasOnlyReadOnly.Foo == null)
-                throw new ArgumentNullException(nameof(hasOnlyReadOnly.Foo), "Property is required for class HasOnlyReadOnly.");
+                throw new JsonException("Cannot write null property HasOnlyReadOnly.Foo to non-nullable JSON property 'foo'.");
 
             if (hasOnlyReadOnly.BarOption.IsSet)
                 writer.WriteString("bar", hasOnlyReadOnly.Bar);

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
@@ -337,22 +337,22 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, InjectedVendorExtensionsTest injectedVendorExtensionsTest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessorOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor to non-nullable JSON property 'potentiallyOverriddenPropertyAccessor'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternalOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternal == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternal), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternal to non-nullable JSON property 'potentiallyOverriddenPropertyToInternal'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivateOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivate == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivate), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivate to non-nullable JSON property 'potentiallyOverriddenPropertyToPrivate'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublicOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublic == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublic), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublic to non-nullable JSON property 'potentiallyOverriddenPropertyToPublic'.");
 
             if (injectedVendorExtensionsTest.UnalteredPropertyOption.IsSet && injectedVendorExtensionsTest.UnalteredProperty == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.UnalteredProperty), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.UnalteredProperty to non-nullable JSON property 'unalteredProperty'.");
 
             if (injectedVendorExtensionsTest.UnalteredPropertyAccessorOption.IsSet && injectedVendorExtensionsTest.UnalteredPropertyAccessor == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.UnalteredPropertyAccessor), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.UnalteredPropertyAccessor to non-nullable JSON property 'unalteredPropertyAccessor'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessorOption.IsSet)
                 writer.WriteString("potentiallyOverriddenPropertyAccessor", injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor);

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
@@ -182,12 +182,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, IsoscelesTriangle isoscelesTriangle, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (isoscelesTriangle.ShapeType == null)
-                throw new ArgumentNullException(nameof(isoscelesTriangle.ShapeType), "Property is required for class IsoscelesTriangle.");
-
-            if (isoscelesTriangle.TriangleType == null)
-                throw new ArgumentNullException(nameof(isoscelesTriangle.TriangleType), "Property is required for class IsoscelesTriangle.");
-
             writer.WriteString("shapeType", isoscelesTriangle.ShapeType);
 
             writer.WriteString("triangleType", isoscelesTriangle.TriangleType);

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/List.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, List list, JsonSerializerOptions jsonSerializerOptions)
         {
             if (list.Var123ListOption.IsSet && list.Var123List == null)
-                throw new ArgumentNullException(nameof(list.Var123List), "Property is required for class List.");
+                throw new JsonException("Cannot write null property List.Var123List to non-nullable JSON property '123-list'.");
 
             if (list.Var123ListOption.IsSet)
                 writer.WriteString("123-list", list.Var123List);

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -198,10 +198,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, LiteralStringClass literalStringClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (literalStringClass.EscapedLiteralStringOption.IsSet && literalStringClass.EscapedLiteralString == null)
-                throw new ArgumentNullException(nameof(literalStringClass.EscapedLiteralString), "Property is required for class LiteralStringClass.");
+                throw new JsonException("Cannot write null property LiteralStringClass.EscapedLiteralString to non-nullable JSON property 'escapedLiteralString'.");
 
             if (literalStringClass.UnescapedLiteralStringOption.IsSet && literalStringClass.UnescapedLiteralString == null)
-                throw new ArgumentNullException(nameof(literalStringClass.UnescapedLiteralString), "Property is required for class LiteralStringClass.");
+                throw new JsonException("Cannot write null property LiteralStringClass.UnescapedLiteralString to non-nullable JSON property 'unescapedLiteralString'.");
 
             if (literalStringClass.EscapedLiteralStringOption.IsSet)
                 writer.WriteString("escapedLiteralString", literalStringClass.EscapedLiteralString);

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/MapTest.cs
@@ -244,16 +244,16 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MapTest mapTest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mapTest.DirectMapOption.IsSet && mapTest.DirectMap == null)
-                throw new ArgumentNullException(nameof(mapTest.DirectMap), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.DirectMap to non-nullable JSON property 'direct_map'.");
 
             if (mapTest.IndirectMapOption.IsSet && mapTest.IndirectMap == null)
-                throw new ArgumentNullException(nameof(mapTest.IndirectMap), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.IndirectMap to non-nullable JSON property 'indirect_map'.");
 
             if (mapTest.MapMapOfStringOption.IsSet && mapTest.MapMapOfString == null)
-                throw new ArgumentNullException(nameof(mapTest.MapMapOfString), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.MapMapOfString to non-nullable JSON property 'map_map_of_string'.");
 
             if (mapTest.MapOfEnumStringOption.IsSet && mapTest.MapOfEnumString == null)
-                throw new ArgumentNullException(nameof(mapTest.MapOfEnumString), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.MapOfEnumString to non-nullable JSON property 'map_of_enum_string'.");
 
             if (mapTest.DirectMapOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/MixedAnyOf.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/MixedAnyOf.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedAnyOf mixedAnyOf, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedAnyOf.ContentOption.IsSet && mixedAnyOf.Content == null)
-                throw new ArgumentNullException(nameof(mixedAnyOf.Content), "Property is required for class MixedAnyOf.");
+                throw new JsonException("Cannot write null property MixedAnyOf.Content to non-nullable JSON property 'content'.");
 
             if (mixedAnyOf.ContentOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/MixedOneOf.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/MixedOneOf.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedOneOf mixedOneOf, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedOneOf.ContentOption.IsSet && mixedOneOf.Content == null)
-                throw new ArgumentNullException(nameof(mixedOneOf.Content), "Property is required for class MixedOneOf.");
+                throw new JsonException("Cannot write null property MixedOneOf.Content to non-nullable JSON property 'content'.");
 
             if (mixedOneOf.ContentOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -255,8 +255,17 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, MixedPropertiesAndAdditionalPropertiesClass mixedPropertiesAndAdditionalPropertiesClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.DateTime == null)
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.DateTime to non-nullable JSON property 'dateTime'.");
+
             if (mixedPropertiesAndAdditionalPropertiesClass.MapOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.Map == null)
                 throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.Map to non-nullable JSON property 'map'.");
+
+            if (mixedPropertiesAndAdditionalPropertiesClass.UuidOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.Uuid == null)
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.Uuid to non-nullable JSON property 'uuid'.");
+
+            if (mixedPropertiesAndAdditionalPropertiesClass.UuidWithPatternOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.UuidWithPattern == null)
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.UuidWithPattern to non-nullable JSON property 'uuid_with_pattern'.");
 
             if (mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.IsSet)
                 writer.WriteString("dateTime", mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.Value.Value.ToString(DateTimeFormat));

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -256,7 +256,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedPropertiesAndAdditionalPropertiesClass mixedPropertiesAndAdditionalPropertiesClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedPropertiesAndAdditionalPropertiesClass.MapOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.Map == null)
-                throw new ArgumentNullException(nameof(mixedPropertiesAndAdditionalPropertiesClass.Map), "Property is required for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.Map to non-nullable JSON property 'map'.");
 
             if (mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.IsSet)
                 writer.WriteString("dateTime", mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.Value.Value.ToString(DateTimeFormat));

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/MixedSubId.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/MixedSubId.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedSubId mixedSubId, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedSubId.IdOption.IsSet && mixedSubId.Id == null)
-                throw new ArgumentNullException(nameof(mixedSubId.Id), "Property is required for class MixedSubId.");
+                throw new JsonException("Cannot write null property MixedSubId.Id to non-nullable JSON property 'id'.");
 
             if (mixedSubId.IdOption.IsSet)
                 writer.WriteString("id", mixedSubId.Id);

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -198,7 +198,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Model200Response model200Response, JsonSerializerOptions jsonSerializerOptions)
         {
             if (model200Response.ClassOption.IsSet && model200Response.Class == null)
-                throw new ArgumentNullException(nameof(model200Response.Class), "Property is required for class Model200Response.");
+                throw new JsonException("Cannot write null property Model200Response.Class to non-nullable JSON property 'class'.");
 
             if (model200Response.ClassOption.IsSet)
                 writer.WriteString("class", model200Response.Class);

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -200,6 +200,9 @@ namespace Org.OpenAPITools.Model
             if (model200Response.ClassOption.IsSet && model200Response.Class == null)
                 throw new JsonException("Cannot write null property Model200Response.Class to non-nullable JSON property 'class'.");
 
+            if (model200Response.NameOption.IsSet && model200Response.Name == null)
+                throw new JsonException("Cannot write null property Model200Response.Name to non-nullable JSON property 'name'.");
+
             if (model200Response.ClassOption.IsSet)
                 writer.WriteString("class", model200Response.Class);
 

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ModelClient modelClient, JsonSerializerOptions jsonSerializerOptions)
         {
             if (modelClient.VarClientOption.IsSet && modelClient.VarClient == null)
-                throw new ArgumentNullException(nameof(modelClient.VarClient), "Property is required for class ModelClient.");
+                throw new JsonException("Cannot write null property ModelClient.VarClient to non-nullable JSON property 'client'.");
 
             if (modelClient.VarClientOption.IsSet)
                 writer.WriteString("client", modelClient.VarClient);

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Name.cs
@@ -281,7 +281,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Name name, JsonSerializerOptions jsonSerializerOptions)
         {
             if (name.PropertyOption.IsSet && name.Property == null)
-                throw new ArgumentNullException(nameof(name.Property), "Property is required for class Name.");
+                throw new JsonException("Cannot write null property Name.Property to non-nullable JSON property 'property'.");
 
             writer.WriteNumber("name", name.VarName);
 

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Name.cs
@@ -283,6 +283,12 @@ namespace Org.OpenAPITools.Model
             if (name.PropertyOption.IsSet && name.Property == null)
                 throw new JsonException("Cannot write null property Name.Property to non-nullable JSON property 'property'.");
 
+            if (name.SnakeCaseOption.IsSet && name.SnakeCase == null)
+                throw new JsonException("Cannot write null property Name.SnakeCase to non-nullable JSON property 'snake_case'.");
+
+            if (name.Var123NumberOption.IsSet && name.Var123Number == null)
+                throw new JsonException("Cannot write null property Name.Var123Number to non-nullable JSON property '123Number'.");
+
             writer.WriteNumber("name", name.VarName);
 
             if (name.PropertyOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
@@ -189,9 +189,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, NotificationtestGetElementsV1ResponseMPayload notificationtestGetElementsV1ResponseMPayload, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (notificationtestGetElementsV1ResponseMPayload.AObjVariableobject == null)
-                throw new ArgumentNullException(nameof(notificationtestGetElementsV1ResponseMPayload.AObjVariableobject), "Property is required for class NotificationtestGetElementsV1ResponseMPayload.");
-
             writer.WritePropertyName("a_objVariableobject");
             JsonSerializer.Serialize(writer, notificationtestGetElementsV1ResponseMPayload.AObjVariableobject, jsonSerializerOptions);
             writer.WriteNumber("pkiNotificationtestID", notificationtestGetElementsV1ResponseMPayload.PkiNotificationtestID);

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -408,10 +408,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, NullableClass nullableClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (nullableClass.ArrayItemsNullableOption.IsSet && nullableClass.ArrayItemsNullable == null)
-                throw new ArgumentNullException(nameof(nullableClass.ArrayItemsNullable), "Property is required for class NullableClass.");
+                throw new JsonException("Cannot write null property NullableClass.ArrayItemsNullable to non-nullable JSON property 'array_items_nullable'.");
 
             if (nullableClass.ObjectItemsNullableOption.IsSet && nullableClass.ObjectItemsNullable == null)
-                throw new ArgumentNullException(nameof(nullableClass.ObjectItemsNullable), "Property is required for class NullableClass.");
+                throw new JsonException("Cannot write null property NullableClass.ObjectItemsNullable to non-nullable JSON property 'object_items_nullable'.");
 
             if (nullableClass.ArrayAndItemsNullablePropOption.IsSet)
                 if (nullableClass.ArrayAndItemsNullablePropOption.Value != null)

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -174,6 +174,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, NumberOnly numberOnly, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (numberOnly.JustNumberOption.IsSet && numberOnly.JustNumber == null)
+                throw new JsonException("Cannot write null property NumberOnly.JustNumber to non-nullable JSON property 'JustNumber'.");
+
             if (numberOnly.JustNumberOption.IsSet)
                 writer.WriteNumber("JustNumber", numberOnly.JustNumberOption.Value.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -247,13 +247,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ObjectWithDeprecatedFields objectWithDeprecatedFields, JsonSerializerOptions jsonSerializerOptions)
         {
             if (objectWithDeprecatedFields.BarsOption.IsSet && objectWithDeprecatedFields.Bars == null)
-                throw new ArgumentNullException(nameof(objectWithDeprecatedFields.Bars), "Property is required for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Bars to non-nullable JSON property 'bars'.");
 
             if (objectWithDeprecatedFields.DeprecatedRefOption.IsSet && objectWithDeprecatedFields.DeprecatedRef == null)
-                throw new ArgumentNullException(nameof(objectWithDeprecatedFields.DeprecatedRef), "Property is required for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.DeprecatedRef to non-nullable JSON property 'deprecatedRef'.");
 
             if (objectWithDeprecatedFields.UuidOption.IsSet && objectWithDeprecatedFields.Uuid == null)
-                throw new ArgumentNullException(nameof(objectWithDeprecatedFields.Uuid), "Property is required for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Uuid to non-nullable JSON property 'uuid'.");
 
             if (objectWithDeprecatedFields.BarsOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -252,6 +252,9 @@ namespace Org.OpenAPITools.Model
             if (objectWithDeprecatedFields.DeprecatedRefOption.IsSet && objectWithDeprecatedFields.DeprecatedRef == null)
                 throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.DeprecatedRef to non-nullable JSON property 'deprecatedRef'.");
 
+            if (objectWithDeprecatedFields.IdOption.IsSet && objectWithDeprecatedFields.Id == null)
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Id to non-nullable JSON property 'id'.");
+
             if (objectWithDeprecatedFields.UuidOption.IsSet && objectWithDeprecatedFields.Uuid == null)
                 throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Uuid to non-nullable JSON property 'uuid'.");
 

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Order.cs
@@ -295,6 +295,24 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Order order, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (order.CompleteOption.IsSet && order.Complete == null)
+                throw new JsonException("Cannot write null property Order.Complete to non-nullable JSON property 'complete'.");
+
+            if (order.IdOption.IsSet && order.Id == null)
+                throw new JsonException("Cannot write null property Order.Id to non-nullable JSON property 'id'.");
+
+            if (order.PetIdOption.IsSet && order.PetId == null)
+                throw new JsonException("Cannot write null property Order.PetId to non-nullable JSON property 'petId'.");
+
+            if (order.QuantityOption.IsSet && order.Quantity == null)
+                throw new JsonException("Cannot write null property Order.Quantity to non-nullable JSON property 'quantity'.");
+
+            if (order.ShipDateOption.IsSet && order.ShipDate == null)
+                throw new JsonException("Cannot write null property Order.ShipDate to non-nullable JSON property 'shipDate'.");
+
+            if (order.StatusOption.IsSet && order.Status == null)
+                throw new JsonException("Cannot write null property Order.Status to non-nullable JSON property 'status'.");
+
             if (order.CompleteOption.IsSet)
                 writer.WriteBoolean("complete", order.CompleteOption.Value.Value);
 

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -220,6 +220,12 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, OuterComposite outerComposite, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (outerComposite.MyBooleanOption.IsSet && outerComposite.MyBoolean == null)
+                throw new JsonException("Cannot write null property OuterComposite.MyBoolean to non-nullable JSON property 'my_boolean'.");
+
+            if (outerComposite.MyNumberOption.IsSet && outerComposite.MyNumber == null)
+                throw new JsonException("Cannot write null property OuterComposite.MyNumber to non-nullable JSON property 'my_number'.");
+
             if (outerComposite.MyStringOption.IsSet && outerComposite.MyString == null)
                 throw new JsonException("Cannot write null property OuterComposite.MyString to non-nullable JSON property 'my_string'.");
 

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -221,7 +221,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, OuterComposite outerComposite, JsonSerializerOptions jsonSerializerOptions)
         {
             if (outerComposite.MyStringOption.IsSet && outerComposite.MyString == null)
-                throw new ArgumentNullException(nameof(outerComposite.MyString), "Property is required for class OuterComposite.");
+                throw new JsonException("Cannot write null property OuterComposite.MyString to non-nullable JSON property 'my_string'.");
 
             if (outerComposite.MyBooleanOption.IsSet)
                 writer.WriteBoolean("my_boolean", outerComposite.MyBooleanOption.Value.Value);

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Pet.cs
@@ -282,17 +282,11 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Pet pet, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (pet.Name == null)
-                throw new ArgumentNullException(nameof(pet.Name), "Property is required for class Pet.");
-
-            if (pet.PhotoUrls == null)
-                throw new ArgumentNullException(nameof(pet.PhotoUrls), "Property is required for class Pet.");
-
             if (pet.CategoryOption.IsSet && pet.Category == null)
-                throw new ArgumentNullException(nameof(pet.Category), "Property is required for class Pet.");
+                throw new JsonException("Cannot write null property Pet.Category to non-nullable JSON property 'category'.");
 
             if (pet.TagsOption.IsSet && pet.Tags == null)
-                throw new ArgumentNullException(nameof(pet.Tags), "Property is required for class Pet.");
+                throw new JsonException("Cannot write null property Pet.Tags to non-nullable JSON property 'tags'.");
 
             writer.WriteString("name", pet.Name);
 

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Pet.cs
@@ -285,6 +285,12 @@ namespace Org.OpenAPITools.Model
             if (pet.CategoryOption.IsSet && pet.Category == null)
                 throw new JsonException("Cannot write null property Pet.Category to non-nullable JSON property 'category'.");
 
+            if (pet.IdOption.IsSet && pet.Id == null)
+                throw new JsonException("Cannot write null property Pet.Id to non-nullable JSON property 'id'.");
+
+            if (pet.StatusOption.IsSet && pet.Status == null)
+                throw new JsonException("Cannot write null property Pet.Status to non-nullable JSON property 'status'.");
+
             if (pet.TagsOption.IsSet && pet.Tags == null)
                 throw new JsonException("Cannot write null property Pet.Tags to non-nullable JSON property 'tags'.");
 

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
@@ -170,9 +170,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, QuadrilateralInterface quadrilateralInterface, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (quadrilateralInterface.QuadrilateralType == null)
-                throw new ArgumentNullException(nameof(quadrilateralInterface.QuadrilateralType), "Property is required for class QuadrilateralInterface.");
-
             writer.WriteString("quadrilateralType", quadrilateralInterface.QuadrilateralType);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -236,10 +236,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ReadOnlyFirst readOnlyFirst, JsonSerializerOptions jsonSerializerOptions)
         {
             if (readOnlyFirst.BarOption.IsSet && readOnlyFirst.Bar == null)
-                throw new ArgumentNullException(nameof(readOnlyFirst.Bar), "Property is required for class ReadOnlyFirst.");
+                throw new JsonException("Cannot write null property ReadOnlyFirst.Bar to non-nullable JSON property 'bar'.");
 
             if (readOnlyFirst.BazOption.IsSet && readOnlyFirst.Baz == null)
-                throw new ArgumentNullException(nameof(readOnlyFirst.Baz), "Property is required for class ReadOnlyFirst.");
+                throw new JsonException("Cannot write null property ReadOnlyFirst.Baz to non-nullable JSON property 'baz'.");
 
             if (readOnlyFirst.BarOption.IsSet)
                 writer.WriteString("bar", readOnlyFirst.Bar);

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -1053,11 +1053,38 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, RequiredClass requiredClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (requiredClass.NotRequiredNotnullableDatePropOption.IsSet && requiredClass.NotRequiredNotnullableDateProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotRequiredNotnullableDateProp to non-nullable JSON property 'not_required_notnullable_date_prop'.");
+
+            if (requiredClass.NotRequiredNotnullableintegerPropOption.IsSet && requiredClass.NotRequiredNotnullableintegerProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotRequiredNotnullableintegerProp to non-nullable JSON property 'not_required_notnullableinteger_prop'.");
+
             if (requiredClass.NotrequiredNotnullableArrayOfStringOption.IsSet && requiredClass.NotrequiredNotnullableArrayOfString == null)
                 throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableArrayOfString to non-nullable JSON property 'notrequired_notnullable_array_of_string'.");
 
+            if (requiredClass.NotrequiredNotnullableBooleanPropOption.IsSet && requiredClass.NotrequiredNotnullableBooleanProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableBooleanProp to non-nullable JSON property 'notrequired_notnullable_boolean_prop'.");
+
+            if (requiredClass.NotrequiredNotnullableDatetimePropOption.IsSet && requiredClass.NotrequiredNotnullableDatetimeProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableDatetimeProp to non-nullable JSON property 'notrequired_notnullable_datetime_prop'.");
+
+            if (requiredClass.NotrequiredNotnullableEnumIntegerOption.IsSet && requiredClass.NotrequiredNotnullableEnumInteger == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableEnumInteger to non-nullable JSON property 'notrequired_notnullable_enum_integer'.");
+
+            if (requiredClass.NotrequiredNotnullableEnumIntegerOnlyOption.IsSet && requiredClass.NotrequiredNotnullableEnumIntegerOnly == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableEnumIntegerOnly to non-nullable JSON property 'notrequired_notnullable_enum_integer_only'.");
+
+            if (requiredClass.NotrequiredNotnullableEnumStringOption.IsSet && requiredClass.NotrequiredNotnullableEnumString == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableEnumString to non-nullable JSON property 'notrequired_notnullable_enum_string'.");
+
+            if (requiredClass.NotrequiredNotnullableOuterEnumDefaultValueOption.IsSet && requiredClass.NotrequiredNotnullableOuterEnumDefaultValue == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableOuterEnumDefaultValue to non-nullable JSON property 'notrequired_notnullable_outerEnumDefaultValue'.");
+
             if (requiredClass.NotrequiredNotnullableStringPropOption.IsSet && requiredClass.NotrequiredNotnullableStringProp == null)
                 throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableStringProp to non-nullable JSON property 'notrequired_notnullable_string_prop'.");
+
+            if (requiredClass.NotrequiredNotnullableUuidOption.IsSet && requiredClass.NotrequiredNotnullableUuid == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableUuid to non-nullable JSON property 'notrequired_notnullable_uuid'.");
 
             writer.WriteString("required_not_nullable_date_prop", requiredClass.RequiredNotNullableDateProp.ToString(RequiredNotNullableDatePropFormat));
 

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -1053,17 +1053,11 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, RequiredClass requiredClass, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (requiredClass.RequiredNotnullableArrayOfString == null)
-                throw new ArgumentNullException(nameof(requiredClass.RequiredNotnullableArrayOfString), "Property is required for class RequiredClass.");
-
-            if (requiredClass.RequiredNotnullableStringProp == null)
-                throw new ArgumentNullException(nameof(requiredClass.RequiredNotnullableStringProp), "Property is required for class RequiredClass.");
-
             if (requiredClass.NotrequiredNotnullableArrayOfStringOption.IsSet && requiredClass.NotrequiredNotnullableArrayOfString == null)
-                throw new ArgumentNullException(nameof(requiredClass.NotrequiredNotnullableArrayOfString), "Property is required for class RequiredClass.");
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableArrayOfString to non-nullable JSON property 'notrequired_notnullable_array_of_string'.");
 
             if (requiredClass.NotrequiredNotnullableStringPropOption.IsSet && requiredClass.NotrequiredNotnullableStringProp == null)
-                throw new ArgumentNullException(nameof(requiredClass.NotrequiredNotnullableStringProp), "Property is required for class RequiredClass.");
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableStringProp to non-nullable JSON property 'notrequired_notnullable_string_prop'.");
 
             writer.WriteString("required_not_nullable_date_prop", requiredClass.RequiredNotNullableDateProp.ToString(RequiredNotNullableDatePropFormat));
 

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Result.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Result.cs
@@ -224,13 +224,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Result result, JsonSerializerOptions jsonSerializerOptions)
         {
             if (result.CodeOption.IsSet && result.Code == null)
-                throw new ArgumentNullException(nameof(result.Code), "Property is required for class Result.");
+                throw new JsonException("Cannot write null property Result.Code to non-nullable JSON property 'code'.");
 
             if (result.DataOption.IsSet && result.Data == null)
-                throw new ArgumentNullException(nameof(result.Data), "Property is required for class Result.");
+                throw new JsonException("Cannot write null property Result.Data to non-nullable JSON property 'data'.");
 
             if (result.UuidOption.IsSet && result.Uuid == null)
-                throw new ArgumentNullException(nameof(result.Uuid), "Property is required for class Result.");
+                throw new JsonException("Cannot write null property Result.Uuid to non-nullable JSON property 'uuid'.");
 
             if (result.CodeOption.IsSet)
                 writer.WriteString("code", result.Code);

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Return.cs
@@ -232,11 +232,8 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Return varReturn, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (varReturn.Lock == null)
-                throw new ArgumentNullException(nameof(varReturn.Lock), "Property is required for class Return.");
-
             if (varReturn.UnsafeOption.IsSet && varReturn.Unsafe == null)
-                throw new ArgumentNullException(nameof(varReturn.Unsafe), "Property is required for class Return.");
+                throw new JsonException("Cannot write null property Return.Unsafe to non-nullable JSON property 'unsafe'.");
 
             writer.WriteString("lock", varReturn.Lock);
 

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Return.cs
@@ -232,6 +232,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Return varReturn, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (varReturn.VarReturnOption.IsSet && varReturn.VarReturn == null)
+                throw new JsonException("Cannot write null property Return.VarReturn to non-nullable JSON property 'return'.");
+
             if (varReturn.UnsafeOption.IsSet && varReturn.Unsafe == null)
                 throw new JsonException("Cannot write null property Return.Unsafe to non-nullable JSON property 'unsafe'.");
 

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -198,7 +198,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, RolesReportsHash rolesReportsHash, JsonSerializerOptions jsonSerializerOptions)
         {
             if (rolesReportsHash.RoleOption.IsSet && rolesReportsHash.Role == null)
-                throw new ArgumentNullException(nameof(rolesReportsHash.Role), "Property is required for class RolesReportsHash.");
+                throw new JsonException("Cannot write null property RolesReportsHash.Role to non-nullable JSON property 'role'.");
 
             if (rolesReportsHash.RoleOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -200,6 +200,9 @@ namespace Org.OpenAPITools.Model
             if (rolesReportsHash.RoleOption.IsSet && rolesReportsHash.Role == null)
                 throw new JsonException("Cannot write null property RolesReportsHash.Role to non-nullable JSON property 'role'.");
 
+            if (rolesReportsHash.RoleUuidOption.IsSet && rolesReportsHash.RoleUuid == null)
+                throw new JsonException("Cannot write null property RolesReportsHash.RoleUuid to non-nullable JSON property 'role_uuid'.");
+
             if (rolesReportsHash.RoleOption.IsSet)
             {
                 writer.WritePropertyName("role");

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, RolesReportsHashRole rolesReportsHashRole, JsonSerializerOptions jsonSerializerOptions)
         {
             if (rolesReportsHashRole.NameOption.IsSet && rolesReportsHashRole.Name == null)
-                throw new ArgumentNullException(nameof(rolesReportsHashRole.Name), "Property is required for class RolesReportsHashRole.");
+                throw new JsonException("Cannot write null property RolesReportsHashRole.Name to non-nullable JSON property 'name'.");
 
             if (rolesReportsHashRole.NameOption.IsSet)
                 writer.WriteString("name", rolesReportsHashRole.Name);

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
@@ -189,12 +189,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ScaleneTriangle scaleneTriangle, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (scaleneTriangle.ShapeType == null)
-                throw new ArgumentNullException(nameof(scaleneTriangle.ShapeType), "Property is required for class ScaleneTriangle.");
-
-            if (scaleneTriangle.TriangleType == null)
-                throw new ArgumentNullException(nameof(scaleneTriangle.TriangleType), "Property is required for class ScaleneTriangle.");
-
             writer.WriteString("shapeType", scaleneTriangle.ShapeType);
 
             writer.WriteString("triangleType", scaleneTriangle.TriangleType);

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ShapeInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ShapeInterface.cs
@@ -170,9 +170,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ShapeInterface shapeInterface, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (shapeInterface.ShapeType == null)
-                throw new ArgumentNullException(nameof(shapeInterface.ShapeType), "Property is required for class ShapeInterface.");
-
             writer.WriteString("shapeType", shapeInterface.ShapeType);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
@@ -189,12 +189,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, SimpleQuadrilateral simpleQuadrilateral, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (simpleQuadrilateral.QuadrilateralType == null)
-                throw new ArgumentNullException(nameof(simpleQuadrilateral.QuadrilateralType), "Property is required for class SimpleQuadrilateral.");
-
-            if (simpleQuadrilateral.ShapeType == null)
-                throw new ArgumentNullException(nameof(simpleQuadrilateral.ShapeType), "Property is required for class SimpleQuadrilateral.");
-
             writer.WriteString("quadrilateralType", simpleQuadrilateral.QuadrilateralType);
 
             writer.WriteString("shapeType", simpleQuadrilateral.ShapeType);

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -200,6 +200,9 @@ namespace Org.OpenAPITools.Model
             if (specialModelName.VarSpecialModelNameOption.IsSet && specialModelName.VarSpecialModelName == null)
                 throw new JsonException("Cannot write null property SpecialModelName.VarSpecialModelName to non-nullable JSON property '_special_model.name_'.");
 
+            if (specialModelName.SpecialPropertyNameOption.IsSet && specialModelName.SpecialPropertyName == null)
+                throw new JsonException("Cannot write null property SpecialModelName.SpecialPropertyName to non-nullable JSON property '$special[property.name]'.");
+
             if (specialModelName.VarSpecialModelNameOption.IsSet)
                 writer.WriteString("_special_model.name_", specialModelName.VarSpecialModelName);
 

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -198,7 +198,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, SpecialModelName specialModelName, JsonSerializerOptions jsonSerializerOptions)
         {
             if (specialModelName.VarSpecialModelNameOption.IsSet && specialModelName.VarSpecialModelName == null)
-                throw new ArgumentNullException(nameof(specialModelName.VarSpecialModelName), "Property is required for class SpecialModelName.");
+                throw new JsonException("Cannot write null property SpecialModelName.VarSpecialModelName to non-nullable JSON property '_special_model.name_'.");
 
             if (specialModelName.VarSpecialModelNameOption.IsSet)
                 writer.WriteString("_special_model.name_", specialModelName.VarSpecialModelName);

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Tag.cs
@@ -198,7 +198,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Tag tag, JsonSerializerOptions jsonSerializerOptions)
         {
             if (tag.NameOption.IsSet && tag.Name == null)
-                throw new ArgumentNullException(nameof(tag.Name), "Property is required for class Tag.");
+                throw new JsonException("Cannot write null property Tag.Name to non-nullable JSON property 'name'.");
 
             if (tag.IdOption.IsSet)
                 writer.WriteNumber("id", tag.IdOption.Value.Value);

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Tag.cs
@@ -197,6 +197,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Tag tag, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (tag.IdOption.IsSet && tag.Id == null)
+                throw new JsonException("Cannot write null property Tag.Id to non-nullable JSON property 'id'.");
+
             if (tag.NameOption.IsSet && tag.Name == null)
                 throw new JsonException("Cannot write null property Tag.Name to non-nullable JSON property 'name'.");
 

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestCollectionEndingWithWordList testCollectionEndingWithWordList, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testCollectionEndingWithWordList.ValueOption.IsSet && testCollectionEndingWithWordList.Value == null)
-                throw new ArgumentNullException(nameof(testCollectionEndingWithWordList.Value), "Property is required for class TestCollectionEndingWithWordList.");
+                throw new JsonException("Cannot write null property TestCollectionEndingWithWordList.Value to non-nullable JSON property 'value'.");
 
             if (testCollectionEndingWithWordList.ValueOption.IsSet)
                 writer.WriteString("value", testCollectionEndingWithWordList.Value);

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestCollectionEndingWithWordListObject testCollectionEndingWithWordListObject, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testCollectionEndingWithWordListObject.TestCollectionEndingWithWordListOption.IsSet && testCollectionEndingWithWordListObject.TestCollectionEndingWithWordList == null)
-                throw new ArgumentNullException(nameof(testCollectionEndingWithWordListObject.TestCollectionEndingWithWordList), "Property is required for class TestCollectionEndingWithWordListObject.");
+                throw new JsonException("Cannot write null property TestCollectionEndingWithWordListObject.TestCollectionEndingWithWordList to non-nullable JSON property 'TestCollectionEndingWithWordList'.");
 
             if (testCollectionEndingWithWordListObject.TestCollectionEndingWithWordListOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/TestDescendants.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/TestDescendants.cs
@@ -216,9 +216,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, TestDescendants testDescendants, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (testDescendants.AlternativeName == null)
-                throw new ArgumentNullException(nameof(testDescendants.AlternativeName), "Property is required for class TestDescendants.");
-
             writer.WriteString("alternativeName", testDescendants.AlternativeName);
 
             writer.WriteString("objectType", TestDescendantsObjectTypeValueConverter.ToJsonValue(testDescendants.ObjectType));

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestInlineFreeformAdditionalPropertiesRequest testInlineFreeformAdditionalPropertiesRequest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testInlineFreeformAdditionalPropertiesRequest.SomePropertyOption.IsSet && testInlineFreeformAdditionalPropertiesRequest.SomeProperty == null)
-                throw new ArgumentNullException(nameof(testInlineFreeformAdditionalPropertiesRequest.SomeProperty), "Property is required for class TestInlineFreeformAdditionalPropertiesRequest.");
+                throw new JsonException("Cannot write null property TestInlineFreeformAdditionalPropertiesRequest.SomeProperty to non-nullable JSON property 'someProperty'.");
 
             if (testInlineFreeformAdditionalPropertiesRequest.SomePropertyOption.IsSet)
                 writer.WriteString("someProperty", testInlineFreeformAdditionalPropertiesRequest.SomeProperty);

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/TestResult.cs
@@ -222,6 +222,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, TestResult testResult, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (testResult.CodeOption.IsSet && testResult.Code == null)
+                throw new JsonException("Cannot write null property TestResult.Code to non-nullable JSON property 'code'.");
+
             if (testResult.DataOption.IsSet && testResult.Data == null)
                 throw new JsonException("Cannot write null property TestResult.Data to non-nullable JSON property 'data'.");
 

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/TestResult.cs
@@ -223,10 +223,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestResult testResult, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testResult.DataOption.IsSet && testResult.Data == null)
-                throw new ArgumentNullException(nameof(testResult.Data), "Property is required for class TestResult.");
+                throw new JsonException("Cannot write null property TestResult.Data to non-nullable JSON property 'data'.");
 
             if (testResult.UuidOption.IsSet && testResult.Uuid == null)
-                throw new ArgumentNullException(nameof(testResult.Uuid), "Property is required for class TestResult.");
+                throw new JsonException("Cannot write null property TestResult.Uuid to non-nullable JSON property 'uuid'.");
 
             if (testResult.CodeOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/TriangleInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/TriangleInterface.cs
@@ -170,9 +170,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, TriangleInterface triangleInterface, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (triangleInterface.TriangleType == null)
-                throw new ArgumentNullException(nameof(triangleInterface.TriangleType), "Property is required for class TriangleInterface.");
-
             writer.WriteString("triangleType", triangleInterface.TriangleType);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/User.cs
@@ -429,6 +429,9 @@ namespace Org.OpenAPITools.Model
             if (user.FirstNameOption.IsSet && user.FirstName == null)
                 throw new JsonException("Cannot write null property User.FirstName to non-nullable JSON property 'firstName'.");
 
+            if (user.IdOption.IsSet && user.Id == null)
+                throw new JsonException("Cannot write null property User.Id to non-nullable JSON property 'id'.");
+
             if (user.LastNameOption.IsSet && user.LastName == null)
                 throw new JsonException("Cannot write null property User.LastName to non-nullable JSON property 'lastName'.");
 
@@ -440,6 +443,9 @@ namespace Org.OpenAPITools.Model
 
             if (user.PhoneOption.IsSet && user.Phone == null)
                 throw new JsonException("Cannot write null property User.Phone to non-nullable JSON property 'phone'.");
+
+            if (user.UserStatusOption.IsSet && user.UserStatus == null)
+                throw new JsonException("Cannot write null property User.UserStatus to non-nullable JSON property 'userStatus'.");
 
             if (user.UsernameOption.IsSet && user.Username == null)
                 throw new JsonException("Cannot write null property User.Username to non-nullable JSON property 'username'.");

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/User.cs
@@ -424,25 +424,25 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, User user, JsonSerializerOptions jsonSerializerOptions)
         {
             if (user.EmailOption.IsSet && user.Email == null)
-                throw new ArgumentNullException(nameof(user.Email), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Email to non-nullable JSON property 'email'.");
 
             if (user.FirstNameOption.IsSet && user.FirstName == null)
-                throw new ArgumentNullException(nameof(user.FirstName), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.FirstName to non-nullable JSON property 'firstName'.");
 
             if (user.LastNameOption.IsSet && user.LastName == null)
-                throw new ArgumentNullException(nameof(user.LastName), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.LastName to non-nullable JSON property 'lastName'.");
 
             if (user.ObjectWithNoDeclaredPropsOption.IsSet && user.ObjectWithNoDeclaredProps == null)
-                throw new ArgumentNullException(nameof(user.ObjectWithNoDeclaredProps), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.ObjectWithNoDeclaredProps to non-nullable JSON property 'objectWithNoDeclaredProps'.");
 
             if (user.PasswordOption.IsSet && user.Password == null)
-                throw new ArgumentNullException(nameof(user.Password), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Password to non-nullable JSON property 'password'.");
 
             if (user.PhoneOption.IsSet && user.Phone == null)
-                throw new ArgumentNullException(nameof(user.Phone), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Phone to non-nullable JSON property 'phone'.");
 
             if (user.UsernameOption.IsSet && user.Username == null)
-                throw new ArgumentNullException(nameof(user.Username), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Username to non-nullable JSON property 'username'.");
 
             if (user.AnyTypePropOption.IsSet)
                 if (user.AnyTypePropOption.Value != null)

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Whale.cs
@@ -216,9 +216,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Whale whale, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (whale.ClassName == null)
-                throw new ArgumentNullException(nameof(whale.ClassName), "Property is required for class Whale.");
-
             writer.WriteString("className", whale.ClassName);
 
             if (whale.HasBaleenOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Whale.cs
@@ -216,6 +216,12 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Whale whale, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (whale.HasBaleenOption.IsSet && whale.HasBaleen == null)
+                throw new JsonException("Cannot write null property Whale.HasBaleen to non-nullable JSON property 'hasBaleen'.");
+
+            if (whale.HasTeethOption.IsSet && whale.HasTeeth == null)
+                throw new JsonException("Cannot write null property Whale.HasTeeth to non-nullable JSON property 'hasTeeth'.");
+
             writer.WriteString("className", whale.ClassName);
 
             if (whale.HasBaleenOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Zebra.cs
@@ -193,6 +193,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Zebra zebra, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (zebra.TypeOption.IsSet && zebra.Type == null)
+                throw new JsonException("Cannot write null property Zebra.Type to non-nullable JSON property 'type'.");
+
             writer.WriteString("className", zebra.ClassName);
 
             if (zebra.TypeOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Zebra.cs
@@ -193,9 +193,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Zebra zebra, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (zebra.ClassName == null)
-                throw new ArgumentNullException(nameof(zebra.ClassName), "Property is required for class Zebra.");
-
             writer.WriteString("className", zebra.ClassName);
 
             if (zebra.TypeOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
@@ -174,6 +174,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ZeroBasedEnumClass zeroBasedEnumClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (zeroBasedEnumClass.ZeroBasedEnumOption.IsSet && zeroBasedEnumClass.ZeroBasedEnum == null)
+                throw new JsonException("Cannot write null property ZeroBasedEnumClass.ZeroBasedEnum to non-nullable JSON property 'ZeroBasedEnum'.");
+
             if (zeroBasedEnumClass.ZeroBasedEnumOption.IsSet)
             {
                 var zeroBasedEnumRawValue = ZeroBasedEnumClassZeroBasedEnumValueConverter.ToJsonValue(zeroBasedEnumClass.ZeroBasedEnum.Value);

--- a/samples/client/petstore/csharp/generichost/net4.8/OneOf/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/OneOf/src/Org.OpenAPITools/Model/Apple.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Apple apple, JsonSerializerOptions jsonSerializerOptions)
         {
             if (apple.KindOption.IsSet && apple.Kind == null)
-                throw new ArgumentNullException(nameof(apple.Kind), "Property is required for class Apple.");
+                throw new JsonException("Cannot write null property Apple.Kind to non-nullable JSON property 'kind'.");
 
             if (apple.KindOption.IsSet)
                 writer.WriteString("kind", apple.Kind);

--- a/samples/client/petstore/csharp/generichost/net4.8/OneOf/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/OneOf/src/Org.OpenAPITools/Model/Banana.cs
@@ -174,6 +174,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Banana banana, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (banana.CountOption.IsSet && banana.Count == null)
+                throw new JsonException("Cannot write null property Banana.Count to non-nullable JSON property 'count'.");
+
             if (banana.CountOption.IsSet)
                 writer.WriteNumber("count", banana.CountOption.Value.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/OneOf/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/OneOf/src/Org.OpenAPITools/Model/Fruit.cs
@@ -250,7 +250,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Fruit fruit, JsonSerializerOptions jsonSerializerOptions)
         {
             if (fruit.ColorOption.IsSet && fruit.Color == null)
-                throw new ArgumentNullException(nameof(fruit.Color), "Property is required for class Fruit.");
+                throw new JsonException("Cannot write null property Fruit.Color to non-nullable JSON property 'color'.");
 
             if (fruit.ColorOption.IsSet)
                 writer.WriteString("color", fruit.Color);

--- a/samples/client/petstore/csharp/generichost/net4.8/OneOf/src/Org.OpenAPITools/Model/Orange.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/OneOf/src/Org.OpenAPITools/Model/Orange.cs
@@ -174,6 +174,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Orange orange, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (orange.SweetOption.IsSet && orange.Sweet == null)
+                throw new JsonException("Cannot write null property Orange.Sweet to non-nullable JSON property 'sweet'.");
+
             if (orange.SweetOption.IsSet)
                 writer.WriteBoolean("sweet", orange.SweetOption.Value.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Activity.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Activity activity, JsonSerializerOptions jsonSerializerOptions)
         {
             if (activity.ActivityOutputsOption.IsSet && activity.ActivityOutputs == null)
-                throw new ArgumentNullException(nameof(activity.ActivityOutputs), "Property is required for class Activity.");
+                throw new JsonException("Cannot write null property Activity.ActivityOutputs to non-nullable JSON property 'activity_outputs'.");
 
             if (activity.ActivityOutputsOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -198,10 +198,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ActivityOutputElementRepresentation activityOutputElementRepresentation, JsonSerializerOptions jsonSerializerOptions)
         {
             if (activityOutputElementRepresentation.Prop1Option.IsSet && activityOutputElementRepresentation.Prop1 == null)
-                throw new ArgumentNullException(nameof(activityOutputElementRepresentation.Prop1), "Property is required for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Cannot write null property ActivityOutputElementRepresentation.Prop1 to non-nullable JSON property 'prop1'.");
 
             if (activityOutputElementRepresentation.Prop2Option.IsSet && activityOutputElementRepresentation.Prop2 == null)
-                throw new ArgumentNullException(nameof(activityOutputElementRepresentation.Prop2), "Property is required for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Cannot write null property ActivityOutputElementRepresentation.Prop2 to non-nullable JSON property 'prop2'.");
 
             if (activityOutputElementRepresentation.Prop1Option.IsSet)
                 writer.WriteString("prop1", activityOutputElementRepresentation.Prop1);

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -334,25 +334,25 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, AdditionalPropertiesClass additionalPropertiesClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (additionalPropertiesClass.EmptyMapOption.IsSet && additionalPropertiesClass.EmptyMap == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.EmptyMap), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.EmptyMap to non-nullable JSON property 'empty_map'.");
 
             if (additionalPropertiesClass.MapOfMapPropertyOption.IsSet && additionalPropertiesClass.MapOfMapProperty == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapOfMapProperty), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapOfMapProperty to non-nullable JSON property 'map_of_map_property'.");
 
             if (additionalPropertiesClass.MapPropertyOption.IsSet && additionalPropertiesClass.MapProperty == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapProperty), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapProperty to non-nullable JSON property 'map_property'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1Option.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1 == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1 to non-nullable JSON property 'map_with_undeclared_properties_anytype_1'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2Option.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2 == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2 to non-nullable JSON property 'map_with_undeclared_properties_anytype_2'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3Option.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3 == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3 to non-nullable JSON property 'map_with_undeclared_properties_anytype_3'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesStringOption.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesString == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesString), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesString to non-nullable JSON property 'map_with_undeclared_properties_string'.");
 
             if (additionalPropertiesClass.Anytype1Option.IsSet)
                 if (additionalPropertiesClass.Anytype1Option.Value != null)

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Animal.cs
@@ -221,7 +221,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Animal animal, JsonSerializerOptions jsonSerializerOptions)
         {
             if (animal.ColorOption.IsSet && animal.Color == null)
-                throw new ArgumentNullException(nameof(animal.Color), "Property is required for class Animal.");
+                throw new JsonException("Cannot write null property Animal.Color to non-nullable JSON property 'color'.");
 
             writer.WriteString("className", animal.ClassName);
 

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -221,10 +221,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ApiResponse apiResponse, JsonSerializerOptions jsonSerializerOptions)
         {
             if (apiResponse.MessageOption.IsSet && apiResponse.Message == null)
-                throw new ArgumentNullException(nameof(apiResponse.Message), "Property is required for class ApiResponse.");
+                throw new JsonException("Cannot write null property ApiResponse.Message to non-nullable JSON property 'message'.");
 
             if (apiResponse.TypeOption.IsSet && apiResponse.Type == null)
-                throw new ArgumentNullException(nameof(apiResponse.Type), "Property is required for class ApiResponse.");
+                throw new JsonException("Cannot write null property ApiResponse.Type to non-nullable JSON property 'type'.");
 
             if (apiResponse.CodeOption.IsSet)
                 writer.WriteNumber("code", apiResponse.CodeOption.Value.Value);

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -220,6 +220,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ApiResponse apiResponse, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (apiResponse.CodeOption.IsSet && apiResponse.Code == null)
+                throw new JsonException("Cannot write null property ApiResponse.Code to non-nullable JSON property 'code'.");
+
             if (apiResponse.MessageOption.IsSet && apiResponse.Message == null)
                 throw new JsonException("Cannot write null property ApiResponse.Message to non-nullable JSON property 'message'.");
 

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Apple.cs
@@ -251,13 +251,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Apple apple, JsonSerializerOptions jsonSerializerOptions)
         {
             if (apple.ColorCodeOption.IsSet && apple.ColorCode == null)
-                throw new ArgumentNullException(nameof(apple.ColorCode), "Property is required for class Apple.");
+                throw new JsonException("Cannot write null property Apple.ColorCode to non-nullable JSON property 'color_code'.");
 
             if (apple.CultivarOption.IsSet && apple.Cultivar == null)
-                throw new ArgumentNullException(nameof(apple.Cultivar), "Property is required for class Apple.");
+                throw new JsonException("Cannot write null property Apple.Cultivar to non-nullable JSON property 'cultivar'.");
 
             if (apple.OriginOption.IsSet && apple.Origin == null)
-                throw new ArgumentNullException(nameof(apple.Origin), "Property is required for class Apple.");
+                throw new JsonException("Cannot write null property Apple.Origin to non-nullable JSON property 'origin'.");
 
             if (apple.ColorCodeOption.IsSet)
                 writer.WriteString("color_code", apple.ColorCode);

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -186,9 +186,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, AppleReq appleReq, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (appleReq.Cultivar == null)
-                throw new ArgumentNullException(nameof(appleReq.Cultivar), "Property is required for class AppleReq.");
-
             writer.WriteString("cultivar", appleReq.Cultivar);
 
             if (appleReq.MealyOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -186,6 +186,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, AppleReq appleReq, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (appleReq.MealyOption.IsSet && appleReq.Mealy == null)
+                throw new JsonException("Cannot write null property AppleReq.Mealy to non-nullable JSON property 'mealy'.");
+
             writer.WriteString("cultivar", appleReq.Cultivar);
 
             if (appleReq.MealyOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ArrayOfArrayOfNumberOnly arrayOfArrayOfNumberOnly, JsonSerializerOptions jsonSerializerOptions)
         {
             if (arrayOfArrayOfNumberOnly.ArrayArrayNumberOption.IsSet && arrayOfArrayOfNumberOnly.ArrayArrayNumber == null)
-                throw new ArgumentNullException(nameof(arrayOfArrayOfNumberOnly.ArrayArrayNumber), "Property is required for class ArrayOfArrayOfNumberOnly.");
+                throw new JsonException("Cannot write null property ArrayOfArrayOfNumberOnly.ArrayArrayNumber to non-nullable JSON property 'ArrayArrayNumber'.");
 
             if (arrayOfArrayOfNumberOnly.ArrayArrayNumberOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ArrayOfNumberOnly arrayOfNumberOnly, JsonSerializerOptions jsonSerializerOptions)
         {
             if (arrayOfNumberOnly.ArrayNumberOption.IsSet && arrayOfNumberOnly.ArrayNumber == null)
-                throw new ArgumentNullException(nameof(arrayOfNumberOnly.ArrayNumber), "Property is required for class ArrayOfNumberOnly.");
+                throw new JsonException("Cannot write null property ArrayOfNumberOnly.ArrayNumber to non-nullable JSON property 'ArrayNumber'.");
 
             if (arrayOfNumberOnly.ArrayNumberOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -221,13 +221,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ArrayTest arrayTest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (arrayTest.ArrayArrayOfIntegerOption.IsSet && arrayTest.ArrayArrayOfInteger == null)
-                throw new ArgumentNullException(nameof(arrayTest.ArrayArrayOfInteger), "Property is required for class ArrayTest.");
+                throw new JsonException("Cannot write null property ArrayTest.ArrayArrayOfInteger to non-nullable JSON property 'array_array_of_integer'.");
 
             if (arrayTest.ArrayArrayOfModelOption.IsSet && arrayTest.ArrayArrayOfModel == null)
-                throw new ArgumentNullException(nameof(arrayTest.ArrayArrayOfModel), "Property is required for class ArrayTest.");
+                throw new JsonException("Cannot write null property ArrayTest.ArrayArrayOfModel to non-nullable JSON property 'array_array_of_model'.");
 
             if (arrayTest.ArrayOfStringOption.IsSet && arrayTest.ArrayOfString == null)
-                throw new ArgumentNullException(nameof(arrayTest.ArrayOfString), "Property is required for class ArrayTest.");
+                throw new JsonException("Cannot write null property ArrayTest.ArrayOfString to non-nullable JSON property 'array_of_string'.");
 
             if (arrayTest.ArrayArrayOfIntegerOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Banana.cs
@@ -174,6 +174,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Banana banana, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (banana.LengthCmOption.IsSet && banana.LengthCm == null)
+                throw new JsonException("Cannot write null property Banana.LengthCm to non-nullable JSON property 'lengthCm'.");
+
             if (banana.LengthCmOption.IsSet)
                 writer.WriteNumber("lengthCm", banana.LengthCmOption.Value.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -186,6 +186,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, BananaReq bananaReq, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (bananaReq.SweetOption.IsSet && bananaReq.Sweet == null)
+                throw new JsonException("Cannot write null property BananaReq.Sweet to non-nullable JSON property 'sweet'.");
+
             writer.WriteNumber("lengthCm", bananaReq.LengthCm);
 
             if (bananaReq.SweetOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/BasquePig.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/BasquePig.cs
@@ -170,9 +170,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, BasquePig basquePig, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (basquePig.ClassName == null)
-                throw new ArgumentNullException(nameof(basquePig.ClassName), "Property is required for class BasquePig.");
-
             writer.WriteString("className", basquePig.ClassName);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -291,22 +291,22 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Capitalization capitalization, JsonSerializerOptions jsonSerializerOptions)
         {
             if (capitalization.ATT_NAMEOption.IsSet && capitalization.ATT_NAME == null)
-                throw new ArgumentNullException(nameof(capitalization.ATT_NAME), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.ATT_NAME to non-nullable JSON property 'ATT_NAME'.");
 
             if (capitalization.CapitalCamelOption.IsSet && capitalization.CapitalCamel == null)
-                throw new ArgumentNullException(nameof(capitalization.CapitalCamel), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.CapitalCamel to non-nullable JSON property 'CapitalCamel'.");
 
             if (capitalization.CapitalSnakeOption.IsSet && capitalization.CapitalSnake == null)
-                throw new ArgumentNullException(nameof(capitalization.CapitalSnake), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.CapitalSnake to non-nullable JSON property 'Capital_Snake'.");
 
             if (capitalization.SCAETHFlowPointsOption.IsSet && capitalization.SCAETHFlowPoints == null)
-                throw new ArgumentNullException(nameof(capitalization.SCAETHFlowPoints), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.SCAETHFlowPoints to non-nullable JSON property 'SCA_ETH_Flow_Points'.");
 
             if (capitalization.SmallCamelOption.IsSet && capitalization.SmallCamel == null)
-                throw new ArgumentNullException(nameof(capitalization.SmallCamel), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.SmallCamel to non-nullable JSON property 'smallCamel'.");
 
             if (capitalization.SmallSnakeOption.IsSet && capitalization.SmallSnake == null)
-                throw new ArgumentNullException(nameof(capitalization.SmallSnake), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.SmallSnake to non-nullable JSON property 'small_Snake'.");
 
             if (capitalization.ATT_NAMEOption.IsSet)
                 writer.WriteString("ATT_NAME", capitalization.ATT_NAME);

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Cat.cs
@@ -179,6 +179,9 @@ namespace Org.OpenAPITools.Model
             if (cat.ColorOption.IsSet && cat.Color == null)
                 throw new JsonException("Cannot write null property Cat.Color to non-nullable JSON property 'color'.");
 
+            if (cat.DeclawedOption.IsSet && cat.Declawed == null)
+                throw new JsonException("Cannot write null property Cat.Declawed to non-nullable JSON property 'declawed'.");
+
             writer.WriteString("className", cat.ClassName);
 
             if (cat.ColorOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Cat.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Cat cat, JsonSerializerOptions jsonSerializerOptions)
         {
             if (cat.ColorOption.IsSet && cat.Color == null)
-                throw new ArgumentNullException(nameof(cat.Color), "Property is required for class Cat.");
+                throw new JsonException("Cannot write null property Cat.Color to non-nullable JSON property 'color'.");
 
             writer.WriteString("className", cat.ClassName);
 

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Category.cs
@@ -193,9 +193,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Category category, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (category.Name == null)
-                throw new ArgumentNullException(nameof(category.Name), "Property is required for class Category.");
-
             if (category.IdOption.IsSet)
                 writer.WriteNumber("id", category.IdOption.Value.Value);
 

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Category.cs
@@ -193,6 +193,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Category category, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (category.IdOption.IsSet && category.Id == null)
+                throw new JsonException("Cannot write null property Category.Id to non-nullable JSON property 'id'.");
+
             if (category.IdOption.IsSet)
                 writer.WriteNumber("id", category.IdOption.Value.Value);
 

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -236,7 +236,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ChildCat childCat, JsonSerializerOptions jsonSerializerOptions)
         {
             if (childCat.NameOption.IsSet && childCat.Name == null)
-                throw new ArgumentNullException(nameof(childCat.Name), "Property is required for class ChildCat.");
+                throw new JsonException("Cannot write null property ChildCat.Name to non-nullable JSON property 'name'.");
 
             if (childCat.NameOption.IsSet)
                 writer.WriteString("name", childCat.Name);

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ClassModel classModel, JsonSerializerOptions jsonSerializerOptions)
         {
             if (classModel.ClassOption.IsSet && classModel.Class == null)
-                throw new ArgumentNullException(nameof(classModel.Class), "Property is required for class ClassModel.");
+                throw new JsonException("Cannot write null property ClassModel.Class to non-nullable JSON property '_class'.");
 
             if (classModel.ClassOption.IsSet)
                 writer.WriteString("_class", classModel.Class);

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
@@ -189,12 +189,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ComplexQuadrilateral complexQuadrilateral, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (complexQuadrilateral.QuadrilateralType == null)
-                throw new ArgumentNullException(nameof(complexQuadrilateral.QuadrilateralType), "Property is required for class ComplexQuadrilateral.");
-
-            if (complexQuadrilateral.ShapeType == null)
-                throw new ArgumentNullException(nameof(complexQuadrilateral.ShapeType), "Property is required for class ComplexQuadrilateral.");
-
             writer.WriteString("quadrilateralType", complexQuadrilateral.QuadrilateralType);
 
             writer.WriteString("shapeType", complexQuadrilateral.ShapeType);

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/CopyActivity.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/CopyActivity.cs
@@ -231,9 +231,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, CopyActivity copyActivity, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (copyActivity.CopyActivitytt == null)
-                throw new ArgumentNullException(nameof(copyActivity.CopyActivitytt), "Property is required for class CopyActivity.");
-
             writer.WriteString("copyActivitytt", copyActivity.CopyActivitytt);
 
             writer.WriteString("$schema", CopyActivity.SchemaEnumToJsonValue(copyActivity.Schema));

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/DanishPig.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/DanishPig.cs
@@ -170,9 +170,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, DanishPig danishPig, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (danishPig.ClassName == null)
-                throw new ArgumentNullException(nameof(danishPig.ClassName), "Property is required for class DanishPig.");
-
             writer.WriteString("className", danishPig.ClassName);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -180,6 +180,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, DateOnlyClass dateOnlyClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (dateOnlyClass.DateOnlyPropertyOption.IsSet && dateOnlyClass.DateOnlyProperty == null)
+                throw new JsonException("Cannot write null property DateOnlyClass.DateOnlyProperty to non-nullable JSON property 'dateOnlyProperty'.");
+
             if (dateOnlyClass.DateOnlyPropertyOption.IsSet)
                 writer.WriteString("dateOnlyProperty", dateOnlyClass.DateOnlyPropertyOption.Value.Value.ToString(DateOnlyPropertyFormat));
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, DeprecatedObject deprecatedObject, JsonSerializerOptions jsonSerializerOptions)
         {
             if (deprecatedObject.NameOption.IsSet && deprecatedObject.Name == null)
-                throw new ArgumentNullException(nameof(deprecatedObject.Name), "Property is required for class DeprecatedObject.");
+                throw new JsonException("Cannot write null property DeprecatedObject.Name to non-nullable JSON property 'name'.");
 
             if (deprecatedObject.NameOption.IsSet)
                 writer.WriteString("name", deprecatedObject.Name);

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Descendant1.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Descendant1.cs
@@ -182,12 +182,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Descendant1 descendant1, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (descendant1.AlternativeName == null)
-                throw new ArgumentNullException(nameof(descendant1.AlternativeName), "Property is required for class Descendant1.");
-
-            if (descendant1.DescendantName == null)
-                throw new ArgumentNullException(nameof(descendant1.DescendantName), "Property is required for class Descendant1.");
-
             writer.WriteString("alternativeName", descendant1.AlternativeName);
 
             writer.WriteString("descendantName", descendant1.DescendantName);

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Descendant2.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Descendant2.cs
@@ -182,12 +182,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Descendant2 descendant2, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (descendant2.AlternativeName == null)
-                throw new ArgumentNullException(nameof(descendant2.AlternativeName), "Property is required for class Descendant2.");
-
-            if (descendant2.Confidentiality == null)
-                throw new ArgumentNullException(nameof(descendant2.Confidentiality), "Property is required for class Descendant2.");
-
             writer.WriteString("alternativeName", descendant2.AlternativeName);
 
             writer.WriteString("confidentiality", descendant2.Confidentiality);

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Dog.cs
@@ -177,10 +177,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Dog dog, JsonSerializerOptions jsonSerializerOptions)
         {
             if (dog.BreedOption.IsSet && dog.Breed == null)
-                throw new ArgumentNullException(nameof(dog.Breed), "Property is required for class Dog.");
+                throw new JsonException("Cannot write null property Dog.Breed to non-nullable JSON property 'breed'.");
 
             if (dog.ColorOption.IsSet && dog.Color == null)
-                throw new ArgumentNullException(nameof(dog.Color), "Property is required for class Dog.");
+                throw new JsonException("Cannot write null property Dog.Color to non-nullable JSON property 'color'.");
 
             writer.WriteString("className", dog.ClassName);
 

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Drawing.cs
@@ -238,10 +238,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Drawing drawing, JsonSerializerOptions jsonSerializerOptions)
         {
             if (drawing.MainShapeOption.IsSet && drawing.MainShape == null)
-                throw new ArgumentNullException(nameof(drawing.MainShape), "Property is required for class Drawing.");
+                throw new JsonException("Cannot write null property Drawing.MainShape to non-nullable JSON property 'mainShape'.");
 
             if (drawing.ShapesOption.IsSet && drawing.Shapes == null)
-                throw new ArgumentNullException(nameof(drawing.Shapes), "Property is required for class Drawing.");
+                throw new JsonException("Cannot write null property Drawing.Shapes to non-nullable JSON property 'shapes'.");
 
             if (drawing.MainShapeOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -337,7 +337,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, EnumArrays enumArrays, JsonSerializerOptions jsonSerializerOptions)
         {
             if (enumArrays.ArrayEnumOption.IsSet && enumArrays.ArrayEnum == null)
-                throw new ArgumentNullException(nameof(enumArrays.ArrayEnum), "Property is required for class EnumArrays.");
+                throw new JsonException("Cannot write null property EnumArrays.ArrayEnum to non-nullable JSON property 'array_enum'.");
 
             if (enumArrays.ArrayEnumOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -339,6 +339,9 @@ namespace Org.OpenAPITools.Model
             if (enumArrays.ArrayEnumOption.IsSet && enumArrays.ArrayEnum == null)
                 throw new JsonException("Cannot write null property EnumArrays.ArrayEnum to non-nullable JSON property 'array_enum'.");
 
+            if (enumArrays.JustSymbolOption.IsSet && enumArrays.JustSymbol == null)
+                throw new JsonException("Cannot write null property EnumArrays.JustSymbol to non-nullable JSON property 'just_symbol'.");
+
             if (enumArrays.ArrayEnumOption.IsSet)
             {
                 writer.WritePropertyName("array_enum");

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -875,6 +875,27 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, EnumTest enumTest, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (enumTest.EnumIntegerOption.IsSet && enumTest.EnumInteger == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumInteger to non-nullable JSON property 'enum_integer'.");
+
+            if (enumTest.EnumIntegerOnlyOption.IsSet && enumTest.EnumIntegerOnly == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumIntegerOnly to non-nullable JSON property 'enum_integer_only'.");
+
+            if (enumTest.EnumNumberOption.IsSet && enumTest.EnumNumber == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumNumber to non-nullable JSON property 'enum_number'.");
+
+            if (enumTest.EnumStringOption.IsSet && enumTest.EnumString == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumString to non-nullable JSON property 'enum_string'.");
+
+            if (enumTest.OuterEnumDefaultValueOption.IsSet && enumTest.OuterEnumDefaultValue == null)
+                throw new JsonException("Cannot write null property EnumTest.OuterEnumDefaultValue to non-nullable JSON property 'outerEnumDefaultValue'.");
+
+            if (enumTest.OuterEnumIntegerOption.IsSet && enumTest.OuterEnumInteger == null)
+                throw new JsonException("Cannot write null property EnumTest.OuterEnumInteger to non-nullable JSON property 'outerEnumInteger'.");
+
+            if (enumTest.OuterEnumIntegerDefaultValueOption.IsSet && enumTest.OuterEnumIntegerDefaultValue == null)
+                throw new JsonException("Cannot write null property EnumTest.OuterEnumIntegerDefaultValue to non-nullable JSON property 'outerEnumIntegerDefaultValue'.");
+
             var enumStringRequiredRawValue = EnumTest.EnumStringRequiredEnumToJsonValue(enumTest.EnumStringRequired);
             writer.WriteString("enum_string_required", enumStringRequiredRawValue);
             if (enumTest.EnumIntegerOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
@@ -189,12 +189,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, EquilateralTriangle equilateralTriangle, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (equilateralTriangle.ShapeType == null)
-                throw new ArgumentNullException(nameof(equilateralTriangle.ShapeType), "Property is required for class EquilateralTriangle.");
-
-            if (equilateralTriangle.TriangleType == null)
-                throw new ArgumentNullException(nameof(equilateralTriangle.TriangleType), "Property is required for class EquilateralTriangle.");
-
             writer.WriteString("shapeType", equilateralTriangle.ShapeType);
 
             writer.WriteString("triangleType", equilateralTriangle.TriangleType);

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/File.cs
@@ -176,7 +176,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, File file, JsonSerializerOptions jsonSerializerOptions)
         {
             if (file.SourceURIOption.IsSet && file.SourceURI == null)
-                throw new ArgumentNullException(nameof(file.SourceURI), "Property is required for class File.");
+                throw new JsonException("Cannot write null property File.SourceURI to non-nullable JSON property 'sourceURI'.");
 
             if (file.SourceURIOption.IsSet)
                 writer.WriteString("sourceURI", file.SourceURI);

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -198,10 +198,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, FileSchemaTestClass fileSchemaTestClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (fileSchemaTestClass.FileOption.IsSet && fileSchemaTestClass.File == null)
-                throw new ArgumentNullException(nameof(fileSchemaTestClass.File), "Property is required for class FileSchemaTestClass.");
+                throw new JsonException("Cannot write null property FileSchemaTestClass.File to non-nullable JSON property 'file'.");
 
             if (fileSchemaTestClass.FilesOption.IsSet && fileSchemaTestClass.Files == null)
-                throw new ArgumentNullException(nameof(fileSchemaTestClass.Files), "Property is required for class FileSchemaTestClass.");
+                throw new JsonException("Cannot write null property FileSchemaTestClass.Files to non-nullable JSON property 'files'.");
 
             if (fileSchemaTestClass.FileOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Foo.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Foo foo, JsonSerializerOptions jsonSerializerOptions)
         {
             if (foo.BarOption.IsSet && foo.Bar == null)
-                throw new ArgumentNullException(nameof(foo.Bar), "Property is required for class Foo.");
+                throw new JsonException("Cannot write null property Foo.Bar to non-nullable JSON property 'bar'.");
 
             if (foo.BarOption.IsSet)
                 writer.WriteString("bar", foo.Bar);

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, FooGetDefaultResponse fooGetDefaultResponse, JsonSerializerOptions jsonSerializerOptions)
         {
             if (fooGetDefaultResponse.StringOption.IsSet && fooGetDefaultResponse.String == null)
-                throw new ArgumentNullException(nameof(fooGetDefaultResponse.String), "Property is required for class FooGetDefaultResponse.");
+                throw new JsonException("Cannot write null property FooGetDefaultResponse.String to non-nullable JSON property 'string'.");
 
             if (fooGetDefaultResponse.StringOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -954,11 +954,47 @@ namespace Org.OpenAPITools.Model
             if (formatTest.BinaryOption.IsSet && formatTest.Binary == null)
                 throw new JsonException("Cannot write null property FormatTest.Binary to non-nullable JSON property 'binary'.");
 
+            if (formatTest.DateTimeOption.IsSet && formatTest.DateTime == null)
+                throw new JsonException("Cannot write null property FormatTest.DateTime to non-nullable JSON property 'dateTime'.");
+
+            if (formatTest.DecimalOption.IsSet && formatTest.Decimal == null)
+                throw new JsonException("Cannot write null property FormatTest.Decimal to non-nullable JSON property 'decimal'.");
+
+            if (formatTest.DoubleOption.IsSet && formatTest.Double == null)
+                throw new JsonException("Cannot write null property FormatTest.Double to non-nullable JSON property 'double'.");
+
             if (formatTest.DuplicatePropertyName2Option.IsSet && formatTest.DuplicatePropertyName2 == null)
                 throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName2 to non-nullable JSON property 'duplicate_property_name'.");
 
             if (formatTest.DuplicatePropertyNameOption.IsSet && formatTest.DuplicatePropertyName == null)
                 throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName to non-nullable JSON property '@duplicate_property_name'.");
+
+            if (formatTest.FloatOption.IsSet && formatTest.Float == null)
+                throw new JsonException("Cannot write null property FormatTest.Float to non-nullable JSON property 'float'.");
+
+            if (formatTest.Int32Option.IsSet && formatTest.Int32 == null)
+                throw new JsonException("Cannot write null property FormatTest.Int32 to non-nullable JSON property 'int32'.");
+
+            if (formatTest.Int32RangeOption.IsSet && formatTest.Int32Range == null)
+                throw new JsonException("Cannot write null property FormatTest.Int32Range to non-nullable JSON property 'int32Range'.");
+
+            if (formatTest.Int64Option.IsSet && formatTest.Int64 == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64 to non-nullable JSON property 'int64'.");
+
+            if (formatTest.Int64NegativeOption.IsSet && formatTest.Int64Negative == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64Negative to non-nullable JSON property 'int64Negative'.");
+
+            if (formatTest.Int64NegativeExclusiveOption.IsSet && formatTest.Int64NegativeExclusive == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64NegativeExclusive to non-nullable JSON property 'int64NegativeExclusive'.");
+
+            if (formatTest.Int64PositiveOption.IsSet && formatTest.Int64Positive == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64Positive to non-nullable JSON property 'int64Positive'.");
+
+            if (formatTest.Int64PositiveExclusiveOption.IsSet && formatTest.Int64PositiveExclusive == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64PositiveExclusive to non-nullable JSON property 'int64PositiveExclusive'.");
+
+            if (formatTest.IntegerOption.IsSet && formatTest.Integer == null)
+                throw new JsonException("Cannot write null property FormatTest.Integer to non-nullable JSON property 'integer'.");
 
             if (formatTest.PatternWithBackslashOption.IsSet && formatTest.PatternWithBackslash == null)
                 throw new JsonException("Cannot write null property FormatTest.PatternWithBackslash to non-nullable JSON property 'pattern_with_backslash'.");
@@ -971,6 +1007,18 @@ namespace Org.OpenAPITools.Model
 
             if (formatTest.StringOption.IsSet && formatTest.String == null)
                 throw new JsonException("Cannot write null property FormatTest.String to non-nullable JSON property 'string'.");
+
+            if (formatTest.StringFormattedAsDecimalOption.IsSet && formatTest.StringFormattedAsDecimal == null)
+                throw new JsonException("Cannot write null property FormatTest.StringFormattedAsDecimal to non-nullable JSON property 'string_formatted_as_decimal'.");
+
+            if (formatTest.UnsignedIntegerOption.IsSet && formatTest.UnsignedInteger == null)
+                throw new JsonException("Cannot write null property FormatTest.UnsignedInteger to non-nullable JSON property 'unsigned_integer'.");
+
+            if (formatTest.UnsignedLongOption.IsSet && formatTest.UnsignedLong == null)
+                throw new JsonException("Cannot write null property FormatTest.UnsignedLong to non-nullable JSON property 'unsigned_long'.");
+
+            if (formatTest.UuidOption.IsSet && formatTest.Uuid == null)
+                throw new JsonException("Cannot write null property FormatTest.Uuid to non-nullable JSON property 'uuid'.");
 
             writer.WritePropertyName("byte");
             JsonSerializer.Serialize(writer, formatTest.Byte, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -951,32 +951,26 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, FormatTest formatTest, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (formatTest.Byte == null)
-                throw new ArgumentNullException(nameof(formatTest.Byte), "Property is required for class FormatTest.");
-
-            if (formatTest.Password == null)
-                throw new ArgumentNullException(nameof(formatTest.Password), "Property is required for class FormatTest.");
-
             if (formatTest.BinaryOption.IsSet && formatTest.Binary == null)
-                throw new ArgumentNullException(nameof(formatTest.Binary), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.Binary to non-nullable JSON property 'binary'.");
 
             if (formatTest.DuplicatePropertyName2Option.IsSet && formatTest.DuplicatePropertyName2 == null)
-                throw new ArgumentNullException(nameof(formatTest.DuplicatePropertyName2), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName2 to non-nullable JSON property 'duplicate_property_name'.");
 
             if (formatTest.DuplicatePropertyNameOption.IsSet && formatTest.DuplicatePropertyName == null)
-                throw new ArgumentNullException(nameof(formatTest.DuplicatePropertyName), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName to non-nullable JSON property '@duplicate_property_name'.");
 
             if (formatTest.PatternWithBackslashOption.IsSet && formatTest.PatternWithBackslash == null)
-                throw new ArgumentNullException(nameof(formatTest.PatternWithBackslash), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.PatternWithBackslash to non-nullable JSON property 'pattern_with_backslash'.");
 
             if (formatTest.PatternWithDigitsOption.IsSet && formatTest.PatternWithDigits == null)
-                throw new ArgumentNullException(nameof(formatTest.PatternWithDigits), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.PatternWithDigits to non-nullable JSON property 'pattern_with_digits'.");
 
             if (formatTest.PatternWithDigitsAndDelimiterOption.IsSet && formatTest.PatternWithDigitsAndDelimiter == null)
-                throw new ArgumentNullException(nameof(formatTest.PatternWithDigitsAndDelimiter), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.PatternWithDigitsAndDelimiter to non-nullable JSON property 'pattern_with_digits_and_delimiter'.");
 
             if (formatTest.StringOption.IsSet && formatTest.String == null)
-                throw new ArgumentNullException(nameof(formatTest.String), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.String to non-nullable JSON property 'string'.");
 
             writer.WritePropertyName("byte");
             JsonSerializer.Serialize(writer, formatTest.Byte, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
@@ -219,7 +219,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Fruit fruit, JsonSerializerOptions jsonSerializerOptions)
         {
             if (fruit.ColorOption.IsSet && fruit.Color == null)
-                throw new ArgumentNullException(nameof(fruit.Color), "Property is required for class Fruit.");
+                throw new JsonException("Cannot write null property Fruit.Color to non-nullable JSON property 'color'.");
 
             if (fruit.ColorOption.IsSet)
                 writer.WriteString("color", fruit.Color);

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -236,7 +236,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, GmFruit gmFruit, JsonSerializerOptions jsonSerializerOptions)
         {
             if (gmFruit.ColorOption.IsSet && gmFruit.Color == null)
-                throw new ArgumentNullException(nameof(gmFruit.Color), "Property is required for class GmFruit.");
+                throw new JsonException("Cannot write null property GmFruit.Color to non-nullable JSON property 'color'.");
 
             if (gmFruit.ColorOption.IsSet)
                 writer.WriteString("color", gmFruit.Color);

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -239,10 +239,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, HasOnlyReadOnly hasOnlyReadOnly, JsonSerializerOptions jsonSerializerOptions)
         {
             if (hasOnlyReadOnly.BarOption.IsSet && hasOnlyReadOnly.Bar == null)
-                throw new ArgumentNullException(nameof(hasOnlyReadOnly.Bar), "Property is required for class HasOnlyReadOnly.");
+                throw new JsonException("Cannot write null property HasOnlyReadOnly.Bar to non-nullable JSON property 'bar'.");
 
             if (hasOnlyReadOnly.FooOption.IsSet && hasOnlyReadOnly.Foo == null)
-                throw new ArgumentNullException(nameof(hasOnlyReadOnly.Foo), "Property is required for class HasOnlyReadOnly.");
+                throw new JsonException("Cannot write null property HasOnlyReadOnly.Foo to non-nullable JSON property 'foo'.");
 
             if (hasOnlyReadOnly.BarOption.IsSet)
                 writer.WriteString("bar", hasOnlyReadOnly.Bar);

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
@@ -337,22 +337,22 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, InjectedVendorExtensionsTest injectedVendorExtensionsTest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessorOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor to non-nullable JSON property 'potentiallyOverriddenPropertyAccessor'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternalOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternal == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternal), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternal to non-nullable JSON property 'potentiallyOverriddenPropertyToInternal'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivateOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivate == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivate), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivate to non-nullable JSON property 'potentiallyOverriddenPropertyToPrivate'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublicOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublic == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublic), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublic to non-nullable JSON property 'potentiallyOverriddenPropertyToPublic'.");
 
             if (injectedVendorExtensionsTest.UnalteredPropertyOption.IsSet && injectedVendorExtensionsTest.UnalteredProperty == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.UnalteredProperty), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.UnalteredProperty to non-nullable JSON property 'unalteredProperty'.");
 
             if (injectedVendorExtensionsTest.UnalteredPropertyAccessorOption.IsSet && injectedVendorExtensionsTest.UnalteredPropertyAccessor == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.UnalteredPropertyAccessor), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.UnalteredPropertyAccessor to non-nullable JSON property 'unalteredPropertyAccessor'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessorOption.IsSet)
                 writer.WriteString("potentiallyOverriddenPropertyAccessor", injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor);

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
@@ -182,12 +182,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, IsoscelesTriangle isoscelesTriangle, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (isoscelesTriangle.ShapeType == null)
-                throw new ArgumentNullException(nameof(isoscelesTriangle.ShapeType), "Property is required for class IsoscelesTriangle.");
-
-            if (isoscelesTriangle.TriangleType == null)
-                throw new ArgumentNullException(nameof(isoscelesTriangle.TriangleType), "Property is required for class IsoscelesTriangle.");
-
             writer.WriteString("shapeType", isoscelesTriangle.ShapeType);
 
             writer.WriteString("triangleType", isoscelesTriangle.TriangleType);

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/List.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, List list, JsonSerializerOptions jsonSerializerOptions)
         {
             if (list.Var123ListOption.IsSet && list.Var123List == null)
-                throw new ArgumentNullException(nameof(list.Var123List), "Property is required for class List.");
+                throw new JsonException("Cannot write null property List.Var123List to non-nullable JSON property '123-list'.");
 
             if (list.Var123ListOption.IsSet)
                 writer.WriteString("123-list", list.Var123List);

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -198,10 +198,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, LiteralStringClass literalStringClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (literalStringClass.EscapedLiteralStringOption.IsSet && literalStringClass.EscapedLiteralString == null)
-                throw new ArgumentNullException(nameof(literalStringClass.EscapedLiteralString), "Property is required for class LiteralStringClass.");
+                throw new JsonException("Cannot write null property LiteralStringClass.EscapedLiteralString to non-nullable JSON property 'escapedLiteralString'.");
 
             if (literalStringClass.UnescapedLiteralStringOption.IsSet && literalStringClass.UnescapedLiteralString == null)
-                throw new ArgumentNullException(nameof(literalStringClass.UnescapedLiteralString), "Property is required for class LiteralStringClass.");
+                throw new JsonException("Cannot write null property LiteralStringClass.UnescapedLiteralString to non-nullable JSON property 'unescapedLiteralString'.");
 
             if (literalStringClass.EscapedLiteralStringOption.IsSet)
                 writer.WriteString("escapedLiteralString", literalStringClass.EscapedLiteralString);

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/MapTest.cs
@@ -310,16 +310,16 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MapTest mapTest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mapTest.DirectMapOption.IsSet && mapTest.DirectMap == null)
-                throw new ArgumentNullException(nameof(mapTest.DirectMap), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.DirectMap to non-nullable JSON property 'direct_map'.");
 
             if (mapTest.IndirectMapOption.IsSet && mapTest.IndirectMap == null)
-                throw new ArgumentNullException(nameof(mapTest.IndirectMap), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.IndirectMap to non-nullable JSON property 'indirect_map'.");
 
             if (mapTest.MapMapOfStringOption.IsSet && mapTest.MapMapOfString == null)
-                throw new ArgumentNullException(nameof(mapTest.MapMapOfString), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.MapMapOfString to non-nullable JSON property 'map_map_of_string'.");
 
             if (mapTest.MapOfEnumStringOption.IsSet && mapTest.MapOfEnumString == null)
-                throw new ArgumentNullException(nameof(mapTest.MapOfEnumString), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.MapOfEnumString to non-nullable JSON property 'map_of_enum_string'.");
 
             if (mapTest.DirectMapOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/MixedAnyOf.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/MixedAnyOf.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedAnyOf mixedAnyOf, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedAnyOf.ContentOption.IsSet && mixedAnyOf.Content == null)
-                throw new ArgumentNullException(nameof(mixedAnyOf.Content), "Property is required for class MixedAnyOf.");
+                throw new JsonException("Cannot write null property MixedAnyOf.Content to non-nullable JSON property 'content'.");
 
             if (mixedAnyOf.ContentOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/MixedOneOf.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/MixedOneOf.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedOneOf mixedOneOf, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedOneOf.ContentOption.IsSet && mixedOneOf.Content == null)
-                throw new ArgumentNullException(nameof(mixedOneOf.Content), "Property is required for class MixedOneOf.");
+                throw new JsonException("Cannot write null property MixedOneOf.Content to non-nullable JSON property 'content'.");
 
             if (mixedOneOf.ContentOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -255,8 +255,17 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, MixedPropertiesAndAdditionalPropertiesClass mixedPropertiesAndAdditionalPropertiesClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.DateTime == null)
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.DateTime to non-nullable JSON property 'dateTime'.");
+
             if (mixedPropertiesAndAdditionalPropertiesClass.MapOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.Map == null)
                 throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.Map to non-nullable JSON property 'map'.");
+
+            if (mixedPropertiesAndAdditionalPropertiesClass.UuidOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.Uuid == null)
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.Uuid to non-nullable JSON property 'uuid'.");
+
+            if (mixedPropertiesAndAdditionalPropertiesClass.UuidWithPatternOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.UuidWithPattern == null)
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.UuidWithPattern to non-nullable JSON property 'uuid_with_pattern'.");
 
             if (mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.IsSet)
                 writer.WriteString("dateTime", mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.Value.Value.ToString(DateTimeFormat));

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -256,7 +256,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedPropertiesAndAdditionalPropertiesClass mixedPropertiesAndAdditionalPropertiesClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedPropertiesAndAdditionalPropertiesClass.MapOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.Map == null)
-                throw new ArgumentNullException(nameof(mixedPropertiesAndAdditionalPropertiesClass.Map), "Property is required for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.Map to non-nullable JSON property 'map'.");
 
             if (mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.IsSet)
                 writer.WriteString("dateTime", mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.Value.Value.ToString(DateTimeFormat));

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/MixedSubId.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/MixedSubId.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedSubId mixedSubId, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedSubId.IdOption.IsSet && mixedSubId.Id == null)
-                throw new ArgumentNullException(nameof(mixedSubId.Id), "Property is required for class MixedSubId.");
+                throw new JsonException("Cannot write null property MixedSubId.Id to non-nullable JSON property 'id'.");
 
             if (mixedSubId.IdOption.IsSet)
                 writer.WriteString("id", mixedSubId.Id);

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -198,7 +198,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Model200Response model200Response, JsonSerializerOptions jsonSerializerOptions)
         {
             if (model200Response.ClassOption.IsSet && model200Response.Class == null)
-                throw new ArgumentNullException(nameof(model200Response.Class), "Property is required for class Model200Response.");
+                throw new JsonException("Cannot write null property Model200Response.Class to non-nullable JSON property 'class'.");
 
             if (model200Response.ClassOption.IsSet)
                 writer.WriteString("class", model200Response.Class);

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -200,6 +200,9 @@ namespace Org.OpenAPITools.Model
             if (model200Response.ClassOption.IsSet && model200Response.Class == null)
                 throw new JsonException("Cannot write null property Model200Response.Class to non-nullable JSON property 'class'.");
 
+            if (model200Response.NameOption.IsSet && model200Response.Name == null)
+                throw new JsonException("Cannot write null property Model200Response.Name to non-nullable JSON property 'name'.");
+
             if (model200Response.ClassOption.IsSet)
                 writer.WriteString("class", model200Response.Class);
 

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ModelClient modelClient, JsonSerializerOptions jsonSerializerOptions)
         {
             if (modelClient.VarClientOption.IsSet && modelClient.VarClient == null)
-                throw new ArgumentNullException(nameof(modelClient.VarClient), "Property is required for class ModelClient.");
+                throw new JsonException("Cannot write null property ModelClient.VarClient to non-nullable JSON property 'client'.");
 
             if (modelClient.VarClientOption.IsSet)
                 writer.WriteString("client", modelClient.VarClient);

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Name.cs
@@ -281,7 +281,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Name name, JsonSerializerOptions jsonSerializerOptions)
         {
             if (name.PropertyOption.IsSet && name.Property == null)
-                throw new ArgumentNullException(nameof(name.Property), "Property is required for class Name.");
+                throw new JsonException("Cannot write null property Name.Property to non-nullable JSON property 'property'.");
 
             writer.WriteNumber("name", name.VarName);
 

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Name.cs
@@ -283,6 +283,12 @@ namespace Org.OpenAPITools.Model
             if (name.PropertyOption.IsSet && name.Property == null)
                 throw new JsonException("Cannot write null property Name.Property to non-nullable JSON property 'property'.");
 
+            if (name.SnakeCaseOption.IsSet && name.SnakeCase == null)
+                throw new JsonException("Cannot write null property Name.SnakeCase to non-nullable JSON property 'snake_case'.");
+
+            if (name.Var123NumberOption.IsSet && name.Var123Number == null)
+                throw new JsonException("Cannot write null property Name.Var123Number to non-nullable JSON property '123Number'.");
+
             writer.WriteNumber("name", name.VarName);
 
             if (name.PropertyOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
@@ -189,9 +189,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, NotificationtestGetElementsV1ResponseMPayload notificationtestGetElementsV1ResponseMPayload, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (notificationtestGetElementsV1ResponseMPayload.AObjVariableobject == null)
-                throw new ArgumentNullException(nameof(notificationtestGetElementsV1ResponseMPayload.AObjVariableobject), "Property is required for class NotificationtestGetElementsV1ResponseMPayload.");
-
             writer.WritePropertyName("a_objVariableobject");
             JsonSerializer.Serialize(writer, notificationtestGetElementsV1ResponseMPayload.AObjVariableobject, jsonSerializerOptions);
             writer.WriteNumber("pkiNotificationtestID", notificationtestGetElementsV1ResponseMPayload.PkiNotificationtestID);

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -408,10 +408,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, NullableClass nullableClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (nullableClass.ArrayItemsNullableOption.IsSet && nullableClass.ArrayItemsNullable == null)
-                throw new ArgumentNullException(nameof(nullableClass.ArrayItemsNullable), "Property is required for class NullableClass.");
+                throw new JsonException("Cannot write null property NullableClass.ArrayItemsNullable to non-nullable JSON property 'array_items_nullable'.");
 
             if (nullableClass.ObjectItemsNullableOption.IsSet && nullableClass.ObjectItemsNullable == null)
-                throw new ArgumentNullException(nameof(nullableClass.ObjectItemsNullable), "Property is required for class NullableClass.");
+                throw new JsonException("Cannot write null property NullableClass.ObjectItemsNullable to non-nullable JSON property 'object_items_nullable'.");
 
             if (nullableClass.ArrayAndItemsNullablePropOption.IsSet)
                 if (nullableClass.ArrayAndItemsNullablePropOption.Value != null)

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -174,6 +174,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, NumberOnly numberOnly, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (numberOnly.JustNumberOption.IsSet && numberOnly.JustNumber == null)
+                throw new JsonException("Cannot write null property NumberOnly.JustNumber to non-nullable JSON property 'JustNumber'.");
+
             if (numberOnly.JustNumberOption.IsSet)
                 writer.WriteNumber("JustNumber", numberOnly.JustNumberOption.Value.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -247,13 +247,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ObjectWithDeprecatedFields objectWithDeprecatedFields, JsonSerializerOptions jsonSerializerOptions)
         {
             if (objectWithDeprecatedFields.BarsOption.IsSet && objectWithDeprecatedFields.Bars == null)
-                throw new ArgumentNullException(nameof(objectWithDeprecatedFields.Bars), "Property is required for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Bars to non-nullable JSON property 'bars'.");
 
             if (objectWithDeprecatedFields.DeprecatedRefOption.IsSet && objectWithDeprecatedFields.DeprecatedRef == null)
-                throw new ArgumentNullException(nameof(objectWithDeprecatedFields.DeprecatedRef), "Property is required for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.DeprecatedRef to non-nullable JSON property 'deprecatedRef'.");
 
             if (objectWithDeprecatedFields.UuidOption.IsSet && objectWithDeprecatedFields.Uuid == null)
-                throw new ArgumentNullException(nameof(objectWithDeprecatedFields.Uuid), "Property is required for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Uuid to non-nullable JSON property 'uuid'.");
 
             if (objectWithDeprecatedFields.BarsOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -252,6 +252,9 @@ namespace Org.OpenAPITools.Model
             if (objectWithDeprecatedFields.DeprecatedRefOption.IsSet && objectWithDeprecatedFields.DeprecatedRef == null)
                 throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.DeprecatedRef to non-nullable JSON property 'deprecatedRef'.");
 
+            if (objectWithDeprecatedFields.IdOption.IsSet && objectWithDeprecatedFields.Id == null)
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Id to non-nullable JSON property 'id'.");
+
             if (objectWithDeprecatedFields.UuidOption.IsSet && objectWithDeprecatedFields.Uuid == null)
                 throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Uuid to non-nullable JSON property 'uuid'.");
 

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Order.cs
@@ -384,6 +384,24 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Order order, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (order.CompleteOption.IsSet && order.Complete == null)
+                throw new JsonException("Cannot write null property Order.Complete to non-nullable JSON property 'complete'.");
+
+            if (order.IdOption.IsSet && order.Id == null)
+                throw new JsonException("Cannot write null property Order.Id to non-nullable JSON property 'id'.");
+
+            if (order.PetIdOption.IsSet && order.PetId == null)
+                throw new JsonException("Cannot write null property Order.PetId to non-nullable JSON property 'petId'.");
+
+            if (order.QuantityOption.IsSet && order.Quantity == null)
+                throw new JsonException("Cannot write null property Order.Quantity to non-nullable JSON property 'quantity'.");
+
+            if (order.ShipDateOption.IsSet && order.ShipDate == null)
+                throw new JsonException("Cannot write null property Order.ShipDate to non-nullable JSON property 'shipDate'.");
+
+            if (order.StatusOption.IsSet && order.Status == null)
+                throw new JsonException("Cannot write null property Order.Status to non-nullable JSON property 'status'.");
+
             if (order.CompleteOption.IsSet)
                 writer.WriteBoolean("complete", order.CompleteOption.Value.Value);
 

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -220,6 +220,12 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, OuterComposite outerComposite, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (outerComposite.MyBooleanOption.IsSet && outerComposite.MyBoolean == null)
+                throw new JsonException("Cannot write null property OuterComposite.MyBoolean to non-nullable JSON property 'my_boolean'.");
+
+            if (outerComposite.MyNumberOption.IsSet && outerComposite.MyNumber == null)
+                throw new JsonException("Cannot write null property OuterComposite.MyNumber to non-nullable JSON property 'my_number'.");
+
             if (outerComposite.MyStringOption.IsSet && outerComposite.MyString == null)
                 throw new JsonException("Cannot write null property OuterComposite.MyString to non-nullable JSON property 'my_string'.");
 

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -221,7 +221,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, OuterComposite outerComposite, JsonSerializerOptions jsonSerializerOptions)
         {
             if (outerComposite.MyStringOption.IsSet && outerComposite.MyString == null)
-                throw new ArgumentNullException(nameof(outerComposite.MyString), "Property is required for class OuterComposite.");
+                throw new JsonException("Cannot write null property OuterComposite.MyString to non-nullable JSON property 'my_string'.");
 
             if (outerComposite.MyBooleanOption.IsSet)
                 writer.WriteBoolean("my_boolean", outerComposite.MyBooleanOption.Value.Value);

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Pet.cs
@@ -371,17 +371,11 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Pet pet, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (pet.Name == null)
-                throw new ArgumentNullException(nameof(pet.Name), "Property is required for class Pet.");
-
-            if (pet.PhotoUrls == null)
-                throw new ArgumentNullException(nameof(pet.PhotoUrls), "Property is required for class Pet.");
-
             if (pet.CategoryOption.IsSet && pet.Category == null)
-                throw new ArgumentNullException(nameof(pet.Category), "Property is required for class Pet.");
+                throw new JsonException("Cannot write null property Pet.Category to non-nullable JSON property 'category'.");
 
             if (pet.TagsOption.IsSet && pet.Tags == null)
-                throw new ArgumentNullException(nameof(pet.Tags), "Property is required for class Pet.");
+                throw new JsonException("Cannot write null property Pet.Tags to non-nullable JSON property 'tags'.");
 
             writer.WriteString("name", pet.Name);
 

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Pet.cs
@@ -374,6 +374,12 @@ namespace Org.OpenAPITools.Model
             if (pet.CategoryOption.IsSet && pet.Category == null)
                 throw new JsonException("Cannot write null property Pet.Category to non-nullable JSON property 'category'.");
 
+            if (pet.IdOption.IsSet && pet.Id == null)
+                throw new JsonException("Cannot write null property Pet.Id to non-nullable JSON property 'id'.");
+
+            if (pet.StatusOption.IsSet && pet.Status == null)
+                throw new JsonException("Cannot write null property Pet.Status to non-nullable JSON property 'status'.");
+
             if (pet.TagsOption.IsSet && pet.Tags == null)
                 throw new JsonException("Cannot write null property Pet.Tags to non-nullable JSON property 'tags'.");
 

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
@@ -170,9 +170,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, QuadrilateralInterface quadrilateralInterface, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (quadrilateralInterface.QuadrilateralType == null)
-                throw new ArgumentNullException(nameof(quadrilateralInterface.QuadrilateralType), "Property is required for class QuadrilateralInterface.");
-
             writer.WriteString("quadrilateralType", quadrilateralInterface.QuadrilateralType);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -236,10 +236,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ReadOnlyFirst readOnlyFirst, JsonSerializerOptions jsonSerializerOptions)
         {
             if (readOnlyFirst.BarOption.IsSet && readOnlyFirst.Bar == null)
-                throw new ArgumentNullException(nameof(readOnlyFirst.Bar), "Property is required for class ReadOnlyFirst.");
+                throw new JsonException("Cannot write null property ReadOnlyFirst.Bar to non-nullable JSON property 'bar'.");
 
             if (readOnlyFirst.BazOption.IsSet && readOnlyFirst.Baz == null)
-                throw new ArgumentNullException(nameof(readOnlyFirst.Baz), "Property is required for class ReadOnlyFirst.");
+                throw new JsonException("Cannot write null property ReadOnlyFirst.Baz to non-nullable JSON property 'baz'.");
 
             if (readOnlyFirst.BarOption.IsSet)
                 writer.WriteString("bar", readOnlyFirst.Bar);

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -2235,17 +2235,11 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, RequiredClass requiredClass, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (requiredClass.RequiredNotnullableArrayOfString == null)
-                throw new ArgumentNullException(nameof(requiredClass.RequiredNotnullableArrayOfString), "Property is required for class RequiredClass.");
-
-            if (requiredClass.RequiredNotnullableStringProp == null)
-                throw new ArgumentNullException(nameof(requiredClass.RequiredNotnullableStringProp), "Property is required for class RequiredClass.");
-
             if (requiredClass.NotrequiredNotnullableArrayOfStringOption.IsSet && requiredClass.NotrequiredNotnullableArrayOfString == null)
-                throw new ArgumentNullException(nameof(requiredClass.NotrequiredNotnullableArrayOfString), "Property is required for class RequiredClass.");
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableArrayOfString to non-nullable JSON property 'notrequired_notnullable_array_of_string'.");
 
             if (requiredClass.NotrequiredNotnullableStringPropOption.IsSet && requiredClass.NotrequiredNotnullableStringProp == null)
-                throw new ArgumentNullException(nameof(requiredClass.NotrequiredNotnullableStringProp), "Property is required for class RequiredClass.");
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableStringProp to non-nullable JSON property 'notrequired_notnullable_string_prop'.");
 
             writer.WriteString("required_not_nullable_date_prop", requiredClass.RequiredNotNullableDateProp.ToString(RequiredNotNullableDatePropFormat));
 

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -2235,11 +2235,38 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, RequiredClass requiredClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (requiredClass.NotRequiredNotnullableDatePropOption.IsSet && requiredClass.NotRequiredNotnullableDateProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotRequiredNotnullableDateProp to non-nullable JSON property 'not_required_notnullable_date_prop'.");
+
+            if (requiredClass.NotRequiredNotnullableintegerPropOption.IsSet && requiredClass.NotRequiredNotnullableintegerProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotRequiredNotnullableintegerProp to non-nullable JSON property 'not_required_notnullableinteger_prop'.");
+
             if (requiredClass.NotrequiredNotnullableArrayOfStringOption.IsSet && requiredClass.NotrequiredNotnullableArrayOfString == null)
                 throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableArrayOfString to non-nullable JSON property 'notrequired_notnullable_array_of_string'.");
 
+            if (requiredClass.NotrequiredNotnullableBooleanPropOption.IsSet && requiredClass.NotrequiredNotnullableBooleanProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableBooleanProp to non-nullable JSON property 'notrequired_notnullable_boolean_prop'.");
+
+            if (requiredClass.NotrequiredNotnullableDatetimePropOption.IsSet && requiredClass.NotrequiredNotnullableDatetimeProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableDatetimeProp to non-nullable JSON property 'notrequired_notnullable_datetime_prop'.");
+
+            if (requiredClass.NotrequiredNotnullableEnumIntegerOption.IsSet && requiredClass.NotrequiredNotnullableEnumInteger == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableEnumInteger to non-nullable JSON property 'notrequired_notnullable_enum_integer'.");
+
+            if (requiredClass.NotrequiredNotnullableEnumIntegerOnlyOption.IsSet && requiredClass.NotrequiredNotnullableEnumIntegerOnly == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableEnumIntegerOnly to non-nullable JSON property 'notrequired_notnullable_enum_integer_only'.");
+
+            if (requiredClass.NotrequiredNotnullableEnumStringOption.IsSet && requiredClass.NotrequiredNotnullableEnumString == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableEnumString to non-nullable JSON property 'notrequired_notnullable_enum_string'.");
+
+            if (requiredClass.NotrequiredNotnullableOuterEnumDefaultValueOption.IsSet && requiredClass.NotrequiredNotnullableOuterEnumDefaultValue == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableOuterEnumDefaultValue to non-nullable JSON property 'notrequired_notnullable_outerEnumDefaultValue'.");
+
             if (requiredClass.NotrequiredNotnullableStringPropOption.IsSet && requiredClass.NotrequiredNotnullableStringProp == null)
                 throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableStringProp to non-nullable JSON property 'notrequired_notnullable_string_prop'.");
+
+            if (requiredClass.NotrequiredNotnullableUuidOption.IsSet && requiredClass.NotrequiredNotnullableUuid == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableUuid to non-nullable JSON property 'notrequired_notnullable_uuid'.");
 
             writer.WriteString("required_not_nullable_date_prop", requiredClass.RequiredNotNullableDateProp.ToString(RequiredNotNullableDatePropFormat));
 

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Result.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Result.cs
@@ -224,13 +224,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Result result, JsonSerializerOptions jsonSerializerOptions)
         {
             if (result.CodeOption.IsSet && result.Code == null)
-                throw new ArgumentNullException(nameof(result.Code), "Property is required for class Result.");
+                throw new JsonException("Cannot write null property Result.Code to non-nullable JSON property 'code'.");
 
             if (result.DataOption.IsSet && result.Data == null)
-                throw new ArgumentNullException(nameof(result.Data), "Property is required for class Result.");
+                throw new JsonException("Cannot write null property Result.Data to non-nullable JSON property 'data'.");
 
             if (result.UuidOption.IsSet && result.Uuid == null)
-                throw new ArgumentNullException(nameof(result.Uuid), "Property is required for class Result.");
+                throw new JsonException("Cannot write null property Result.Uuid to non-nullable JSON property 'uuid'.");
 
             if (result.CodeOption.IsSet)
                 writer.WriteString("code", result.Code);

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Return.cs
@@ -232,11 +232,8 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Return varReturn, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (varReturn.Lock == null)
-                throw new ArgumentNullException(nameof(varReturn.Lock), "Property is required for class Return.");
-
             if (varReturn.UnsafeOption.IsSet && varReturn.Unsafe == null)
-                throw new ArgumentNullException(nameof(varReturn.Unsafe), "Property is required for class Return.");
+                throw new JsonException("Cannot write null property Return.Unsafe to non-nullable JSON property 'unsafe'.");
 
             writer.WriteString("lock", varReturn.Lock);
 

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Return.cs
@@ -232,6 +232,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Return varReturn, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (varReturn.VarReturnOption.IsSet && varReturn.VarReturn == null)
+                throw new JsonException("Cannot write null property Return.VarReturn to non-nullable JSON property 'return'.");
+
             if (varReturn.UnsafeOption.IsSet && varReturn.Unsafe == null)
                 throw new JsonException("Cannot write null property Return.Unsafe to non-nullable JSON property 'unsafe'.");
 

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -198,7 +198,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, RolesReportsHash rolesReportsHash, JsonSerializerOptions jsonSerializerOptions)
         {
             if (rolesReportsHash.RoleOption.IsSet && rolesReportsHash.Role == null)
-                throw new ArgumentNullException(nameof(rolesReportsHash.Role), "Property is required for class RolesReportsHash.");
+                throw new JsonException("Cannot write null property RolesReportsHash.Role to non-nullable JSON property 'role'.");
 
             if (rolesReportsHash.RoleOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -200,6 +200,9 @@ namespace Org.OpenAPITools.Model
             if (rolesReportsHash.RoleOption.IsSet && rolesReportsHash.Role == null)
                 throw new JsonException("Cannot write null property RolesReportsHash.Role to non-nullable JSON property 'role'.");
 
+            if (rolesReportsHash.RoleUuidOption.IsSet && rolesReportsHash.RoleUuid == null)
+                throw new JsonException("Cannot write null property RolesReportsHash.RoleUuid to non-nullable JSON property 'role_uuid'.");
+
             if (rolesReportsHash.RoleOption.IsSet)
             {
                 writer.WritePropertyName("role");

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, RolesReportsHashRole rolesReportsHashRole, JsonSerializerOptions jsonSerializerOptions)
         {
             if (rolesReportsHashRole.NameOption.IsSet && rolesReportsHashRole.Name == null)
-                throw new ArgumentNullException(nameof(rolesReportsHashRole.Name), "Property is required for class RolesReportsHashRole.");
+                throw new JsonException("Cannot write null property RolesReportsHashRole.Name to non-nullable JSON property 'name'.");
 
             if (rolesReportsHashRole.NameOption.IsSet)
                 writer.WriteString("name", rolesReportsHashRole.Name);

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
@@ -189,12 +189,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ScaleneTriangle scaleneTriangle, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (scaleneTriangle.ShapeType == null)
-                throw new ArgumentNullException(nameof(scaleneTriangle.ShapeType), "Property is required for class ScaleneTriangle.");
-
-            if (scaleneTriangle.TriangleType == null)
-                throw new ArgumentNullException(nameof(scaleneTriangle.TriangleType), "Property is required for class ScaleneTriangle.");
-
             writer.WriteString("shapeType", scaleneTriangle.ShapeType);
 
             writer.WriteString("triangleType", scaleneTriangle.TriangleType);

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ShapeInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ShapeInterface.cs
@@ -170,9 +170,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ShapeInterface shapeInterface, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (shapeInterface.ShapeType == null)
-                throw new ArgumentNullException(nameof(shapeInterface.ShapeType), "Property is required for class ShapeInterface.");
-
             writer.WriteString("shapeType", shapeInterface.ShapeType);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
@@ -189,12 +189,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, SimpleQuadrilateral simpleQuadrilateral, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (simpleQuadrilateral.QuadrilateralType == null)
-                throw new ArgumentNullException(nameof(simpleQuadrilateral.QuadrilateralType), "Property is required for class SimpleQuadrilateral.");
-
-            if (simpleQuadrilateral.ShapeType == null)
-                throw new ArgumentNullException(nameof(simpleQuadrilateral.ShapeType), "Property is required for class SimpleQuadrilateral.");
-
             writer.WriteString("quadrilateralType", simpleQuadrilateral.QuadrilateralType);
 
             writer.WriteString("shapeType", simpleQuadrilateral.ShapeType);

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -200,6 +200,9 @@ namespace Org.OpenAPITools.Model
             if (specialModelName.VarSpecialModelNameOption.IsSet && specialModelName.VarSpecialModelName == null)
                 throw new JsonException("Cannot write null property SpecialModelName.VarSpecialModelName to non-nullable JSON property '_special_model.name_'.");
 
+            if (specialModelName.SpecialPropertyNameOption.IsSet && specialModelName.SpecialPropertyName == null)
+                throw new JsonException("Cannot write null property SpecialModelName.SpecialPropertyName to non-nullable JSON property '$special[property.name]'.");
+
             if (specialModelName.VarSpecialModelNameOption.IsSet)
                 writer.WriteString("_special_model.name_", specialModelName.VarSpecialModelName);
 

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -198,7 +198,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, SpecialModelName specialModelName, JsonSerializerOptions jsonSerializerOptions)
         {
             if (specialModelName.VarSpecialModelNameOption.IsSet && specialModelName.VarSpecialModelName == null)
-                throw new ArgumentNullException(nameof(specialModelName.VarSpecialModelName), "Property is required for class SpecialModelName.");
+                throw new JsonException("Cannot write null property SpecialModelName.VarSpecialModelName to non-nullable JSON property '_special_model.name_'.");
 
             if (specialModelName.VarSpecialModelNameOption.IsSet)
                 writer.WriteString("_special_model.name_", specialModelName.VarSpecialModelName);

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Tag.cs
@@ -198,7 +198,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Tag tag, JsonSerializerOptions jsonSerializerOptions)
         {
             if (tag.NameOption.IsSet && tag.Name == null)
-                throw new ArgumentNullException(nameof(tag.Name), "Property is required for class Tag.");
+                throw new JsonException("Cannot write null property Tag.Name to non-nullable JSON property 'name'.");
 
             if (tag.IdOption.IsSet)
                 writer.WriteNumber("id", tag.IdOption.Value.Value);

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Tag.cs
@@ -197,6 +197,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Tag tag, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (tag.IdOption.IsSet && tag.Id == null)
+                throw new JsonException("Cannot write null property Tag.Id to non-nullable JSON property 'id'.");
+
             if (tag.NameOption.IsSet && tag.Name == null)
                 throw new JsonException("Cannot write null property Tag.Name to non-nullable JSON property 'name'.");
 

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestCollectionEndingWithWordList testCollectionEndingWithWordList, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testCollectionEndingWithWordList.ValueOption.IsSet && testCollectionEndingWithWordList.Value == null)
-                throw new ArgumentNullException(nameof(testCollectionEndingWithWordList.Value), "Property is required for class TestCollectionEndingWithWordList.");
+                throw new JsonException("Cannot write null property TestCollectionEndingWithWordList.Value to non-nullable JSON property 'value'.");
 
             if (testCollectionEndingWithWordList.ValueOption.IsSet)
                 writer.WriteString("value", testCollectionEndingWithWordList.Value);

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestCollectionEndingWithWordListObject testCollectionEndingWithWordListObject, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testCollectionEndingWithWordListObject.TestCollectionEndingWithWordListOption.IsSet && testCollectionEndingWithWordListObject.TestCollectionEndingWithWordList == null)
-                throw new ArgumentNullException(nameof(testCollectionEndingWithWordListObject.TestCollectionEndingWithWordList), "Property is required for class TestCollectionEndingWithWordListObject.");
+                throw new JsonException("Cannot write null property TestCollectionEndingWithWordListObject.TestCollectionEndingWithWordList to non-nullable JSON property 'TestCollectionEndingWithWordList'.");
 
             if (testCollectionEndingWithWordListObject.TestCollectionEndingWithWordListOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/TestDescendants.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/TestDescendants.cs
@@ -289,9 +289,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, TestDescendants testDescendants, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (testDescendants.AlternativeName == null)
-                throw new ArgumentNullException(nameof(testDescendants.AlternativeName), "Property is required for class TestDescendants.");
-
             writer.WriteString("alternativeName", testDescendants.AlternativeName);
 
             writer.WriteString("objectType", TestDescendants.ObjectTypeEnumToJsonValue(testDescendants.ObjectType));

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestInlineFreeformAdditionalPropertiesRequest testInlineFreeformAdditionalPropertiesRequest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testInlineFreeformAdditionalPropertiesRequest.SomePropertyOption.IsSet && testInlineFreeformAdditionalPropertiesRequest.SomeProperty == null)
-                throw new ArgumentNullException(nameof(testInlineFreeformAdditionalPropertiesRequest.SomeProperty), "Property is required for class TestInlineFreeformAdditionalPropertiesRequest.");
+                throw new JsonException("Cannot write null property TestInlineFreeformAdditionalPropertiesRequest.SomeProperty to non-nullable JSON property 'someProperty'.");
 
             if (testInlineFreeformAdditionalPropertiesRequest.SomePropertyOption.IsSet)
                 writer.WriteString("someProperty", testInlineFreeformAdditionalPropertiesRequest.SomeProperty);

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/TestResult.cs
@@ -222,6 +222,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, TestResult testResult, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (testResult.CodeOption.IsSet && testResult.Code == null)
+                throw new JsonException("Cannot write null property TestResult.Code to non-nullable JSON property 'code'.");
+
             if (testResult.DataOption.IsSet && testResult.Data == null)
                 throw new JsonException("Cannot write null property TestResult.Data to non-nullable JSON property 'data'.");
 

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/TestResult.cs
@@ -223,10 +223,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestResult testResult, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testResult.DataOption.IsSet && testResult.Data == null)
-                throw new ArgumentNullException(nameof(testResult.Data), "Property is required for class TestResult.");
+                throw new JsonException("Cannot write null property TestResult.Data to non-nullable JSON property 'data'.");
 
             if (testResult.UuidOption.IsSet && testResult.Uuid == null)
-                throw new ArgumentNullException(nameof(testResult.Uuid), "Property is required for class TestResult.");
+                throw new JsonException("Cannot write null property TestResult.Uuid to non-nullable JSON property 'uuid'.");
 
             if (testResult.CodeOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/TriangleInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/TriangleInterface.cs
@@ -170,9 +170,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, TriangleInterface triangleInterface, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (triangleInterface.TriangleType == null)
-                throw new ArgumentNullException(nameof(triangleInterface.TriangleType), "Property is required for class TriangleInterface.");
-
             writer.WriteString("triangleType", triangleInterface.TriangleType);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/User.cs
@@ -429,6 +429,9 @@ namespace Org.OpenAPITools.Model
             if (user.FirstNameOption.IsSet && user.FirstName == null)
                 throw new JsonException("Cannot write null property User.FirstName to non-nullable JSON property 'firstName'.");
 
+            if (user.IdOption.IsSet && user.Id == null)
+                throw new JsonException("Cannot write null property User.Id to non-nullable JSON property 'id'.");
+
             if (user.LastNameOption.IsSet && user.LastName == null)
                 throw new JsonException("Cannot write null property User.LastName to non-nullable JSON property 'lastName'.");
 
@@ -440,6 +443,9 @@ namespace Org.OpenAPITools.Model
 
             if (user.PhoneOption.IsSet && user.Phone == null)
                 throw new JsonException("Cannot write null property User.Phone to non-nullable JSON property 'phone'.");
+
+            if (user.UserStatusOption.IsSet && user.UserStatus == null)
+                throw new JsonException("Cannot write null property User.UserStatus to non-nullable JSON property 'userStatus'.");
 
             if (user.UsernameOption.IsSet && user.Username == null)
                 throw new JsonException("Cannot write null property User.Username to non-nullable JSON property 'username'.");

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/User.cs
@@ -424,25 +424,25 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, User user, JsonSerializerOptions jsonSerializerOptions)
         {
             if (user.EmailOption.IsSet && user.Email == null)
-                throw new ArgumentNullException(nameof(user.Email), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Email to non-nullable JSON property 'email'.");
 
             if (user.FirstNameOption.IsSet && user.FirstName == null)
-                throw new ArgumentNullException(nameof(user.FirstName), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.FirstName to non-nullable JSON property 'firstName'.");
 
             if (user.LastNameOption.IsSet && user.LastName == null)
-                throw new ArgumentNullException(nameof(user.LastName), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.LastName to non-nullable JSON property 'lastName'.");
 
             if (user.ObjectWithNoDeclaredPropsOption.IsSet && user.ObjectWithNoDeclaredProps == null)
-                throw new ArgumentNullException(nameof(user.ObjectWithNoDeclaredProps), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.ObjectWithNoDeclaredProps to non-nullable JSON property 'objectWithNoDeclaredProps'.");
 
             if (user.PasswordOption.IsSet && user.Password == null)
-                throw new ArgumentNullException(nameof(user.Password), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Password to non-nullable JSON property 'password'.");
 
             if (user.PhoneOption.IsSet && user.Phone == null)
-                throw new ArgumentNullException(nameof(user.Phone), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Phone to non-nullable JSON property 'phone'.");
 
             if (user.UsernameOption.IsSet && user.Username == null)
-                throw new ArgumentNullException(nameof(user.Username), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Username to non-nullable JSON property 'username'.");
 
             if (user.AnyTypePropOption.IsSet)
                 if (user.AnyTypePropOption.Value != null)

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Whale.cs
@@ -216,9 +216,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Whale whale, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (whale.ClassName == null)
-                throw new ArgumentNullException(nameof(whale.ClassName), "Property is required for class Whale.");
-
             writer.WriteString("className", whale.ClassName);
 
             if (whale.HasBaleenOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Whale.cs
@@ -216,6 +216,12 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Whale whale, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (whale.HasBaleenOption.IsSet && whale.HasBaleen == null)
+                throw new JsonException("Cannot write null property Whale.HasBaleen to non-nullable JSON property 'hasBaleen'.");
+
+            if (whale.HasTeethOption.IsSet && whale.HasTeeth == null)
+                throw new JsonException("Cannot write null property Whale.HasTeeth to non-nullable JSON property 'hasTeeth'.");
+
             writer.WriteString("className", whale.ClassName);
 
             if (whale.HasBaleenOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Zebra.cs
@@ -280,6 +280,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Zebra zebra, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (zebra.TypeOption.IsSet && zebra.Type == null)
+                throw new JsonException("Cannot write null property Zebra.Type to non-nullable JSON property 'type'.");
+
             writer.WriteString("className", zebra.ClassName);
 
             var typeRawValue = Zebra.TypeEnumToJsonValue(zebra.TypeOption.Value.Value);

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Zebra.cs
@@ -280,9 +280,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Zebra zebra, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (zebra.ClassName == null)
-                throw new ArgumentNullException(nameof(zebra.ClassName), "Property is required for class Zebra.");
-
             writer.WriteString("className", zebra.ClassName);
 
             var typeRawValue = Zebra.TypeEnumToJsonValue(zebra.TypeOption.Value.Value);

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
@@ -247,6 +247,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ZeroBasedEnumClass zeroBasedEnumClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (zeroBasedEnumClass.ZeroBasedEnumOption.IsSet && zeroBasedEnumClass.ZeroBasedEnum == null)
+                throw new JsonException("Cannot write null property ZeroBasedEnumClass.ZeroBasedEnum to non-nullable JSON property 'ZeroBasedEnum'.");
+
             var zeroBasedEnumRawValue = ZeroBasedEnumClass.ZeroBasedEnumEnumToJsonValue(zeroBasedEnumClass.ZeroBasedEnumOption.Value.Value);
             writer.WriteString("ZeroBasedEnum", zeroBasedEnumRawValue);
         }

--- a/samples/client/petstore/csharp/generichost/net4.8/UseDateTimeForDate/src/Org.OpenAPITools/Model/NowGet200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/UseDateTimeForDate/src/Org.OpenAPITools/Model/NowGet200Response.cs
@@ -199,6 +199,12 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, NowGet200Response nowGet200Response, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (nowGet200Response.NowOption.IsSet && nowGet200Response.Now == null)
+                throw new JsonException("Cannot write null property NowGet200Response.Now to non-nullable JSON property 'now'.");
+
+            if (nowGet200Response.TodayOption.IsSet && nowGet200Response.Today == null)
+                throw new JsonException("Cannot write null property NowGet200Response.Today to non-nullable JSON property 'today'.");
+
             if (nowGet200Response.NowOption.IsSet)
                 writer.WriteString("now", nowGet200Response.NowOption.Value.Value.ToString(NowFormat));
 

--- a/samples/client/petstore/csharp/generichost/net8/AllOf/src/Org.OpenAPITools/Model/Adult.cs
+++ b/samples/client/petstore/csharp/generichost/net8/AllOf/src/Org.OpenAPITools/Model/Adult.cs
@@ -184,13 +184,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Adult adult, JsonSerializerOptions jsonSerializerOptions)
         {
             if (adult.ChildrenOption.IsSet && adult.Children == null)
-                throw new ArgumentNullException(nameof(adult.Children), "Property is required for class Adult.");
+                throw new JsonException("Cannot write null property Adult.Children to non-nullable JSON property 'children'.");
 
             if (adult.FirstNameOption.IsSet && adult.FirstName == null)
-                throw new ArgumentNullException(nameof(adult.FirstName), "Property is required for class Adult.");
+                throw new JsonException("Cannot write null property Adult.FirstName to non-nullable JSON property 'firstName'.");
 
             if (adult.LastNameOption.IsSet && adult.LastName == null)
-                throw new ArgumentNullException(nameof(adult.LastName), "Property is required for class Adult.");
+                throw new JsonException("Cannot write null property Adult.LastName to non-nullable JSON property 'lastName'.");
 
             if (adult.ChildrenOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net8/AllOf/src/Org.OpenAPITools/Model/Child.cs
+++ b/samples/client/petstore/csharp/generichost/net8/AllOf/src/Org.OpenAPITools/Model/Child.cs
@@ -206,6 +206,12 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Child child, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (child.AgeOption.IsSet && child.Age == null)
+                throw new JsonException("Cannot write null property Child.Age to non-nullable JSON property 'age'.");
+
+            if (child.BoosterSeatOption.IsSet && child.BoosterSeat == null)
+                throw new JsonException("Cannot write null property Child.BoosterSeat to non-nullable JSON property 'boosterSeat'.");
+
             if (child.FirstNameOption.IsSet && child.FirstName == null)
                 throw new JsonException("Cannot write null property Child.FirstName to non-nullable JSON property 'firstName'.");
 

--- a/samples/client/petstore/csharp/generichost/net8/AllOf/src/Org.OpenAPITools/Model/Child.cs
+++ b/samples/client/petstore/csharp/generichost/net8/AllOf/src/Org.OpenAPITools/Model/Child.cs
@@ -207,10 +207,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Child child, JsonSerializerOptions jsonSerializerOptions)
         {
             if (child.FirstNameOption.IsSet && child.FirstName == null)
-                throw new ArgumentNullException(nameof(child.FirstName), "Property is required for class Child.");
+                throw new JsonException("Cannot write null property Child.FirstName to non-nullable JSON property 'firstName'.");
 
             if (child.LastNameOption.IsSet && child.LastName == null)
-                throw new ArgumentNullException(nameof(child.LastName), "Property is required for class Child.");
+                throw new JsonException("Cannot write null property Child.LastName to non-nullable JSON property 'lastName'.");
 
             if (child.AgeOption.IsSet)
                 writer.WriteNumber("age", child.AgeOption.Value!.Value);

--- a/samples/client/petstore/csharp/generichost/net8/AllOf/src/Org.OpenAPITools/Model/Person.cs
+++ b/samples/client/petstore/csharp/generichost/net8/AllOf/src/Org.OpenAPITools/Model/Person.cs
@@ -243,10 +243,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Person person, JsonSerializerOptions jsonSerializerOptions)
         {
             if (person.FirstNameOption.IsSet && person.FirstName == null)
-                throw new ArgumentNullException(nameof(person.FirstName), "Property is required for class Person.");
+                throw new JsonException("Cannot write null property Person.FirstName to non-nullable JSON property 'firstName'.");
 
             if (person.LastNameOption.IsSet && person.LastName == null)
-                throw new ArgumentNullException(nameof(person.LastName), "Property is required for class Person.");
+                throw new JsonException("Cannot write null property Person.LastName to non-nullable JSON property 'lastName'.");
 
             if (person.FirstNameOption.IsSet)
                 writer.WriteString("firstName", person.FirstName);

--- a/samples/client/petstore/csharp/generichost/net8/AnyOf/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net8/AnyOf/src/Org.OpenAPITools/Model/Apple.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Apple apple, JsonSerializerOptions jsonSerializerOptions)
         {
             if (apple.KindOption.IsSet && apple.Kind == null)
-                throw new ArgumentNullException(nameof(apple.Kind), "Property is required for class Apple.");
+                throw new JsonException("Cannot write null property Apple.Kind to non-nullable JSON property 'kind'.");
 
             if (apple.KindOption.IsSet)
                 writer.WriteString("kind", apple.Kind);

--- a/samples/client/petstore/csharp/generichost/net8/AnyOf/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net8/AnyOf/src/Org.OpenAPITools/Model/Banana.cs
@@ -176,6 +176,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Banana banana, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (banana.CountOption.IsSet && banana.Count == null)
+                throw new JsonException("Cannot write null property Banana.Count to non-nullable JSON property 'count'.");
+
             if (banana.CountOption.IsSet)
                 writer.WriteNumber("count", banana.CountOption.Value!.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net8/AnyOf/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net8/AnyOf/src/Org.OpenAPITools/Model/Fruit.cs
@@ -245,7 +245,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Fruit fruit, JsonSerializerOptions jsonSerializerOptions)
         {
             if (fruit.ColorOption.IsSet && fruit.Color == null)
-                throw new ArgumentNullException(nameof(fruit.Color), "Property is required for class Fruit.");
+                throw new JsonException("Cannot write null property Fruit.Color to non-nullable JSON property 'color'.");
 
             if (fruit.ColorOption.IsSet)
                 writer.WriteString("color", fruit.Color);

--- a/samples/client/petstore/csharp/generichost/net8/AnyOfNoCompare/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net8/AnyOfNoCompare/src/Org.OpenAPITools/Model/Apple.cs
@@ -176,7 +176,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Apple apple, JsonSerializerOptions jsonSerializerOptions)
         {
             if (apple.KindOption.IsSet && apple.Kind == null)
-                throw new ArgumentNullException(nameof(apple.Kind), "Property is required for class Apple.");
+                throw new JsonException("Cannot write null property Apple.Kind to non-nullable JSON property 'kind'.");
 
             if (apple.KindOption.IsSet)
                 writer.WriteString("kind", apple.Kind);

--- a/samples/client/petstore/csharp/generichost/net8/AnyOfNoCompare/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net8/AnyOfNoCompare/src/Org.OpenAPITools/Model/Banana.cs
@@ -175,6 +175,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Banana banana, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (banana.CountOption.IsSet && banana.Count == null)
+                throw new JsonException("Cannot write null property Banana.Count to non-nullable JSON property 'count'.");
+
             if (banana.CountOption.IsSet)
                 writer.WriteNumber("count", banana.CountOption.Value!.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net8/AnyOfNoCompare/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net8/AnyOfNoCompare/src/Org.OpenAPITools/Model/Fruit.cs
@@ -244,7 +244,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Fruit fruit, JsonSerializerOptions jsonSerializerOptions)
         {
             if (fruit.ColorOption.IsSet && fruit.Color == null)
-                throw new ArgumentNullException(nameof(fruit.Color), "Property is required for class Fruit.");
+                throw new JsonException("Cannot write null property Fruit.Color to non-nullable JSON property 'color'.");
 
             if (fruit.ColorOption.IsSet)
                 writer.WriteString("color", fruit.Color);

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Activity.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Activity activity, JsonSerializerOptions jsonSerializerOptions)
         {
             if (activity.ActivityOutputsOption.IsSet && activity.ActivityOutputs == null)
-                throw new ArgumentNullException(nameof(activity.ActivityOutputs), "Property is required for class Activity.");
+                throw new JsonException("Cannot write null property Activity.ActivityOutputs to non-nullable JSON property 'activity_outputs'.");
 
             if (activity.ActivityOutputsOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -198,10 +198,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ActivityOutputElementRepresentation activityOutputElementRepresentation, JsonSerializerOptions jsonSerializerOptions)
         {
             if (activityOutputElementRepresentation.Prop1Option.IsSet && activityOutputElementRepresentation.Prop1 == null)
-                throw new ArgumentNullException(nameof(activityOutputElementRepresentation.Prop1), "Property is required for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Cannot write null property ActivityOutputElementRepresentation.Prop1 to non-nullable JSON property 'prop1'.");
 
             if (activityOutputElementRepresentation.Prop2Option.IsSet && activityOutputElementRepresentation.Prop2 == null)
-                throw new ArgumentNullException(nameof(activityOutputElementRepresentation.Prop2), "Property is required for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Cannot write null property ActivityOutputElementRepresentation.Prop2 to non-nullable JSON property 'prop2'.");
 
             if (activityOutputElementRepresentation.Prop1Option.IsSet)
                 writer.WriteString("prop1", activityOutputElementRepresentation.Prop1);

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -334,25 +334,25 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, AdditionalPropertiesClass additionalPropertiesClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (additionalPropertiesClass.EmptyMapOption.IsSet && additionalPropertiesClass.EmptyMap == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.EmptyMap), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.EmptyMap to non-nullable JSON property 'empty_map'.");
 
             if (additionalPropertiesClass.MapOfMapPropertyOption.IsSet && additionalPropertiesClass.MapOfMapProperty == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapOfMapProperty), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapOfMapProperty to non-nullable JSON property 'map_of_map_property'.");
 
             if (additionalPropertiesClass.MapPropertyOption.IsSet && additionalPropertiesClass.MapProperty == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapProperty), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapProperty to non-nullable JSON property 'map_property'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1Option.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1 == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1 to non-nullable JSON property 'map_with_undeclared_properties_anytype_1'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2Option.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2 == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2 to non-nullable JSON property 'map_with_undeclared_properties_anytype_2'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3Option.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3 == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3 to non-nullable JSON property 'map_with_undeclared_properties_anytype_3'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesStringOption.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesString == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesString), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesString to non-nullable JSON property 'map_with_undeclared_properties_string'.");
 
             if (additionalPropertiesClass.Anytype1Option.IsSet)
                 if (additionalPropertiesClass.Anytype1Option.Value != null)

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Animal.cs
@@ -221,7 +221,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Animal animal, JsonSerializerOptions jsonSerializerOptions)
         {
             if (animal.ColorOption.IsSet && animal.Color == null)
-                throw new ArgumentNullException(nameof(animal.Color), "Property is required for class Animal.");
+                throw new JsonException("Cannot write null property Animal.Color to non-nullable JSON property 'color'.");
 
             writer.WriteString("className", animal.ClassName);
 

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -221,10 +221,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ApiResponse apiResponse, JsonSerializerOptions jsonSerializerOptions)
         {
             if (apiResponse.MessageOption.IsSet && apiResponse.Message == null)
-                throw new ArgumentNullException(nameof(apiResponse.Message), "Property is required for class ApiResponse.");
+                throw new JsonException("Cannot write null property ApiResponse.Message to non-nullable JSON property 'message'.");
 
             if (apiResponse.TypeOption.IsSet && apiResponse.Type == null)
-                throw new ArgumentNullException(nameof(apiResponse.Type), "Property is required for class ApiResponse.");
+                throw new JsonException("Cannot write null property ApiResponse.Type to non-nullable JSON property 'type'.");
 
             if (apiResponse.CodeOption.IsSet)
                 writer.WriteNumber("code", apiResponse.CodeOption.Value.Value);

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -220,6 +220,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ApiResponse apiResponse, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (apiResponse.CodeOption.IsSet && apiResponse.Code == null)
+                throw new JsonException("Cannot write null property ApiResponse.Code to non-nullable JSON property 'code'.");
+
             if (apiResponse.MessageOption.IsSet && apiResponse.Message == null)
                 throw new JsonException("Cannot write null property ApiResponse.Message to non-nullable JSON property 'message'.");
 

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Apple.cs
@@ -251,13 +251,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Apple apple, JsonSerializerOptions jsonSerializerOptions)
         {
             if (apple.ColorCodeOption.IsSet && apple.ColorCode == null)
-                throw new ArgumentNullException(nameof(apple.ColorCode), "Property is required for class Apple.");
+                throw new JsonException("Cannot write null property Apple.ColorCode to non-nullable JSON property 'color_code'.");
 
             if (apple.CultivarOption.IsSet && apple.Cultivar == null)
-                throw new ArgumentNullException(nameof(apple.Cultivar), "Property is required for class Apple.");
+                throw new JsonException("Cannot write null property Apple.Cultivar to non-nullable JSON property 'cultivar'.");
 
             if (apple.OriginOption.IsSet && apple.Origin == null)
-                throw new ArgumentNullException(nameof(apple.Origin), "Property is required for class Apple.");
+                throw new JsonException("Cannot write null property Apple.Origin to non-nullable JSON property 'origin'.");
 
             if (apple.ColorCodeOption.IsSet)
                 writer.WriteString("color_code", apple.ColorCode);

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -186,9 +186,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, AppleReq appleReq, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (appleReq.Cultivar == null)
-                throw new ArgumentNullException(nameof(appleReq.Cultivar), "Property is required for class AppleReq.");
-
             writer.WriteString("cultivar", appleReq.Cultivar);
 
             if (appleReq.MealyOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -186,6 +186,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, AppleReq appleReq, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (appleReq.MealyOption.IsSet && appleReq.Mealy == null)
+                throw new JsonException("Cannot write null property AppleReq.Mealy to non-nullable JSON property 'mealy'.");
+
             writer.WriteString("cultivar", appleReq.Cultivar);
 
             if (appleReq.MealyOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ArrayOfArrayOfNumberOnly arrayOfArrayOfNumberOnly, JsonSerializerOptions jsonSerializerOptions)
         {
             if (arrayOfArrayOfNumberOnly.ArrayArrayNumberOption.IsSet && arrayOfArrayOfNumberOnly.ArrayArrayNumber == null)
-                throw new ArgumentNullException(nameof(arrayOfArrayOfNumberOnly.ArrayArrayNumber), "Property is required for class ArrayOfArrayOfNumberOnly.");
+                throw new JsonException("Cannot write null property ArrayOfArrayOfNumberOnly.ArrayArrayNumber to non-nullable JSON property 'ArrayArrayNumber'.");
 
             if (arrayOfArrayOfNumberOnly.ArrayArrayNumberOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ArrayOfNumberOnly arrayOfNumberOnly, JsonSerializerOptions jsonSerializerOptions)
         {
             if (arrayOfNumberOnly.ArrayNumberOption.IsSet && arrayOfNumberOnly.ArrayNumber == null)
-                throw new ArgumentNullException(nameof(arrayOfNumberOnly.ArrayNumber), "Property is required for class ArrayOfNumberOnly.");
+                throw new JsonException("Cannot write null property ArrayOfNumberOnly.ArrayNumber to non-nullable JSON property 'ArrayNumber'.");
 
             if (arrayOfNumberOnly.ArrayNumberOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -221,13 +221,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ArrayTest arrayTest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (arrayTest.ArrayArrayOfIntegerOption.IsSet && arrayTest.ArrayArrayOfInteger == null)
-                throw new ArgumentNullException(nameof(arrayTest.ArrayArrayOfInteger), "Property is required for class ArrayTest.");
+                throw new JsonException("Cannot write null property ArrayTest.ArrayArrayOfInteger to non-nullable JSON property 'array_array_of_integer'.");
 
             if (arrayTest.ArrayArrayOfModelOption.IsSet && arrayTest.ArrayArrayOfModel == null)
-                throw new ArgumentNullException(nameof(arrayTest.ArrayArrayOfModel), "Property is required for class ArrayTest.");
+                throw new JsonException("Cannot write null property ArrayTest.ArrayArrayOfModel to non-nullable JSON property 'array_array_of_model'.");
 
             if (arrayTest.ArrayOfStringOption.IsSet && arrayTest.ArrayOfString == null)
-                throw new ArgumentNullException(nameof(arrayTest.ArrayOfString), "Property is required for class ArrayTest.");
+                throw new JsonException("Cannot write null property ArrayTest.ArrayOfString to non-nullable JSON property 'array_of_string'.");
 
             if (arrayTest.ArrayArrayOfIntegerOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Banana.cs
@@ -174,6 +174,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Banana banana, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (banana.LengthCmOption.IsSet && banana.LengthCm == null)
+                throw new JsonException("Cannot write null property Banana.LengthCm to non-nullable JSON property 'lengthCm'.");
+
             if (banana.LengthCmOption.IsSet)
                 writer.WriteNumber("lengthCm", banana.LengthCmOption.Value.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -186,6 +186,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, BananaReq bananaReq, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (bananaReq.SweetOption.IsSet && bananaReq.Sweet == null)
+                throw new JsonException("Cannot write null property BananaReq.Sweet to non-nullable JSON property 'sweet'.");
+
             writer.WriteNumber("lengthCm", bananaReq.LengthCm);
 
             if (bananaReq.SweetOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/BasquePig.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/BasquePig.cs
@@ -170,9 +170,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, BasquePig basquePig, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (basquePig.ClassName == null)
-                throw new ArgumentNullException(nameof(basquePig.ClassName), "Property is required for class BasquePig.");
-
             writer.WriteString("className", basquePig.ClassName);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -291,22 +291,22 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Capitalization capitalization, JsonSerializerOptions jsonSerializerOptions)
         {
             if (capitalization.ATT_NAMEOption.IsSet && capitalization.ATT_NAME == null)
-                throw new ArgumentNullException(nameof(capitalization.ATT_NAME), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.ATT_NAME to non-nullable JSON property 'ATT_NAME'.");
 
             if (capitalization.CapitalCamelOption.IsSet && capitalization.CapitalCamel == null)
-                throw new ArgumentNullException(nameof(capitalization.CapitalCamel), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.CapitalCamel to non-nullable JSON property 'CapitalCamel'.");
 
             if (capitalization.CapitalSnakeOption.IsSet && capitalization.CapitalSnake == null)
-                throw new ArgumentNullException(nameof(capitalization.CapitalSnake), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.CapitalSnake to non-nullable JSON property 'Capital_Snake'.");
 
             if (capitalization.SCAETHFlowPointsOption.IsSet && capitalization.SCAETHFlowPoints == null)
-                throw new ArgumentNullException(nameof(capitalization.SCAETHFlowPoints), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.SCAETHFlowPoints to non-nullable JSON property 'SCA_ETH_Flow_Points'.");
 
             if (capitalization.SmallCamelOption.IsSet && capitalization.SmallCamel == null)
-                throw new ArgumentNullException(nameof(capitalization.SmallCamel), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.SmallCamel to non-nullable JSON property 'smallCamel'.");
 
             if (capitalization.SmallSnakeOption.IsSet && capitalization.SmallSnake == null)
-                throw new ArgumentNullException(nameof(capitalization.SmallSnake), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.SmallSnake to non-nullable JSON property 'small_Snake'.");
 
             if (capitalization.ATT_NAMEOption.IsSet)
                 writer.WriteString("ATT_NAME", capitalization.ATT_NAME);

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Cat.cs
@@ -179,6 +179,9 @@ namespace Org.OpenAPITools.Model
             if (cat.ColorOption.IsSet && cat.Color == null)
                 throw new JsonException("Cannot write null property Cat.Color to non-nullable JSON property 'color'.");
 
+            if (cat.DeclawedOption.IsSet && cat.Declawed == null)
+                throw new JsonException("Cannot write null property Cat.Declawed to non-nullable JSON property 'declawed'.");
+
             writer.WriteString("className", cat.ClassName);
 
             if (cat.ColorOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Cat.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Cat cat, JsonSerializerOptions jsonSerializerOptions)
         {
             if (cat.ColorOption.IsSet && cat.Color == null)
-                throw new ArgumentNullException(nameof(cat.Color), "Property is required for class Cat.");
+                throw new JsonException("Cannot write null property Cat.Color to non-nullable JSON property 'color'.");
 
             writer.WriteString("className", cat.ClassName);
 

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Category.cs
@@ -193,9 +193,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Category category, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (category.Name == null)
-                throw new ArgumentNullException(nameof(category.Name), "Property is required for class Category.");
-
             if (category.IdOption.IsSet)
                 writer.WriteNumber("id", category.IdOption.Value.Value);
 

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Category.cs
@@ -193,6 +193,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Category category, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (category.IdOption.IsSet && category.Id == null)
+                throw new JsonException("Cannot write null property Category.Id to non-nullable JSON property 'id'.");
+
             if (category.IdOption.IsSet)
                 writer.WriteNumber("id", category.IdOption.Value.Value);
 

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ChildCat childCat, JsonSerializerOptions jsonSerializerOptions)
         {
             if (childCat.NameOption.IsSet && childCat.Name == null)
-                throw new ArgumentNullException(nameof(childCat.Name), "Property is required for class ChildCat.");
+                throw new JsonException("Cannot write null property ChildCat.Name to non-nullable JSON property 'name'.");
 
             writer.WriteString("pet_type", ChildCatAllOfPetTypeValueConverter.ToJsonValue(childCat.PetType));
 

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ClassModel classModel, JsonSerializerOptions jsonSerializerOptions)
         {
             if (classModel.ClassOption.IsSet && classModel.Class == null)
-                throw new ArgumentNullException(nameof(classModel.Class), "Property is required for class ClassModel.");
+                throw new JsonException("Cannot write null property ClassModel.Class to non-nullable JSON property '_class'.");
 
             if (classModel.ClassOption.IsSet)
                 writer.WriteString("_class", classModel.Class);

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
@@ -189,12 +189,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ComplexQuadrilateral complexQuadrilateral, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (complexQuadrilateral.QuadrilateralType == null)
-                throw new ArgumentNullException(nameof(complexQuadrilateral.QuadrilateralType), "Property is required for class ComplexQuadrilateral.");
-
-            if (complexQuadrilateral.ShapeType == null)
-                throw new ArgumentNullException(nameof(complexQuadrilateral.ShapeType), "Property is required for class ComplexQuadrilateral.");
-
             writer.WriteString("quadrilateralType", complexQuadrilateral.QuadrilateralType);
 
             writer.WriteString("shapeType", complexQuadrilateral.ShapeType);

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/CopyActivity.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/CopyActivity.cs
@@ -172,9 +172,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, CopyActivity copyActivity, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (copyActivity.CopyActivitytt == null)
-                throw new ArgumentNullException(nameof(copyActivity.CopyActivitytt), "Property is required for class CopyActivity.");
-
             writer.WriteString("copyActivitytt", copyActivity.CopyActivitytt);
 
             writer.WriteString("$schema", CopyActivityAllOfSchemaValueConverter.ToJsonValue(copyActivity.Schema));

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/DanishPig.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/DanishPig.cs
@@ -170,9 +170,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, DanishPig danishPig, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (danishPig.ClassName == null)
-                throw new ArgumentNullException(nameof(danishPig.ClassName), "Property is required for class DanishPig.");
-
             writer.WriteString("className", danishPig.ClassName);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -180,6 +180,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, DateOnlyClass dateOnlyClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (dateOnlyClass.DateOnlyPropertyOption.IsSet && dateOnlyClass.DateOnlyProperty == null)
+                throw new JsonException("Cannot write null property DateOnlyClass.DateOnlyProperty to non-nullable JSON property 'dateOnlyProperty'.");
+
             if (dateOnlyClass.DateOnlyPropertyOption.IsSet)
                 writer.WriteString("dateOnlyProperty", dateOnlyClass.DateOnlyPropertyOption.Value.Value.ToString(DateOnlyPropertyFormat));
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, DeprecatedObject deprecatedObject, JsonSerializerOptions jsonSerializerOptions)
         {
             if (deprecatedObject.NameOption.IsSet && deprecatedObject.Name == null)
-                throw new ArgumentNullException(nameof(deprecatedObject.Name), "Property is required for class DeprecatedObject.");
+                throw new JsonException("Cannot write null property DeprecatedObject.Name to non-nullable JSON property 'name'.");
 
             if (deprecatedObject.NameOption.IsSet)
                 writer.WriteString("name", deprecatedObject.Name);

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Descendant1.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Descendant1.cs
@@ -175,12 +175,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Descendant1 descendant1, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (descendant1.AlternativeName == null)
-                throw new ArgumentNullException(nameof(descendant1.AlternativeName), "Property is required for class Descendant1.");
-
-            if (descendant1.DescendantName == null)
-                throw new ArgumentNullException(nameof(descendant1.DescendantName), "Property is required for class Descendant1.");
-
             writer.WriteString("alternativeName", descendant1.AlternativeName);
 
             writer.WriteString("descendantName", descendant1.DescendantName);

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Descendant2.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Descendant2.cs
@@ -175,12 +175,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Descendant2 descendant2, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (descendant2.AlternativeName == null)
-                throw new ArgumentNullException(nameof(descendant2.AlternativeName), "Property is required for class Descendant2.");
-
-            if (descendant2.Confidentiality == null)
-                throw new ArgumentNullException(nameof(descendant2.Confidentiality), "Property is required for class Descendant2.");
-
             writer.WriteString("alternativeName", descendant2.AlternativeName);
 
             writer.WriteString("confidentiality", descendant2.Confidentiality);

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Dog.cs
@@ -177,10 +177,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Dog dog, JsonSerializerOptions jsonSerializerOptions)
         {
             if (dog.BreedOption.IsSet && dog.Breed == null)
-                throw new ArgumentNullException(nameof(dog.Breed), "Property is required for class Dog.");
+                throw new JsonException("Cannot write null property Dog.Breed to non-nullable JSON property 'breed'.");
 
             if (dog.ColorOption.IsSet && dog.Color == null)
-                throw new ArgumentNullException(nameof(dog.Color), "Property is required for class Dog.");
+                throw new JsonException("Cannot write null property Dog.Color to non-nullable JSON property 'color'.");
 
             writer.WriteString("className", dog.ClassName);
 

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Drawing.cs
@@ -238,10 +238,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Drawing drawing, JsonSerializerOptions jsonSerializerOptions)
         {
             if (drawing.MainShapeOption.IsSet && drawing.MainShape == null)
-                throw new ArgumentNullException(nameof(drawing.MainShape), "Property is required for class Drawing.");
+                throw new JsonException("Cannot write null property Drawing.MainShape to non-nullable JSON property 'mainShape'.");
 
             if (drawing.ShapesOption.IsSet && drawing.Shapes == null)
-                throw new ArgumentNullException(nameof(drawing.Shapes), "Property is required for class Drawing.");
+                throw new JsonException("Cannot write null property Drawing.Shapes to non-nullable JSON property 'shapes'.");
 
             if (drawing.MainShapeOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -200,6 +200,9 @@ namespace Org.OpenAPITools.Model
             if (enumArrays.ArrayEnumOption.IsSet && enumArrays.ArrayEnum == null)
                 throw new JsonException("Cannot write null property EnumArrays.ArrayEnum to non-nullable JSON property 'array_enum'.");
 
+            if (enumArrays.JustSymbolOption.IsSet && enumArrays.JustSymbol == null)
+                throw new JsonException("Cannot write null property EnumArrays.JustSymbol to non-nullable JSON property 'just_symbol'.");
+
             if (enumArrays.ArrayEnumOption.IsSet)
             {
                 writer.WritePropertyName("array_enum");

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -198,7 +198,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, EnumArrays enumArrays, JsonSerializerOptions jsonSerializerOptions)
         {
             if (enumArrays.ArrayEnumOption.IsSet && enumArrays.ArrayEnum == null)
-                throw new ArgumentNullException(nameof(enumArrays.ArrayEnum), "Property is required for class EnumArrays.");
+                throw new JsonException("Cannot write null property EnumArrays.ArrayEnum to non-nullable JSON property 'array_enum'.");
 
             if (enumArrays.ArrayEnumOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -351,6 +351,27 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, EnumTest enumTest, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (enumTest.EnumIntegerOption.IsSet && enumTest.EnumInteger == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumInteger to non-nullable JSON property 'enum_integer'.");
+
+            if (enumTest.EnumIntegerOnlyOption.IsSet && enumTest.EnumIntegerOnly == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumIntegerOnly to non-nullable JSON property 'enum_integer_only'.");
+
+            if (enumTest.EnumNumberOption.IsSet && enumTest.EnumNumber == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumNumber to non-nullable JSON property 'enum_number'.");
+
+            if (enumTest.EnumStringOption.IsSet && enumTest.EnumString == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumString to non-nullable JSON property 'enum_string'.");
+
+            if (enumTest.OuterEnumDefaultValueOption.IsSet && enumTest.OuterEnumDefaultValue == null)
+                throw new JsonException("Cannot write null property EnumTest.OuterEnumDefaultValue to non-nullable JSON property 'outerEnumDefaultValue'.");
+
+            if (enumTest.OuterEnumIntegerOption.IsSet && enumTest.OuterEnumInteger == null)
+                throw new JsonException("Cannot write null property EnumTest.OuterEnumInteger to non-nullable JSON property 'outerEnumInteger'.");
+
+            if (enumTest.OuterEnumIntegerDefaultValueOption.IsSet && enumTest.OuterEnumIntegerDefaultValue == null)
+                throw new JsonException("Cannot write null property EnumTest.OuterEnumIntegerDefaultValue to non-nullable JSON property 'outerEnumIntegerDefaultValue'.");
+
             var enumStringRequiredRawValue = EnumTestEnumStringValueConverter.ToJsonValue(enumTest.EnumStringRequired);
             writer.WriteString("enum_string_required", enumStringRequiredRawValue);
 

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
@@ -189,12 +189,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, EquilateralTriangle equilateralTriangle, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (equilateralTriangle.ShapeType == null)
-                throw new ArgumentNullException(nameof(equilateralTriangle.ShapeType), "Property is required for class EquilateralTriangle.");
-
-            if (equilateralTriangle.TriangleType == null)
-                throw new ArgumentNullException(nameof(equilateralTriangle.TriangleType), "Property is required for class EquilateralTriangle.");
-
             writer.WriteString("shapeType", equilateralTriangle.ShapeType);
 
             writer.WriteString("triangleType", equilateralTriangle.TriangleType);

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/File.cs
@@ -176,7 +176,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, File file, JsonSerializerOptions jsonSerializerOptions)
         {
             if (file.SourceURIOption.IsSet && file.SourceURI == null)
-                throw new ArgumentNullException(nameof(file.SourceURI), "Property is required for class File.");
+                throw new JsonException("Cannot write null property File.SourceURI to non-nullable JSON property 'sourceURI'.");
 
             if (file.SourceURIOption.IsSet)
                 writer.WriteString("sourceURI", file.SourceURI);

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -198,10 +198,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, FileSchemaTestClass fileSchemaTestClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (fileSchemaTestClass.FileOption.IsSet && fileSchemaTestClass.File == null)
-                throw new ArgumentNullException(nameof(fileSchemaTestClass.File), "Property is required for class FileSchemaTestClass.");
+                throw new JsonException("Cannot write null property FileSchemaTestClass.File to non-nullable JSON property 'file'.");
 
             if (fileSchemaTestClass.FilesOption.IsSet && fileSchemaTestClass.Files == null)
-                throw new ArgumentNullException(nameof(fileSchemaTestClass.Files), "Property is required for class FileSchemaTestClass.");
+                throw new JsonException("Cannot write null property FileSchemaTestClass.Files to non-nullable JSON property 'files'.");
 
             if (fileSchemaTestClass.FileOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Foo.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Foo foo, JsonSerializerOptions jsonSerializerOptions)
         {
             if (foo.BarOption.IsSet && foo.Bar == null)
-                throw new ArgumentNullException(nameof(foo.Bar), "Property is required for class Foo.");
+                throw new JsonException("Cannot write null property Foo.Bar to non-nullable JSON property 'bar'.");
 
             if (foo.BarOption.IsSet)
                 writer.WriteString("bar", foo.Bar);

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, FooGetDefaultResponse fooGetDefaultResponse, JsonSerializerOptions jsonSerializerOptions)
         {
             if (fooGetDefaultResponse.StringOption.IsSet && fooGetDefaultResponse.String == null)
-                throw new ArgumentNullException(nameof(fooGetDefaultResponse.String), "Property is required for class FooGetDefaultResponse.");
+                throw new JsonException("Cannot write null property FooGetDefaultResponse.String to non-nullable JSON property 'string'.");
 
             if (fooGetDefaultResponse.StringOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -954,11 +954,47 @@ namespace Org.OpenAPITools.Model
             if (formatTest.BinaryOption.IsSet && formatTest.Binary == null)
                 throw new JsonException("Cannot write null property FormatTest.Binary to non-nullable JSON property 'binary'.");
 
+            if (formatTest.DateTimeOption.IsSet && formatTest.DateTime == null)
+                throw new JsonException("Cannot write null property FormatTest.DateTime to non-nullable JSON property 'dateTime'.");
+
+            if (formatTest.DecimalOption.IsSet && formatTest.Decimal == null)
+                throw new JsonException("Cannot write null property FormatTest.Decimal to non-nullable JSON property 'decimal'.");
+
+            if (formatTest.DoubleOption.IsSet && formatTest.Double == null)
+                throw new JsonException("Cannot write null property FormatTest.Double to non-nullable JSON property 'double'.");
+
             if (formatTest.DuplicatePropertyName2Option.IsSet && formatTest.DuplicatePropertyName2 == null)
                 throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName2 to non-nullable JSON property 'duplicate_property_name'.");
 
             if (formatTest.DuplicatePropertyNameOption.IsSet && formatTest.DuplicatePropertyName == null)
                 throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName to non-nullable JSON property '@duplicate_property_name'.");
+
+            if (formatTest.FloatOption.IsSet && formatTest.Float == null)
+                throw new JsonException("Cannot write null property FormatTest.Float to non-nullable JSON property 'float'.");
+
+            if (formatTest.Int32Option.IsSet && formatTest.Int32 == null)
+                throw new JsonException("Cannot write null property FormatTest.Int32 to non-nullable JSON property 'int32'.");
+
+            if (formatTest.Int32RangeOption.IsSet && formatTest.Int32Range == null)
+                throw new JsonException("Cannot write null property FormatTest.Int32Range to non-nullable JSON property 'int32Range'.");
+
+            if (formatTest.Int64Option.IsSet && formatTest.Int64 == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64 to non-nullable JSON property 'int64'.");
+
+            if (formatTest.Int64NegativeOption.IsSet && formatTest.Int64Negative == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64Negative to non-nullable JSON property 'int64Negative'.");
+
+            if (formatTest.Int64NegativeExclusiveOption.IsSet && formatTest.Int64NegativeExclusive == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64NegativeExclusive to non-nullable JSON property 'int64NegativeExclusive'.");
+
+            if (formatTest.Int64PositiveOption.IsSet && formatTest.Int64Positive == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64Positive to non-nullable JSON property 'int64Positive'.");
+
+            if (formatTest.Int64PositiveExclusiveOption.IsSet && formatTest.Int64PositiveExclusive == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64PositiveExclusive to non-nullable JSON property 'int64PositiveExclusive'.");
+
+            if (formatTest.IntegerOption.IsSet && formatTest.Integer == null)
+                throw new JsonException("Cannot write null property FormatTest.Integer to non-nullable JSON property 'integer'.");
 
             if (formatTest.PatternWithBackslashOption.IsSet && formatTest.PatternWithBackslash == null)
                 throw new JsonException("Cannot write null property FormatTest.PatternWithBackslash to non-nullable JSON property 'pattern_with_backslash'.");
@@ -971,6 +1007,18 @@ namespace Org.OpenAPITools.Model
 
             if (formatTest.StringOption.IsSet && formatTest.String == null)
                 throw new JsonException("Cannot write null property FormatTest.String to non-nullable JSON property 'string'.");
+
+            if (formatTest.StringFormattedAsDecimalOption.IsSet && formatTest.StringFormattedAsDecimal == null)
+                throw new JsonException("Cannot write null property FormatTest.StringFormattedAsDecimal to non-nullable JSON property 'string_formatted_as_decimal'.");
+
+            if (formatTest.UnsignedIntegerOption.IsSet && formatTest.UnsignedInteger == null)
+                throw new JsonException("Cannot write null property FormatTest.UnsignedInteger to non-nullable JSON property 'unsigned_integer'.");
+
+            if (formatTest.UnsignedLongOption.IsSet && formatTest.UnsignedLong == null)
+                throw new JsonException("Cannot write null property FormatTest.UnsignedLong to non-nullable JSON property 'unsigned_long'.");
+
+            if (formatTest.UuidOption.IsSet && formatTest.Uuid == null)
+                throw new JsonException("Cannot write null property FormatTest.Uuid to non-nullable JSON property 'uuid'.");
 
             writer.WritePropertyName("byte");
             JsonSerializer.Serialize(writer, formatTest.Byte, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -951,32 +951,26 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, FormatTest formatTest, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (formatTest.Byte == null)
-                throw new ArgumentNullException(nameof(formatTest.Byte), "Property is required for class FormatTest.");
-
-            if (formatTest.Password == null)
-                throw new ArgumentNullException(nameof(formatTest.Password), "Property is required for class FormatTest.");
-
             if (formatTest.BinaryOption.IsSet && formatTest.Binary == null)
-                throw new ArgumentNullException(nameof(formatTest.Binary), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.Binary to non-nullable JSON property 'binary'.");
 
             if (formatTest.DuplicatePropertyName2Option.IsSet && formatTest.DuplicatePropertyName2 == null)
-                throw new ArgumentNullException(nameof(formatTest.DuplicatePropertyName2), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName2 to non-nullable JSON property 'duplicate_property_name'.");
 
             if (formatTest.DuplicatePropertyNameOption.IsSet && formatTest.DuplicatePropertyName == null)
-                throw new ArgumentNullException(nameof(formatTest.DuplicatePropertyName), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName to non-nullable JSON property '@duplicate_property_name'.");
 
             if (formatTest.PatternWithBackslashOption.IsSet && formatTest.PatternWithBackslash == null)
-                throw new ArgumentNullException(nameof(formatTest.PatternWithBackslash), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.PatternWithBackslash to non-nullable JSON property 'pattern_with_backslash'.");
 
             if (formatTest.PatternWithDigitsOption.IsSet && formatTest.PatternWithDigits == null)
-                throw new ArgumentNullException(nameof(formatTest.PatternWithDigits), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.PatternWithDigits to non-nullable JSON property 'pattern_with_digits'.");
 
             if (formatTest.PatternWithDigitsAndDelimiterOption.IsSet && formatTest.PatternWithDigitsAndDelimiter == null)
-                throw new ArgumentNullException(nameof(formatTest.PatternWithDigitsAndDelimiter), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.PatternWithDigitsAndDelimiter to non-nullable JSON property 'pattern_with_digits_and_delimiter'.");
 
             if (formatTest.StringOption.IsSet && formatTest.String == null)
-                throw new ArgumentNullException(nameof(formatTest.String), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.String to non-nullable JSON property 'string'.");
 
             writer.WritePropertyName("byte");
             JsonSerializer.Serialize(writer, formatTest.Byte, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Fruit.cs
@@ -219,7 +219,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Fruit fruit, JsonSerializerOptions jsonSerializerOptions)
         {
             if (fruit.ColorOption.IsSet && fruit.Color == null)
-                throw new ArgumentNullException(nameof(fruit.Color), "Property is required for class Fruit.");
+                throw new JsonException("Cannot write null property Fruit.Color to non-nullable JSON property 'color'.");
 
             if (fruit.ColorOption.IsSet)
                 writer.WriteString("color", fruit.Color);

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -236,7 +236,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, GmFruit gmFruit, JsonSerializerOptions jsonSerializerOptions)
         {
             if (gmFruit.ColorOption.IsSet && gmFruit.Color == null)
-                throw new ArgumentNullException(nameof(gmFruit.Color), "Property is required for class GmFruit.");
+                throw new JsonException("Cannot write null property GmFruit.Color to non-nullable JSON property 'color'.");
 
             if (gmFruit.ColorOption.IsSet)
                 writer.WriteString("color", gmFruit.Color);

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -239,10 +239,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, HasOnlyReadOnly hasOnlyReadOnly, JsonSerializerOptions jsonSerializerOptions)
         {
             if (hasOnlyReadOnly.BarOption.IsSet && hasOnlyReadOnly.Bar == null)
-                throw new ArgumentNullException(nameof(hasOnlyReadOnly.Bar), "Property is required for class HasOnlyReadOnly.");
+                throw new JsonException("Cannot write null property HasOnlyReadOnly.Bar to non-nullable JSON property 'bar'.");
 
             if (hasOnlyReadOnly.FooOption.IsSet && hasOnlyReadOnly.Foo == null)
-                throw new ArgumentNullException(nameof(hasOnlyReadOnly.Foo), "Property is required for class HasOnlyReadOnly.");
+                throw new JsonException("Cannot write null property HasOnlyReadOnly.Foo to non-nullable JSON property 'foo'.");
 
             if (hasOnlyReadOnly.BarOption.IsSet)
                 writer.WriteString("bar", hasOnlyReadOnly.Bar);

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
@@ -337,22 +337,22 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, InjectedVendorExtensionsTest injectedVendorExtensionsTest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessorOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor to non-nullable JSON property 'potentiallyOverriddenPropertyAccessor'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternalOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternal == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternal), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternal to non-nullable JSON property 'potentiallyOverriddenPropertyToInternal'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivateOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivate == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivate), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivate to non-nullable JSON property 'potentiallyOverriddenPropertyToPrivate'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublicOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublic == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublic), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublic to non-nullable JSON property 'potentiallyOverriddenPropertyToPublic'.");
 
             if (injectedVendorExtensionsTest.UnalteredPropertyOption.IsSet && injectedVendorExtensionsTest.UnalteredProperty == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.UnalteredProperty), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.UnalteredProperty to non-nullable JSON property 'unalteredProperty'.");
 
             if (injectedVendorExtensionsTest.UnalteredPropertyAccessorOption.IsSet && injectedVendorExtensionsTest.UnalteredPropertyAccessor == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.UnalteredPropertyAccessor), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.UnalteredPropertyAccessor to non-nullable JSON property 'unalteredPropertyAccessor'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessorOption.IsSet)
                 writer.WriteString("potentiallyOverriddenPropertyAccessor", injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor);

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
@@ -182,12 +182,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, IsoscelesTriangle isoscelesTriangle, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (isoscelesTriangle.ShapeType == null)
-                throw new ArgumentNullException(nameof(isoscelesTriangle.ShapeType), "Property is required for class IsoscelesTriangle.");
-
-            if (isoscelesTriangle.TriangleType == null)
-                throw new ArgumentNullException(nameof(isoscelesTriangle.TriangleType), "Property is required for class IsoscelesTriangle.");
-
             writer.WriteString("shapeType", isoscelesTriangle.ShapeType);
 
             writer.WriteString("triangleType", isoscelesTriangle.TriangleType);

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/List.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, List list, JsonSerializerOptions jsonSerializerOptions)
         {
             if (list.Var123ListOption.IsSet && list.Var123List == null)
-                throw new ArgumentNullException(nameof(list.Var123List), "Property is required for class List.");
+                throw new JsonException("Cannot write null property List.Var123List to non-nullable JSON property '123-list'.");
 
             if (list.Var123ListOption.IsSet)
                 writer.WriteString("123-list", list.Var123List);

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -198,10 +198,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, LiteralStringClass literalStringClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (literalStringClass.EscapedLiteralStringOption.IsSet && literalStringClass.EscapedLiteralString == null)
-                throw new ArgumentNullException(nameof(literalStringClass.EscapedLiteralString), "Property is required for class LiteralStringClass.");
+                throw new JsonException("Cannot write null property LiteralStringClass.EscapedLiteralString to non-nullable JSON property 'escapedLiteralString'.");
 
             if (literalStringClass.UnescapedLiteralStringOption.IsSet && literalStringClass.UnescapedLiteralString == null)
-                throw new ArgumentNullException(nameof(literalStringClass.UnescapedLiteralString), "Property is required for class LiteralStringClass.");
+                throw new JsonException("Cannot write null property LiteralStringClass.UnescapedLiteralString to non-nullable JSON property 'unescapedLiteralString'.");
 
             if (literalStringClass.EscapedLiteralStringOption.IsSet)
                 writer.WriteString("escapedLiteralString", literalStringClass.EscapedLiteralString);

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/MapTest.cs
@@ -244,16 +244,16 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MapTest mapTest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mapTest.DirectMapOption.IsSet && mapTest.DirectMap == null)
-                throw new ArgumentNullException(nameof(mapTest.DirectMap), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.DirectMap to non-nullable JSON property 'direct_map'.");
 
             if (mapTest.IndirectMapOption.IsSet && mapTest.IndirectMap == null)
-                throw new ArgumentNullException(nameof(mapTest.IndirectMap), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.IndirectMap to non-nullable JSON property 'indirect_map'.");
 
             if (mapTest.MapMapOfStringOption.IsSet && mapTest.MapMapOfString == null)
-                throw new ArgumentNullException(nameof(mapTest.MapMapOfString), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.MapMapOfString to non-nullable JSON property 'map_map_of_string'.");
 
             if (mapTest.MapOfEnumStringOption.IsSet && mapTest.MapOfEnumString == null)
-                throw new ArgumentNullException(nameof(mapTest.MapOfEnumString), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.MapOfEnumString to non-nullable JSON property 'map_of_enum_string'.");
 
             if (mapTest.DirectMapOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/MixedAnyOf.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/MixedAnyOf.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedAnyOf mixedAnyOf, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedAnyOf.ContentOption.IsSet && mixedAnyOf.Content == null)
-                throw new ArgumentNullException(nameof(mixedAnyOf.Content), "Property is required for class MixedAnyOf.");
+                throw new JsonException("Cannot write null property MixedAnyOf.Content to non-nullable JSON property 'content'.");
 
             if (mixedAnyOf.ContentOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/MixedOneOf.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/MixedOneOf.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedOneOf mixedOneOf, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedOneOf.ContentOption.IsSet && mixedOneOf.Content == null)
-                throw new ArgumentNullException(nameof(mixedOneOf.Content), "Property is required for class MixedOneOf.");
+                throw new JsonException("Cannot write null property MixedOneOf.Content to non-nullable JSON property 'content'.");
 
             if (mixedOneOf.ContentOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -255,8 +255,17 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, MixedPropertiesAndAdditionalPropertiesClass mixedPropertiesAndAdditionalPropertiesClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.DateTime == null)
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.DateTime to non-nullable JSON property 'dateTime'.");
+
             if (mixedPropertiesAndAdditionalPropertiesClass.MapOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.Map == null)
                 throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.Map to non-nullable JSON property 'map'.");
+
+            if (mixedPropertiesAndAdditionalPropertiesClass.UuidOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.Uuid == null)
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.Uuid to non-nullable JSON property 'uuid'.");
+
+            if (mixedPropertiesAndAdditionalPropertiesClass.UuidWithPatternOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.UuidWithPattern == null)
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.UuidWithPattern to non-nullable JSON property 'uuid_with_pattern'.");
 
             if (mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.IsSet)
                 writer.WriteString("dateTime", mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.Value.Value.ToString(DateTimeFormat));

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -256,7 +256,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedPropertiesAndAdditionalPropertiesClass mixedPropertiesAndAdditionalPropertiesClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedPropertiesAndAdditionalPropertiesClass.MapOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.Map == null)
-                throw new ArgumentNullException(nameof(mixedPropertiesAndAdditionalPropertiesClass.Map), "Property is required for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.Map to non-nullable JSON property 'map'.");
 
             if (mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.IsSet)
                 writer.WriteString("dateTime", mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.Value.Value.ToString(DateTimeFormat));

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/MixedSubId.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/MixedSubId.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedSubId mixedSubId, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedSubId.IdOption.IsSet && mixedSubId.Id == null)
-                throw new ArgumentNullException(nameof(mixedSubId.Id), "Property is required for class MixedSubId.");
+                throw new JsonException("Cannot write null property MixedSubId.Id to non-nullable JSON property 'id'.");
 
             if (mixedSubId.IdOption.IsSet)
                 writer.WriteString("id", mixedSubId.Id);

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -198,7 +198,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Model200Response model200Response, JsonSerializerOptions jsonSerializerOptions)
         {
             if (model200Response.ClassOption.IsSet && model200Response.Class == null)
-                throw new ArgumentNullException(nameof(model200Response.Class), "Property is required for class Model200Response.");
+                throw new JsonException("Cannot write null property Model200Response.Class to non-nullable JSON property 'class'.");
 
             if (model200Response.ClassOption.IsSet)
                 writer.WriteString("class", model200Response.Class);

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -200,6 +200,9 @@ namespace Org.OpenAPITools.Model
             if (model200Response.ClassOption.IsSet && model200Response.Class == null)
                 throw new JsonException("Cannot write null property Model200Response.Class to non-nullable JSON property 'class'.");
 
+            if (model200Response.NameOption.IsSet && model200Response.Name == null)
+                throw new JsonException("Cannot write null property Model200Response.Name to non-nullable JSON property 'name'.");
+
             if (model200Response.ClassOption.IsSet)
                 writer.WriteString("class", model200Response.Class);
 

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ModelClient modelClient, JsonSerializerOptions jsonSerializerOptions)
         {
             if (modelClient.VarClientOption.IsSet && modelClient.VarClient == null)
-                throw new ArgumentNullException(nameof(modelClient.VarClient), "Property is required for class ModelClient.");
+                throw new JsonException("Cannot write null property ModelClient.VarClient to non-nullable JSON property 'client'.");
 
             if (modelClient.VarClientOption.IsSet)
                 writer.WriteString("client", modelClient.VarClient);

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Name.cs
@@ -281,7 +281,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Name name, JsonSerializerOptions jsonSerializerOptions)
         {
             if (name.PropertyOption.IsSet && name.Property == null)
-                throw new ArgumentNullException(nameof(name.Property), "Property is required for class Name.");
+                throw new JsonException("Cannot write null property Name.Property to non-nullable JSON property 'property'.");
 
             writer.WriteNumber("name", name.VarName);
 

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Name.cs
@@ -283,6 +283,12 @@ namespace Org.OpenAPITools.Model
             if (name.PropertyOption.IsSet && name.Property == null)
                 throw new JsonException("Cannot write null property Name.Property to non-nullable JSON property 'property'.");
 
+            if (name.SnakeCaseOption.IsSet && name.SnakeCase == null)
+                throw new JsonException("Cannot write null property Name.SnakeCase to non-nullable JSON property 'snake_case'.");
+
+            if (name.Var123NumberOption.IsSet && name.Var123Number == null)
+                throw new JsonException("Cannot write null property Name.Var123Number to non-nullable JSON property '123Number'.");
+
             writer.WriteNumber("name", name.VarName);
 
             if (name.PropertyOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
@@ -189,9 +189,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, NotificationtestGetElementsV1ResponseMPayload notificationtestGetElementsV1ResponseMPayload, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (notificationtestGetElementsV1ResponseMPayload.AObjVariableobject == null)
-                throw new ArgumentNullException(nameof(notificationtestGetElementsV1ResponseMPayload.AObjVariableobject), "Property is required for class NotificationtestGetElementsV1ResponseMPayload.");
-
             writer.WritePropertyName("a_objVariableobject");
             JsonSerializer.Serialize(writer, notificationtestGetElementsV1ResponseMPayload.AObjVariableobject, jsonSerializerOptions);
             writer.WriteNumber("pkiNotificationtestID", notificationtestGetElementsV1ResponseMPayload.PkiNotificationtestID);

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -408,10 +408,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, NullableClass nullableClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (nullableClass.ArrayItemsNullableOption.IsSet && nullableClass.ArrayItemsNullable == null)
-                throw new ArgumentNullException(nameof(nullableClass.ArrayItemsNullable), "Property is required for class NullableClass.");
+                throw new JsonException("Cannot write null property NullableClass.ArrayItemsNullable to non-nullable JSON property 'array_items_nullable'.");
 
             if (nullableClass.ObjectItemsNullableOption.IsSet && nullableClass.ObjectItemsNullable == null)
-                throw new ArgumentNullException(nameof(nullableClass.ObjectItemsNullable), "Property is required for class NullableClass.");
+                throw new JsonException("Cannot write null property NullableClass.ObjectItemsNullable to non-nullable JSON property 'object_items_nullable'.");
 
             if (nullableClass.ArrayAndItemsNullablePropOption.IsSet)
                 if (nullableClass.ArrayAndItemsNullablePropOption.Value != null)

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -174,6 +174,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, NumberOnly numberOnly, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (numberOnly.JustNumberOption.IsSet && numberOnly.JustNumber == null)
+                throw new JsonException("Cannot write null property NumberOnly.JustNumber to non-nullable JSON property 'JustNumber'.");
+
             if (numberOnly.JustNumberOption.IsSet)
                 writer.WriteNumber("JustNumber", numberOnly.JustNumberOption.Value.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -247,13 +247,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ObjectWithDeprecatedFields objectWithDeprecatedFields, JsonSerializerOptions jsonSerializerOptions)
         {
             if (objectWithDeprecatedFields.BarsOption.IsSet && objectWithDeprecatedFields.Bars == null)
-                throw new ArgumentNullException(nameof(objectWithDeprecatedFields.Bars), "Property is required for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Bars to non-nullable JSON property 'bars'.");
 
             if (objectWithDeprecatedFields.DeprecatedRefOption.IsSet && objectWithDeprecatedFields.DeprecatedRef == null)
-                throw new ArgumentNullException(nameof(objectWithDeprecatedFields.DeprecatedRef), "Property is required for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.DeprecatedRef to non-nullable JSON property 'deprecatedRef'.");
 
             if (objectWithDeprecatedFields.UuidOption.IsSet && objectWithDeprecatedFields.Uuid == null)
-                throw new ArgumentNullException(nameof(objectWithDeprecatedFields.Uuid), "Property is required for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Uuid to non-nullable JSON property 'uuid'.");
 
             if (objectWithDeprecatedFields.BarsOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -252,6 +252,9 @@ namespace Org.OpenAPITools.Model
             if (objectWithDeprecatedFields.DeprecatedRefOption.IsSet && objectWithDeprecatedFields.DeprecatedRef == null)
                 throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.DeprecatedRef to non-nullable JSON property 'deprecatedRef'.");
 
+            if (objectWithDeprecatedFields.IdOption.IsSet && objectWithDeprecatedFields.Id == null)
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Id to non-nullable JSON property 'id'.");
+
             if (objectWithDeprecatedFields.UuidOption.IsSet && objectWithDeprecatedFields.Uuid == null)
                 throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Uuid to non-nullable JSON property 'uuid'.");
 

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Order.cs
@@ -295,6 +295,24 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Order order, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (order.CompleteOption.IsSet && order.Complete == null)
+                throw new JsonException("Cannot write null property Order.Complete to non-nullable JSON property 'complete'.");
+
+            if (order.IdOption.IsSet && order.Id == null)
+                throw new JsonException("Cannot write null property Order.Id to non-nullable JSON property 'id'.");
+
+            if (order.PetIdOption.IsSet && order.PetId == null)
+                throw new JsonException("Cannot write null property Order.PetId to non-nullable JSON property 'petId'.");
+
+            if (order.QuantityOption.IsSet && order.Quantity == null)
+                throw new JsonException("Cannot write null property Order.Quantity to non-nullable JSON property 'quantity'.");
+
+            if (order.ShipDateOption.IsSet && order.ShipDate == null)
+                throw new JsonException("Cannot write null property Order.ShipDate to non-nullable JSON property 'shipDate'.");
+
+            if (order.StatusOption.IsSet && order.Status == null)
+                throw new JsonException("Cannot write null property Order.Status to non-nullable JSON property 'status'.");
+
             if (order.CompleteOption.IsSet)
                 writer.WriteBoolean("complete", order.CompleteOption.Value.Value);
 

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -220,6 +220,12 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, OuterComposite outerComposite, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (outerComposite.MyBooleanOption.IsSet && outerComposite.MyBoolean == null)
+                throw new JsonException("Cannot write null property OuterComposite.MyBoolean to non-nullable JSON property 'my_boolean'.");
+
+            if (outerComposite.MyNumberOption.IsSet && outerComposite.MyNumber == null)
+                throw new JsonException("Cannot write null property OuterComposite.MyNumber to non-nullable JSON property 'my_number'.");
+
             if (outerComposite.MyStringOption.IsSet && outerComposite.MyString == null)
                 throw new JsonException("Cannot write null property OuterComposite.MyString to non-nullable JSON property 'my_string'.");
 

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -221,7 +221,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, OuterComposite outerComposite, JsonSerializerOptions jsonSerializerOptions)
         {
             if (outerComposite.MyStringOption.IsSet && outerComposite.MyString == null)
-                throw new ArgumentNullException(nameof(outerComposite.MyString), "Property is required for class OuterComposite.");
+                throw new JsonException("Cannot write null property OuterComposite.MyString to non-nullable JSON property 'my_string'.");
 
             if (outerComposite.MyBooleanOption.IsSet)
                 writer.WriteBoolean("my_boolean", outerComposite.MyBooleanOption.Value.Value);

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Pet.cs
@@ -282,17 +282,11 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Pet pet, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (pet.Name == null)
-                throw new ArgumentNullException(nameof(pet.Name), "Property is required for class Pet.");
-
-            if (pet.PhotoUrls == null)
-                throw new ArgumentNullException(nameof(pet.PhotoUrls), "Property is required for class Pet.");
-
             if (pet.CategoryOption.IsSet && pet.Category == null)
-                throw new ArgumentNullException(nameof(pet.Category), "Property is required for class Pet.");
+                throw new JsonException("Cannot write null property Pet.Category to non-nullable JSON property 'category'.");
 
             if (pet.TagsOption.IsSet && pet.Tags == null)
-                throw new ArgumentNullException(nameof(pet.Tags), "Property is required for class Pet.");
+                throw new JsonException("Cannot write null property Pet.Tags to non-nullable JSON property 'tags'.");
 
             writer.WriteString("name", pet.Name);
 

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Pet.cs
@@ -285,6 +285,12 @@ namespace Org.OpenAPITools.Model
             if (pet.CategoryOption.IsSet && pet.Category == null)
                 throw new JsonException("Cannot write null property Pet.Category to non-nullable JSON property 'category'.");
 
+            if (pet.IdOption.IsSet && pet.Id == null)
+                throw new JsonException("Cannot write null property Pet.Id to non-nullable JSON property 'id'.");
+
+            if (pet.StatusOption.IsSet && pet.Status == null)
+                throw new JsonException("Cannot write null property Pet.Status to non-nullable JSON property 'status'.");
+
             if (pet.TagsOption.IsSet && pet.Tags == null)
                 throw new JsonException("Cannot write null property Pet.Tags to non-nullable JSON property 'tags'.");
 

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
@@ -170,9 +170,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, QuadrilateralInterface quadrilateralInterface, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (quadrilateralInterface.QuadrilateralType == null)
-                throw new ArgumentNullException(nameof(quadrilateralInterface.QuadrilateralType), "Property is required for class QuadrilateralInterface.");
-
             writer.WriteString("quadrilateralType", quadrilateralInterface.QuadrilateralType);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -236,10 +236,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ReadOnlyFirst readOnlyFirst, JsonSerializerOptions jsonSerializerOptions)
         {
             if (readOnlyFirst.BarOption.IsSet && readOnlyFirst.Bar == null)
-                throw new ArgumentNullException(nameof(readOnlyFirst.Bar), "Property is required for class ReadOnlyFirst.");
+                throw new JsonException("Cannot write null property ReadOnlyFirst.Bar to non-nullable JSON property 'bar'.");
 
             if (readOnlyFirst.BazOption.IsSet && readOnlyFirst.Baz == null)
-                throw new ArgumentNullException(nameof(readOnlyFirst.Baz), "Property is required for class ReadOnlyFirst.");
+                throw new JsonException("Cannot write null property ReadOnlyFirst.Baz to non-nullable JSON property 'baz'.");
 
             if (readOnlyFirst.BarOption.IsSet)
                 writer.WriteString("bar", readOnlyFirst.Bar);

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -1053,11 +1053,38 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, RequiredClass requiredClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (requiredClass.NotRequiredNotnullableDatePropOption.IsSet && requiredClass.NotRequiredNotnullableDateProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotRequiredNotnullableDateProp to non-nullable JSON property 'not_required_notnullable_date_prop'.");
+
+            if (requiredClass.NotRequiredNotnullableintegerPropOption.IsSet && requiredClass.NotRequiredNotnullableintegerProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotRequiredNotnullableintegerProp to non-nullable JSON property 'not_required_notnullableinteger_prop'.");
+
             if (requiredClass.NotrequiredNotnullableArrayOfStringOption.IsSet && requiredClass.NotrequiredNotnullableArrayOfString == null)
                 throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableArrayOfString to non-nullable JSON property 'notrequired_notnullable_array_of_string'.");
 
+            if (requiredClass.NotrequiredNotnullableBooleanPropOption.IsSet && requiredClass.NotrequiredNotnullableBooleanProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableBooleanProp to non-nullable JSON property 'notrequired_notnullable_boolean_prop'.");
+
+            if (requiredClass.NotrequiredNotnullableDatetimePropOption.IsSet && requiredClass.NotrequiredNotnullableDatetimeProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableDatetimeProp to non-nullable JSON property 'notrequired_notnullable_datetime_prop'.");
+
+            if (requiredClass.NotrequiredNotnullableEnumIntegerOption.IsSet && requiredClass.NotrequiredNotnullableEnumInteger == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableEnumInteger to non-nullable JSON property 'notrequired_notnullable_enum_integer'.");
+
+            if (requiredClass.NotrequiredNotnullableEnumIntegerOnlyOption.IsSet && requiredClass.NotrequiredNotnullableEnumIntegerOnly == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableEnumIntegerOnly to non-nullable JSON property 'notrequired_notnullable_enum_integer_only'.");
+
+            if (requiredClass.NotrequiredNotnullableEnumStringOption.IsSet && requiredClass.NotrequiredNotnullableEnumString == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableEnumString to non-nullable JSON property 'notrequired_notnullable_enum_string'.");
+
+            if (requiredClass.NotrequiredNotnullableOuterEnumDefaultValueOption.IsSet && requiredClass.NotrequiredNotnullableOuterEnumDefaultValue == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableOuterEnumDefaultValue to non-nullable JSON property 'notrequired_notnullable_outerEnumDefaultValue'.");
+
             if (requiredClass.NotrequiredNotnullableStringPropOption.IsSet && requiredClass.NotrequiredNotnullableStringProp == null)
                 throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableStringProp to non-nullable JSON property 'notrequired_notnullable_string_prop'.");
+
+            if (requiredClass.NotrequiredNotnullableUuidOption.IsSet && requiredClass.NotrequiredNotnullableUuid == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableUuid to non-nullable JSON property 'notrequired_notnullable_uuid'.");
 
             writer.WriteString("required_not_nullable_date_prop", requiredClass.RequiredNotNullableDateProp.ToString(RequiredNotNullableDatePropFormat));
 

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -1053,17 +1053,11 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, RequiredClass requiredClass, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (requiredClass.RequiredNotnullableArrayOfString == null)
-                throw new ArgumentNullException(nameof(requiredClass.RequiredNotnullableArrayOfString), "Property is required for class RequiredClass.");
-
-            if (requiredClass.RequiredNotnullableStringProp == null)
-                throw new ArgumentNullException(nameof(requiredClass.RequiredNotnullableStringProp), "Property is required for class RequiredClass.");
-
             if (requiredClass.NotrequiredNotnullableArrayOfStringOption.IsSet && requiredClass.NotrequiredNotnullableArrayOfString == null)
-                throw new ArgumentNullException(nameof(requiredClass.NotrequiredNotnullableArrayOfString), "Property is required for class RequiredClass.");
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableArrayOfString to non-nullable JSON property 'notrequired_notnullable_array_of_string'.");
 
             if (requiredClass.NotrequiredNotnullableStringPropOption.IsSet && requiredClass.NotrequiredNotnullableStringProp == null)
-                throw new ArgumentNullException(nameof(requiredClass.NotrequiredNotnullableStringProp), "Property is required for class RequiredClass.");
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableStringProp to non-nullable JSON property 'notrequired_notnullable_string_prop'.");
 
             writer.WriteString("required_not_nullable_date_prop", requiredClass.RequiredNotNullableDateProp.ToString(RequiredNotNullableDatePropFormat));
 

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Result.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Result.cs
@@ -224,13 +224,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Result result, JsonSerializerOptions jsonSerializerOptions)
         {
             if (result.CodeOption.IsSet && result.Code == null)
-                throw new ArgumentNullException(nameof(result.Code), "Property is required for class Result.");
+                throw new JsonException("Cannot write null property Result.Code to non-nullable JSON property 'code'.");
 
             if (result.DataOption.IsSet && result.Data == null)
-                throw new ArgumentNullException(nameof(result.Data), "Property is required for class Result.");
+                throw new JsonException("Cannot write null property Result.Data to non-nullable JSON property 'data'.");
 
             if (result.UuidOption.IsSet && result.Uuid == null)
-                throw new ArgumentNullException(nameof(result.Uuid), "Property is required for class Result.");
+                throw new JsonException("Cannot write null property Result.Uuid to non-nullable JSON property 'uuid'.");
 
             if (result.CodeOption.IsSet)
                 writer.WriteString("code", result.Code);

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Return.cs
@@ -232,11 +232,8 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Return varReturn, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (varReturn.Lock == null)
-                throw new ArgumentNullException(nameof(varReturn.Lock), "Property is required for class Return.");
-
             if (varReturn.UnsafeOption.IsSet && varReturn.Unsafe == null)
-                throw new ArgumentNullException(nameof(varReturn.Unsafe), "Property is required for class Return.");
+                throw new JsonException("Cannot write null property Return.Unsafe to non-nullable JSON property 'unsafe'.");
 
             writer.WriteString("lock", varReturn.Lock);
 

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Return.cs
@@ -232,6 +232,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Return varReturn, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (varReturn.VarReturnOption.IsSet && varReturn.VarReturn == null)
+                throw new JsonException("Cannot write null property Return.VarReturn to non-nullable JSON property 'return'.");
+
             if (varReturn.UnsafeOption.IsSet && varReturn.Unsafe == null)
                 throw new JsonException("Cannot write null property Return.Unsafe to non-nullable JSON property 'unsafe'.");
 

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -198,7 +198,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, RolesReportsHash rolesReportsHash, JsonSerializerOptions jsonSerializerOptions)
         {
             if (rolesReportsHash.RoleOption.IsSet && rolesReportsHash.Role == null)
-                throw new ArgumentNullException(nameof(rolesReportsHash.Role), "Property is required for class RolesReportsHash.");
+                throw new JsonException("Cannot write null property RolesReportsHash.Role to non-nullable JSON property 'role'.");
 
             if (rolesReportsHash.RoleOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -200,6 +200,9 @@ namespace Org.OpenAPITools.Model
             if (rolesReportsHash.RoleOption.IsSet && rolesReportsHash.Role == null)
                 throw new JsonException("Cannot write null property RolesReportsHash.Role to non-nullable JSON property 'role'.");
 
+            if (rolesReportsHash.RoleUuidOption.IsSet && rolesReportsHash.RoleUuid == null)
+                throw new JsonException("Cannot write null property RolesReportsHash.RoleUuid to non-nullable JSON property 'role_uuid'.");
+
             if (rolesReportsHash.RoleOption.IsSet)
             {
                 writer.WritePropertyName("role");

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, RolesReportsHashRole rolesReportsHashRole, JsonSerializerOptions jsonSerializerOptions)
         {
             if (rolesReportsHashRole.NameOption.IsSet && rolesReportsHashRole.Name == null)
-                throw new ArgumentNullException(nameof(rolesReportsHashRole.Name), "Property is required for class RolesReportsHashRole.");
+                throw new JsonException("Cannot write null property RolesReportsHashRole.Name to non-nullable JSON property 'name'.");
 
             if (rolesReportsHashRole.NameOption.IsSet)
                 writer.WriteString("name", rolesReportsHashRole.Name);

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
@@ -189,12 +189,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ScaleneTriangle scaleneTriangle, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (scaleneTriangle.ShapeType == null)
-                throw new ArgumentNullException(nameof(scaleneTriangle.ShapeType), "Property is required for class ScaleneTriangle.");
-
-            if (scaleneTriangle.TriangleType == null)
-                throw new ArgumentNullException(nameof(scaleneTriangle.TriangleType), "Property is required for class ScaleneTriangle.");
-
             writer.WriteString("shapeType", scaleneTriangle.ShapeType);
 
             writer.WriteString("triangleType", scaleneTriangle.TriangleType);

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ShapeInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ShapeInterface.cs
@@ -170,9 +170,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ShapeInterface shapeInterface, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (shapeInterface.ShapeType == null)
-                throw new ArgumentNullException(nameof(shapeInterface.ShapeType), "Property is required for class ShapeInterface.");
-
             writer.WriteString("shapeType", shapeInterface.ShapeType);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
@@ -189,12 +189,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, SimpleQuadrilateral simpleQuadrilateral, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (simpleQuadrilateral.QuadrilateralType == null)
-                throw new ArgumentNullException(nameof(simpleQuadrilateral.QuadrilateralType), "Property is required for class SimpleQuadrilateral.");
-
-            if (simpleQuadrilateral.ShapeType == null)
-                throw new ArgumentNullException(nameof(simpleQuadrilateral.ShapeType), "Property is required for class SimpleQuadrilateral.");
-
             writer.WriteString("quadrilateralType", simpleQuadrilateral.QuadrilateralType);
 
             writer.WriteString("shapeType", simpleQuadrilateral.ShapeType);

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -200,6 +200,9 @@ namespace Org.OpenAPITools.Model
             if (specialModelName.VarSpecialModelNameOption.IsSet && specialModelName.VarSpecialModelName == null)
                 throw new JsonException("Cannot write null property SpecialModelName.VarSpecialModelName to non-nullable JSON property '_special_model.name_'.");
 
+            if (specialModelName.SpecialPropertyNameOption.IsSet && specialModelName.SpecialPropertyName == null)
+                throw new JsonException("Cannot write null property SpecialModelName.SpecialPropertyName to non-nullable JSON property '$special[property.name]'.");
+
             if (specialModelName.VarSpecialModelNameOption.IsSet)
                 writer.WriteString("_special_model.name_", specialModelName.VarSpecialModelName);
 

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -198,7 +198,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, SpecialModelName specialModelName, JsonSerializerOptions jsonSerializerOptions)
         {
             if (specialModelName.VarSpecialModelNameOption.IsSet && specialModelName.VarSpecialModelName == null)
-                throw new ArgumentNullException(nameof(specialModelName.VarSpecialModelName), "Property is required for class SpecialModelName.");
+                throw new JsonException("Cannot write null property SpecialModelName.VarSpecialModelName to non-nullable JSON property '_special_model.name_'.");
 
             if (specialModelName.VarSpecialModelNameOption.IsSet)
                 writer.WriteString("_special_model.name_", specialModelName.VarSpecialModelName);

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Tag.cs
@@ -198,7 +198,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Tag tag, JsonSerializerOptions jsonSerializerOptions)
         {
             if (tag.NameOption.IsSet && tag.Name == null)
-                throw new ArgumentNullException(nameof(tag.Name), "Property is required for class Tag.");
+                throw new JsonException("Cannot write null property Tag.Name to non-nullable JSON property 'name'.");
 
             if (tag.IdOption.IsSet)
                 writer.WriteNumber("id", tag.IdOption.Value.Value);

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Tag.cs
@@ -197,6 +197,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Tag tag, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (tag.IdOption.IsSet && tag.Id == null)
+                throw new JsonException("Cannot write null property Tag.Id to non-nullable JSON property 'id'.");
+
             if (tag.NameOption.IsSet && tag.Name == null)
                 throw new JsonException("Cannot write null property Tag.Name to non-nullable JSON property 'name'.");
 

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestCollectionEndingWithWordList testCollectionEndingWithWordList, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testCollectionEndingWithWordList.ValueOption.IsSet && testCollectionEndingWithWordList.Value == null)
-                throw new ArgumentNullException(nameof(testCollectionEndingWithWordList.Value), "Property is required for class TestCollectionEndingWithWordList.");
+                throw new JsonException("Cannot write null property TestCollectionEndingWithWordList.Value to non-nullable JSON property 'value'.");
 
             if (testCollectionEndingWithWordList.ValueOption.IsSet)
                 writer.WriteString("value", testCollectionEndingWithWordList.Value);

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestCollectionEndingWithWordListObject testCollectionEndingWithWordListObject, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testCollectionEndingWithWordListObject.TestCollectionEndingWithWordListOption.IsSet && testCollectionEndingWithWordListObject.TestCollectionEndingWithWordList == null)
-                throw new ArgumentNullException(nameof(testCollectionEndingWithWordListObject.TestCollectionEndingWithWordList), "Property is required for class TestCollectionEndingWithWordListObject.");
+                throw new JsonException("Cannot write null property TestCollectionEndingWithWordListObject.TestCollectionEndingWithWordList to non-nullable JSON property 'TestCollectionEndingWithWordList'.");
 
             if (testCollectionEndingWithWordListObject.TestCollectionEndingWithWordListOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/TestDescendants.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/TestDescendants.cs
@@ -216,9 +216,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, TestDescendants testDescendants, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (testDescendants.AlternativeName == null)
-                throw new ArgumentNullException(nameof(testDescendants.AlternativeName), "Property is required for class TestDescendants.");
-
             writer.WriteString("alternativeName", testDescendants.AlternativeName);
 
             writer.WriteString("objectType", TestDescendantsObjectTypeValueConverter.ToJsonValue(testDescendants.ObjectType));

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestInlineFreeformAdditionalPropertiesRequest testInlineFreeformAdditionalPropertiesRequest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testInlineFreeformAdditionalPropertiesRequest.SomePropertyOption.IsSet && testInlineFreeformAdditionalPropertiesRequest.SomeProperty == null)
-                throw new ArgumentNullException(nameof(testInlineFreeformAdditionalPropertiesRequest.SomeProperty), "Property is required for class TestInlineFreeformAdditionalPropertiesRequest.");
+                throw new JsonException("Cannot write null property TestInlineFreeformAdditionalPropertiesRequest.SomeProperty to non-nullable JSON property 'someProperty'.");
 
             if (testInlineFreeformAdditionalPropertiesRequest.SomePropertyOption.IsSet)
                 writer.WriteString("someProperty", testInlineFreeformAdditionalPropertiesRequest.SomeProperty);

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/TestResult.cs
@@ -222,6 +222,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, TestResult testResult, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (testResult.CodeOption.IsSet && testResult.Code == null)
+                throw new JsonException("Cannot write null property TestResult.Code to non-nullable JSON property 'code'.");
+
             if (testResult.DataOption.IsSet && testResult.Data == null)
                 throw new JsonException("Cannot write null property TestResult.Data to non-nullable JSON property 'data'.");
 

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/TestResult.cs
@@ -223,10 +223,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestResult testResult, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testResult.DataOption.IsSet && testResult.Data == null)
-                throw new ArgumentNullException(nameof(testResult.Data), "Property is required for class TestResult.");
+                throw new JsonException("Cannot write null property TestResult.Data to non-nullable JSON property 'data'.");
 
             if (testResult.UuidOption.IsSet && testResult.Uuid == null)
-                throw new ArgumentNullException(nameof(testResult.Uuid), "Property is required for class TestResult.");
+                throw new JsonException("Cannot write null property TestResult.Uuid to non-nullable JSON property 'uuid'.");
 
             if (testResult.CodeOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/TriangleInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/TriangleInterface.cs
@@ -170,9 +170,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, TriangleInterface triangleInterface, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (triangleInterface.TriangleType == null)
-                throw new ArgumentNullException(nameof(triangleInterface.TriangleType), "Property is required for class TriangleInterface.");
-
             writer.WriteString("triangleType", triangleInterface.TriangleType);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/User.cs
@@ -429,6 +429,9 @@ namespace Org.OpenAPITools.Model
             if (user.FirstNameOption.IsSet && user.FirstName == null)
                 throw new JsonException("Cannot write null property User.FirstName to non-nullable JSON property 'firstName'.");
 
+            if (user.IdOption.IsSet && user.Id == null)
+                throw new JsonException("Cannot write null property User.Id to non-nullable JSON property 'id'.");
+
             if (user.LastNameOption.IsSet && user.LastName == null)
                 throw new JsonException("Cannot write null property User.LastName to non-nullable JSON property 'lastName'.");
 
@@ -440,6 +443,9 @@ namespace Org.OpenAPITools.Model
 
             if (user.PhoneOption.IsSet && user.Phone == null)
                 throw new JsonException("Cannot write null property User.Phone to non-nullable JSON property 'phone'.");
+
+            if (user.UserStatusOption.IsSet && user.UserStatus == null)
+                throw new JsonException("Cannot write null property User.UserStatus to non-nullable JSON property 'userStatus'.");
 
             if (user.UsernameOption.IsSet && user.Username == null)
                 throw new JsonException("Cannot write null property User.Username to non-nullable JSON property 'username'.");

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/User.cs
@@ -424,25 +424,25 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, User user, JsonSerializerOptions jsonSerializerOptions)
         {
             if (user.EmailOption.IsSet && user.Email == null)
-                throw new ArgumentNullException(nameof(user.Email), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Email to non-nullable JSON property 'email'.");
 
             if (user.FirstNameOption.IsSet && user.FirstName == null)
-                throw new ArgumentNullException(nameof(user.FirstName), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.FirstName to non-nullable JSON property 'firstName'.");
 
             if (user.LastNameOption.IsSet && user.LastName == null)
-                throw new ArgumentNullException(nameof(user.LastName), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.LastName to non-nullable JSON property 'lastName'.");
 
             if (user.ObjectWithNoDeclaredPropsOption.IsSet && user.ObjectWithNoDeclaredProps == null)
-                throw new ArgumentNullException(nameof(user.ObjectWithNoDeclaredProps), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.ObjectWithNoDeclaredProps to non-nullable JSON property 'objectWithNoDeclaredProps'.");
 
             if (user.PasswordOption.IsSet && user.Password == null)
-                throw new ArgumentNullException(nameof(user.Password), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Password to non-nullable JSON property 'password'.");
 
             if (user.PhoneOption.IsSet && user.Phone == null)
-                throw new ArgumentNullException(nameof(user.Phone), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Phone to non-nullable JSON property 'phone'.");
 
             if (user.UsernameOption.IsSet && user.Username == null)
-                throw new ArgumentNullException(nameof(user.Username), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Username to non-nullable JSON property 'username'.");
 
             if (user.AnyTypePropOption.IsSet)
                 if (user.AnyTypePropOption.Value != null)

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Whale.cs
@@ -216,9 +216,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Whale whale, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (whale.ClassName == null)
-                throw new ArgumentNullException(nameof(whale.ClassName), "Property is required for class Whale.");
-
             writer.WriteString("className", whale.ClassName);
 
             if (whale.HasBaleenOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Whale.cs
@@ -216,6 +216,12 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Whale whale, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (whale.HasBaleenOption.IsSet && whale.HasBaleen == null)
+                throw new JsonException("Cannot write null property Whale.HasBaleen to non-nullable JSON property 'hasBaleen'.");
+
+            if (whale.HasTeethOption.IsSet && whale.HasTeeth == null)
+                throw new JsonException("Cannot write null property Whale.HasTeeth to non-nullable JSON property 'hasTeeth'.");
+
             writer.WriteString("className", whale.ClassName);
 
             if (whale.HasBaleenOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Zebra.cs
@@ -193,6 +193,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Zebra zebra, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (zebra.TypeOption.IsSet && zebra.Type == null)
+                throw new JsonException("Cannot write null property Zebra.Type to non-nullable JSON property 'type'.");
+
             writer.WriteString("className", zebra.ClassName);
 
             if (zebra.TypeOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Zebra.cs
@@ -193,9 +193,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Zebra zebra, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (zebra.ClassName == null)
-                throw new ArgumentNullException(nameof(zebra.ClassName), "Property is required for class Zebra.");
-
             writer.WriteString("className", zebra.ClassName);
 
             if (zebra.TypeOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
@@ -174,6 +174,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ZeroBasedEnumClass zeroBasedEnumClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (zeroBasedEnumClass.ZeroBasedEnumOption.IsSet && zeroBasedEnumClass.ZeroBasedEnum == null)
+                throw new JsonException("Cannot write null property ZeroBasedEnumClass.ZeroBasedEnum to non-nullable JSON property 'ZeroBasedEnum'.");
+
             if (zeroBasedEnumClass.ZeroBasedEnumOption.IsSet)
             {
                 var zeroBasedEnumRawValue = ZeroBasedEnumClassZeroBasedEnumValueConverter.ToJsonValue(zeroBasedEnumClass.ZeroBasedEnum.Value);

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Activity.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Activity activity, JsonSerializerOptions jsonSerializerOptions)
         {
             if (activity.ActivityOutputsOption.IsSet && activity.ActivityOutputs == null)
-                throw new ArgumentNullException(nameof(activity.ActivityOutputs), "Property is required for class Activity.");
+                throw new JsonException("Cannot write null property Activity.ActivityOutputs to non-nullable JSON property 'activity_outputs'.");
 
             if (activity.ActivityOutputsOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -200,10 +200,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ActivityOutputElementRepresentation activityOutputElementRepresentation, JsonSerializerOptions jsonSerializerOptions)
         {
             if (activityOutputElementRepresentation.Prop1Option.IsSet && activityOutputElementRepresentation.Prop1 == null)
-                throw new ArgumentNullException(nameof(activityOutputElementRepresentation.Prop1), "Property is required for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Cannot write null property ActivityOutputElementRepresentation.Prop1 to non-nullable JSON property 'prop1'.");
 
             if (activityOutputElementRepresentation.Prop2Option.IsSet && activityOutputElementRepresentation.Prop2 == null)
-                throw new ArgumentNullException(nameof(activityOutputElementRepresentation.Prop2), "Property is required for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Cannot write null property ActivityOutputElementRepresentation.Prop2 to non-nullable JSON property 'prop2'.");
 
             if (activityOutputElementRepresentation.Prop1Option.IsSet)
                 writer.WriteString("prop1", activityOutputElementRepresentation.Prop1);

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -336,25 +336,25 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, AdditionalPropertiesClass additionalPropertiesClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (additionalPropertiesClass.EmptyMapOption.IsSet && additionalPropertiesClass.EmptyMap == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.EmptyMap), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.EmptyMap to non-nullable JSON property 'empty_map'.");
 
             if (additionalPropertiesClass.MapOfMapPropertyOption.IsSet && additionalPropertiesClass.MapOfMapProperty == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapOfMapProperty), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapOfMapProperty to non-nullable JSON property 'map_of_map_property'.");
 
             if (additionalPropertiesClass.MapPropertyOption.IsSet && additionalPropertiesClass.MapProperty == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapProperty), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapProperty to non-nullable JSON property 'map_property'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1Option.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1 == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1 to non-nullable JSON property 'map_with_undeclared_properties_anytype_1'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2Option.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2 == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2 to non-nullable JSON property 'map_with_undeclared_properties_anytype_2'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3Option.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3 == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3 to non-nullable JSON property 'map_with_undeclared_properties_anytype_3'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesStringOption.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesString == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesString), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesString to non-nullable JSON property 'map_with_undeclared_properties_string'.");
 
             if (additionalPropertiesClass.Anytype1Option.IsSet)
                 if (additionalPropertiesClass.Anytype1Option.Value != null)

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Animal.cs
@@ -223,7 +223,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Animal animal, JsonSerializerOptions jsonSerializerOptions)
         {
             if (animal.ColorOption.IsSet && animal.Color == null)
-                throw new ArgumentNullException(nameof(animal.Color), "Property is required for class Animal.");
+                throw new JsonException("Cannot write null property Animal.Color to non-nullable JSON property 'color'.");
 
             writer.WriteString("className", animal.ClassName);
 

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -223,10 +223,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ApiResponse apiResponse, JsonSerializerOptions jsonSerializerOptions)
         {
             if (apiResponse.MessageOption.IsSet && apiResponse.Message == null)
-                throw new ArgumentNullException(nameof(apiResponse.Message), "Property is required for class ApiResponse.");
+                throw new JsonException("Cannot write null property ApiResponse.Message to non-nullable JSON property 'message'.");
 
             if (apiResponse.TypeOption.IsSet && apiResponse.Type == null)
-                throw new ArgumentNullException(nameof(apiResponse.Type), "Property is required for class ApiResponse.");
+                throw new JsonException("Cannot write null property ApiResponse.Type to non-nullable JSON property 'type'.");
 
             if (apiResponse.CodeOption.IsSet)
                 writer.WriteNumber("code", apiResponse.CodeOption.Value!.Value);

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -222,6 +222,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ApiResponse apiResponse, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (apiResponse.CodeOption.IsSet && apiResponse.Code == null)
+                throw new JsonException("Cannot write null property ApiResponse.Code to non-nullable JSON property 'code'.");
+
             if (apiResponse.MessageOption.IsSet && apiResponse.Message == null)
                 throw new JsonException("Cannot write null property ApiResponse.Message to non-nullable JSON property 'message'.");
 

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Apple.cs
@@ -253,13 +253,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Apple apple, JsonSerializerOptions jsonSerializerOptions)
         {
             if (apple.ColorCodeOption.IsSet && apple.ColorCode == null)
-                throw new ArgumentNullException(nameof(apple.ColorCode), "Property is required for class Apple.");
+                throw new JsonException("Cannot write null property Apple.ColorCode to non-nullable JSON property 'color_code'.");
 
             if (apple.CultivarOption.IsSet && apple.Cultivar == null)
-                throw new ArgumentNullException(nameof(apple.Cultivar), "Property is required for class Apple.");
+                throw new JsonException("Cannot write null property Apple.Cultivar to non-nullable JSON property 'cultivar'.");
 
             if (apple.OriginOption.IsSet && apple.Origin == null)
-                throw new ArgumentNullException(nameof(apple.Origin), "Property is required for class Apple.");
+                throw new JsonException("Cannot write null property Apple.Origin to non-nullable JSON property 'origin'.");
 
             if (apple.ColorCodeOption.IsSet)
                 writer.WriteString("color_code", apple.ColorCode);

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -188,6 +188,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, AppleReq appleReq, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (appleReq.MealyOption.IsSet && appleReq.Mealy == null)
+                throw new JsonException("Cannot write null property AppleReq.Mealy to non-nullable JSON property 'mealy'.");
+
             writer.WriteString("cultivar", appleReq.Cultivar);
 
             if (appleReq.MealyOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -188,9 +188,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, AppleReq appleReq, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (appleReq.Cultivar == null)
-                throw new ArgumentNullException(nameof(appleReq.Cultivar), "Property is required for class AppleReq.");
-
             writer.WriteString("cultivar", appleReq.Cultivar);
 
             if (appleReq.MealyOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ArrayOfArrayOfNumberOnly arrayOfArrayOfNumberOnly, JsonSerializerOptions jsonSerializerOptions)
         {
             if (arrayOfArrayOfNumberOnly.ArrayArrayNumberOption.IsSet && arrayOfArrayOfNumberOnly.ArrayArrayNumber == null)
-                throw new ArgumentNullException(nameof(arrayOfArrayOfNumberOnly.ArrayArrayNumber), "Property is required for class ArrayOfArrayOfNumberOnly.");
+                throw new JsonException("Cannot write null property ArrayOfArrayOfNumberOnly.ArrayArrayNumber to non-nullable JSON property 'ArrayArrayNumber'.");
 
             if (arrayOfArrayOfNumberOnly.ArrayArrayNumberOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ArrayOfNumberOnly arrayOfNumberOnly, JsonSerializerOptions jsonSerializerOptions)
         {
             if (arrayOfNumberOnly.ArrayNumberOption.IsSet && arrayOfNumberOnly.ArrayNumber == null)
-                throw new ArgumentNullException(nameof(arrayOfNumberOnly.ArrayNumber), "Property is required for class ArrayOfNumberOnly.");
+                throw new JsonException("Cannot write null property ArrayOfNumberOnly.ArrayNumber to non-nullable JSON property 'ArrayNumber'.");
 
             if (arrayOfNumberOnly.ArrayNumberOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -223,13 +223,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ArrayTest arrayTest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (arrayTest.ArrayArrayOfIntegerOption.IsSet && arrayTest.ArrayArrayOfInteger == null)
-                throw new ArgumentNullException(nameof(arrayTest.ArrayArrayOfInteger), "Property is required for class ArrayTest.");
+                throw new JsonException("Cannot write null property ArrayTest.ArrayArrayOfInteger to non-nullable JSON property 'array_array_of_integer'.");
 
             if (arrayTest.ArrayArrayOfModelOption.IsSet && arrayTest.ArrayArrayOfModel == null)
-                throw new ArgumentNullException(nameof(arrayTest.ArrayArrayOfModel), "Property is required for class ArrayTest.");
+                throw new JsonException("Cannot write null property ArrayTest.ArrayArrayOfModel to non-nullable JSON property 'array_array_of_model'.");
 
             if (arrayTest.ArrayOfStringOption.IsSet && arrayTest.ArrayOfString == null)
-                throw new ArgumentNullException(nameof(arrayTest.ArrayOfString), "Property is required for class ArrayTest.");
+                throw new JsonException("Cannot write null property ArrayTest.ArrayOfString to non-nullable JSON property 'array_of_string'.");
 
             if (arrayTest.ArrayArrayOfIntegerOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Banana.cs
@@ -176,6 +176,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Banana banana, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (banana.LengthCmOption.IsSet && banana.LengthCm == null)
+                throw new JsonException("Cannot write null property Banana.LengthCm to non-nullable JSON property 'lengthCm'.");
+
             if (banana.LengthCmOption.IsSet)
                 writer.WriteNumber("lengthCm", banana.LengthCmOption.Value!.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -188,6 +188,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, BananaReq bananaReq, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (bananaReq.SweetOption.IsSet && bananaReq.Sweet == null)
+                throw new JsonException("Cannot write null property BananaReq.Sweet to non-nullable JSON property 'sweet'.");
+
             writer.WriteNumber("lengthCm", bananaReq.LengthCm);
 
             if (bananaReq.SweetOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/BasquePig.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/BasquePig.cs
@@ -172,9 +172,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, BasquePig basquePig, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (basquePig.ClassName == null)
-                throw new ArgumentNullException(nameof(basquePig.ClassName), "Property is required for class BasquePig.");
-
             writer.WriteString("className", basquePig.ClassName);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -293,22 +293,22 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Capitalization capitalization, JsonSerializerOptions jsonSerializerOptions)
         {
             if (capitalization.ATT_NAMEOption.IsSet && capitalization.ATT_NAME == null)
-                throw new ArgumentNullException(nameof(capitalization.ATT_NAME), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.ATT_NAME to non-nullable JSON property 'ATT_NAME'.");
 
             if (capitalization.CapitalCamelOption.IsSet && capitalization.CapitalCamel == null)
-                throw new ArgumentNullException(nameof(capitalization.CapitalCamel), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.CapitalCamel to non-nullable JSON property 'CapitalCamel'.");
 
             if (capitalization.CapitalSnakeOption.IsSet && capitalization.CapitalSnake == null)
-                throw new ArgumentNullException(nameof(capitalization.CapitalSnake), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.CapitalSnake to non-nullable JSON property 'Capital_Snake'.");
 
             if (capitalization.SCAETHFlowPointsOption.IsSet && capitalization.SCAETHFlowPoints == null)
-                throw new ArgumentNullException(nameof(capitalization.SCAETHFlowPoints), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.SCAETHFlowPoints to non-nullable JSON property 'SCA_ETH_Flow_Points'.");
 
             if (capitalization.SmallCamelOption.IsSet && capitalization.SmallCamel == null)
-                throw new ArgumentNullException(nameof(capitalization.SmallCamel), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.SmallCamel to non-nullable JSON property 'smallCamel'.");
 
             if (capitalization.SmallSnakeOption.IsSet && capitalization.SmallSnake == null)
-                throw new ArgumentNullException(nameof(capitalization.SmallSnake), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.SmallSnake to non-nullable JSON property 'small_Snake'.");
 
             if (capitalization.ATT_NAMEOption.IsSet)
                 writer.WriteString("ATT_NAME", capitalization.ATT_NAME);

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Cat.cs
@@ -179,7 +179,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Cat cat, JsonSerializerOptions jsonSerializerOptions)
         {
             if (cat.ColorOption.IsSet && cat.Color == null)
-                throw new ArgumentNullException(nameof(cat.Color), "Property is required for class Cat.");
+                throw new JsonException("Cannot write null property Cat.Color to non-nullable JSON property 'color'.");
 
             writer.WriteString("className", cat.ClassName);
 

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Cat.cs
@@ -181,6 +181,9 @@ namespace Org.OpenAPITools.Model
             if (cat.ColorOption.IsSet && cat.Color == null)
                 throw new JsonException("Cannot write null property Cat.Color to non-nullable JSON property 'color'.");
 
+            if (cat.DeclawedOption.IsSet && cat.Declawed == null)
+                throw new JsonException("Cannot write null property Cat.Declawed to non-nullable JSON property 'declawed'.");
+
             writer.WriteString("className", cat.ClassName);
 
             if (cat.ColorOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Category.cs
@@ -195,9 +195,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Category category, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (category.Name == null)
-                throw new ArgumentNullException(nameof(category.Name), "Property is required for class Category.");
-
             if (category.IdOption.IsSet)
                 writer.WriteNumber("id", category.IdOption.Value!.Value);
 

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Category.cs
@@ -195,6 +195,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Category category, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (category.IdOption.IsSet && category.Id == null)
+                throw new JsonException("Cannot write null property Category.Id to non-nullable JSON property 'id'.");
+
             if (category.IdOption.IsSet)
                 writer.WriteNumber("id", category.IdOption.Value!.Value);
 

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -238,7 +238,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ChildCat childCat, JsonSerializerOptions jsonSerializerOptions)
         {
             if (childCat.NameOption.IsSet && childCat.Name == null)
-                throw new ArgumentNullException(nameof(childCat.Name), "Property is required for class ChildCat.");
+                throw new JsonException("Cannot write null property ChildCat.Name to non-nullable JSON property 'name'.");
 
             if (childCat.NameOption.IsSet)
                 writer.WriteString("name", childCat.Name);

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ClassModel classModel, JsonSerializerOptions jsonSerializerOptions)
         {
             if (classModel.ClassOption.IsSet && classModel.Class == null)
-                throw new ArgumentNullException(nameof(classModel.Class), "Property is required for class ClassModel.");
+                throw new JsonException("Cannot write null property ClassModel.Class to non-nullable JSON property '_class'.");
 
             if (classModel.ClassOption.IsSet)
                 writer.WriteString("_class", classModel.Class);

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
@@ -191,12 +191,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ComplexQuadrilateral complexQuadrilateral, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (complexQuadrilateral.QuadrilateralType == null)
-                throw new ArgumentNullException(nameof(complexQuadrilateral.QuadrilateralType), "Property is required for class ComplexQuadrilateral.");
-
-            if (complexQuadrilateral.ShapeType == null)
-                throw new ArgumentNullException(nameof(complexQuadrilateral.ShapeType), "Property is required for class ComplexQuadrilateral.");
-
             writer.WriteString("quadrilateralType", complexQuadrilateral.QuadrilateralType);
 
             writer.WriteString("shapeType", complexQuadrilateral.ShapeType);

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/CopyActivity.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/CopyActivity.cs
@@ -233,9 +233,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, CopyActivity copyActivity, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (copyActivity.CopyActivitytt == null)
-                throw new ArgumentNullException(nameof(copyActivity.CopyActivitytt), "Property is required for class CopyActivity.");
-
             writer.WriteString("copyActivitytt", copyActivity.CopyActivitytt);
 
             writer.WriteString("$schema", CopyActivity.SchemaEnumToJsonValue(copyActivity.Schema));

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/DanishPig.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/DanishPig.cs
@@ -172,9 +172,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, DanishPig danishPig, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (danishPig.ClassName == null)
-                throw new ArgumentNullException(nameof(danishPig.ClassName), "Property is required for class DanishPig.");
-
             writer.WriteString("className", danishPig.ClassName);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -182,6 +182,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, DateOnlyClass dateOnlyClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (dateOnlyClass.DateOnlyPropertyOption.IsSet && dateOnlyClass.DateOnlyProperty == null)
+                throw new JsonException("Cannot write null property DateOnlyClass.DateOnlyProperty to non-nullable JSON property 'dateOnlyProperty'.");
+
             if (dateOnlyClass.DateOnlyPropertyOption.IsSet)
                 writer.WriteString("dateOnlyProperty", dateOnlyClass.DateOnlyPropertyOption.Value!.Value.ToString(DateOnlyPropertyFormat));
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, DeprecatedObject deprecatedObject, JsonSerializerOptions jsonSerializerOptions)
         {
             if (deprecatedObject.NameOption.IsSet && deprecatedObject.Name == null)
-                throw new ArgumentNullException(nameof(deprecatedObject.Name), "Property is required for class DeprecatedObject.");
+                throw new JsonException("Cannot write null property DeprecatedObject.Name to non-nullable JSON property 'name'.");
 
             if (deprecatedObject.NameOption.IsSet)
                 writer.WriteString("name", deprecatedObject.Name);

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Descendant1.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Descendant1.cs
@@ -184,12 +184,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Descendant1 descendant1, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (descendant1.AlternativeName == null)
-                throw new ArgumentNullException(nameof(descendant1.AlternativeName), "Property is required for class Descendant1.");
-
-            if (descendant1.DescendantName == null)
-                throw new ArgumentNullException(nameof(descendant1.DescendantName), "Property is required for class Descendant1.");
-
             writer.WriteString("alternativeName", descendant1.AlternativeName);
 
             writer.WriteString("descendantName", descendant1.DescendantName);

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Descendant2.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Descendant2.cs
@@ -184,12 +184,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Descendant2 descendant2, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (descendant2.AlternativeName == null)
-                throw new ArgumentNullException(nameof(descendant2.AlternativeName), "Property is required for class Descendant2.");
-
-            if (descendant2.Confidentiality == null)
-                throw new ArgumentNullException(nameof(descendant2.Confidentiality), "Property is required for class Descendant2.");
-
             writer.WriteString("alternativeName", descendant2.AlternativeName);
 
             writer.WriteString("confidentiality", descendant2.Confidentiality);

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Dog.cs
@@ -179,10 +179,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Dog dog, JsonSerializerOptions jsonSerializerOptions)
         {
             if (dog.BreedOption.IsSet && dog.Breed == null)
-                throw new ArgumentNullException(nameof(dog.Breed), "Property is required for class Dog.");
+                throw new JsonException("Cannot write null property Dog.Breed to non-nullable JSON property 'breed'.");
 
             if (dog.ColorOption.IsSet && dog.Color == null)
-                throw new ArgumentNullException(nameof(dog.Color), "Property is required for class Dog.");
+                throw new JsonException("Cannot write null property Dog.Color to non-nullable JSON property 'color'.");
 
             writer.WriteString("className", dog.ClassName);
 

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Drawing.cs
@@ -240,10 +240,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Drawing drawing, JsonSerializerOptions jsonSerializerOptions)
         {
             if (drawing.MainShapeOption.IsSet && drawing.MainShape == null)
-                throw new ArgumentNullException(nameof(drawing.MainShape), "Property is required for class Drawing.");
+                throw new JsonException("Cannot write null property Drawing.MainShape to non-nullable JSON property 'mainShape'.");
 
             if (drawing.ShapesOption.IsSet && drawing.Shapes == null)
-                throw new ArgumentNullException(nameof(drawing.Shapes), "Property is required for class Drawing.");
+                throw new JsonException("Cannot write null property Drawing.Shapes to non-nullable JSON property 'shapes'.");
 
             if (drawing.MainShapeOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -339,7 +339,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, EnumArrays enumArrays, JsonSerializerOptions jsonSerializerOptions)
         {
             if (enumArrays.ArrayEnumOption.IsSet && enumArrays.ArrayEnum == null)
-                throw new ArgumentNullException(nameof(enumArrays.ArrayEnum), "Property is required for class EnumArrays.");
+                throw new JsonException("Cannot write null property EnumArrays.ArrayEnum to non-nullable JSON property 'array_enum'.");
 
             if (enumArrays.ArrayEnumOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -341,6 +341,9 @@ namespace Org.OpenAPITools.Model
             if (enumArrays.ArrayEnumOption.IsSet && enumArrays.ArrayEnum == null)
                 throw new JsonException("Cannot write null property EnumArrays.ArrayEnum to non-nullable JSON property 'array_enum'.");
 
+            if (enumArrays.JustSymbolOption.IsSet && enumArrays.JustSymbol == null)
+                throw new JsonException("Cannot write null property EnumArrays.JustSymbol to non-nullable JSON property 'just_symbol'.");
+
             if (enumArrays.ArrayEnumOption.IsSet)
             {
                 writer.WritePropertyName("array_enum");

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -877,6 +877,27 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, EnumTest enumTest, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (enumTest.EnumIntegerOption.IsSet && enumTest.EnumInteger == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumInteger to non-nullable JSON property 'enum_integer'.");
+
+            if (enumTest.EnumIntegerOnlyOption.IsSet && enumTest.EnumIntegerOnly == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumIntegerOnly to non-nullable JSON property 'enum_integer_only'.");
+
+            if (enumTest.EnumNumberOption.IsSet && enumTest.EnumNumber == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumNumber to non-nullable JSON property 'enum_number'.");
+
+            if (enumTest.EnumStringOption.IsSet && enumTest.EnumString == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumString to non-nullable JSON property 'enum_string'.");
+
+            if (enumTest.OuterEnumDefaultValueOption.IsSet && enumTest.OuterEnumDefaultValue == null)
+                throw new JsonException("Cannot write null property EnumTest.OuterEnumDefaultValue to non-nullable JSON property 'outerEnumDefaultValue'.");
+
+            if (enumTest.OuterEnumIntegerOption.IsSet && enumTest.OuterEnumInteger == null)
+                throw new JsonException("Cannot write null property EnumTest.OuterEnumInteger to non-nullable JSON property 'outerEnumInteger'.");
+
+            if (enumTest.OuterEnumIntegerDefaultValueOption.IsSet && enumTest.OuterEnumIntegerDefaultValue == null)
+                throw new JsonException("Cannot write null property EnumTest.OuterEnumIntegerDefaultValue to non-nullable JSON property 'outerEnumIntegerDefaultValue'.");
+
             var enumStringRequiredRawValue = EnumTest.EnumStringRequiredEnumToJsonValue(enumTest.EnumStringRequired);
             writer.WriteString("enum_string_required", enumStringRequiredRawValue);
             if (enumTest.EnumIntegerOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
@@ -191,12 +191,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, EquilateralTriangle equilateralTriangle, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (equilateralTriangle.ShapeType == null)
-                throw new ArgumentNullException(nameof(equilateralTriangle.ShapeType), "Property is required for class EquilateralTriangle.");
-
-            if (equilateralTriangle.TriangleType == null)
-                throw new ArgumentNullException(nameof(equilateralTriangle.TriangleType), "Property is required for class EquilateralTriangle.");
-
             writer.WriteString("shapeType", equilateralTriangle.ShapeType);
 
             writer.WriteString("triangleType", equilateralTriangle.TriangleType);

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/File.cs
@@ -178,7 +178,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, File file, JsonSerializerOptions jsonSerializerOptions)
         {
             if (file.SourceURIOption.IsSet && file.SourceURI == null)
-                throw new ArgumentNullException(nameof(file.SourceURI), "Property is required for class File.");
+                throw new JsonException("Cannot write null property File.SourceURI to non-nullable JSON property 'sourceURI'.");
 
             if (file.SourceURIOption.IsSet)
                 writer.WriteString("sourceURI", file.SourceURI);

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -200,10 +200,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, FileSchemaTestClass fileSchemaTestClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (fileSchemaTestClass.FileOption.IsSet && fileSchemaTestClass.File == null)
-                throw new ArgumentNullException(nameof(fileSchemaTestClass.File), "Property is required for class FileSchemaTestClass.");
+                throw new JsonException("Cannot write null property FileSchemaTestClass.File to non-nullable JSON property 'file'.");
 
             if (fileSchemaTestClass.FilesOption.IsSet && fileSchemaTestClass.Files == null)
-                throw new ArgumentNullException(nameof(fileSchemaTestClass.Files), "Property is required for class FileSchemaTestClass.");
+                throw new JsonException("Cannot write null property FileSchemaTestClass.Files to non-nullable JSON property 'files'.");
 
             if (fileSchemaTestClass.FileOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Foo.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Foo foo, JsonSerializerOptions jsonSerializerOptions)
         {
             if (foo.BarOption.IsSet && foo.Bar == null)
-                throw new ArgumentNullException(nameof(foo.Bar), "Property is required for class Foo.");
+                throw new JsonException("Cannot write null property Foo.Bar to non-nullable JSON property 'bar'.");
 
             if (foo.BarOption.IsSet)
                 writer.WriteString("bar", foo.Bar);

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, FooGetDefaultResponse fooGetDefaultResponse, JsonSerializerOptions jsonSerializerOptions)
         {
             if (fooGetDefaultResponse.StringOption.IsSet && fooGetDefaultResponse.String == null)
-                throw new ArgumentNullException(nameof(fooGetDefaultResponse.String), "Property is required for class FooGetDefaultResponse.");
+                throw new JsonException("Cannot write null property FooGetDefaultResponse.String to non-nullable JSON property 'string'.");
 
             if (fooGetDefaultResponse.StringOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -956,11 +956,47 @@ namespace Org.OpenAPITools.Model
             if (formatTest.BinaryOption.IsSet && formatTest.Binary == null)
                 throw new JsonException("Cannot write null property FormatTest.Binary to non-nullable JSON property 'binary'.");
 
+            if (formatTest.DateTimeOption.IsSet && formatTest.DateTime == null)
+                throw new JsonException("Cannot write null property FormatTest.DateTime to non-nullable JSON property 'dateTime'.");
+
+            if (formatTest.DecimalOption.IsSet && formatTest.Decimal == null)
+                throw new JsonException("Cannot write null property FormatTest.Decimal to non-nullable JSON property 'decimal'.");
+
+            if (formatTest.DoubleOption.IsSet && formatTest.Double == null)
+                throw new JsonException("Cannot write null property FormatTest.Double to non-nullable JSON property 'double'.");
+
             if (formatTest.DuplicatePropertyName2Option.IsSet && formatTest.DuplicatePropertyName2 == null)
                 throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName2 to non-nullable JSON property 'duplicate_property_name'.");
 
             if (formatTest.DuplicatePropertyNameOption.IsSet && formatTest.DuplicatePropertyName == null)
                 throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName to non-nullable JSON property '@duplicate_property_name'.");
+
+            if (formatTest.FloatOption.IsSet && formatTest.Float == null)
+                throw new JsonException("Cannot write null property FormatTest.Float to non-nullable JSON property 'float'.");
+
+            if (formatTest.Int32Option.IsSet && formatTest.Int32 == null)
+                throw new JsonException("Cannot write null property FormatTest.Int32 to non-nullable JSON property 'int32'.");
+
+            if (formatTest.Int32RangeOption.IsSet && formatTest.Int32Range == null)
+                throw new JsonException("Cannot write null property FormatTest.Int32Range to non-nullable JSON property 'int32Range'.");
+
+            if (formatTest.Int64Option.IsSet && formatTest.Int64 == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64 to non-nullable JSON property 'int64'.");
+
+            if (formatTest.Int64NegativeOption.IsSet && formatTest.Int64Negative == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64Negative to non-nullable JSON property 'int64Negative'.");
+
+            if (formatTest.Int64NegativeExclusiveOption.IsSet && formatTest.Int64NegativeExclusive == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64NegativeExclusive to non-nullable JSON property 'int64NegativeExclusive'.");
+
+            if (formatTest.Int64PositiveOption.IsSet && formatTest.Int64Positive == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64Positive to non-nullable JSON property 'int64Positive'.");
+
+            if (formatTest.Int64PositiveExclusiveOption.IsSet && formatTest.Int64PositiveExclusive == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64PositiveExclusive to non-nullable JSON property 'int64PositiveExclusive'.");
+
+            if (formatTest.IntegerOption.IsSet && formatTest.Integer == null)
+                throw new JsonException("Cannot write null property FormatTest.Integer to non-nullable JSON property 'integer'.");
 
             if (formatTest.PatternWithBackslashOption.IsSet && formatTest.PatternWithBackslash == null)
                 throw new JsonException("Cannot write null property FormatTest.PatternWithBackslash to non-nullable JSON property 'pattern_with_backslash'.");
@@ -973,6 +1009,18 @@ namespace Org.OpenAPITools.Model
 
             if (formatTest.StringOption.IsSet && formatTest.String == null)
                 throw new JsonException("Cannot write null property FormatTest.String to non-nullable JSON property 'string'.");
+
+            if (formatTest.StringFormattedAsDecimalOption.IsSet && formatTest.StringFormattedAsDecimal == null)
+                throw new JsonException("Cannot write null property FormatTest.StringFormattedAsDecimal to non-nullable JSON property 'string_formatted_as_decimal'.");
+
+            if (formatTest.UnsignedIntegerOption.IsSet && formatTest.UnsignedInteger == null)
+                throw new JsonException("Cannot write null property FormatTest.UnsignedInteger to non-nullable JSON property 'unsigned_integer'.");
+
+            if (formatTest.UnsignedLongOption.IsSet && formatTest.UnsignedLong == null)
+                throw new JsonException("Cannot write null property FormatTest.UnsignedLong to non-nullable JSON property 'unsigned_long'.");
+
+            if (formatTest.UuidOption.IsSet && formatTest.Uuid == null)
+                throw new JsonException("Cannot write null property FormatTest.Uuid to non-nullable JSON property 'uuid'.");
 
             writer.WritePropertyName("byte");
             JsonSerializer.Serialize(writer, formatTest.Byte, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -953,32 +953,26 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, FormatTest formatTest, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (formatTest.Byte == null)
-                throw new ArgumentNullException(nameof(formatTest.Byte), "Property is required for class FormatTest.");
-
-            if (formatTest.Password == null)
-                throw new ArgumentNullException(nameof(formatTest.Password), "Property is required for class FormatTest.");
-
             if (formatTest.BinaryOption.IsSet && formatTest.Binary == null)
-                throw new ArgumentNullException(nameof(formatTest.Binary), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.Binary to non-nullable JSON property 'binary'.");
 
             if (formatTest.DuplicatePropertyName2Option.IsSet && formatTest.DuplicatePropertyName2 == null)
-                throw new ArgumentNullException(nameof(formatTest.DuplicatePropertyName2), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName2 to non-nullable JSON property 'duplicate_property_name'.");
 
             if (formatTest.DuplicatePropertyNameOption.IsSet && formatTest.DuplicatePropertyName == null)
-                throw new ArgumentNullException(nameof(formatTest.DuplicatePropertyName), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName to non-nullable JSON property '@duplicate_property_name'.");
 
             if (formatTest.PatternWithBackslashOption.IsSet && formatTest.PatternWithBackslash == null)
-                throw new ArgumentNullException(nameof(formatTest.PatternWithBackslash), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.PatternWithBackslash to non-nullable JSON property 'pattern_with_backslash'.");
 
             if (formatTest.PatternWithDigitsOption.IsSet && formatTest.PatternWithDigits == null)
-                throw new ArgumentNullException(nameof(formatTest.PatternWithDigits), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.PatternWithDigits to non-nullable JSON property 'pattern_with_digits'.");
 
             if (formatTest.PatternWithDigitsAndDelimiterOption.IsSet && formatTest.PatternWithDigitsAndDelimiter == null)
-                throw new ArgumentNullException(nameof(formatTest.PatternWithDigitsAndDelimiter), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.PatternWithDigitsAndDelimiter to non-nullable JSON property 'pattern_with_digits_and_delimiter'.");
 
             if (formatTest.StringOption.IsSet && formatTest.String == null)
-                throw new ArgumentNullException(nameof(formatTest.String), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.String to non-nullable JSON property 'string'.");
 
             writer.WritePropertyName("byte");
             JsonSerializer.Serialize(writer, formatTest.Byte, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Fruit.cs
@@ -221,7 +221,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Fruit fruit, JsonSerializerOptions jsonSerializerOptions)
         {
             if (fruit.ColorOption.IsSet && fruit.Color == null)
-                throw new ArgumentNullException(nameof(fruit.Color), "Property is required for class Fruit.");
+                throw new JsonException("Cannot write null property Fruit.Color to non-nullable JSON property 'color'.");
 
             if (fruit.ColorOption.IsSet)
                 writer.WriteString("color", fruit.Color);

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -238,7 +238,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, GmFruit gmFruit, JsonSerializerOptions jsonSerializerOptions)
         {
             if (gmFruit.ColorOption.IsSet && gmFruit.Color == null)
-                throw new ArgumentNullException(nameof(gmFruit.Color), "Property is required for class GmFruit.");
+                throw new JsonException("Cannot write null property GmFruit.Color to non-nullable JSON property 'color'.");
 
             if (gmFruit.ColorOption.IsSet)
                 writer.WriteString("color", gmFruit.Color);

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -241,10 +241,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, HasOnlyReadOnly hasOnlyReadOnly, JsonSerializerOptions jsonSerializerOptions)
         {
             if (hasOnlyReadOnly.BarOption.IsSet && hasOnlyReadOnly.Bar == null)
-                throw new ArgumentNullException(nameof(hasOnlyReadOnly.Bar), "Property is required for class HasOnlyReadOnly.");
+                throw new JsonException("Cannot write null property HasOnlyReadOnly.Bar to non-nullable JSON property 'bar'.");
 
             if (hasOnlyReadOnly.FooOption.IsSet && hasOnlyReadOnly.Foo == null)
-                throw new ArgumentNullException(nameof(hasOnlyReadOnly.Foo), "Property is required for class HasOnlyReadOnly.");
+                throw new JsonException("Cannot write null property HasOnlyReadOnly.Foo to non-nullable JSON property 'foo'.");
 
             if (hasOnlyReadOnly.BarOption.IsSet)
                 writer.WriteString("bar", hasOnlyReadOnly.Bar);

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
@@ -339,22 +339,22 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, InjectedVendorExtensionsTest injectedVendorExtensionsTest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessorOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor to non-nullable JSON property 'potentiallyOverriddenPropertyAccessor'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternalOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternal == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternal), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternal to non-nullable JSON property 'potentiallyOverriddenPropertyToInternal'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivateOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivate == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivate), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivate to non-nullable JSON property 'potentiallyOverriddenPropertyToPrivate'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublicOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublic == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublic), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublic to non-nullable JSON property 'potentiallyOverriddenPropertyToPublic'.");
 
             if (injectedVendorExtensionsTest.UnalteredPropertyOption.IsSet && injectedVendorExtensionsTest.UnalteredProperty == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.UnalteredProperty), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.UnalteredProperty to non-nullable JSON property 'unalteredProperty'.");
 
             if (injectedVendorExtensionsTest.UnalteredPropertyAccessorOption.IsSet && injectedVendorExtensionsTest.UnalteredPropertyAccessor == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.UnalteredPropertyAccessor), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.UnalteredPropertyAccessor to non-nullable JSON property 'unalteredPropertyAccessor'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessorOption.IsSet)
                 writer.WriteString("potentiallyOverriddenPropertyAccessor", injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor);

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
@@ -184,12 +184,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, IsoscelesTriangle isoscelesTriangle, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (isoscelesTriangle.ShapeType == null)
-                throw new ArgumentNullException(nameof(isoscelesTriangle.ShapeType), "Property is required for class IsoscelesTriangle.");
-
-            if (isoscelesTriangle.TriangleType == null)
-                throw new ArgumentNullException(nameof(isoscelesTriangle.TriangleType), "Property is required for class IsoscelesTriangle.");
-
             writer.WriteString("shapeType", isoscelesTriangle.ShapeType);
 
             writer.WriteString("triangleType", isoscelesTriangle.TriangleType);

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/List.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, List list, JsonSerializerOptions jsonSerializerOptions)
         {
             if (list.Var123ListOption.IsSet && list.Var123List == null)
-                throw new ArgumentNullException(nameof(list.Var123List), "Property is required for class List.");
+                throw new JsonException("Cannot write null property List.Var123List to non-nullable JSON property '123-list'.");
 
             if (list.Var123ListOption.IsSet)
                 writer.WriteString("123-list", list.Var123List);

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -200,10 +200,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, LiteralStringClass literalStringClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (literalStringClass.EscapedLiteralStringOption.IsSet && literalStringClass.EscapedLiteralString == null)
-                throw new ArgumentNullException(nameof(literalStringClass.EscapedLiteralString), "Property is required for class LiteralStringClass.");
+                throw new JsonException("Cannot write null property LiteralStringClass.EscapedLiteralString to non-nullable JSON property 'escapedLiteralString'.");
 
             if (literalStringClass.UnescapedLiteralStringOption.IsSet && literalStringClass.UnescapedLiteralString == null)
-                throw new ArgumentNullException(nameof(literalStringClass.UnescapedLiteralString), "Property is required for class LiteralStringClass.");
+                throw new JsonException("Cannot write null property LiteralStringClass.UnescapedLiteralString to non-nullable JSON property 'unescapedLiteralString'.");
 
             if (literalStringClass.EscapedLiteralStringOption.IsSet)
                 writer.WriteString("escapedLiteralString", literalStringClass.EscapedLiteralString);

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/MapTest.cs
@@ -312,16 +312,16 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MapTest mapTest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mapTest.DirectMapOption.IsSet && mapTest.DirectMap == null)
-                throw new ArgumentNullException(nameof(mapTest.DirectMap), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.DirectMap to non-nullable JSON property 'direct_map'.");
 
             if (mapTest.IndirectMapOption.IsSet && mapTest.IndirectMap == null)
-                throw new ArgumentNullException(nameof(mapTest.IndirectMap), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.IndirectMap to non-nullable JSON property 'indirect_map'.");
 
             if (mapTest.MapMapOfStringOption.IsSet && mapTest.MapMapOfString == null)
-                throw new ArgumentNullException(nameof(mapTest.MapMapOfString), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.MapMapOfString to non-nullable JSON property 'map_map_of_string'.");
 
             if (mapTest.MapOfEnumStringOption.IsSet && mapTest.MapOfEnumString == null)
-                throw new ArgumentNullException(nameof(mapTest.MapOfEnumString), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.MapOfEnumString to non-nullable JSON property 'map_of_enum_string'.");
 
             if (mapTest.DirectMapOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedAnyOf.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedAnyOf.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedAnyOf mixedAnyOf, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedAnyOf.ContentOption.IsSet && mixedAnyOf.Content == null)
-                throw new ArgumentNullException(nameof(mixedAnyOf.Content), "Property is required for class MixedAnyOf.");
+                throw new JsonException("Cannot write null property MixedAnyOf.Content to non-nullable JSON property 'content'.");
 
             if (mixedAnyOf.ContentOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedOneOf.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedOneOf.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedOneOf mixedOneOf, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedOneOf.ContentOption.IsSet && mixedOneOf.Content == null)
-                throw new ArgumentNullException(nameof(mixedOneOf.Content), "Property is required for class MixedOneOf.");
+                throw new JsonException("Cannot write null property MixedOneOf.Content to non-nullable JSON property 'content'.");
 
             if (mixedOneOf.ContentOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -257,8 +257,17 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, MixedPropertiesAndAdditionalPropertiesClass mixedPropertiesAndAdditionalPropertiesClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.DateTime == null)
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.DateTime to non-nullable JSON property 'dateTime'.");
+
             if (mixedPropertiesAndAdditionalPropertiesClass.MapOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.Map == null)
                 throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.Map to non-nullable JSON property 'map'.");
+
+            if (mixedPropertiesAndAdditionalPropertiesClass.UuidOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.Uuid == null)
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.Uuid to non-nullable JSON property 'uuid'.");
+
+            if (mixedPropertiesAndAdditionalPropertiesClass.UuidWithPatternOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.UuidWithPattern == null)
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.UuidWithPattern to non-nullable JSON property 'uuid_with_pattern'.");
 
             if (mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.IsSet)
                 writer.WriteString("dateTime", mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.Value!.Value.ToString(DateTimeFormat));

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -258,7 +258,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedPropertiesAndAdditionalPropertiesClass mixedPropertiesAndAdditionalPropertiesClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedPropertiesAndAdditionalPropertiesClass.MapOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.Map == null)
-                throw new ArgumentNullException(nameof(mixedPropertiesAndAdditionalPropertiesClass.Map), "Property is required for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.Map to non-nullable JSON property 'map'.");
 
             if (mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.IsSet)
                 writer.WriteString("dateTime", mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.Value!.Value.ToString(DateTimeFormat));

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedSubId.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedSubId.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedSubId mixedSubId, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedSubId.IdOption.IsSet && mixedSubId.Id == null)
-                throw new ArgumentNullException(nameof(mixedSubId.Id), "Property is required for class MixedSubId.");
+                throw new JsonException("Cannot write null property MixedSubId.Id to non-nullable JSON property 'id'.");
 
             if (mixedSubId.IdOption.IsSet)
                 writer.WriteString("id", mixedSubId.Id);

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -202,6 +202,9 @@ namespace Org.OpenAPITools.Model
             if (model200Response.ClassOption.IsSet && model200Response.Class == null)
                 throw new JsonException("Cannot write null property Model200Response.Class to non-nullable JSON property 'class'.");
 
+            if (model200Response.NameOption.IsSet && model200Response.Name == null)
+                throw new JsonException("Cannot write null property Model200Response.Name to non-nullable JSON property 'name'.");
+
             if (model200Response.ClassOption.IsSet)
                 writer.WriteString("class", model200Response.Class);
 

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -200,7 +200,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Model200Response model200Response, JsonSerializerOptions jsonSerializerOptions)
         {
             if (model200Response.ClassOption.IsSet && model200Response.Class == null)
-                throw new ArgumentNullException(nameof(model200Response.Class), "Property is required for class Model200Response.");
+                throw new JsonException("Cannot write null property Model200Response.Class to non-nullable JSON property 'class'.");
 
             if (model200Response.ClassOption.IsSet)
                 writer.WriteString("class", model200Response.Class);

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ModelClient modelClient, JsonSerializerOptions jsonSerializerOptions)
         {
             if (modelClient.VarClientOption.IsSet && modelClient.VarClient == null)
-                throw new ArgumentNullException(nameof(modelClient.VarClient), "Property is required for class ModelClient.");
+                throw new JsonException("Cannot write null property ModelClient.VarClient to non-nullable JSON property 'client'.");
 
             if (modelClient.VarClientOption.IsSet)
                 writer.WriteString("client", modelClient.VarClient);

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Name.cs
@@ -283,7 +283,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Name name, JsonSerializerOptions jsonSerializerOptions)
         {
             if (name.PropertyOption.IsSet && name.Property == null)
-                throw new ArgumentNullException(nameof(name.Property), "Property is required for class Name.");
+                throw new JsonException("Cannot write null property Name.Property to non-nullable JSON property 'property'.");
 
             writer.WriteNumber("name", name.VarName);
 

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Name.cs
@@ -285,6 +285,12 @@ namespace Org.OpenAPITools.Model
             if (name.PropertyOption.IsSet && name.Property == null)
                 throw new JsonException("Cannot write null property Name.Property to non-nullable JSON property 'property'.");
 
+            if (name.SnakeCaseOption.IsSet && name.SnakeCase == null)
+                throw new JsonException("Cannot write null property Name.SnakeCase to non-nullable JSON property 'snake_case'.");
+
+            if (name.Var123NumberOption.IsSet && name.Var123Number == null)
+                throw new JsonException("Cannot write null property Name.Var123Number to non-nullable JSON property '123Number'.");
+
             writer.WriteNumber("name", name.VarName);
 
             if (name.PropertyOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
@@ -191,9 +191,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, NotificationtestGetElementsV1ResponseMPayload notificationtestGetElementsV1ResponseMPayload, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (notificationtestGetElementsV1ResponseMPayload.AObjVariableobject == null)
-                throw new ArgumentNullException(nameof(notificationtestGetElementsV1ResponseMPayload.AObjVariableobject), "Property is required for class NotificationtestGetElementsV1ResponseMPayload.");
-
             writer.WritePropertyName("a_objVariableobject");
             JsonSerializer.Serialize(writer, notificationtestGetElementsV1ResponseMPayload.AObjVariableobject, jsonSerializerOptions);
             writer.WriteNumber("pkiNotificationtestID", notificationtestGetElementsV1ResponseMPayload.PkiNotificationtestID);

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -410,10 +410,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, NullableClass nullableClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (nullableClass.ArrayItemsNullableOption.IsSet && nullableClass.ArrayItemsNullable == null)
-                throw new ArgumentNullException(nameof(nullableClass.ArrayItemsNullable), "Property is required for class NullableClass.");
+                throw new JsonException("Cannot write null property NullableClass.ArrayItemsNullable to non-nullable JSON property 'array_items_nullable'.");
 
             if (nullableClass.ObjectItemsNullableOption.IsSet && nullableClass.ObjectItemsNullable == null)
-                throw new ArgumentNullException(nameof(nullableClass.ObjectItemsNullable), "Property is required for class NullableClass.");
+                throw new JsonException("Cannot write null property NullableClass.ObjectItemsNullable to non-nullable JSON property 'object_items_nullable'.");
 
             if (nullableClass.ArrayAndItemsNullablePropOption.IsSet)
                 if (nullableClass.ArrayAndItemsNullablePropOption.Value != null)

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -176,6 +176,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, NumberOnly numberOnly, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (numberOnly.JustNumberOption.IsSet && numberOnly.JustNumber == null)
+                throw new JsonException("Cannot write null property NumberOnly.JustNumber to non-nullable JSON property 'JustNumber'.");
+
             if (numberOnly.JustNumberOption.IsSet)
                 writer.WriteNumber("JustNumber", numberOnly.JustNumberOption.Value!.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -254,6 +254,9 @@ namespace Org.OpenAPITools.Model
             if (objectWithDeprecatedFields.DeprecatedRefOption.IsSet && objectWithDeprecatedFields.DeprecatedRef == null)
                 throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.DeprecatedRef to non-nullable JSON property 'deprecatedRef'.");
 
+            if (objectWithDeprecatedFields.IdOption.IsSet && objectWithDeprecatedFields.Id == null)
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Id to non-nullable JSON property 'id'.");
+
             if (objectWithDeprecatedFields.UuidOption.IsSet && objectWithDeprecatedFields.Uuid == null)
                 throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Uuid to non-nullable JSON property 'uuid'.");
 

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -249,13 +249,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ObjectWithDeprecatedFields objectWithDeprecatedFields, JsonSerializerOptions jsonSerializerOptions)
         {
             if (objectWithDeprecatedFields.BarsOption.IsSet && objectWithDeprecatedFields.Bars == null)
-                throw new ArgumentNullException(nameof(objectWithDeprecatedFields.Bars), "Property is required for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Bars to non-nullable JSON property 'bars'.");
 
             if (objectWithDeprecatedFields.DeprecatedRefOption.IsSet && objectWithDeprecatedFields.DeprecatedRef == null)
-                throw new ArgumentNullException(nameof(objectWithDeprecatedFields.DeprecatedRef), "Property is required for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.DeprecatedRef to non-nullable JSON property 'deprecatedRef'.");
 
             if (objectWithDeprecatedFields.UuidOption.IsSet && objectWithDeprecatedFields.Uuid == null)
-                throw new ArgumentNullException(nameof(objectWithDeprecatedFields.Uuid), "Property is required for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Uuid to non-nullable JSON property 'uuid'.");
 
             if (objectWithDeprecatedFields.BarsOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Order.cs
@@ -386,6 +386,24 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Order order, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (order.CompleteOption.IsSet && order.Complete == null)
+                throw new JsonException("Cannot write null property Order.Complete to non-nullable JSON property 'complete'.");
+
+            if (order.IdOption.IsSet && order.Id == null)
+                throw new JsonException("Cannot write null property Order.Id to non-nullable JSON property 'id'.");
+
+            if (order.PetIdOption.IsSet && order.PetId == null)
+                throw new JsonException("Cannot write null property Order.PetId to non-nullable JSON property 'petId'.");
+
+            if (order.QuantityOption.IsSet && order.Quantity == null)
+                throw new JsonException("Cannot write null property Order.Quantity to non-nullable JSON property 'quantity'.");
+
+            if (order.ShipDateOption.IsSet && order.ShipDate == null)
+                throw new JsonException("Cannot write null property Order.ShipDate to non-nullable JSON property 'shipDate'.");
+
+            if (order.StatusOption.IsSet && order.Status == null)
+                throw new JsonException("Cannot write null property Order.Status to non-nullable JSON property 'status'.");
+
             if (order.CompleteOption.IsSet)
                 writer.WriteBoolean("complete", order.CompleteOption.Value!.Value);
 

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -223,7 +223,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, OuterComposite outerComposite, JsonSerializerOptions jsonSerializerOptions)
         {
             if (outerComposite.MyStringOption.IsSet && outerComposite.MyString == null)
-                throw new ArgumentNullException(nameof(outerComposite.MyString), "Property is required for class OuterComposite.");
+                throw new JsonException("Cannot write null property OuterComposite.MyString to non-nullable JSON property 'my_string'.");
 
             if (outerComposite.MyBooleanOption.IsSet)
                 writer.WriteBoolean("my_boolean", outerComposite.MyBooleanOption.Value!.Value);

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -222,6 +222,12 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, OuterComposite outerComposite, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (outerComposite.MyBooleanOption.IsSet && outerComposite.MyBoolean == null)
+                throw new JsonException("Cannot write null property OuterComposite.MyBoolean to non-nullable JSON property 'my_boolean'.");
+
+            if (outerComposite.MyNumberOption.IsSet && outerComposite.MyNumber == null)
+                throw new JsonException("Cannot write null property OuterComposite.MyNumber to non-nullable JSON property 'my_number'.");
+
             if (outerComposite.MyStringOption.IsSet && outerComposite.MyString == null)
                 throw new JsonException("Cannot write null property OuterComposite.MyString to non-nullable JSON property 'my_string'.");
 

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Pet.cs
@@ -376,6 +376,12 @@ namespace Org.OpenAPITools.Model
             if (pet.CategoryOption.IsSet && pet.Category == null)
                 throw new JsonException("Cannot write null property Pet.Category to non-nullable JSON property 'category'.");
 
+            if (pet.IdOption.IsSet && pet.Id == null)
+                throw new JsonException("Cannot write null property Pet.Id to non-nullable JSON property 'id'.");
+
+            if (pet.StatusOption.IsSet && pet.Status == null)
+                throw new JsonException("Cannot write null property Pet.Status to non-nullable JSON property 'status'.");
+
             if (pet.TagsOption.IsSet && pet.Tags == null)
                 throw new JsonException("Cannot write null property Pet.Tags to non-nullable JSON property 'tags'.");
 

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Pet.cs
@@ -373,17 +373,11 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Pet pet, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (pet.Name == null)
-                throw new ArgumentNullException(nameof(pet.Name), "Property is required for class Pet.");
-
-            if (pet.PhotoUrls == null)
-                throw new ArgumentNullException(nameof(pet.PhotoUrls), "Property is required for class Pet.");
-
             if (pet.CategoryOption.IsSet && pet.Category == null)
-                throw new ArgumentNullException(nameof(pet.Category), "Property is required for class Pet.");
+                throw new JsonException("Cannot write null property Pet.Category to non-nullable JSON property 'category'.");
 
             if (pet.TagsOption.IsSet && pet.Tags == null)
-                throw new ArgumentNullException(nameof(pet.Tags), "Property is required for class Pet.");
+                throw new JsonException("Cannot write null property Pet.Tags to non-nullable JSON property 'tags'.");
 
             writer.WriteString("name", pet.Name);
 

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
@@ -172,9 +172,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, QuadrilateralInterface quadrilateralInterface, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (quadrilateralInterface.QuadrilateralType == null)
-                throw new ArgumentNullException(nameof(quadrilateralInterface.QuadrilateralType), "Property is required for class QuadrilateralInterface.");
-
             writer.WriteString("quadrilateralType", quadrilateralInterface.QuadrilateralType);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -238,10 +238,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ReadOnlyFirst readOnlyFirst, JsonSerializerOptions jsonSerializerOptions)
         {
             if (readOnlyFirst.BarOption.IsSet && readOnlyFirst.Bar == null)
-                throw new ArgumentNullException(nameof(readOnlyFirst.Bar), "Property is required for class ReadOnlyFirst.");
+                throw new JsonException("Cannot write null property ReadOnlyFirst.Bar to non-nullable JSON property 'bar'.");
 
             if (readOnlyFirst.BazOption.IsSet && readOnlyFirst.Baz == null)
-                throw new ArgumentNullException(nameof(readOnlyFirst.Baz), "Property is required for class ReadOnlyFirst.");
+                throw new JsonException("Cannot write null property ReadOnlyFirst.Baz to non-nullable JSON property 'baz'.");
 
             if (readOnlyFirst.BarOption.IsSet)
                 writer.WriteString("bar", readOnlyFirst.Bar);

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -2237,17 +2237,11 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, RequiredClass requiredClass, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (requiredClass.RequiredNotnullableArrayOfString == null)
-                throw new ArgumentNullException(nameof(requiredClass.RequiredNotnullableArrayOfString), "Property is required for class RequiredClass.");
-
-            if (requiredClass.RequiredNotnullableStringProp == null)
-                throw new ArgumentNullException(nameof(requiredClass.RequiredNotnullableStringProp), "Property is required for class RequiredClass.");
-
             if (requiredClass.NotrequiredNotnullableArrayOfStringOption.IsSet && requiredClass.NotrequiredNotnullableArrayOfString == null)
-                throw new ArgumentNullException(nameof(requiredClass.NotrequiredNotnullableArrayOfString), "Property is required for class RequiredClass.");
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableArrayOfString to non-nullable JSON property 'notrequired_notnullable_array_of_string'.");
 
             if (requiredClass.NotrequiredNotnullableStringPropOption.IsSet && requiredClass.NotrequiredNotnullableStringProp == null)
-                throw new ArgumentNullException(nameof(requiredClass.NotrequiredNotnullableStringProp), "Property is required for class RequiredClass.");
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableStringProp to non-nullable JSON property 'notrequired_notnullable_string_prop'.");
 
             writer.WriteString("required_not_nullable_date_prop", requiredClass.RequiredNotNullableDateProp.ToString(RequiredNotNullableDatePropFormat));
 

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -2237,11 +2237,38 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, RequiredClass requiredClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (requiredClass.NotRequiredNotnullableDatePropOption.IsSet && requiredClass.NotRequiredNotnullableDateProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotRequiredNotnullableDateProp to non-nullable JSON property 'not_required_notnullable_date_prop'.");
+
+            if (requiredClass.NotRequiredNotnullableintegerPropOption.IsSet && requiredClass.NotRequiredNotnullableintegerProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotRequiredNotnullableintegerProp to non-nullable JSON property 'not_required_notnullableinteger_prop'.");
+
             if (requiredClass.NotrequiredNotnullableArrayOfStringOption.IsSet && requiredClass.NotrequiredNotnullableArrayOfString == null)
                 throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableArrayOfString to non-nullable JSON property 'notrequired_notnullable_array_of_string'.");
 
+            if (requiredClass.NotrequiredNotnullableBooleanPropOption.IsSet && requiredClass.NotrequiredNotnullableBooleanProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableBooleanProp to non-nullable JSON property 'notrequired_notnullable_boolean_prop'.");
+
+            if (requiredClass.NotrequiredNotnullableDatetimePropOption.IsSet && requiredClass.NotrequiredNotnullableDatetimeProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableDatetimeProp to non-nullable JSON property 'notrequired_notnullable_datetime_prop'.");
+
+            if (requiredClass.NotrequiredNotnullableEnumIntegerOption.IsSet && requiredClass.NotrequiredNotnullableEnumInteger == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableEnumInteger to non-nullable JSON property 'notrequired_notnullable_enum_integer'.");
+
+            if (requiredClass.NotrequiredNotnullableEnumIntegerOnlyOption.IsSet && requiredClass.NotrequiredNotnullableEnumIntegerOnly == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableEnumIntegerOnly to non-nullable JSON property 'notrequired_notnullable_enum_integer_only'.");
+
+            if (requiredClass.NotrequiredNotnullableEnumStringOption.IsSet && requiredClass.NotrequiredNotnullableEnumString == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableEnumString to non-nullable JSON property 'notrequired_notnullable_enum_string'.");
+
+            if (requiredClass.NotrequiredNotnullableOuterEnumDefaultValueOption.IsSet && requiredClass.NotrequiredNotnullableOuterEnumDefaultValue == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableOuterEnumDefaultValue to non-nullable JSON property 'notrequired_notnullable_outerEnumDefaultValue'.");
+
             if (requiredClass.NotrequiredNotnullableStringPropOption.IsSet && requiredClass.NotrequiredNotnullableStringProp == null)
                 throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableStringProp to non-nullable JSON property 'notrequired_notnullable_string_prop'.");
+
+            if (requiredClass.NotrequiredNotnullableUuidOption.IsSet && requiredClass.NotrequiredNotnullableUuid == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableUuid to non-nullable JSON property 'notrequired_notnullable_uuid'.");
 
             writer.WriteString("required_not_nullable_date_prop", requiredClass.RequiredNotNullableDateProp.ToString(RequiredNotNullableDatePropFormat));
 

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Result.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Result.cs
@@ -226,13 +226,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Result result, JsonSerializerOptions jsonSerializerOptions)
         {
             if (result.CodeOption.IsSet && result.Code == null)
-                throw new ArgumentNullException(nameof(result.Code), "Property is required for class Result.");
+                throw new JsonException("Cannot write null property Result.Code to non-nullable JSON property 'code'.");
 
             if (result.DataOption.IsSet && result.Data == null)
-                throw new ArgumentNullException(nameof(result.Data), "Property is required for class Result.");
+                throw new JsonException("Cannot write null property Result.Data to non-nullable JSON property 'data'.");
 
             if (result.UuidOption.IsSet && result.Uuid == null)
-                throw new ArgumentNullException(nameof(result.Uuid), "Property is required for class Result.");
+                throw new JsonException("Cannot write null property Result.Uuid to non-nullable JSON property 'uuid'.");
 
             if (result.CodeOption.IsSet)
                 writer.WriteString("code", result.Code);

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Return.cs
@@ -234,11 +234,8 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Return varReturn, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (varReturn.Lock == null)
-                throw new ArgumentNullException(nameof(varReturn.Lock), "Property is required for class Return.");
-
             if (varReturn.UnsafeOption.IsSet && varReturn.Unsafe == null)
-                throw new ArgumentNullException(nameof(varReturn.Unsafe), "Property is required for class Return.");
+                throw new JsonException("Cannot write null property Return.Unsafe to non-nullable JSON property 'unsafe'.");
 
             writer.WriteString("lock", varReturn.Lock);
 

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Return.cs
@@ -234,6 +234,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Return varReturn, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (varReturn.VarReturnOption.IsSet && varReturn.VarReturn == null)
+                throw new JsonException("Cannot write null property Return.VarReturn to non-nullable JSON property 'return'.");
+
             if (varReturn.UnsafeOption.IsSet && varReturn.Unsafe == null)
                 throw new JsonException("Cannot write null property Return.Unsafe to non-nullable JSON property 'unsafe'.");
 

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -200,7 +200,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, RolesReportsHash rolesReportsHash, JsonSerializerOptions jsonSerializerOptions)
         {
             if (rolesReportsHash.RoleOption.IsSet && rolesReportsHash.Role == null)
-                throw new ArgumentNullException(nameof(rolesReportsHash.Role), "Property is required for class RolesReportsHash.");
+                throw new JsonException("Cannot write null property RolesReportsHash.Role to non-nullable JSON property 'role'.");
 
             if (rolesReportsHash.RoleOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -202,6 +202,9 @@ namespace Org.OpenAPITools.Model
             if (rolesReportsHash.RoleOption.IsSet && rolesReportsHash.Role == null)
                 throw new JsonException("Cannot write null property RolesReportsHash.Role to non-nullable JSON property 'role'.");
 
+            if (rolesReportsHash.RoleUuidOption.IsSet && rolesReportsHash.RoleUuid == null)
+                throw new JsonException("Cannot write null property RolesReportsHash.RoleUuid to non-nullable JSON property 'role_uuid'.");
+
             if (rolesReportsHash.RoleOption.IsSet)
             {
                 writer.WritePropertyName("role");

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, RolesReportsHashRole rolesReportsHashRole, JsonSerializerOptions jsonSerializerOptions)
         {
             if (rolesReportsHashRole.NameOption.IsSet && rolesReportsHashRole.Name == null)
-                throw new ArgumentNullException(nameof(rolesReportsHashRole.Name), "Property is required for class RolesReportsHashRole.");
+                throw new JsonException("Cannot write null property RolesReportsHashRole.Name to non-nullable JSON property 'name'.");
 
             if (rolesReportsHashRole.NameOption.IsSet)
                 writer.WriteString("name", rolesReportsHashRole.Name);

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
@@ -191,12 +191,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ScaleneTriangle scaleneTriangle, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (scaleneTriangle.ShapeType == null)
-                throw new ArgumentNullException(nameof(scaleneTriangle.ShapeType), "Property is required for class ScaleneTriangle.");
-
-            if (scaleneTriangle.TriangleType == null)
-                throw new ArgumentNullException(nameof(scaleneTriangle.TriangleType), "Property is required for class ScaleneTriangle.");
-
             writer.WriteString("shapeType", scaleneTriangle.ShapeType);
 
             writer.WriteString("triangleType", scaleneTriangle.TriangleType);

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ShapeInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ShapeInterface.cs
@@ -172,9 +172,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ShapeInterface shapeInterface, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (shapeInterface.ShapeType == null)
-                throw new ArgumentNullException(nameof(shapeInterface.ShapeType), "Property is required for class ShapeInterface.");
-
             writer.WriteString("shapeType", shapeInterface.ShapeType);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
@@ -191,12 +191,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, SimpleQuadrilateral simpleQuadrilateral, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (simpleQuadrilateral.QuadrilateralType == null)
-                throw new ArgumentNullException(nameof(simpleQuadrilateral.QuadrilateralType), "Property is required for class SimpleQuadrilateral.");
-
-            if (simpleQuadrilateral.ShapeType == null)
-                throw new ArgumentNullException(nameof(simpleQuadrilateral.ShapeType), "Property is required for class SimpleQuadrilateral.");
-
             writer.WriteString("quadrilateralType", simpleQuadrilateral.QuadrilateralType);
 
             writer.WriteString("shapeType", simpleQuadrilateral.ShapeType);

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -202,6 +202,9 @@ namespace Org.OpenAPITools.Model
             if (specialModelName.VarSpecialModelNameOption.IsSet && specialModelName.VarSpecialModelName == null)
                 throw new JsonException("Cannot write null property SpecialModelName.VarSpecialModelName to non-nullable JSON property '_special_model.name_'.");
 
+            if (specialModelName.SpecialPropertyNameOption.IsSet && specialModelName.SpecialPropertyName == null)
+                throw new JsonException("Cannot write null property SpecialModelName.SpecialPropertyName to non-nullable JSON property '$special[property.name]'.");
+
             if (specialModelName.VarSpecialModelNameOption.IsSet)
                 writer.WriteString("_special_model.name_", specialModelName.VarSpecialModelName);
 

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -200,7 +200,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, SpecialModelName specialModelName, JsonSerializerOptions jsonSerializerOptions)
         {
             if (specialModelName.VarSpecialModelNameOption.IsSet && specialModelName.VarSpecialModelName == null)
-                throw new ArgumentNullException(nameof(specialModelName.VarSpecialModelName), "Property is required for class SpecialModelName.");
+                throw new JsonException("Cannot write null property SpecialModelName.VarSpecialModelName to non-nullable JSON property '_special_model.name_'.");
 
             if (specialModelName.VarSpecialModelNameOption.IsSet)
                 writer.WriteString("_special_model.name_", specialModelName.VarSpecialModelName);

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Tag.cs
@@ -199,6 +199,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Tag tag, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (tag.IdOption.IsSet && tag.Id == null)
+                throw new JsonException("Cannot write null property Tag.Id to non-nullable JSON property 'id'.");
+
             if (tag.NameOption.IsSet && tag.Name == null)
                 throw new JsonException("Cannot write null property Tag.Name to non-nullable JSON property 'name'.");
 

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Tag.cs
@@ -200,7 +200,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Tag tag, JsonSerializerOptions jsonSerializerOptions)
         {
             if (tag.NameOption.IsSet && tag.Name == null)
-                throw new ArgumentNullException(nameof(tag.Name), "Property is required for class Tag.");
+                throw new JsonException("Cannot write null property Tag.Name to non-nullable JSON property 'name'.");
 
             if (tag.IdOption.IsSet)
                 writer.WriteNumber("id", tag.IdOption.Value!.Value);

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestCollectionEndingWithWordList testCollectionEndingWithWordList, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testCollectionEndingWithWordList.ValueOption.IsSet && testCollectionEndingWithWordList.Value == null)
-                throw new ArgumentNullException(nameof(testCollectionEndingWithWordList.Value), "Property is required for class TestCollectionEndingWithWordList.");
+                throw new JsonException("Cannot write null property TestCollectionEndingWithWordList.Value to non-nullable JSON property 'value'.");
 
             if (testCollectionEndingWithWordList.ValueOption.IsSet)
                 writer.WriteString("value", testCollectionEndingWithWordList.Value);

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestCollectionEndingWithWordListObject testCollectionEndingWithWordListObject, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testCollectionEndingWithWordListObject.TestCollectionEndingWithWordListOption.IsSet && testCollectionEndingWithWordListObject.TestCollectionEndingWithWordList == null)
-                throw new ArgumentNullException(nameof(testCollectionEndingWithWordListObject.TestCollectionEndingWithWordList), "Property is required for class TestCollectionEndingWithWordListObject.");
+                throw new JsonException("Cannot write null property TestCollectionEndingWithWordListObject.TestCollectionEndingWithWordList to non-nullable JSON property 'TestCollectionEndingWithWordList'.");
 
             if (testCollectionEndingWithWordListObject.TestCollectionEndingWithWordListOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/TestDescendants.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/TestDescendants.cs
@@ -291,9 +291,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, TestDescendants testDescendants, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (testDescendants.AlternativeName == null)
-                throw new ArgumentNullException(nameof(testDescendants.AlternativeName), "Property is required for class TestDescendants.");
-
             writer.WriteString("alternativeName", testDescendants.AlternativeName);
 
             writer.WriteString("objectType", TestDescendants.ObjectTypeEnumToJsonValue(testDescendants.ObjectType));

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestInlineFreeformAdditionalPropertiesRequest testInlineFreeformAdditionalPropertiesRequest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testInlineFreeformAdditionalPropertiesRequest.SomePropertyOption.IsSet && testInlineFreeformAdditionalPropertiesRequest.SomeProperty == null)
-                throw new ArgumentNullException(nameof(testInlineFreeformAdditionalPropertiesRequest.SomeProperty), "Property is required for class TestInlineFreeformAdditionalPropertiesRequest.");
+                throw new JsonException("Cannot write null property TestInlineFreeformAdditionalPropertiesRequest.SomeProperty to non-nullable JSON property 'someProperty'.");
 
             if (testInlineFreeformAdditionalPropertiesRequest.SomePropertyOption.IsSet)
                 writer.WriteString("someProperty", testInlineFreeformAdditionalPropertiesRequest.SomeProperty);

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/TestResult.cs
@@ -224,6 +224,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, TestResult testResult, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (testResult.CodeOption.IsSet && testResult.Code == null)
+                throw new JsonException("Cannot write null property TestResult.Code to non-nullable JSON property 'code'.");
+
             if (testResult.DataOption.IsSet && testResult.Data == null)
                 throw new JsonException("Cannot write null property TestResult.Data to non-nullable JSON property 'data'.");
 

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/TestResult.cs
@@ -225,10 +225,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestResult testResult, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testResult.DataOption.IsSet && testResult.Data == null)
-                throw new ArgumentNullException(nameof(testResult.Data), "Property is required for class TestResult.");
+                throw new JsonException("Cannot write null property TestResult.Data to non-nullable JSON property 'data'.");
 
             if (testResult.UuidOption.IsSet && testResult.Uuid == null)
-                throw new ArgumentNullException(nameof(testResult.Uuid), "Property is required for class TestResult.");
+                throw new JsonException("Cannot write null property TestResult.Uuid to non-nullable JSON property 'uuid'.");
 
             if (testResult.CodeOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/TriangleInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/TriangleInterface.cs
@@ -172,9 +172,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, TriangleInterface triangleInterface, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (triangleInterface.TriangleType == null)
-                throw new ArgumentNullException(nameof(triangleInterface.TriangleType), "Property is required for class TriangleInterface.");
-
             writer.WriteString("triangleType", triangleInterface.TriangleType);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/User.cs
@@ -431,6 +431,9 @@ namespace Org.OpenAPITools.Model
             if (user.FirstNameOption.IsSet && user.FirstName == null)
                 throw new JsonException("Cannot write null property User.FirstName to non-nullable JSON property 'firstName'.");
 
+            if (user.IdOption.IsSet && user.Id == null)
+                throw new JsonException("Cannot write null property User.Id to non-nullable JSON property 'id'.");
+
             if (user.LastNameOption.IsSet && user.LastName == null)
                 throw new JsonException("Cannot write null property User.LastName to non-nullable JSON property 'lastName'.");
 
@@ -442,6 +445,9 @@ namespace Org.OpenAPITools.Model
 
             if (user.PhoneOption.IsSet && user.Phone == null)
                 throw new JsonException("Cannot write null property User.Phone to non-nullable JSON property 'phone'.");
+
+            if (user.UserStatusOption.IsSet && user.UserStatus == null)
+                throw new JsonException("Cannot write null property User.UserStatus to non-nullable JSON property 'userStatus'.");
 
             if (user.UsernameOption.IsSet && user.Username == null)
                 throw new JsonException("Cannot write null property User.Username to non-nullable JSON property 'username'.");

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/User.cs
@@ -426,25 +426,25 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, User user, JsonSerializerOptions jsonSerializerOptions)
         {
             if (user.EmailOption.IsSet && user.Email == null)
-                throw new ArgumentNullException(nameof(user.Email), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Email to non-nullable JSON property 'email'.");
 
             if (user.FirstNameOption.IsSet && user.FirstName == null)
-                throw new ArgumentNullException(nameof(user.FirstName), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.FirstName to non-nullable JSON property 'firstName'.");
 
             if (user.LastNameOption.IsSet && user.LastName == null)
-                throw new ArgumentNullException(nameof(user.LastName), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.LastName to non-nullable JSON property 'lastName'.");
 
             if (user.ObjectWithNoDeclaredPropsOption.IsSet && user.ObjectWithNoDeclaredProps == null)
-                throw new ArgumentNullException(nameof(user.ObjectWithNoDeclaredProps), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.ObjectWithNoDeclaredProps to non-nullable JSON property 'objectWithNoDeclaredProps'.");
 
             if (user.PasswordOption.IsSet && user.Password == null)
-                throw new ArgumentNullException(nameof(user.Password), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Password to non-nullable JSON property 'password'.");
 
             if (user.PhoneOption.IsSet && user.Phone == null)
-                throw new ArgumentNullException(nameof(user.Phone), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Phone to non-nullable JSON property 'phone'.");
 
             if (user.UsernameOption.IsSet && user.Username == null)
-                throw new ArgumentNullException(nameof(user.Username), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Username to non-nullable JSON property 'username'.");
 
             if (user.AnyTypePropOption.IsSet)
                 if (user.AnyTypePropOption.Value != null)

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Whale.cs
@@ -218,6 +218,12 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Whale whale, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (whale.HasBaleenOption.IsSet && whale.HasBaleen == null)
+                throw new JsonException("Cannot write null property Whale.HasBaleen to non-nullable JSON property 'hasBaleen'.");
+
+            if (whale.HasTeethOption.IsSet && whale.HasTeeth == null)
+                throw new JsonException("Cannot write null property Whale.HasTeeth to non-nullable JSON property 'hasTeeth'.");
+
             writer.WriteString("className", whale.ClassName);
 
             if (whale.HasBaleenOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Whale.cs
@@ -218,9 +218,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Whale whale, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (whale.ClassName == null)
-                throw new ArgumentNullException(nameof(whale.ClassName), "Property is required for class Whale.");
-
             writer.WriteString("className", whale.ClassName);
 
             if (whale.HasBaleenOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Zebra.cs
@@ -282,6 +282,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Zebra zebra, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (zebra.TypeOption.IsSet && zebra.Type == null)
+                throw new JsonException("Cannot write null property Zebra.Type to non-nullable JSON property 'type'.");
+
             writer.WriteString("className", zebra.ClassName);
 
             var typeRawValue = Zebra.TypeEnumToJsonValue(zebra.TypeOption.Value!.Value);

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Zebra.cs
@@ -282,9 +282,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Zebra zebra, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (zebra.ClassName == null)
-                throw new ArgumentNullException(nameof(zebra.ClassName), "Property is required for class Zebra.");
-
             writer.WriteString("className", zebra.ClassName);
 
             var typeRawValue = Zebra.TypeEnumToJsonValue(zebra.TypeOption.Value!.Value);

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
@@ -249,6 +249,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ZeroBasedEnumClass zeroBasedEnumClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (zeroBasedEnumClass.ZeroBasedEnumOption.IsSet && zeroBasedEnumClass.ZeroBasedEnum == null)
+                throw new JsonException("Cannot write null property ZeroBasedEnumClass.ZeroBasedEnum to non-nullable JSON property 'ZeroBasedEnum'.");
+
             var zeroBasedEnumRawValue = ZeroBasedEnumClass.ZeroBasedEnumEnumToJsonValue(zeroBasedEnumClass.ZeroBasedEnumOption.Value!.Value);
             writer.WriteString("ZeroBasedEnum", zeroBasedEnumRawValue);
         }

--- a/samples/client/petstore/csharp/generichost/net8/OneOf/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net8/OneOf/src/Org.OpenAPITools/Model/Apple.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Apple apple, JsonSerializerOptions jsonSerializerOptions)
         {
             if (apple.KindOption.IsSet && apple.Kind == null)
-                throw new ArgumentNullException(nameof(apple.Kind), "Property is required for class Apple.");
+                throw new JsonException("Cannot write null property Apple.Kind to non-nullable JSON property 'kind'.");
 
             if (apple.KindOption.IsSet)
                 writer.WriteString("kind", apple.Kind);

--- a/samples/client/petstore/csharp/generichost/net8/OneOf/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net8/OneOf/src/Org.OpenAPITools/Model/Banana.cs
@@ -176,6 +176,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Banana banana, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (banana.CountOption.IsSet && banana.Count == null)
+                throw new JsonException("Cannot write null property Banana.Count to non-nullable JSON property 'count'.");
+
             if (banana.CountOption.IsSet)
                 writer.WriteNumber("count", banana.CountOption.Value!.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net8/OneOf/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net8/OneOf/src/Org.OpenAPITools/Model/Fruit.cs
@@ -252,7 +252,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Fruit fruit, JsonSerializerOptions jsonSerializerOptions)
         {
             if (fruit.ColorOption.IsSet && fruit.Color == null)
-                throw new ArgumentNullException(nameof(fruit.Color), "Property is required for class Fruit.");
+                throw new JsonException("Cannot write null property Fruit.Color to non-nullable JSON property 'color'.");
 
             if (fruit.ColorOption.IsSet)
                 writer.WriteString("color", fruit.Color);

--- a/samples/client/petstore/csharp/generichost/net8/OneOf/src/Org.OpenAPITools/Model/Orange.cs
+++ b/samples/client/petstore/csharp/generichost/net8/OneOf/src/Org.OpenAPITools/Model/Orange.cs
@@ -176,6 +176,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Orange orange, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (orange.SweetOption.IsSet && orange.Sweet == null)
+                throw new JsonException("Cannot write null property Orange.Sweet to non-nullable JSON property 'sweet'.");
+
             if (orange.SweetOption.IsSet)
                 writer.WriteBoolean("sweet", orange.SweetOption.Value!.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Activity.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Activity activity, JsonSerializerOptions jsonSerializerOptions)
         {
             if (activity.ActivityOutputsOption.IsSet && activity.ActivityOutputs == null)
-                throw new ArgumentNullException(nameof(activity.ActivityOutputs), "Property is required for class Activity.");
+                throw new JsonException("Cannot write null property Activity.ActivityOutputs to non-nullable JSON property 'activity_outputs'.");
 
             if (activity.ActivityOutputsOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -198,10 +198,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ActivityOutputElementRepresentation activityOutputElementRepresentation, JsonSerializerOptions jsonSerializerOptions)
         {
             if (activityOutputElementRepresentation.Prop1Option.IsSet && activityOutputElementRepresentation.Prop1 == null)
-                throw new ArgumentNullException(nameof(activityOutputElementRepresentation.Prop1), "Property is required for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Cannot write null property ActivityOutputElementRepresentation.Prop1 to non-nullable JSON property 'prop1'.");
 
             if (activityOutputElementRepresentation.Prop2Option.IsSet && activityOutputElementRepresentation.Prop2 == null)
-                throw new ArgumentNullException(nameof(activityOutputElementRepresentation.Prop2), "Property is required for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Cannot write null property ActivityOutputElementRepresentation.Prop2 to non-nullable JSON property 'prop2'.");
 
             if (activityOutputElementRepresentation.Prop1Option.IsSet)
                 writer.WriteString("prop1", activityOutputElementRepresentation.Prop1);

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -334,25 +334,25 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, AdditionalPropertiesClass additionalPropertiesClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (additionalPropertiesClass.EmptyMapOption.IsSet && additionalPropertiesClass.EmptyMap == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.EmptyMap), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.EmptyMap to non-nullable JSON property 'empty_map'.");
 
             if (additionalPropertiesClass.MapOfMapPropertyOption.IsSet && additionalPropertiesClass.MapOfMapProperty == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapOfMapProperty), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapOfMapProperty to non-nullable JSON property 'map_of_map_property'.");
 
             if (additionalPropertiesClass.MapPropertyOption.IsSet && additionalPropertiesClass.MapProperty == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapProperty), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapProperty to non-nullable JSON property 'map_property'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1Option.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1 == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1 to non-nullable JSON property 'map_with_undeclared_properties_anytype_1'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2Option.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2 == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2 to non-nullable JSON property 'map_with_undeclared_properties_anytype_2'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3Option.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3 == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3 to non-nullable JSON property 'map_with_undeclared_properties_anytype_3'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesStringOption.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesString == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesString), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesString to non-nullable JSON property 'map_with_undeclared_properties_string'.");
 
             if (additionalPropertiesClass.Anytype1Option.IsSet)
                 if (additionalPropertiesClass.Anytype1Option.Value != null)

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Animal.cs
@@ -221,7 +221,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Animal animal, JsonSerializerOptions jsonSerializerOptions)
         {
             if (animal.ColorOption.IsSet && animal.Color == null)
-                throw new ArgumentNullException(nameof(animal.Color), "Property is required for class Animal.");
+                throw new JsonException("Cannot write null property Animal.Color to non-nullable JSON property 'color'.");
 
             writer.WriteString("className", animal.ClassName);
 

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -221,10 +221,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ApiResponse apiResponse, JsonSerializerOptions jsonSerializerOptions)
         {
             if (apiResponse.MessageOption.IsSet && apiResponse.Message == null)
-                throw new ArgumentNullException(nameof(apiResponse.Message), "Property is required for class ApiResponse.");
+                throw new JsonException("Cannot write null property ApiResponse.Message to non-nullable JSON property 'message'.");
 
             if (apiResponse.TypeOption.IsSet && apiResponse.Type == null)
-                throw new ArgumentNullException(nameof(apiResponse.Type), "Property is required for class ApiResponse.");
+                throw new JsonException("Cannot write null property ApiResponse.Type to non-nullable JSON property 'type'.");
 
             if (apiResponse.CodeOption.IsSet)
                 writer.WriteNumber("code", apiResponse.CodeOption.Value.Value);

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -220,6 +220,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ApiResponse apiResponse, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (apiResponse.CodeOption.IsSet && apiResponse.Code == null)
+                throw new JsonException("Cannot write null property ApiResponse.Code to non-nullable JSON property 'code'.");
+
             if (apiResponse.MessageOption.IsSet && apiResponse.Message == null)
                 throw new JsonException("Cannot write null property ApiResponse.Message to non-nullable JSON property 'message'.");
 

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Apple.cs
@@ -251,13 +251,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Apple apple, JsonSerializerOptions jsonSerializerOptions)
         {
             if (apple.ColorCodeOption.IsSet && apple.ColorCode == null)
-                throw new ArgumentNullException(nameof(apple.ColorCode), "Property is required for class Apple.");
+                throw new JsonException("Cannot write null property Apple.ColorCode to non-nullable JSON property 'color_code'.");
 
             if (apple.CultivarOption.IsSet && apple.Cultivar == null)
-                throw new ArgumentNullException(nameof(apple.Cultivar), "Property is required for class Apple.");
+                throw new JsonException("Cannot write null property Apple.Cultivar to non-nullable JSON property 'cultivar'.");
 
             if (apple.OriginOption.IsSet && apple.Origin == null)
-                throw new ArgumentNullException(nameof(apple.Origin), "Property is required for class Apple.");
+                throw new JsonException("Cannot write null property Apple.Origin to non-nullable JSON property 'origin'.");
 
             if (apple.ColorCodeOption.IsSet)
                 writer.WriteString("color_code", apple.ColorCode);

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -186,9 +186,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, AppleReq appleReq, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (appleReq.Cultivar == null)
-                throw new ArgumentNullException(nameof(appleReq.Cultivar), "Property is required for class AppleReq.");
-
             writer.WriteString("cultivar", appleReq.Cultivar);
 
             if (appleReq.MealyOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -186,6 +186,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, AppleReq appleReq, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (appleReq.MealyOption.IsSet && appleReq.Mealy == null)
+                throw new JsonException("Cannot write null property AppleReq.Mealy to non-nullable JSON property 'mealy'.");
+
             writer.WriteString("cultivar", appleReq.Cultivar);
 
             if (appleReq.MealyOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ArrayOfArrayOfNumberOnly arrayOfArrayOfNumberOnly, JsonSerializerOptions jsonSerializerOptions)
         {
             if (arrayOfArrayOfNumberOnly.ArrayArrayNumberOption.IsSet && arrayOfArrayOfNumberOnly.ArrayArrayNumber == null)
-                throw new ArgumentNullException(nameof(arrayOfArrayOfNumberOnly.ArrayArrayNumber), "Property is required for class ArrayOfArrayOfNumberOnly.");
+                throw new JsonException("Cannot write null property ArrayOfArrayOfNumberOnly.ArrayArrayNumber to non-nullable JSON property 'ArrayArrayNumber'.");
 
             if (arrayOfArrayOfNumberOnly.ArrayArrayNumberOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ArrayOfNumberOnly arrayOfNumberOnly, JsonSerializerOptions jsonSerializerOptions)
         {
             if (arrayOfNumberOnly.ArrayNumberOption.IsSet && arrayOfNumberOnly.ArrayNumber == null)
-                throw new ArgumentNullException(nameof(arrayOfNumberOnly.ArrayNumber), "Property is required for class ArrayOfNumberOnly.");
+                throw new JsonException("Cannot write null property ArrayOfNumberOnly.ArrayNumber to non-nullable JSON property 'ArrayNumber'.");
 
             if (arrayOfNumberOnly.ArrayNumberOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -221,13 +221,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ArrayTest arrayTest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (arrayTest.ArrayArrayOfIntegerOption.IsSet && arrayTest.ArrayArrayOfInteger == null)
-                throw new ArgumentNullException(nameof(arrayTest.ArrayArrayOfInteger), "Property is required for class ArrayTest.");
+                throw new JsonException("Cannot write null property ArrayTest.ArrayArrayOfInteger to non-nullable JSON property 'array_array_of_integer'.");
 
             if (arrayTest.ArrayArrayOfModelOption.IsSet && arrayTest.ArrayArrayOfModel == null)
-                throw new ArgumentNullException(nameof(arrayTest.ArrayArrayOfModel), "Property is required for class ArrayTest.");
+                throw new JsonException("Cannot write null property ArrayTest.ArrayArrayOfModel to non-nullable JSON property 'array_array_of_model'.");
 
             if (arrayTest.ArrayOfStringOption.IsSet && arrayTest.ArrayOfString == null)
-                throw new ArgumentNullException(nameof(arrayTest.ArrayOfString), "Property is required for class ArrayTest.");
+                throw new JsonException("Cannot write null property ArrayTest.ArrayOfString to non-nullable JSON property 'array_of_string'.");
 
             if (arrayTest.ArrayArrayOfIntegerOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Banana.cs
@@ -174,6 +174,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Banana banana, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (banana.LengthCmOption.IsSet && banana.LengthCm == null)
+                throw new JsonException("Cannot write null property Banana.LengthCm to non-nullable JSON property 'lengthCm'.");
+
             if (banana.LengthCmOption.IsSet)
                 writer.WriteNumber("lengthCm", banana.LengthCmOption.Value.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -186,6 +186,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, BananaReq bananaReq, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (bananaReq.SweetOption.IsSet && bananaReq.Sweet == null)
+                throw new JsonException("Cannot write null property BananaReq.Sweet to non-nullable JSON property 'sweet'.");
+
             writer.WriteNumber("lengthCm", bananaReq.LengthCm);
 
             if (bananaReq.SweetOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/BasquePig.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/BasquePig.cs
@@ -170,9 +170,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, BasquePig basquePig, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (basquePig.ClassName == null)
-                throw new ArgumentNullException(nameof(basquePig.ClassName), "Property is required for class BasquePig.");
-
             writer.WriteString("className", basquePig.ClassName);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -291,22 +291,22 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Capitalization capitalization, JsonSerializerOptions jsonSerializerOptions)
         {
             if (capitalization.ATT_NAMEOption.IsSet && capitalization.ATT_NAME == null)
-                throw new ArgumentNullException(nameof(capitalization.ATT_NAME), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.ATT_NAME to non-nullable JSON property 'ATT_NAME'.");
 
             if (capitalization.CapitalCamelOption.IsSet && capitalization.CapitalCamel == null)
-                throw new ArgumentNullException(nameof(capitalization.CapitalCamel), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.CapitalCamel to non-nullable JSON property 'CapitalCamel'.");
 
             if (capitalization.CapitalSnakeOption.IsSet && capitalization.CapitalSnake == null)
-                throw new ArgumentNullException(nameof(capitalization.CapitalSnake), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.CapitalSnake to non-nullable JSON property 'Capital_Snake'.");
 
             if (capitalization.SCAETHFlowPointsOption.IsSet && capitalization.SCAETHFlowPoints == null)
-                throw new ArgumentNullException(nameof(capitalization.SCAETHFlowPoints), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.SCAETHFlowPoints to non-nullable JSON property 'SCA_ETH_Flow_Points'.");
 
             if (capitalization.SmallCamelOption.IsSet && capitalization.SmallCamel == null)
-                throw new ArgumentNullException(nameof(capitalization.SmallCamel), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.SmallCamel to non-nullable JSON property 'smallCamel'.");
 
             if (capitalization.SmallSnakeOption.IsSet && capitalization.SmallSnake == null)
-                throw new ArgumentNullException(nameof(capitalization.SmallSnake), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.SmallSnake to non-nullable JSON property 'small_Snake'.");
 
             if (capitalization.ATT_NAMEOption.IsSet)
                 writer.WriteString("ATT_NAME", capitalization.ATT_NAME);

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Cat.cs
@@ -179,6 +179,9 @@ namespace Org.OpenAPITools.Model
             if (cat.ColorOption.IsSet && cat.Color == null)
                 throw new JsonException("Cannot write null property Cat.Color to non-nullable JSON property 'color'.");
 
+            if (cat.DeclawedOption.IsSet && cat.Declawed == null)
+                throw new JsonException("Cannot write null property Cat.Declawed to non-nullable JSON property 'declawed'.");
+
             writer.WriteString("className", cat.ClassName);
 
             if (cat.ColorOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Cat.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Cat cat, JsonSerializerOptions jsonSerializerOptions)
         {
             if (cat.ColorOption.IsSet && cat.Color == null)
-                throw new ArgumentNullException(nameof(cat.Color), "Property is required for class Cat.");
+                throw new JsonException("Cannot write null property Cat.Color to non-nullable JSON property 'color'.");
 
             writer.WriteString("className", cat.ClassName);
 

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Category.cs
@@ -193,9 +193,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Category category, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (category.Name == null)
-                throw new ArgumentNullException(nameof(category.Name), "Property is required for class Category.");
-
             if (category.IdOption.IsSet)
                 writer.WriteNumber("id", category.IdOption.Value.Value);
 

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Category.cs
@@ -193,6 +193,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Category category, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (category.IdOption.IsSet && category.Id == null)
+                throw new JsonException("Cannot write null property Category.Id to non-nullable JSON property 'id'.");
+
             if (category.IdOption.IsSet)
                 writer.WriteNumber("id", category.IdOption.Value.Value);
 

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -236,7 +236,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ChildCat childCat, JsonSerializerOptions jsonSerializerOptions)
         {
             if (childCat.NameOption.IsSet && childCat.Name == null)
-                throw new ArgumentNullException(nameof(childCat.Name), "Property is required for class ChildCat.");
+                throw new JsonException("Cannot write null property ChildCat.Name to non-nullable JSON property 'name'.");
 
             if (childCat.NameOption.IsSet)
                 writer.WriteString("name", childCat.Name);

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ClassModel classModel, JsonSerializerOptions jsonSerializerOptions)
         {
             if (classModel.ClassOption.IsSet && classModel.Class == null)
-                throw new ArgumentNullException(nameof(classModel.Class), "Property is required for class ClassModel.");
+                throw new JsonException("Cannot write null property ClassModel.Class to non-nullable JSON property '_class'.");
 
             if (classModel.ClassOption.IsSet)
                 writer.WriteString("_class", classModel.Class);

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
@@ -189,12 +189,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ComplexQuadrilateral complexQuadrilateral, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (complexQuadrilateral.QuadrilateralType == null)
-                throw new ArgumentNullException(nameof(complexQuadrilateral.QuadrilateralType), "Property is required for class ComplexQuadrilateral.");
-
-            if (complexQuadrilateral.ShapeType == null)
-                throw new ArgumentNullException(nameof(complexQuadrilateral.ShapeType), "Property is required for class ComplexQuadrilateral.");
-
             writer.WriteString("quadrilateralType", complexQuadrilateral.QuadrilateralType);
 
             writer.WriteString("shapeType", complexQuadrilateral.ShapeType);

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/CopyActivity.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/CopyActivity.cs
@@ -231,9 +231,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, CopyActivity copyActivity, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (copyActivity.CopyActivitytt == null)
-                throw new ArgumentNullException(nameof(copyActivity.CopyActivitytt), "Property is required for class CopyActivity.");
-
             writer.WriteString("copyActivitytt", copyActivity.CopyActivitytt);
 
             writer.WriteString("$schema", CopyActivity.SchemaEnumToJsonValue(copyActivity.Schema));

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/DanishPig.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/DanishPig.cs
@@ -170,9 +170,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, DanishPig danishPig, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (danishPig.ClassName == null)
-                throw new ArgumentNullException(nameof(danishPig.ClassName), "Property is required for class DanishPig.");
-
             writer.WriteString("className", danishPig.ClassName);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -180,6 +180,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, DateOnlyClass dateOnlyClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (dateOnlyClass.DateOnlyPropertyOption.IsSet && dateOnlyClass.DateOnlyProperty == null)
+                throw new JsonException("Cannot write null property DateOnlyClass.DateOnlyProperty to non-nullable JSON property 'dateOnlyProperty'.");
+
             if (dateOnlyClass.DateOnlyPropertyOption.IsSet)
                 writer.WriteString("dateOnlyProperty", dateOnlyClass.DateOnlyPropertyOption.Value.Value.ToString(DateOnlyPropertyFormat));
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, DeprecatedObject deprecatedObject, JsonSerializerOptions jsonSerializerOptions)
         {
             if (deprecatedObject.NameOption.IsSet && deprecatedObject.Name == null)
-                throw new ArgumentNullException(nameof(deprecatedObject.Name), "Property is required for class DeprecatedObject.");
+                throw new JsonException("Cannot write null property DeprecatedObject.Name to non-nullable JSON property 'name'.");
 
             if (deprecatedObject.NameOption.IsSet)
                 writer.WriteString("name", deprecatedObject.Name);

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Descendant1.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Descendant1.cs
@@ -182,12 +182,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Descendant1 descendant1, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (descendant1.AlternativeName == null)
-                throw new ArgumentNullException(nameof(descendant1.AlternativeName), "Property is required for class Descendant1.");
-
-            if (descendant1.DescendantName == null)
-                throw new ArgumentNullException(nameof(descendant1.DescendantName), "Property is required for class Descendant1.");
-
             writer.WriteString("alternativeName", descendant1.AlternativeName);
 
             writer.WriteString("descendantName", descendant1.DescendantName);

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Descendant2.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Descendant2.cs
@@ -182,12 +182,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Descendant2 descendant2, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (descendant2.AlternativeName == null)
-                throw new ArgumentNullException(nameof(descendant2.AlternativeName), "Property is required for class Descendant2.");
-
-            if (descendant2.Confidentiality == null)
-                throw new ArgumentNullException(nameof(descendant2.Confidentiality), "Property is required for class Descendant2.");
-
             writer.WriteString("alternativeName", descendant2.AlternativeName);
 
             writer.WriteString("confidentiality", descendant2.Confidentiality);

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Dog.cs
@@ -177,10 +177,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Dog dog, JsonSerializerOptions jsonSerializerOptions)
         {
             if (dog.BreedOption.IsSet && dog.Breed == null)
-                throw new ArgumentNullException(nameof(dog.Breed), "Property is required for class Dog.");
+                throw new JsonException("Cannot write null property Dog.Breed to non-nullable JSON property 'breed'.");
 
             if (dog.ColorOption.IsSet && dog.Color == null)
-                throw new ArgumentNullException(nameof(dog.Color), "Property is required for class Dog.");
+                throw new JsonException("Cannot write null property Dog.Color to non-nullable JSON property 'color'.");
 
             writer.WriteString("className", dog.ClassName);
 

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Drawing.cs
@@ -238,10 +238,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Drawing drawing, JsonSerializerOptions jsonSerializerOptions)
         {
             if (drawing.MainShapeOption.IsSet && drawing.MainShape == null)
-                throw new ArgumentNullException(nameof(drawing.MainShape), "Property is required for class Drawing.");
+                throw new JsonException("Cannot write null property Drawing.MainShape to non-nullable JSON property 'mainShape'.");
 
             if (drawing.ShapesOption.IsSet && drawing.Shapes == null)
-                throw new ArgumentNullException(nameof(drawing.Shapes), "Property is required for class Drawing.");
+                throw new JsonException("Cannot write null property Drawing.Shapes to non-nullable JSON property 'shapes'.");
 
             if (drawing.MainShapeOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -337,7 +337,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, EnumArrays enumArrays, JsonSerializerOptions jsonSerializerOptions)
         {
             if (enumArrays.ArrayEnumOption.IsSet && enumArrays.ArrayEnum == null)
-                throw new ArgumentNullException(nameof(enumArrays.ArrayEnum), "Property is required for class EnumArrays.");
+                throw new JsonException("Cannot write null property EnumArrays.ArrayEnum to non-nullable JSON property 'array_enum'.");
 
             if (enumArrays.ArrayEnumOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -339,6 +339,9 @@ namespace Org.OpenAPITools.Model
             if (enumArrays.ArrayEnumOption.IsSet && enumArrays.ArrayEnum == null)
                 throw new JsonException("Cannot write null property EnumArrays.ArrayEnum to non-nullable JSON property 'array_enum'.");
 
+            if (enumArrays.JustSymbolOption.IsSet && enumArrays.JustSymbol == null)
+                throw new JsonException("Cannot write null property EnumArrays.JustSymbol to non-nullable JSON property 'just_symbol'.");
+
             if (enumArrays.ArrayEnumOption.IsSet)
             {
                 writer.WritePropertyName("array_enum");

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -875,6 +875,27 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, EnumTest enumTest, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (enumTest.EnumIntegerOption.IsSet && enumTest.EnumInteger == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumInteger to non-nullable JSON property 'enum_integer'.");
+
+            if (enumTest.EnumIntegerOnlyOption.IsSet && enumTest.EnumIntegerOnly == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumIntegerOnly to non-nullable JSON property 'enum_integer_only'.");
+
+            if (enumTest.EnumNumberOption.IsSet && enumTest.EnumNumber == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumNumber to non-nullable JSON property 'enum_number'.");
+
+            if (enumTest.EnumStringOption.IsSet && enumTest.EnumString == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumString to non-nullable JSON property 'enum_string'.");
+
+            if (enumTest.OuterEnumDefaultValueOption.IsSet && enumTest.OuterEnumDefaultValue == null)
+                throw new JsonException("Cannot write null property EnumTest.OuterEnumDefaultValue to non-nullable JSON property 'outerEnumDefaultValue'.");
+
+            if (enumTest.OuterEnumIntegerOption.IsSet && enumTest.OuterEnumInteger == null)
+                throw new JsonException("Cannot write null property EnumTest.OuterEnumInteger to non-nullable JSON property 'outerEnumInteger'.");
+
+            if (enumTest.OuterEnumIntegerDefaultValueOption.IsSet && enumTest.OuterEnumIntegerDefaultValue == null)
+                throw new JsonException("Cannot write null property EnumTest.OuterEnumIntegerDefaultValue to non-nullable JSON property 'outerEnumIntegerDefaultValue'.");
+
             var enumStringRequiredRawValue = EnumTest.EnumStringRequiredEnumToJsonValue(enumTest.EnumStringRequired);
             writer.WriteString("enum_string_required", enumStringRequiredRawValue);
             if (enumTest.EnumIntegerOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
@@ -189,12 +189,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, EquilateralTriangle equilateralTriangle, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (equilateralTriangle.ShapeType == null)
-                throw new ArgumentNullException(nameof(equilateralTriangle.ShapeType), "Property is required for class EquilateralTriangle.");
-
-            if (equilateralTriangle.TriangleType == null)
-                throw new ArgumentNullException(nameof(equilateralTriangle.TriangleType), "Property is required for class EquilateralTriangle.");
-
             writer.WriteString("shapeType", equilateralTriangle.ShapeType);
 
             writer.WriteString("triangleType", equilateralTriangle.TriangleType);

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/File.cs
@@ -176,7 +176,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, File file, JsonSerializerOptions jsonSerializerOptions)
         {
             if (file.SourceURIOption.IsSet && file.SourceURI == null)
-                throw new ArgumentNullException(nameof(file.SourceURI), "Property is required for class File.");
+                throw new JsonException("Cannot write null property File.SourceURI to non-nullable JSON property 'sourceURI'.");
 
             if (file.SourceURIOption.IsSet)
                 writer.WriteString("sourceURI", file.SourceURI);

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -198,10 +198,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, FileSchemaTestClass fileSchemaTestClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (fileSchemaTestClass.FileOption.IsSet && fileSchemaTestClass.File == null)
-                throw new ArgumentNullException(nameof(fileSchemaTestClass.File), "Property is required for class FileSchemaTestClass.");
+                throw new JsonException("Cannot write null property FileSchemaTestClass.File to non-nullable JSON property 'file'.");
 
             if (fileSchemaTestClass.FilesOption.IsSet && fileSchemaTestClass.Files == null)
-                throw new ArgumentNullException(nameof(fileSchemaTestClass.Files), "Property is required for class FileSchemaTestClass.");
+                throw new JsonException("Cannot write null property FileSchemaTestClass.Files to non-nullable JSON property 'files'.");
 
             if (fileSchemaTestClass.FileOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Foo.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Foo foo, JsonSerializerOptions jsonSerializerOptions)
         {
             if (foo.BarOption.IsSet && foo.Bar == null)
-                throw new ArgumentNullException(nameof(foo.Bar), "Property is required for class Foo.");
+                throw new JsonException("Cannot write null property Foo.Bar to non-nullable JSON property 'bar'.");
 
             if (foo.BarOption.IsSet)
                 writer.WriteString("bar", foo.Bar);

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, FooGetDefaultResponse fooGetDefaultResponse, JsonSerializerOptions jsonSerializerOptions)
         {
             if (fooGetDefaultResponse.StringOption.IsSet && fooGetDefaultResponse.String == null)
-                throw new ArgumentNullException(nameof(fooGetDefaultResponse.String), "Property is required for class FooGetDefaultResponse.");
+                throw new JsonException("Cannot write null property FooGetDefaultResponse.String to non-nullable JSON property 'string'.");
 
             if (fooGetDefaultResponse.StringOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -954,11 +954,47 @@ namespace Org.OpenAPITools.Model
             if (formatTest.BinaryOption.IsSet && formatTest.Binary == null)
                 throw new JsonException("Cannot write null property FormatTest.Binary to non-nullable JSON property 'binary'.");
 
+            if (formatTest.DateTimeOption.IsSet && formatTest.DateTime == null)
+                throw new JsonException("Cannot write null property FormatTest.DateTime to non-nullable JSON property 'dateTime'.");
+
+            if (formatTest.DecimalOption.IsSet && formatTest.Decimal == null)
+                throw new JsonException("Cannot write null property FormatTest.Decimal to non-nullable JSON property 'decimal'.");
+
+            if (formatTest.DoubleOption.IsSet && formatTest.Double == null)
+                throw new JsonException("Cannot write null property FormatTest.Double to non-nullable JSON property 'double'.");
+
             if (formatTest.DuplicatePropertyName2Option.IsSet && formatTest.DuplicatePropertyName2 == null)
                 throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName2 to non-nullable JSON property 'duplicate_property_name'.");
 
             if (formatTest.DuplicatePropertyNameOption.IsSet && formatTest.DuplicatePropertyName == null)
                 throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName to non-nullable JSON property '@duplicate_property_name'.");
+
+            if (formatTest.FloatOption.IsSet && formatTest.Float == null)
+                throw new JsonException("Cannot write null property FormatTest.Float to non-nullable JSON property 'float'.");
+
+            if (formatTest.Int32Option.IsSet && formatTest.Int32 == null)
+                throw new JsonException("Cannot write null property FormatTest.Int32 to non-nullable JSON property 'int32'.");
+
+            if (formatTest.Int32RangeOption.IsSet && formatTest.Int32Range == null)
+                throw new JsonException("Cannot write null property FormatTest.Int32Range to non-nullable JSON property 'int32Range'.");
+
+            if (formatTest.Int64Option.IsSet && formatTest.Int64 == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64 to non-nullable JSON property 'int64'.");
+
+            if (formatTest.Int64NegativeOption.IsSet && formatTest.Int64Negative == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64Negative to non-nullable JSON property 'int64Negative'.");
+
+            if (formatTest.Int64NegativeExclusiveOption.IsSet && formatTest.Int64NegativeExclusive == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64NegativeExclusive to non-nullable JSON property 'int64NegativeExclusive'.");
+
+            if (formatTest.Int64PositiveOption.IsSet && formatTest.Int64Positive == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64Positive to non-nullable JSON property 'int64Positive'.");
+
+            if (formatTest.Int64PositiveExclusiveOption.IsSet && formatTest.Int64PositiveExclusive == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64PositiveExclusive to non-nullable JSON property 'int64PositiveExclusive'.");
+
+            if (formatTest.IntegerOption.IsSet && formatTest.Integer == null)
+                throw new JsonException("Cannot write null property FormatTest.Integer to non-nullable JSON property 'integer'.");
 
             if (formatTest.PatternWithBackslashOption.IsSet && formatTest.PatternWithBackslash == null)
                 throw new JsonException("Cannot write null property FormatTest.PatternWithBackslash to non-nullable JSON property 'pattern_with_backslash'.");
@@ -971,6 +1007,18 @@ namespace Org.OpenAPITools.Model
 
             if (formatTest.StringOption.IsSet && formatTest.String == null)
                 throw new JsonException("Cannot write null property FormatTest.String to non-nullable JSON property 'string'.");
+
+            if (formatTest.StringFormattedAsDecimalOption.IsSet && formatTest.StringFormattedAsDecimal == null)
+                throw new JsonException("Cannot write null property FormatTest.StringFormattedAsDecimal to non-nullable JSON property 'string_formatted_as_decimal'.");
+
+            if (formatTest.UnsignedIntegerOption.IsSet && formatTest.UnsignedInteger == null)
+                throw new JsonException("Cannot write null property FormatTest.UnsignedInteger to non-nullable JSON property 'unsigned_integer'.");
+
+            if (formatTest.UnsignedLongOption.IsSet && formatTest.UnsignedLong == null)
+                throw new JsonException("Cannot write null property FormatTest.UnsignedLong to non-nullable JSON property 'unsigned_long'.");
+
+            if (formatTest.UuidOption.IsSet && formatTest.Uuid == null)
+                throw new JsonException("Cannot write null property FormatTest.Uuid to non-nullable JSON property 'uuid'.");
 
             writer.WritePropertyName("byte");
             JsonSerializer.Serialize(writer, formatTest.Byte, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -951,32 +951,26 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, FormatTest formatTest, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (formatTest.Byte == null)
-                throw new ArgumentNullException(nameof(formatTest.Byte), "Property is required for class FormatTest.");
-
-            if (formatTest.Password == null)
-                throw new ArgumentNullException(nameof(formatTest.Password), "Property is required for class FormatTest.");
-
             if (formatTest.BinaryOption.IsSet && formatTest.Binary == null)
-                throw new ArgumentNullException(nameof(formatTest.Binary), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.Binary to non-nullable JSON property 'binary'.");
 
             if (formatTest.DuplicatePropertyName2Option.IsSet && formatTest.DuplicatePropertyName2 == null)
-                throw new ArgumentNullException(nameof(formatTest.DuplicatePropertyName2), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName2 to non-nullable JSON property 'duplicate_property_name'.");
 
             if (formatTest.DuplicatePropertyNameOption.IsSet && formatTest.DuplicatePropertyName == null)
-                throw new ArgumentNullException(nameof(formatTest.DuplicatePropertyName), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName to non-nullable JSON property '@duplicate_property_name'.");
 
             if (formatTest.PatternWithBackslashOption.IsSet && formatTest.PatternWithBackslash == null)
-                throw new ArgumentNullException(nameof(formatTest.PatternWithBackslash), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.PatternWithBackslash to non-nullable JSON property 'pattern_with_backslash'.");
 
             if (formatTest.PatternWithDigitsOption.IsSet && formatTest.PatternWithDigits == null)
-                throw new ArgumentNullException(nameof(formatTest.PatternWithDigits), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.PatternWithDigits to non-nullable JSON property 'pattern_with_digits'.");
 
             if (formatTest.PatternWithDigitsAndDelimiterOption.IsSet && formatTest.PatternWithDigitsAndDelimiter == null)
-                throw new ArgumentNullException(nameof(formatTest.PatternWithDigitsAndDelimiter), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.PatternWithDigitsAndDelimiter to non-nullable JSON property 'pattern_with_digits_and_delimiter'.");
 
             if (formatTest.StringOption.IsSet && formatTest.String == null)
-                throw new ArgumentNullException(nameof(formatTest.String), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.String to non-nullable JSON property 'string'.");
 
             writer.WritePropertyName("byte");
             JsonSerializer.Serialize(writer, formatTest.Byte, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
@@ -219,7 +219,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Fruit fruit, JsonSerializerOptions jsonSerializerOptions)
         {
             if (fruit.ColorOption.IsSet && fruit.Color == null)
-                throw new ArgumentNullException(nameof(fruit.Color), "Property is required for class Fruit.");
+                throw new JsonException("Cannot write null property Fruit.Color to non-nullable JSON property 'color'.");
 
             if (fruit.ColorOption.IsSet)
                 writer.WriteString("color", fruit.Color);

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -236,7 +236,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, GmFruit gmFruit, JsonSerializerOptions jsonSerializerOptions)
         {
             if (gmFruit.ColorOption.IsSet && gmFruit.Color == null)
-                throw new ArgumentNullException(nameof(gmFruit.Color), "Property is required for class GmFruit.");
+                throw new JsonException("Cannot write null property GmFruit.Color to non-nullable JSON property 'color'.");
 
             if (gmFruit.ColorOption.IsSet)
                 writer.WriteString("color", gmFruit.Color);

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -239,10 +239,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, HasOnlyReadOnly hasOnlyReadOnly, JsonSerializerOptions jsonSerializerOptions)
         {
             if (hasOnlyReadOnly.BarOption.IsSet && hasOnlyReadOnly.Bar == null)
-                throw new ArgumentNullException(nameof(hasOnlyReadOnly.Bar), "Property is required for class HasOnlyReadOnly.");
+                throw new JsonException("Cannot write null property HasOnlyReadOnly.Bar to non-nullable JSON property 'bar'.");
 
             if (hasOnlyReadOnly.FooOption.IsSet && hasOnlyReadOnly.Foo == null)
-                throw new ArgumentNullException(nameof(hasOnlyReadOnly.Foo), "Property is required for class HasOnlyReadOnly.");
+                throw new JsonException("Cannot write null property HasOnlyReadOnly.Foo to non-nullable JSON property 'foo'.");
 
             if (hasOnlyReadOnly.BarOption.IsSet)
                 writer.WriteString("bar", hasOnlyReadOnly.Bar);

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
@@ -337,22 +337,22 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, InjectedVendorExtensionsTest injectedVendorExtensionsTest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessorOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor to non-nullable JSON property 'potentiallyOverriddenPropertyAccessor'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternalOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternal == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternal), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternal to non-nullable JSON property 'potentiallyOverriddenPropertyToInternal'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivateOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivate == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivate), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivate to non-nullable JSON property 'potentiallyOverriddenPropertyToPrivate'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublicOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublic == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublic), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublic to non-nullable JSON property 'potentiallyOverriddenPropertyToPublic'.");
 
             if (injectedVendorExtensionsTest.UnalteredPropertyOption.IsSet && injectedVendorExtensionsTest.UnalteredProperty == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.UnalteredProperty), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.UnalteredProperty to non-nullable JSON property 'unalteredProperty'.");
 
             if (injectedVendorExtensionsTest.UnalteredPropertyAccessorOption.IsSet && injectedVendorExtensionsTest.UnalteredPropertyAccessor == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.UnalteredPropertyAccessor), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.UnalteredPropertyAccessor to non-nullable JSON property 'unalteredPropertyAccessor'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessorOption.IsSet)
                 writer.WriteString("potentiallyOverriddenPropertyAccessor", injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor);

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
@@ -182,12 +182,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, IsoscelesTriangle isoscelesTriangle, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (isoscelesTriangle.ShapeType == null)
-                throw new ArgumentNullException(nameof(isoscelesTriangle.ShapeType), "Property is required for class IsoscelesTriangle.");
-
-            if (isoscelesTriangle.TriangleType == null)
-                throw new ArgumentNullException(nameof(isoscelesTriangle.TriangleType), "Property is required for class IsoscelesTriangle.");
-
             writer.WriteString("shapeType", isoscelesTriangle.ShapeType);
 
             writer.WriteString("triangleType", isoscelesTriangle.TriangleType);

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/List.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, List list, JsonSerializerOptions jsonSerializerOptions)
         {
             if (list.Var123ListOption.IsSet && list.Var123List == null)
-                throw new ArgumentNullException(nameof(list.Var123List), "Property is required for class List.");
+                throw new JsonException("Cannot write null property List.Var123List to non-nullable JSON property '123-list'.");
 
             if (list.Var123ListOption.IsSet)
                 writer.WriteString("123-list", list.Var123List);

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -198,10 +198,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, LiteralStringClass literalStringClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (literalStringClass.EscapedLiteralStringOption.IsSet && literalStringClass.EscapedLiteralString == null)
-                throw new ArgumentNullException(nameof(literalStringClass.EscapedLiteralString), "Property is required for class LiteralStringClass.");
+                throw new JsonException("Cannot write null property LiteralStringClass.EscapedLiteralString to non-nullable JSON property 'escapedLiteralString'.");
 
             if (literalStringClass.UnescapedLiteralStringOption.IsSet && literalStringClass.UnescapedLiteralString == null)
-                throw new ArgumentNullException(nameof(literalStringClass.UnescapedLiteralString), "Property is required for class LiteralStringClass.");
+                throw new JsonException("Cannot write null property LiteralStringClass.UnescapedLiteralString to non-nullable JSON property 'unescapedLiteralString'.");
 
             if (literalStringClass.EscapedLiteralStringOption.IsSet)
                 writer.WriteString("escapedLiteralString", literalStringClass.EscapedLiteralString);

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/MapTest.cs
@@ -310,16 +310,16 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MapTest mapTest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mapTest.DirectMapOption.IsSet && mapTest.DirectMap == null)
-                throw new ArgumentNullException(nameof(mapTest.DirectMap), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.DirectMap to non-nullable JSON property 'direct_map'.");
 
             if (mapTest.IndirectMapOption.IsSet && mapTest.IndirectMap == null)
-                throw new ArgumentNullException(nameof(mapTest.IndirectMap), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.IndirectMap to non-nullable JSON property 'indirect_map'.");
 
             if (mapTest.MapMapOfStringOption.IsSet && mapTest.MapMapOfString == null)
-                throw new ArgumentNullException(nameof(mapTest.MapMapOfString), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.MapMapOfString to non-nullable JSON property 'map_map_of_string'.");
 
             if (mapTest.MapOfEnumStringOption.IsSet && mapTest.MapOfEnumString == null)
-                throw new ArgumentNullException(nameof(mapTest.MapOfEnumString), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.MapOfEnumString to non-nullable JSON property 'map_of_enum_string'.");
 
             if (mapTest.DirectMapOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/MixedAnyOf.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/MixedAnyOf.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedAnyOf mixedAnyOf, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedAnyOf.ContentOption.IsSet && mixedAnyOf.Content == null)
-                throw new ArgumentNullException(nameof(mixedAnyOf.Content), "Property is required for class MixedAnyOf.");
+                throw new JsonException("Cannot write null property MixedAnyOf.Content to non-nullable JSON property 'content'.");
 
             if (mixedAnyOf.ContentOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/MixedOneOf.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/MixedOneOf.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedOneOf mixedOneOf, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedOneOf.ContentOption.IsSet && mixedOneOf.Content == null)
-                throw new ArgumentNullException(nameof(mixedOneOf.Content), "Property is required for class MixedOneOf.");
+                throw new JsonException("Cannot write null property MixedOneOf.Content to non-nullable JSON property 'content'.");
 
             if (mixedOneOf.ContentOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -255,8 +255,17 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, MixedPropertiesAndAdditionalPropertiesClass mixedPropertiesAndAdditionalPropertiesClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.DateTime == null)
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.DateTime to non-nullable JSON property 'dateTime'.");
+
             if (mixedPropertiesAndAdditionalPropertiesClass.MapOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.Map == null)
                 throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.Map to non-nullable JSON property 'map'.");
+
+            if (mixedPropertiesAndAdditionalPropertiesClass.UuidOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.Uuid == null)
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.Uuid to non-nullable JSON property 'uuid'.");
+
+            if (mixedPropertiesAndAdditionalPropertiesClass.UuidWithPatternOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.UuidWithPattern == null)
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.UuidWithPattern to non-nullable JSON property 'uuid_with_pattern'.");
 
             if (mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.IsSet)
                 writer.WriteString("dateTime", mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.Value.Value.ToString(DateTimeFormat));

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -256,7 +256,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedPropertiesAndAdditionalPropertiesClass mixedPropertiesAndAdditionalPropertiesClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedPropertiesAndAdditionalPropertiesClass.MapOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.Map == null)
-                throw new ArgumentNullException(nameof(mixedPropertiesAndAdditionalPropertiesClass.Map), "Property is required for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.Map to non-nullable JSON property 'map'.");
 
             if (mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.IsSet)
                 writer.WriteString("dateTime", mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.Value.Value.ToString(DateTimeFormat));

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/MixedSubId.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/MixedSubId.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedSubId mixedSubId, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedSubId.IdOption.IsSet && mixedSubId.Id == null)
-                throw new ArgumentNullException(nameof(mixedSubId.Id), "Property is required for class MixedSubId.");
+                throw new JsonException("Cannot write null property MixedSubId.Id to non-nullable JSON property 'id'.");
 
             if (mixedSubId.IdOption.IsSet)
                 writer.WriteString("id", mixedSubId.Id);

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -198,7 +198,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Model200Response model200Response, JsonSerializerOptions jsonSerializerOptions)
         {
             if (model200Response.ClassOption.IsSet && model200Response.Class == null)
-                throw new ArgumentNullException(nameof(model200Response.Class), "Property is required for class Model200Response.");
+                throw new JsonException("Cannot write null property Model200Response.Class to non-nullable JSON property 'class'.");
 
             if (model200Response.ClassOption.IsSet)
                 writer.WriteString("class", model200Response.Class);

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -200,6 +200,9 @@ namespace Org.OpenAPITools.Model
             if (model200Response.ClassOption.IsSet && model200Response.Class == null)
                 throw new JsonException("Cannot write null property Model200Response.Class to non-nullable JSON property 'class'.");
 
+            if (model200Response.NameOption.IsSet && model200Response.Name == null)
+                throw new JsonException("Cannot write null property Model200Response.Name to non-nullable JSON property 'name'.");
+
             if (model200Response.ClassOption.IsSet)
                 writer.WriteString("class", model200Response.Class);
 

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ModelClient modelClient, JsonSerializerOptions jsonSerializerOptions)
         {
             if (modelClient.VarClientOption.IsSet && modelClient.VarClient == null)
-                throw new ArgumentNullException(nameof(modelClient.VarClient), "Property is required for class ModelClient.");
+                throw new JsonException("Cannot write null property ModelClient.VarClient to non-nullable JSON property 'client'.");
 
             if (modelClient.VarClientOption.IsSet)
                 writer.WriteString("client", modelClient.VarClient);

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Name.cs
@@ -281,7 +281,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Name name, JsonSerializerOptions jsonSerializerOptions)
         {
             if (name.PropertyOption.IsSet && name.Property == null)
-                throw new ArgumentNullException(nameof(name.Property), "Property is required for class Name.");
+                throw new JsonException("Cannot write null property Name.Property to non-nullable JSON property 'property'.");
 
             writer.WriteNumber("name", name.VarName);
 

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Name.cs
@@ -283,6 +283,12 @@ namespace Org.OpenAPITools.Model
             if (name.PropertyOption.IsSet && name.Property == null)
                 throw new JsonException("Cannot write null property Name.Property to non-nullable JSON property 'property'.");
 
+            if (name.SnakeCaseOption.IsSet && name.SnakeCase == null)
+                throw new JsonException("Cannot write null property Name.SnakeCase to non-nullable JSON property 'snake_case'.");
+
+            if (name.Var123NumberOption.IsSet && name.Var123Number == null)
+                throw new JsonException("Cannot write null property Name.Var123Number to non-nullable JSON property '123Number'.");
+
             writer.WriteNumber("name", name.VarName);
 
             if (name.PropertyOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
@@ -189,9 +189,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, NotificationtestGetElementsV1ResponseMPayload notificationtestGetElementsV1ResponseMPayload, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (notificationtestGetElementsV1ResponseMPayload.AObjVariableobject == null)
-                throw new ArgumentNullException(nameof(notificationtestGetElementsV1ResponseMPayload.AObjVariableobject), "Property is required for class NotificationtestGetElementsV1ResponseMPayload.");
-
             writer.WritePropertyName("a_objVariableobject");
             JsonSerializer.Serialize(writer, notificationtestGetElementsV1ResponseMPayload.AObjVariableobject, jsonSerializerOptions);
             writer.WriteNumber("pkiNotificationtestID", notificationtestGetElementsV1ResponseMPayload.PkiNotificationtestID);

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -408,10 +408,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, NullableClass nullableClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (nullableClass.ArrayItemsNullableOption.IsSet && nullableClass.ArrayItemsNullable == null)
-                throw new ArgumentNullException(nameof(nullableClass.ArrayItemsNullable), "Property is required for class NullableClass.");
+                throw new JsonException("Cannot write null property NullableClass.ArrayItemsNullable to non-nullable JSON property 'array_items_nullable'.");
 
             if (nullableClass.ObjectItemsNullableOption.IsSet && nullableClass.ObjectItemsNullable == null)
-                throw new ArgumentNullException(nameof(nullableClass.ObjectItemsNullable), "Property is required for class NullableClass.");
+                throw new JsonException("Cannot write null property NullableClass.ObjectItemsNullable to non-nullable JSON property 'object_items_nullable'.");
 
             if (nullableClass.ArrayAndItemsNullablePropOption.IsSet)
                 if (nullableClass.ArrayAndItemsNullablePropOption.Value != null)

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -174,6 +174,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, NumberOnly numberOnly, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (numberOnly.JustNumberOption.IsSet && numberOnly.JustNumber == null)
+                throw new JsonException("Cannot write null property NumberOnly.JustNumber to non-nullable JSON property 'JustNumber'.");
+
             if (numberOnly.JustNumberOption.IsSet)
                 writer.WriteNumber("JustNumber", numberOnly.JustNumberOption.Value.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -247,13 +247,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ObjectWithDeprecatedFields objectWithDeprecatedFields, JsonSerializerOptions jsonSerializerOptions)
         {
             if (objectWithDeprecatedFields.BarsOption.IsSet && objectWithDeprecatedFields.Bars == null)
-                throw new ArgumentNullException(nameof(objectWithDeprecatedFields.Bars), "Property is required for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Bars to non-nullable JSON property 'bars'.");
 
             if (objectWithDeprecatedFields.DeprecatedRefOption.IsSet && objectWithDeprecatedFields.DeprecatedRef == null)
-                throw new ArgumentNullException(nameof(objectWithDeprecatedFields.DeprecatedRef), "Property is required for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.DeprecatedRef to non-nullable JSON property 'deprecatedRef'.");
 
             if (objectWithDeprecatedFields.UuidOption.IsSet && objectWithDeprecatedFields.Uuid == null)
-                throw new ArgumentNullException(nameof(objectWithDeprecatedFields.Uuid), "Property is required for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Uuid to non-nullable JSON property 'uuid'.");
 
             if (objectWithDeprecatedFields.BarsOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -252,6 +252,9 @@ namespace Org.OpenAPITools.Model
             if (objectWithDeprecatedFields.DeprecatedRefOption.IsSet && objectWithDeprecatedFields.DeprecatedRef == null)
                 throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.DeprecatedRef to non-nullable JSON property 'deprecatedRef'.");
 
+            if (objectWithDeprecatedFields.IdOption.IsSet && objectWithDeprecatedFields.Id == null)
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Id to non-nullable JSON property 'id'.");
+
             if (objectWithDeprecatedFields.UuidOption.IsSet && objectWithDeprecatedFields.Uuid == null)
                 throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Uuid to non-nullable JSON property 'uuid'.");
 

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Order.cs
@@ -384,6 +384,24 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Order order, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (order.CompleteOption.IsSet && order.Complete == null)
+                throw new JsonException("Cannot write null property Order.Complete to non-nullable JSON property 'complete'.");
+
+            if (order.IdOption.IsSet && order.Id == null)
+                throw new JsonException("Cannot write null property Order.Id to non-nullable JSON property 'id'.");
+
+            if (order.PetIdOption.IsSet && order.PetId == null)
+                throw new JsonException("Cannot write null property Order.PetId to non-nullable JSON property 'petId'.");
+
+            if (order.QuantityOption.IsSet && order.Quantity == null)
+                throw new JsonException("Cannot write null property Order.Quantity to non-nullable JSON property 'quantity'.");
+
+            if (order.ShipDateOption.IsSet && order.ShipDate == null)
+                throw new JsonException("Cannot write null property Order.ShipDate to non-nullable JSON property 'shipDate'.");
+
+            if (order.StatusOption.IsSet && order.Status == null)
+                throw new JsonException("Cannot write null property Order.Status to non-nullable JSON property 'status'.");
+
             if (order.CompleteOption.IsSet)
                 writer.WriteBoolean("complete", order.CompleteOption.Value.Value);
 

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -220,6 +220,12 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, OuterComposite outerComposite, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (outerComposite.MyBooleanOption.IsSet && outerComposite.MyBoolean == null)
+                throw new JsonException("Cannot write null property OuterComposite.MyBoolean to non-nullable JSON property 'my_boolean'.");
+
+            if (outerComposite.MyNumberOption.IsSet && outerComposite.MyNumber == null)
+                throw new JsonException("Cannot write null property OuterComposite.MyNumber to non-nullable JSON property 'my_number'.");
+
             if (outerComposite.MyStringOption.IsSet && outerComposite.MyString == null)
                 throw new JsonException("Cannot write null property OuterComposite.MyString to non-nullable JSON property 'my_string'.");
 

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -221,7 +221,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, OuterComposite outerComposite, JsonSerializerOptions jsonSerializerOptions)
         {
             if (outerComposite.MyStringOption.IsSet && outerComposite.MyString == null)
-                throw new ArgumentNullException(nameof(outerComposite.MyString), "Property is required for class OuterComposite.");
+                throw new JsonException("Cannot write null property OuterComposite.MyString to non-nullable JSON property 'my_string'.");
 
             if (outerComposite.MyBooleanOption.IsSet)
                 writer.WriteBoolean("my_boolean", outerComposite.MyBooleanOption.Value.Value);

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Pet.cs
@@ -371,17 +371,11 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Pet pet, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (pet.Name == null)
-                throw new ArgumentNullException(nameof(pet.Name), "Property is required for class Pet.");
-
-            if (pet.PhotoUrls == null)
-                throw new ArgumentNullException(nameof(pet.PhotoUrls), "Property is required for class Pet.");
-
             if (pet.CategoryOption.IsSet && pet.Category == null)
-                throw new ArgumentNullException(nameof(pet.Category), "Property is required for class Pet.");
+                throw new JsonException("Cannot write null property Pet.Category to non-nullable JSON property 'category'.");
 
             if (pet.TagsOption.IsSet && pet.Tags == null)
-                throw new ArgumentNullException(nameof(pet.Tags), "Property is required for class Pet.");
+                throw new JsonException("Cannot write null property Pet.Tags to non-nullable JSON property 'tags'.");
 
             writer.WriteString("name", pet.Name);
 

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Pet.cs
@@ -374,6 +374,12 @@ namespace Org.OpenAPITools.Model
             if (pet.CategoryOption.IsSet && pet.Category == null)
                 throw new JsonException("Cannot write null property Pet.Category to non-nullable JSON property 'category'.");
 
+            if (pet.IdOption.IsSet && pet.Id == null)
+                throw new JsonException("Cannot write null property Pet.Id to non-nullable JSON property 'id'.");
+
+            if (pet.StatusOption.IsSet && pet.Status == null)
+                throw new JsonException("Cannot write null property Pet.Status to non-nullable JSON property 'status'.");
+
             if (pet.TagsOption.IsSet && pet.Tags == null)
                 throw new JsonException("Cannot write null property Pet.Tags to non-nullable JSON property 'tags'.");
 

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
@@ -170,9 +170,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, QuadrilateralInterface quadrilateralInterface, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (quadrilateralInterface.QuadrilateralType == null)
-                throw new ArgumentNullException(nameof(quadrilateralInterface.QuadrilateralType), "Property is required for class QuadrilateralInterface.");
-
             writer.WriteString("quadrilateralType", quadrilateralInterface.QuadrilateralType);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -236,10 +236,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ReadOnlyFirst readOnlyFirst, JsonSerializerOptions jsonSerializerOptions)
         {
             if (readOnlyFirst.BarOption.IsSet && readOnlyFirst.Bar == null)
-                throw new ArgumentNullException(nameof(readOnlyFirst.Bar), "Property is required for class ReadOnlyFirst.");
+                throw new JsonException("Cannot write null property ReadOnlyFirst.Bar to non-nullable JSON property 'bar'.");
 
             if (readOnlyFirst.BazOption.IsSet && readOnlyFirst.Baz == null)
-                throw new ArgumentNullException(nameof(readOnlyFirst.Baz), "Property is required for class ReadOnlyFirst.");
+                throw new JsonException("Cannot write null property ReadOnlyFirst.Baz to non-nullable JSON property 'baz'.");
 
             if (readOnlyFirst.BarOption.IsSet)
                 writer.WriteString("bar", readOnlyFirst.Bar);

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -2235,17 +2235,11 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, RequiredClass requiredClass, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (requiredClass.RequiredNotnullableArrayOfString == null)
-                throw new ArgumentNullException(nameof(requiredClass.RequiredNotnullableArrayOfString), "Property is required for class RequiredClass.");
-
-            if (requiredClass.RequiredNotnullableStringProp == null)
-                throw new ArgumentNullException(nameof(requiredClass.RequiredNotnullableStringProp), "Property is required for class RequiredClass.");
-
             if (requiredClass.NotrequiredNotnullableArrayOfStringOption.IsSet && requiredClass.NotrequiredNotnullableArrayOfString == null)
-                throw new ArgumentNullException(nameof(requiredClass.NotrequiredNotnullableArrayOfString), "Property is required for class RequiredClass.");
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableArrayOfString to non-nullable JSON property 'notrequired_notnullable_array_of_string'.");
 
             if (requiredClass.NotrequiredNotnullableStringPropOption.IsSet && requiredClass.NotrequiredNotnullableStringProp == null)
-                throw new ArgumentNullException(nameof(requiredClass.NotrequiredNotnullableStringProp), "Property is required for class RequiredClass.");
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableStringProp to non-nullable JSON property 'notrequired_notnullable_string_prop'.");
 
             writer.WriteString("required_not_nullable_date_prop", requiredClass.RequiredNotNullableDateProp.ToString(RequiredNotNullableDatePropFormat));
 

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -2235,11 +2235,38 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, RequiredClass requiredClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (requiredClass.NotRequiredNotnullableDatePropOption.IsSet && requiredClass.NotRequiredNotnullableDateProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotRequiredNotnullableDateProp to non-nullable JSON property 'not_required_notnullable_date_prop'.");
+
+            if (requiredClass.NotRequiredNotnullableintegerPropOption.IsSet && requiredClass.NotRequiredNotnullableintegerProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotRequiredNotnullableintegerProp to non-nullable JSON property 'not_required_notnullableinteger_prop'.");
+
             if (requiredClass.NotrequiredNotnullableArrayOfStringOption.IsSet && requiredClass.NotrequiredNotnullableArrayOfString == null)
                 throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableArrayOfString to non-nullable JSON property 'notrequired_notnullable_array_of_string'.");
 
+            if (requiredClass.NotrequiredNotnullableBooleanPropOption.IsSet && requiredClass.NotrequiredNotnullableBooleanProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableBooleanProp to non-nullable JSON property 'notrequired_notnullable_boolean_prop'.");
+
+            if (requiredClass.NotrequiredNotnullableDatetimePropOption.IsSet && requiredClass.NotrequiredNotnullableDatetimeProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableDatetimeProp to non-nullable JSON property 'notrequired_notnullable_datetime_prop'.");
+
+            if (requiredClass.NotrequiredNotnullableEnumIntegerOption.IsSet && requiredClass.NotrequiredNotnullableEnumInteger == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableEnumInteger to non-nullable JSON property 'notrequired_notnullable_enum_integer'.");
+
+            if (requiredClass.NotrequiredNotnullableEnumIntegerOnlyOption.IsSet && requiredClass.NotrequiredNotnullableEnumIntegerOnly == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableEnumIntegerOnly to non-nullable JSON property 'notrequired_notnullable_enum_integer_only'.");
+
+            if (requiredClass.NotrequiredNotnullableEnumStringOption.IsSet && requiredClass.NotrequiredNotnullableEnumString == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableEnumString to non-nullable JSON property 'notrequired_notnullable_enum_string'.");
+
+            if (requiredClass.NotrequiredNotnullableOuterEnumDefaultValueOption.IsSet && requiredClass.NotrequiredNotnullableOuterEnumDefaultValue == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableOuterEnumDefaultValue to non-nullable JSON property 'notrequired_notnullable_outerEnumDefaultValue'.");
+
             if (requiredClass.NotrequiredNotnullableStringPropOption.IsSet && requiredClass.NotrequiredNotnullableStringProp == null)
                 throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableStringProp to non-nullable JSON property 'notrequired_notnullable_string_prop'.");
+
+            if (requiredClass.NotrequiredNotnullableUuidOption.IsSet && requiredClass.NotrequiredNotnullableUuid == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableUuid to non-nullable JSON property 'notrequired_notnullable_uuid'.");
 
             writer.WriteString("required_not_nullable_date_prop", requiredClass.RequiredNotNullableDateProp.ToString(RequiredNotNullableDatePropFormat));
 

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Result.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Result.cs
@@ -224,13 +224,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Result result, JsonSerializerOptions jsonSerializerOptions)
         {
             if (result.CodeOption.IsSet && result.Code == null)
-                throw new ArgumentNullException(nameof(result.Code), "Property is required for class Result.");
+                throw new JsonException("Cannot write null property Result.Code to non-nullable JSON property 'code'.");
 
             if (result.DataOption.IsSet && result.Data == null)
-                throw new ArgumentNullException(nameof(result.Data), "Property is required for class Result.");
+                throw new JsonException("Cannot write null property Result.Data to non-nullable JSON property 'data'.");
 
             if (result.UuidOption.IsSet && result.Uuid == null)
-                throw new ArgumentNullException(nameof(result.Uuid), "Property is required for class Result.");
+                throw new JsonException("Cannot write null property Result.Uuid to non-nullable JSON property 'uuid'.");
 
             if (result.CodeOption.IsSet)
                 writer.WriteString("code", result.Code);

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Return.cs
@@ -232,11 +232,8 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Return varReturn, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (varReturn.Lock == null)
-                throw new ArgumentNullException(nameof(varReturn.Lock), "Property is required for class Return.");
-
             if (varReturn.UnsafeOption.IsSet && varReturn.Unsafe == null)
-                throw new ArgumentNullException(nameof(varReturn.Unsafe), "Property is required for class Return.");
+                throw new JsonException("Cannot write null property Return.Unsafe to non-nullable JSON property 'unsafe'.");
 
             writer.WriteString("lock", varReturn.Lock);
 

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Return.cs
@@ -232,6 +232,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Return varReturn, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (varReturn.VarReturnOption.IsSet && varReturn.VarReturn == null)
+                throw new JsonException("Cannot write null property Return.VarReturn to non-nullable JSON property 'return'.");
+
             if (varReturn.UnsafeOption.IsSet && varReturn.Unsafe == null)
                 throw new JsonException("Cannot write null property Return.Unsafe to non-nullable JSON property 'unsafe'.");
 

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -198,7 +198,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, RolesReportsHash rolesReportsHash, JsonSerializerOptions jsonSerializerOptions)
         {
             if (rolesReportsHash.RoleOption.IsSet && rolesReportsHash.Role == null)
-                throw new ArgumentNullException(nameof(rolesReportsHash.Role), "Property is required for class RolesReportsHash.");
+                throw new JsonException("Cannot write null property RolesReportsHash.Role to non-nullable JSON property 'role'.");
 
             if (rolesReportsHash.RoleOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -200,6 +200,9 @@ namespace Org.OpenAPITools.Model
             if (rolesReportsHash.RoleOption.IsSet && rolesReportsHash.Role == null)
                 throw new JsonException("Cannot write null property RolesReportsHash.Role to non-nullable JSON property 'role'.");
 
+            if (rolesReportsHash.RoleUuidOption.IsSet && rolesReportsHash.RoleUuid == null)
+                throw new JsonException("Cannot write null property RolesReportsHash.RoleUuid to non-nullable JSON property 'role_uuid'.");
+
             if (rolesReportsHash.RoleOption.IsSet)
             {
                 writer.WritePropertyName("role");

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, RolesReportsHashRole rolesReportsHashRole, JsonSerializerOptions jsonSerializerOptions)
         {
             if (rolesReportsHashRole.NameOption.IsSet && rolesReportsHashRole.Name == null)
-                throw new ArgumentNullException(nameof(rolesReportsHashRole.Name), "Property is required for class RolesReportsHashRole.");
+                throw new JsonException("Cannot write null property RolesReportsHashRole.Name to non-nullable JSON property 'name'.");
 
             if (rolesReportsHashRole.NameOption.IsSet)
                 writer.WriteString("name", rolesReportsHashRole.Name);

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
@@ -189,12 +189,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ScaleneTriangle scaleneTriangle, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (scaleneTriangle.ShapeType == null)
-                throw new ArgumentNullException(nameof(scaleneTriangle.ShapeType), "Property is required for class ScaleneTriangle.");
-
-            if (scaleneTriangle.TriangleType == null)
-                throw new ArgumentNullException(nameof(scaleneTriangle.TriangleType), "Property is required for class ScaleneTriangle.");
-
             writer.WriteString("shapeType", scaleneTriangle.ShapeType);
 
             writer.WriteString("triangleType", scaleneTriangle.TriangleType);

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ShapeInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ShapeInterface.cs
@@ -170,9 +170,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ShapeInterface shapeInterface, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (shapeInterface.ShapeType == null)
-                throw new ArgumentNullException(nameof(shapeInterface.ShapeType), "Property is required for class ShapeInterface.");
-
             writer.WriteString("shapeType", shapeInterface.ShapeType);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
@@ -189,12 +189,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, SimpleQuadrilateral simpleQuadrilateral, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (simpleQuadrilateral.QuadrilateralType == null)
-                throw new ArgumentNullException(nameof(simpleQuadrilateral.QuadrilateralType), "Property is required for class SimpleQuadrilateral.");
-
-            if (simpleQuadrilateral.ShapeType == null)
-                throw new ArgumentNullException(nameof(simpleQuadrilateral.ShapeType), "Property is required for class SimpleQuadrilateral.");
-
             writer.WriteString("quadrilateralType", simpleQuadrilateral.QuadrilateralType);
 
             writer.WriteString("shapeType", simpleQuadrilateral.ShapeType);

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -200,6 +200,9 @@ namespace Org.OpenAPITools.Model
             if (specialModelName.VarSpecialModelNameOption.IsSet && specialModelName.VarSpecialModelName == null)
                 throw new JsonException("Cannot write null property SpecialModelName.VarSpecialModelName to non-nullable JSON property '_special_model.name_'.");
 
+            if (specialModelName.SpecialPropertyNameOption.IsSet && specialModelName.SpecialPropertyName == null)
+                throw new JsonException("Cannot write null property SpecialModelName.SpecialPropertyName to non-nullable JSON property '$special[property.name]'.");
+
             if (specialModelName.VarSpecialModelNameOption.IsSet)
                 writer.WriteString("_special_model.name_", specialModelName.VarSpecialModelName);
 

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -198,7 +198,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, SpecialModelName specialModelName, JsonSerializerOptions jsonSerializerOptions)
         {
             if (specialModelName.VarSpecialModelNameOption.IsSet && specialModelName.VarSpecialModelName == null)
-                throw new ArgumentNullException(nameof(specialModelName.VarSpecialModelName), "Property is required for class SpecialModelName.");
+                throw new JsonException("Cannot write null property SpecialModelName.VarSpecialModelName to non-nullable JSON property '_special_model.name_'.");
 
             if (specialModelName.VarSpecialModelNameOption.IsSet)
                 writer.WriteString("_special_model.name_", specialModelName.VarSpecialModelName);

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Tag.cs
@@ -198,7 +198,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Tag tag, JsonSerializerOptions jsonSerializerOptions)
         {
             if (tag.NameOption.IsSet && tag.Name == null)
-                throw new ArgumentNullException(nameof(tag.Name), "Property is required for class Tag.");
+                throw new JsonException("Cannot write null property Tag.Name to non-nullable JSON property 'name'.");
 
             if (tag.IdOption.IsSet)
                 writer.WriteNumber("id", tag.IdOption.Value.Value);

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Tag.cs
@@ -197,6 +197,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Tag tag, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (tag.IdOption.IsSet && tag.Id == null)
+                throw new JsonException("Cannot write null property Tag.Id to non-nullable JSON property 'id'.");
+
             if (tag.NameOption.IsSet && tag.Name == null)
                 throw new JsonException("Cannot write null property Tag.Name to non-nullable JSON property 'name'.");
 

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestCollectionEndingWithWordList testCollectionEndingWithWordList, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testCollectionEndingWithWordList.ValueOption.IsSet && testCollectionEndingWithWordList.Value == null)
-                throw new ArgumentNullException(nameof(testCollectionEndingWithWordList.Value), "Property is required for class TestCollectionEndingWithWordList.");
+                throw new JsonException("Cannot write null property TestCollectionEndingWithWordList.Value to non-nullable JSON property 'value'.");
 
             if (testCollectionEndingWithWordList.ValueOption.IsSet)
                 writer.WriteString("value", testCollectionEndingWithWordList.Value);

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestCollectionEndingWithWordListObject testCollectionEndingWithWordListObject, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testCollectionEndingWithWordListObject.TestCollectionEndingWithWordListOption.IsSet && testCollectionEndingWithWordListObject.TestCollectionEndingWithWordList == null)
-                throw new ArgumentNullException(nameof(testCollectionEndingWithWordListObject.TestCollectionEndingWithWordList), "Property is required for class TestCollectionEndingWithWordListObject.");
+                throw new JsonException("Cannot write null property TestCollectionEndingWithWordListObject.TestCollectionEndingWithWordList to non-nullable JSON property 'TestCollectionEndingWithWordList'.");
 
             if (testCollectionEndingWithWordListObject.TestCollectionEndingWithWordListOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/TestDescendants.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/TestDescendants.cs
@@ -289,9 +289,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, TestDescendants testDescendants, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (testDescendants.AlternativeName == null)
-                throw new ArgumentNullException(nameof(testDescendants.AlternativeName), "Property is required for class TestDescendants.");
-
             writer.WriteString("alternativeName", testDescendants.AlternativeName);
 
             writer.WriteString("objectType", TestDescendants.ObjectTypeEnumToJsonValue(testDescendants.ObjectType));

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestInlineFreeformAdditionalPropertiesRequest testInlineFreeformAdditionalPropertiesRequest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testInlineFreeformAdditionalPropertiesRequest.SomePropertyOption.IsSet && testInlineFreeformAdditionalPropertiesRequest.SomeProperty == null)
-                throw new ArgumentNullException(nameof(testInlineFreeformAdditionalPropertiesRequest.SomeProperty), "Property is required for class TestInlineFreeformAdditionalPropertiesRequest.");
+                throw new JsonException("Cannot write null property TestInlineFreeformAdditionalPropertiesRequest.SomeProperty to non-nullable JSON property 'someProperty'.");
 
             if (testInlineFreeformAdditionalPropertiesRequest.SomePropertyOption.IsSet)
                 writer.WriteString("someProperty", testInlineFreeformAdditionalPropertiesRequest.SomeProperty);

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/TestResult.cs
@@ -222,6 +222,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, TestResult testResult, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (testResult.CodeOption.IsSet && testResult.Code == null)
+                throw new JsonException("Cannot write null property TestResult.Code to non-nullable JSON property 'code'.");
+
             if (testResult.DataOption.IsSet && testResult.Data == null)
                 throw new JsonException("Cannot write null property TestResult.Data to non-nullable JSON property 'data'.");
 

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/TestResult.cs
@@ -223,10 +223,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestResult testResult, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testResult.DataOption.IsSet && testResult.Data == null)
-                throw new ArgumentNullException(nameof(testResult.Data), "Property is required for class TestResult.");
+                throw new JsonException("Cannot write null property TestResult.Data to non-nullable JSON property 'data'.");
 
             if (testResult.UuidOption.IsSet && testResult.Uuid == null)
-                throw new ArgumentNullException(nameof(testResult.Uuid), "Property is required for class TestResult.");
+                throw new JsonException("Cannot write null property TestResult.Uuid to non-nullable JSON property 'uuid'.");
 
             if (testResult.CodeOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/TriangleInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/TriangleInterface.cs
@@ -170,9 +170,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, TriangleInterface triangleInterface, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (triangleInterface.TriangleType == null)
-                throw new ArgumentNullException(nameof(triangleInterface.TriangleType), "Property is required for class TriangleInterface.");
-
             writer.WriteString("triangleType", triangleInterface.TriangleType);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/User.cs
@@ -429,6 +429,9 @@ namespace Org.OpenAPITools.Model
             if (user.FirstNameOption.IsSet && user.FirstName == null)
                 throw new JsonException("Cannot write null property User.FirstName to non-nullable JSON property 'firstName'.");
 
+            if (user.IdOption.IsSet && user.Id == null)
+                throw new JsonException("Cannot write null property User.Id to non-nullable JSON property 'id'.");
+
             if (user.LastNameOption.IsSet && user.LastName == null)
                 throw new JsonException("Cannot write null property User.LastName to non-nullable JSON property 'lastName'.");
 
@@ -440,6 +443,9 @@ namespace Org.OpenAPITools.Model
 
             if (user.PhoneOption.IsSet && user.Phone == null)
                 throw new JsonException("Cannot write null property User.Phone to non-nullable JSON property 'phone'.");
+
+            if (user.UserStatusOption.IsSet && user.UserStatus == null)
+                throw new JsonException("Cannot write null property User.UserStatus to non-nullable JSON property 'userStatus'.");
 
             if (user.UsernameOption.IsSet && user.Username == null)
                 throw new JsonException("Cannot write null property User.Username to non-nullable JSON property 'username'.");

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/User.cs
@@ -424,25 +424,25 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, User user, JsonSerializerOptions jsonSerializerOptions)
         {
             if (user.EmailOption.IsSet && user.Email == null)
-                throw new ArgumentNullException(nameof(user.Email), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Email to non-nullable JSON property 'email'.");
 
             if (user.FirstNameOption.IsSet && user.FirstName == null)
-                throw new ArgumentNullException(nameof(user.FirstName), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.FirstName to non-nullable JSON property 'firstName'.");
 
             if (user.LastNameOption.IsSet && user.LastName == null)
-                throw new ArgumentNullException(nameof(user.LastName), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.LastName to non-nullable JSON property 'lastName'.");
 
             if (user.ObjectWithNoDeclaredPropsOption.IsSet && user.ObjectWithNoDeclaredProps == null)
-                throw new ArgumentNullException(nameof(user.ObjectWithNoDeclaredProps), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.ObjectWithNoDeclaredProps to non-nullable JSON property 'objectWithNoDeclaredProps'.");
 
             if (user.PasswordOption.IsSet && user.Password == null)
-                throw new ArgumentNullException(nameof(user.Password), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Password to non-nullable JSON property 'password'.");
 
             if (user.PhoneOption.IsSet && user.Phone == null)
-                throw new ArgumentNullException(nameof(user.Phone), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Phone to non-nullable JSON property 'phone'.");
 
             if (user.UsernameOption.IsSet && user.Username == null)
-                throw new ArgumentNullException(nameof(user.Username), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Username to non-nullable JSON property 'username'.");
 
             if (user.AnyTypePropOption.IsSet)
                 if (user.AnyTypePropOption.Value != null)

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Whale.cs
@@ -216,9 +216,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Whale whale, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (whale.ClassName == null)
-                throw new ArgumentNullException(nameof(whale.ClassName), "Property is required for class Whale.");
-
             writer.WriteString("className", whale.ClassName);
 
             if (whale.HasBaleenOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Whale.cs
@@ -216,6 +216,12 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Whale whale, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (whale.HasBaleenOption.IsSet && whale.HasBaleen == null)
+                throw new JsonException("Cannot write null property Whale.HasBaleen to non-nullable JSON property 'hasBaleen'.");
+
+            if (whale.HasTeethOption.IsSet && whale.HasTeeth == null)
+                throw new JsonException("Cannot write null property Whale.HasTeeth to non-nullable JSON property 'hasTeeth'.");
+
             writer.WriteString("className", whale.ClassName);
 
             if (whale.HasBaleenOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Zebra.cs
@@ -280,6 +280,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Zebra zebra, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (zebra.TypeOption.IsSet && zebra.Type == null)
+                throw new JsonException("Cannot write null property Zebra.Type to non-nullable JSON property 'type'.");
+
             writer.WriteString("className", zebra.ClassName);
 
             var typeRawValue = Zebra.TypeEnumToJsonValue(zebra.TypeOption.Value.Value);

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Zebra.cs
@@ -280,9 +280,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Zebra zebra, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (zebra.ClassName == null)
-                throw new ArgumentNullException(nameof(zebra.ClassName), "Property is required for class Zebra.");
-
             writer.WriteString("className", zebra.ClassName);
 
             var typeRawValue = Zebra.TypeEnumToJsonValue(zebra.TypeOption.Value.Value);

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
@@ -247,6 +247,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ZeroBasedEnumClass zeroBasedEnumClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (zeroBasedEnumClass.ZeroBasedEnumOption.IsSet && zeroBasedEnumClass.ZeroBasedEnum == null)
+                throw new JsonException("Cannot write null property ZeroBasedEnumClass.ZeroBasedEnum to non-nullable JSON property 'ZeroBasedEnum'.");
+
             var zeroBasedEnumRawValue = ZeroBasedEnumClass.ZeroBasedEnumEnumToJsonValue(zeroBasedEnumClass.ZeroBasedEnumOption.Value.Value);
             writer.WriteString("ZeroBasedEnum", zeroBasedEnumRawValue);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Activity.cs
@@ -178,7 +178,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Activity activity, JsonSerializerOptions jsonSerializerOptions)
         {
             if (activity.ActivityOutputsOption.IsSet && activity.ActivityOutputs == null)
-                throw new ArgumentNullException(nameof(activity.ActivityOutputs), "Property is required for class Activity.");
+                throw new JsonException("Cannot write null property Activity.ActivityOutputs to non-nullable JSON property 'activity_outputs'.");
 
             if (activity.ActivityOutputsOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -201,10 +201,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ActivityOutputElementRepresentation activityOutputElementRepresentation, JsonSerializerOptions jsonSerializerOptions)
         {
             if (activityOutputElementRepresentation.Prop1Option.IsSet && activityOutputElementRepresentation.Prop1 == null)
-                throw new ArgumentNullException(nameof(activityOutputElementRepresentation.Prop1), "Property is required for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Cannot write null property ActivityOutputElementRepresentation.Prop1 to non-nullable JSON property 'prop1'.");
 
             if (activityOutputElementRepresentation.Prop2Option.IsSet && activityOutputElementRepresentation.Prop2 == null)
-                throw new ArgumentNullException(nameof(activityOutputElementRepresentation.Prop2), "Property is required for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Cannot write null property ActivityOutputElementRepresentation.Prop2 to non-nullable JSON property 'prop2'.");
 
             if (activityOutputElementRepresentation.Prop1Option.IsSet)
                 writer.WriteString("prop1", activityOutputElementRepresentation.Prop1);

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -337,25 +337,25 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, AdditionalPropertiesClass additionalPropertiesClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (additionalPropertiesClass.EmptyMapOption.IsSet && additionalPropertiesClass.EmptyMap == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.EmptyMap), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.EmptyMap to non-nullable JSON property 'empty_map'.");
 
             if (additionalPropertiesClass.MapOfMapPropertyOption.IsSet && additionalPropertiesClass.MapOfMapProperty == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapOfMapProperty), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapOfMapProperty to non-nullable JSON property 'map_of_map_property'.");
 
             if (additionalPropertiesClass.MapPropertyOption.IsSet && additionalPropertiesClass.MapProperty == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapProperty), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapProperty to non-nullable JSON property 'map_property'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1Option.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1 == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1 to non-nullable JSON property 'map_with_undeclared_properties_anytype_1'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2Option.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2 == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2 to non-nullable JSON property 'map_with_undeclared_properties_anytype_2'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3Option.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3 == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3 to non-nullable JSON property 'map_with_undeclared_properties_anytype_3'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesStringOption.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesString == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesString), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesString to non-nullable JSON property 'map_with_undeclared_properties_string'.");
 
             if (additionalPropertiesClass.Anytype1Option.IsSet)
                 if (additionalPropertiesClass.Anytype1Option.Value != null)

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Animal.cs
@@ -224,7 +224,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Animal animal, JsonSerializerOptions jsonSerializerOptions)
         {
             if (animal.ColorOption.IsSet && animal.Color == null)
-                throw new ArgumentNullException(nameof(animal.Color), "Property is required for class Animal.");
+                throw new JsonException("Cannot write null property Animal.Color to non-nullable JSON property 'color'.");
 
             writer.WriteString("className", animal.ClassName);
 

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -224,10 +224,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ApiResponse apiResponse, JsonSerializerOptions jsonSerializerOptions)
         {
             if (apiResponse.MessageOption.IsSet && apiResponse.Message == null)
-                throw new ArgumentNullException(nameof(apiResponse.Message), "Property is required for class ApiResponse.");
+                throw new JsonException("Cannot write null property ApiResponse.Message to non-nullable JSON property 'message'.");
 
             if (apiResponse.TypeOption.IsSet && apiResponse.Type == null)
-                throw new ArgumentNullException(nameof(apiResponse.Type), "Property is required for class ApiResponse.");
+                throw new JsonException("Cannot write null property ApiResponse.Type to non-nullable JSON property 'type'.");
 
             if (apiResponse.CodeOption.IsSet)
                 writer.WriteNumber("code", apiResponse.CodeOption.Value!.Value);

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -223,6 +223,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ApiResponse apiResponse, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (apiResponse.CodeOption.IsSet && apiResponse.Code == null)
+                throw new JsonException("Cannot write null property ApiResponse.Code to non-nullable JSON property 'code'.");
+
             if (apiResponse.MessageOption.IsSet && apiResponse.Message == null)
                 throw new JsonException("Cannot write null property ApiResponse.Message to non-nullable JSON property 'message'.");
 

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Apple.cs
@@ -254,13 +254,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Apple apple, JsonSerializerOptions jsonSerializerOptions)
         {
             if (apple.ColorCodeOption.IsSet && apple.ColorCode == null)
-                throw new ArgumentNullException(nameof(apple.ColorCode), "Property is required for class Apple.");
+                throw new JsonException("Cannot write null property Apple.ColorCode to non-nullable JSON property 'color_code'.");
 
             if (apple.CultivarOption.IsSet && apple.Cultivar == null)
-                throw new ArgumentNullException(nameof(apple.Cultivar), "Property is required for class Apple.");
+                throw new JsonException("Cannot write null property Apple.Cultivar to non-nullable JSON property 'cultivar'.");
 
             if (apple.OriginOption.IsSet && apple.Origin == null)
-                throw new ArgumentNullException(nameof(apple.Origin), "Property is required for class Apple.");
+                throw new JsonException("Cannot write null property Apple.Origin to non-nullable JSON property 'origin'.");
 
             if (apple.ColorCodeOption.IsSet)
                 writer.WriteString("color_code", apple.ColorCode);

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -189,9 +189,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, AppleReq appleReq, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (appleReq.Cultivar == null)
-                throw new ArgumentNullException(nameof(appleReq.Cultivar), "Property is required for class AppleReq.");
-
             writer.WriteString("cultivar", appleReq.Cultivar);
 
             if (appleReq.MealyOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -189,6 +189,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, AppleReq appleReq, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (appleReq.MealyOption.IsSet && appleReq.Mealy == null)
+                throw new JsonException("Cannot write null property AppleReq.Mealy to non-nullable JSON property 'mealy'.");
+
             writer.WriteString("cultivar", appleReq.Cultivar);
 
             if (appleReq.MealyOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -178,7 +178,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ArrayOfArrayOfNumberOnly arrayOfArrayOfNumberOnly, JsonSerializerOptions jsonSerializerOptions)
         {
             if (arrayOfArrayOfNumberOnly.ArrayArrayNumberOption.IsSet && arrayOfArrayOfNumberOnly.ArrayArrayNumber == null)
-                throw new ArgumentNullException(nameof(arrayOfArrayOfNumberOnly.ArrayArrayNumber), "Property is required for class ArrayOfArrayOfNumberOnly.");
+                throw new JsonException("Cannot write null property ArrayOfArrayOfNumberOnly.ArrayArrayNumber to non-nullable JSON property 'ArrayArrayNumber'.");
 
             if (arrayOfArrayOfNumberOnly.ArrayArrayNumberOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -178,7 +178,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ArrayOfNumberOnly arrayOfNumberOnly, JsonSerializerOptions jsonSerializerOptions)
         {
             if (arrayOfNumberOnly.ArrayNumberOption.IsSet && arrayOfNumberOnly.ArrayNumber == null)
-                throw new ArgumentNullException(nameof(arrayOfNumberOnly.ArrayNumber), "Property is required for class ArrayOfNumberOnly.");
+                throw new JsonException("Cannot write null property ArrayOfNumberOnly.ArrayNumber to non-nullable JSON property 'ArrayNumber'.");
 
             if (arrayOfNumberOnly.ArrayNumberOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -224,13 +224,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ArrayTest arrayTest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (arrayTest.ArrayArrayOfIntegerOption.IsSet && arrayTest.ArrayArrayOfInteger == null)
-                throw new ArgumentNullException(nameof(arrayTest.ArrayArrayOfInteger), "Property is required for class ArrayTest.");
+                throw new JsonException("Cannot write null property ArrayTest.ArrayArrayOfInteger to non-nullable JSON property 'array_array_of_integer'.");
 
             if (arrayTest.ArrayArrayOfModelOption.IsSet && arrayTest.ArrayArrayOfModel == null)
-                throw new ArgumentNullException(nameof(arrayTest.ArrayArrayOfModel), "Property is required for class ArrayTest.");
+                throw new JsonException("Cannot write null property ArrayTest.ArrayArrayOfModel to non-nullable JSON property 'array_array_of_model'.");
 
             if (arrayTest.ArrayOfStringOption.IsSet && arrayTest.ArrayOfString == null)
-                throw new ArgumentNullException(nameof(arrayTest.ArrayOfString), "Property is required for class ArrayTest.");
+                throw new JsonException("Cannot write null property ArrayTest.ArrayOfString to non-nullable JSON property 'array_of_string'.");
 
             if (arrayTest.ArrayArrayOfIntegerOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Banana.cs
@@ -177,6 +177,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Banana banana, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (banana.LengthCmOption.IsSet && banana.LengthCm == null)
+                throw new JsonException("Cannot write null property Banana.LengthCm to non-nullable JSON property 'lengthCm'.");
+
             if (banana.LengthCmOption.IsSet)
                 writer.WriteNumber("lengthCm", banana.LengthCmOption.Value!.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -189,6 +189,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, BananaReq bananaReq, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (bananaReq.SweetOption.IsSet && bananaReq.Sweet == null)
+                throw new JsonException("Cannot write null property BananaReq.Sweet to non-nullable JSON property 'sweet'.");
+
             writer.WriteNumber("lengthCm", bananaReq.LengthCm);
 
             if (bananaReq.SweetOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/BasquePig.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/BasquePig.cs
@@ -173,9 +173,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, BasquePig basquePig, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (basquePig.ClassName == null)
-                throw new ArgumentNullException(nameof(basquePig.ClassName), "Property is required for class BasquePig.");
-
             writer.WriteString("className", basquePig.ClassName);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -294,22 +294,22 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Capitalization capitalization, JsonSerializerOptions jsonSerializerOptions)
         {
             if (capitalization.ATT_NAMEOption.IsSet && capitalization.ATT_NAME == null)
-                throw new ArgumentNullException(nameof(capitalization.ATT_NAME), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.ATT_NAME to non-nullable JSON property 'ATT_NAME'.");
 
             if (capitalization.CapitalCamelOption.IsSet && capitalization.CapitalCamel == null)
-                throw new ArgumentNullException(nameof(capitalization.CapitalCamel), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.CapitalCamel to non-nullable JSON property 'CapitalCamel'.");
 
             if (capitalization.CapitalSnakeOption.IsSet && capitalization.CapitalSnake == null)
-                throw new ArgumentNullException(nameof(capitalization.CapitalSnake), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.CapitalSnake to non-nullable JSON property 'Capital_Snake'.");
 
             if (capitalization.SCAETHFlowPointsOption.IsSet && capitalization.SCAETHFlowPoints == null)
-                throw new ArgumentNullException(nameof(capitalization.SCAETHFlowPoints), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.SCAETHFlowPoints to non-nullable JSON property 'SCA_ETH_Flow_Points'.");
 
             if (capitalization.SmallCamelOption.IsSet && capitalization.SmallCamel == null)
-                throw new ArgumentNullException(nameof(capitalization.SmallCamel), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.SmallCamel to non-nullable JSON property 'smallCamel'.");
 
             if (capitalization.SmallSnakeOption.IsSet && capitalization.SmallSnake == null)
-                throw new ArgumentNullException(nameof(capitalization.SmallSnake), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.SmallSnake to non-nullable JSON property 'small_Snake'.");
 
             if (capitalization.ATT_NAMEOption.IsSet)
                 writer.WriteString("ATT_NAME", capitalization.ATT_NAME);

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Cat.cs
@@ -182,6 +182,9 @@ namespace Org.OpenAPITools.Model
             if (cat.ColorOption.IsSet && cat.Color == null)
                 throw new JsonException("Cannot write null property Cat.Color to non-nullable JSON property 'color'.");
 
+            if (cat.DeclawedOption.IsSet && cat.Declawed == null)
+                throw new JsonException("Cannot write null property Cat.Declawed to non-nullable JSON property 'declawed'.");
+
             writer.WriteString("className", cat.ClassName);
 
             if (cat.ColorOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Cat.cs
@@ -180,7 +180,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Cat cat, JsonSerializerOptions jsonSerializerOptions)
         {
             if (cat.ColorOption.IsSet && cat.Color == null)
-                throw new ArgumentNullException(nameof(cat.Color), "Property is required for class Cat.");
+                throw new JsonException("Cannot write null property Cat.Color to non-nullable JSON property 'color'.");
 
             writer.WriteString("className", cat.ClassName);
 

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Category.cs
@@ -196,6 +196,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Category category, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (category.IdOption.IsSet && category.Id == null)
+                throw new JsonException("Cannot write null property Category.Id to non-nullable JSON property 'id'.");
+
             if (category.IdOption.IsSet)
                 writer.WriteNumber("id", category.IdOption.Value!.Value);
 

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Category.cs
@@ -196,9 +196,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Category category, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (category.Name == null)
-                throw new ArgumentNullException(nameof(category.Name), "Property is required for class Category.");
-
             if (category.IdOption.IsSet)
                 writer.WriteNumber("id", category.IdOption.Value!.Value);
 

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -239,7 +239,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ChildCat childCat, JsonSerializerOptions jsonSerializerOptions)
         {
             if (childCat.NameOption.IsSet && childCat.Name == null)
-                throw new ArgumentNullException(nameof(childCat.Name), "Property is required for class ChildCat.");
+                throw new JsonException("Cannot write null property ChildCat.Name to non-nullable JSON property 'name'.");
 
             if (childCat.NameOption.IsSet)
                 writer.WriteString("name", childCat.Name);

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -178,7 +178,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ClassModel classModel, JsonSerializerOptions jsonSerializerOptions)
         {
             if (classModel.ClassOption.IsSet && classModel.Class == null)
-                throw new ArgumentNullException(nameof(classModel.Class), "Property is required for class ClassModel.");
+                throw new JsonException("Cannot write null property ClassModel.Class to non-nullable JSON property '_class'.");
 
             if (classModel.ClassOption.IsSet)
                 writer.WriteString("_class", classModel.Class);

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
@@ -192,12 +192,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ComplexQuadrilateral complexQuadrilateral, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (complexQuadrilateral.QuadrilateralType == null)
-                throw new ArgumentNullException(nameof(complexQuadrilateral.QuadrilateralType), "Property is required for class ComplexQuadrilateral.");
-
-            if (complexQuadrilateral.ShapeType == null)
-                throw new ArgumentNullException(nameof(complexQuadrilateral.ShapeType), "Property is required for class ComplexQuadrilateral.");
-
             writer.WriteString("quadrilateralType", complexQuadrilateral.QuadrilateralType);
 
             writer.WriteString("shapeType", complexQuadrilateral.ShapeType);

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/CopyActivity.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/CopyActivity.cs
@@ -234,9 +234,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, CopyActivity copyActivity, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (copyActivity.CopyActivitytt == null)
-                throw new ArgumentNullException(nameof(copyActivity.CopyActivitytt), "Property is required for class CopyActivity.");
-
             writer.WriteString("copyActivitytt", copyActivity.CopyActivitytt);
 
             writer.WriteString("$schema", CopyActivity.SchemaEnumToJsonValue(copyActivity.Schema));

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/DanishPig.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/DanishPig.cs
@@ -173,9 +173,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, DanishPig danishPig, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (danishPig.ClassName == null)
-                throw new ArgumentNullException(nameof(danishPig.ClassName), "Property is required for class DanishPig.");
-
             writer.WriteString("className", danishPig.ClassName);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -183,6 +183,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, DateOnlyClass dateOnlyClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (dateOnlyClass.DateOnlyPropertyOption.IsSet && dateOnlyClass.DateOnlyProperty == null)
+                throw new JsonException("Cannot write null property DateOnlyClass.DateOnlyProperty to non-nullable JSON property 'dateOnlyProperty'.");
+
             if (dateOnlyClass.DateOnlyPropertyOption.IsSet)
                 writer.WriteString("dateOnlyProperty", dateOnlyClass.DateOnlyPropertyOption.Value!.Value.ToString(DateOnlyPropertyFormat));
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -178,7 +178,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, DeprecatedObject deprecatedObject, JsonSerializerOptions jsonSerializerOptions)
         {
             if (deprecatedObject.NameOption.IsSet && deprecatedObject.Name == null)
-                throw new ArgumentNullException(nameof(deprecatedObject.Name), "Property is required for class DeprecatedObject.");
+                throw new JsonException("Cannot write null property DeprecatedObject.Name to non-nullable JSON property 'name'.");
 
             if (deprecatedObject.NameOption.IsSet)
                 writer.WriteString("name", deprecatedObject.Name);

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Descendant1.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Descendant1.cs
@@ -185,12 +185,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Descendant1 descendant1, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (descendant1.AlternativeName == null)
-                throw new ArgumentNullException(nameof(descendant1.AlternativeName), "Property is required for class Descendant1.");
-
-            if (descendant1.DescendantName == null)
-                throw new ArgumentNullException(nameof(descendant1.DescendantName), "Property is required for class Descendant1.");
-
             writer.WriteString("alternativeName", descendant1.AlternativeName);
 
             writer.WriteString("descendantName", descendant1.DescendantName);

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Descendant2.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Descendant2.cs
@@ -185,12 +185,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Descendant2 descendant2, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (descendant2.AlternativeName == null)
-                throw new ArgumentNullException(nameof(descendant2.AlternativeName), "Property is required for class Descendant2.");
-
-            if (descendant2.Confidentiality == null)
-                throw new ArgumentNullException(nameof(descendant2.Confidentiality), "Property is required for class Descendant2.");
-
             writer.WriteString("alternativeName", descendant2.AlternativeName);
 
             writer.WriteString("confidentiality", descendant2.Confidentiality);

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Dog.cs
@@ -180,10 +180,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Dog dog, JsonSerializerOptions jsonSerializerOptions)
         {
             if (dog.BreedOption.IsSet && dog.Breed == null)
-                throw new ArgumentNullException(nameof(dog.Breed), "Property is required for class Dog.");
+                throw new JsonException("Cannot write null property Dog.Breed to non-nullable JSON property 'breed'.");
 
             if (dog.ColorOption.IsSet && dog.Color == null)
-                throw new ArgumentNullException(nameof(dog.Color), "Property is required for class Dog.");
+                throw new JsonException("Cannot write null property Dog.Color to non-nullable JSON property 'color'.");
 
             writer.WriteString("className", dog.ClassName);
 

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Drawing.cs
@@ -241,10 +241,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Drawing drawing, JsonSerializerOptions jsonSerializerOptions)
         {
             if (drawing.MainShapeOption.IsSet && drawing.MainShape == null)
-                throw new ArgumentNullException(nameof(drawing.MainShape), "Property is required for class Drawing.");
+                throw new JsonException("Cannot write null property Drawing.MainShape to non-nullable JSON property 'mainShape'.");
 
             if (drawing.ShapesOption.IsSet && drawing.Shapes == null)
-                throw new ArgumentNullException(nameof(drawing.Shapes), "Property is required for class Drawing.");
+                throw new JsonException("Cannot write null property Drawing.Shapes to non-nullable JSON property 'shapes'.");
 
             if (drawing.MainShapeOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -342,6 +342,9 @@ namespace Org.OpenAPITools.Model
             if (enumArrays.ArrayEnumOption.IsSet && enumArrays.ArrayEnum == null)
                 throw new JsonException("Cannot write null property EnumArrays.ArrayEnum to non-nullable JSON property 'array_enum'.");
 
+            if (enumArrays.JustSymbolOption.IsSet && enumArrays.JustSymbol == null)
+                throw new JsonException("Cannot write null property EnumArrays.JustSymbol to non-nullable JSON property 'just_symbol'.");
+
             if (enumArrays.ArrayEnumOption.IsSet)
             {
                 writer.WritePropertyName("array_enum");

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -340,7 +340,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, EnumArrays enumArrays, JsonSerializerOptions jsonSerializerOptions)
         {
             if (enumArrays.ArrayEnumOption.IsSet && enumArrays.ArrayEnum == null)
-                throw new ArgumentNullException(nameof(enumArrays.ArrayEnum), "Property is required for class EnumArrays.");
+                throw new JsonException("Cannot write null property EnumArrays.ArrayEnum to non-nullable JSON property 'array_enum'.");
 
             if (enumArrays.ArrayEnumOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -878,6 +878,27 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, EnumTest enumTest, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (enumTest.EnumIntegerOption.IsSet && enumTest.EnumInteger == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumInteger to non-nullable JSON property 'enum_integer'.");
+
+            if (enumTest.EnumIntegerOnlyOption.IsSet && enumTest.EnumIntegerOnly == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumIntegerOnly to non-nullable JSON property 'enum_integer_only'.");
+
+            if (enumTest.EnumNumberOption.IsSet && enumTest.EnumNumber == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumNumber to non-nullable JSON property 'enum_number'.");
+
+            if (enumTest.EnumStringOption.IsSet && enumTest.EnumString == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumString to non-nullable JSON property 'enum_string'.");
+
+            if (enumTest.OuterEnumDefaultValueOption.IsSet && enumTest.OuterEnumDefaultValue == null)
+                throw new JsonException("Cannot write null property EnumTest.OuterEnumDefaultValue to non-nullable JSON property 'outerEnumDefaultValue'.");
+
+            if (enumTest.OuterEnumIntegerOption.IsSet && enumTest.OuterEnumInteger == null)
+                throw new JsonException("Cannot write null property EnumTest.OuterEnumInteger to non-nullable JSON property 'outerEnumInteger'.");
+
+            if (enumTest.OuterEnumIntegerDefaultValueOption.IsSet && enumTest.OuterEnumIntegerDefaultValue == null)
+                throw new JsonException("Cannot write null property EnumTest.OuterEnumIntegerDefaultValue to non-nullable JSON property 'outerEnumIntegerDefaultValue'.");
+
             var enumStringRequiredRawValue = EnumTest.EnumStringRequiredEnumToJsonValue(enumTest.EnumStringRequired);
             writer.WriteString("enum_string_required", enumStringRequiredRawValue);
             if (enumTest.EnumIntegerOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
@@ -192,12 +192,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, EquilateralTriangle equilateralTriangle, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (equilateralTriangle.ShapeType == null)
-                throw new ArgumentNullException(nameof(equilateralTriangle.ShapeType), "Property is required for class EquilateralTriangle.");
-
-            if (equilateralTriangle.TriangleType == null)
-                throw new ArgumentNullException(nameof(equilateralTriangle.TriangleType), "Property is required for class EquilateralTriangle.");
-
             writer.WriteString("shapeType", equilateralTriangle.ShapeType);
 
             writer.WriteString("triangleType", equilateralTriangle.TriangleType);

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/File.cs
@@ -179,7 +179,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, File file, JsonSerializerOptions jsonSerializerOptions)
         {
             if (file.SourceURIOption.IsSet && file.SourceURI == null)
-                throw new ArgumentNullException(nameof(file.SourceURI), "Property is required for class File.");
+                throw new JsonException("Cannot write null property File.SourceURI to non-nullable JSON property 'sourceURI'.");
 
             if (file.SourceURIOption.IsSet)
                 writer.WriteString("sourceURI", file.SourceURI);

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -201,10 +201,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, FileSchemaTestClass fileSchemaTestClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (fileSchemaTestClass.FileOption.IsSet && fileSchemaTestClass.File == null)
-                throw new ArgumentNullException(nameof(fileSchemaTestClass.File), "Property is required for class FileSchemaTestClass.");
+                throw new JsonException("Cannot write null property FileSchemaTestClass.File to non-nullable JSON property 'file'.");
 
             if (fileSchemaTestClass.FilesOption.IsSet && fileSchemaTestClass.Files == null)
-                throw new ArgumentNullException(nameof(fileSchemaTestClass.Files), "Property is required for class FileSchemaTestClass.");
+                throw new JsonException("Cannot write null property FileSchemaTestClass.Files to non-nullable JSON property 'files'.");
 
             if (fileSchemaTestClass.FileOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Foo.cs
@@ -178,7 +178,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Foo foo, JsonSerializerOptions jsonSerializerOptions)
         {
             if (foo.BarOption.IsSet && foo.Bar == null)
-                throw new ArgumentNullException(nameof(foo.Bar), "Property is required for class Foo.");
+                throw new JsonException("Cannot write null property Foo.Bar to non-nullable JSON property 'bar'.");
 
             if (foo.BarOption.IsSet)
                 writer.WriteString("bar", foo.Bar);

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -178,7 +178,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, FooGetDefaultResponse fooGetDefaultResponse, JsonSerializerOptions jsonSerializerOptions)
         {
             if (fooGetDefaultResponse.StringOption.IsSet && fooGetDefaultResponse.String == null)
-                throw new ArgumentNullException(nameof(fooGetDefaultResponse.String), "Property is required for class FooGetDefaultResponse.");
+                throw new JsonException("Cannot write null property FooGetDefaultResponse.String to non-nullable JSON property 'string'.");
 
             if (fooGetDefaultResponse.StringOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -957,11 +957,47 @@ namespace Org.OpenAPITools.Model
             if (formatTest.BinaryOption.IsSet && formatTest.Binary == null)
                 throw new JsonException("Cannot write null property FormatTest.Binary to non-nullable JSON property 'binary'.");
 
+            if (formatTest.DateTimeOption.IsSet && formatTest.DateTime == null)
+                throw new JsonException("Cannot write null property FormatTest.DateTime to non-nullable JSON property 'dateTime'.");
+
+            if (formatTest.DecimalOption.IsSet && formatTest.Decimal == null)
+                throw new JsonException("Cannot write null property FormatTest.Decimal to non-nullable JSON property 'decimal'.");
+
+            if (formatTest.DoubleOption.IsSet && formatTest.Double == null)
+                throw new JsonException("Cannot write null property FormatTest.Double to non-nullable JSON property 'double'.");
+
             if (formatTest.DuplicatePropertyName2Option.IsSet && formatTest.DuplicatePropertyName2 == null)
                 throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName2 to non-nullable JSON property 'duplicate_property_name'.");
 
             if (formatTest.DuplicatePropertyNameOption.IsSet && formatTest.DuplicatePropertyName == null)
                 throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName to non-nullable JSON property '@duplicate_property_name'.");
+
+            if (formatTest.FloatOption.IsSet && formatTest.Float == null)
+                throw new JsonException("Cannot write null property FormatTest.Float to non-nullable JSON property 'float'.");
+
+            if (formatTest.Int32Option.IsSet && formatTest.Int32 == null)
+                throw new JsonException("Cannot write null property FormatTest.Int32 to non-nullable JSON property 'int32'.");
+
+            if (formatTest.Int32RangeOption.IsSet && formatTest.Int32Range == null)
+                throw new JsonException("Cannot write null property FormatTest.Int32Range to non-nullable JSON property 'int32Range'.");
+
+            if (formatTest.Int64Option.IsSet && formatTest.Int64 == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64 to non-nullable JSON property 'int64'.");
+
+            if (formatTest.Int64NegativeOption.IsSet && formatTest.Int64Negative == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64Negative to non-nullable JSON property 'int64Negative'.");
+
+            if (formatTest.Int64NegativeExclusiveOption.IsSet && formatTest.Int64NegativeExclusive == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64NegativeExclusive to non-nullable JSON property 'int64NegativeExclusive'.");
+
+            if (formatTest.Int64PositiveOption.IsSet && formatTest.Int64Positive == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64Positive to non-nullable JSON property 'int64Positive'.");
+
+            if (formatTest.Int64PositiveExclusiveOption.IsSet && formatTest.Int64PositiveExclusive == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64PositiveExclusive to non-nullable JSON property 'int64PositiveExclusive'.");
+
+            if (formatTest.IntegerOption.IsSet && formatTest.Integer == null)
+                throw new JsonException("Cannot write null property FormatTest.Integer to non-nullable JSON property 'integer'.");
 
             if (formatTest.PatternWithBackslashOption.IsSet && formatTest.PatternWithBackslash == null)
                 throw new JsonException("Cannot write null property FormatTest.PatternWithBackslash to non-nullable JSON property 'pattern_with_backslash'.");
@@ -974,6 +1010,18 @@ namespace Org.OpenAPITools.Model
 
             if (formatTest.StringOption.IsSet && formatTest.String == null)
                 throw new JsonException("Cannot write null property FormatTest.String to non-nullable JSON property 'string'.");
+
+            if (formatTest.StringFormattedAsDecimalOption.IsSet && formatTest.StringFormattedAsDecimal == null)
+                throw new JsonException("Cannot write null property FormatTest.StringFormattedAsDecimal to non-nullable JSON property 'string_formatted_as_decimal'.");
+
+            if (formatTest.UnsignedIntegerOption.IsSet && formatTest.UnsignedInteger == null)
+                throw new JsonException("Cannot write null property FormatTest.UnsignedInteger to non-nullable JSON property 'unsigned_integer'.");
+
+            if (formatTest.UnsignedLongOption.IsSet && formatTest.UnsignedLong == null)
+                throw new JsonException("Cannot write null property FormatTest.UnsignedLong to non-nullable JSON property 'unsigned_long'.");
+
+            if (formatTest.UuidOption.IsSet && formatTest.Uuid == null)
+                throw new JsonException("Cannot write null property FormatTest.Uuid to non-nullable JSON property 'uuid'.");
 
             writer.WritePropertyName("byte");
             JsonSerializer.Serialize(writer, formatTest.Byte, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -954,32 +954,26 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, FormatTest formatTest, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (formatTest.Byte == null)
-                throw new ArgumentNullException(nameof(formatTest.Byte), "Property is required for class FormatTest.");
-
-            if (formatTest.Password == null)
-                throw new ArgumentNullException(nameof(formatTest.Password), "Property is required for class FormatTest.");
-
             if (formatTest.BinaryOption.IsSet && formatTest.Binary == null)
-                throw new ArgumentNullException(nameof(formatTest.Binary), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.Binary to non-nullable JSON property 'binary'.");
 
             if (formatTest.DuplicatePropertyName2Option.IsSet && formatTest.DuplicatePropertyName2 == null)
-                throw new ArgumentNullException(nameof(formatTest.DuplicatePropertyName2), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName2 to non-nullable JSON property 'duplicate_property_name'.");
 
             if (formatTest.DuplicatePropertyNameOption.IsSet && formatTest.DuplicatePropertyName == null)
-                throw new ArgumentNullException(nameof(formatTest.DuplicatePropertyName), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName to non-nullable JSON property '@duplicate_property_name'.");
 
             if (formatTest.PatternWithBackslashOption.IsSet && formatTest.PatternWithBackslash == null)
-                throw new ArgumentNullException(nameof(formatTest.PatternWithBackslash), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.PatternWithBackslash to non-nullable JSON property 'pattern_with_backslash'.");
 
             if (formatTest.PatternWithDigitsOption.IsSet && formatTest.PatternWithDigits == null)
-                throw new ArgumentNullException(nameof(formatTest.PatternWithDigits), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.PatternWithDigits to non-nullable JSON property 'pattern_with_digits'.");
 
             if (formatTest.PatternWithDigitsAndDelimiterOption.IsSet && formatTest.PatternWithDigitsAndDelimiter == null)
-                throw new ArgumentNullException(nameof(formatTest.PatternWithDigitsAndDelimiter), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.PatternWithDigitsAndDelimiter to non-nullable JSON property 'pattern_with_digits_and_delimiter'.");
 
             if (formatTest.StringOption.IsSet && formatTest.String == null)
-                throw new ArgumentNullException(nameof(formatTest.String), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.String to non-nullable JSON property 'string'.");
 
             writer.WritePropertyName("byte");
             JsonSerializer.Serialize(writer, formatTest.Byte, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Fruit.cs
@@ -222,7 +222,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Fruit fruit, JsonSerializerOptions jsonSerializerOptions)
         {
             if (fruit.ColorOption.IsSet && fruit.Color == null)
-                throw new ArgumentNullException(nameof(fruit.Color), "Property is required for class Fruit.");
+                throw new JsonException("Cannot write null property Fruit.Color to non-nullable JSON property 'color'.");
 
             if (fruit.ColorOption.IsSet)
                 writer.WriteString("color", fruit.Color);

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -239,7 +239,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, GmFruit gmFruit, JsonSerializerOptions jsonSerializerOptions)
         {
             if (gmFruit.ColorOption.IsSet && gmFruit.Color == null)
-                throw new ArgumentNullException(nameof(gmFruit.Color), "Property is required for class GmFruit.");
+                throw new JsonException("Cannot write null property GmFruit.Color to non-nullable JSON property 'color'.");
 
             if (gmFruit.ColorOption.IsSet)
                 writer.WriteString("color", gmFruit.Color);

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -242,10 +242,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, HasOnlyReadOnly hasOnlyReadOnly, JsonSerializerOptions jsonSerializerOptions)
         {
             if (hasOnlyReadOnly.BarOption.IsSet && hasOnlyReadOnly.Bar == null)
-                throw new ArgumentNullException(nameof(hasOnlyReadOnly.Bar), "Property is required for class HasOnlyReadOnly.");
+                throw new JsonException("Cannot write null property HasOnlyReadOnly.Bar to non-nullable JSON property 'bar'.");
 
             if (hasOnlyReadOnly.FooOption.IsSet && hasOnlyReadOnly.Foo == null)
-                throw new ArgumentNullException(nameof(hasOnlyReadOnly.Foo), "Property is required for class HasOnlyReadOnly.");
+                throw new JsonException("Cannot write null property HasOnlyReadOnly.Foo to non-nullable JSON property 'foo'.");
 
             if (hasOnlyReadOnly.BarOption.IsSet)
                 writer.WriteString("bar", hasOnlyReadOnly.Bar);

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
@@ -340,22 +340,22 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, InjectedVendorExtensionsTest injectedVendorExtensionsTest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessorOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor to non-nullable JSON property 'potentiallyOverriddenPropertyAccessor'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternalOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternal == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternal), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternal to non-nullable JSON property 'potentiallyOverriddenPropertyToInternal'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivateOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivate == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivate), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivate to non-nullable JSON property 'potentiallyOverriddenPropertyToPrivate'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublicOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublic == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublic), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublic to non-nullable JSON property 'potentiallyOverriddenPropertyToPublic'.");
 
             if (injectedVendorExtensionsTest.UnalteredPropertyOption.IsSet && injectedVendorExtensionsTest.UnalteredProperty == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.UnalteredProperty), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.UnalteredProperty to non-nullable JSON property 'unalteredProperty'.");
 
             if (injectedVendorExtensionsTest.UnalteredPropertyAccessorOption.IsSet && injectedVendorExtensionsTest.UnalteredPropertyAccessor == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.UnalteredPropertyAccessor), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.UnalteredPropertyAccessor to non-nullable JSON property 'unalteredPropertyAccessor'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessorOption.IsSet)
                 writer.WriteString("potentiallyOverriddenPropertyAccessor", injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor);

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
@@ -185,12 +185,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, IsoscelesTriangle isoscelesTriangle, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (isoscelesTriangle.ShapeType == null)
-                throw new ArgumentNullException(nameof(isoscelesTriangle.ShapeType), "Property is required for class IsoscelesTriangle.");
-
-            if (isoscelesTriangle.TriangleType == null)
-                throw new ArgumentNullException(nameof(isoscelesTriangle.TriangleType), "Property is required for class IsoscelesTriangle.");
-
             writer.WriteString("shapeType", isoscelesTriangle.ShapeType);
 
             writer.WriteString("triangleType", isoscelesTriangle.TriangleType);

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/List.cs
@@ -178,7 +178,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, List list, JsonSerializerOptions jsonSerializerOptions)
         {
             if (list.Var123ListOption.IsSet && list.Var123List == null)
-                throw new ArgumentNullException(nameof(list.Var123List), "Property is required for class List.");
+                throw new JsonException("Cannot write null property List.Var123List to non-nullable JSON property '123-list'.");
 
             if (list.Var123ListOption.IsSet)
                 writer.WriteString("123-list", list.Var123List);

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -201,10 +201,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, LiteralStringClass literalStringClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (literalStringClass.EscapedLiteralStringOption.IsSet && literalStringClass.EscapedLiteralString == null)
-                throw new ArgumentNullException(nameof(literalStringClass.EscapedLiteralString), "Property is required for class LiteralStringClass.");
+                throw new JsonException("Cannot write null property LiteralStringClass.EscapedLiteralString to non-nullable JSON property 'escapedLiteralString'.");
 
             if (literalStringClass.UnescapedLiteralStringOption.IsSet && literalStringClass.UnescapedLiteralString == null)
-                throw new ArgumentNullException(nameof(literalStringClass.UnescapedLiteralString), "Property is required for class LiteralStringClass.");
+                throw new JsonException("Cannot write null property LiteralStringClass.UnescapedLiteralString to non-nullable JSON property 'unescapedLiteralString'.");
 
             if (literalStringClass.EscapedLiteralStringOption.IsSet)
                 writer.WriteString("escapedLiteralString", literalStringClass.EscapedLiteralString);

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/MapTest.cs
@@ -313,16 +313,16 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MapTest mapTest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mapTest.DirectMapOption.IsSet && mapTest.DirectMap == null)
-                throw new ArgumentNullException(nameof(mapTest.DirectMap), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.DirectMap to non-nullable JSON property 'direct_map'.");
 
             if (mapTest.IndirectMapOption.IsSet && mapTest.IndirectMap == null)
-                throw new ArgumentNullException(nameof(mapTest.IndirectMap), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.IndirectMap to non-nullable JSON property 'indirect_map'.");
 
             if (mapTest.MapMapOfStringOption.IsSet && mapTest.MapMapOfString == null)
-                throw new ArgumentNullException(nameof(mapTest.MapMapOfString), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.MapMapOfString to non-nullable JSON property 'map_map_of_string'.");
 
             if (mapTest.MapOfEnumStringOption.IsSet && mapTest.MapOfEnumString == null)
-                throw new ArgumentNullException(nameof(mapTest.MapOfEnumString), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.MapOfEnumString to non-nullable JSON property 'map_of_enum_string'.");
 
             if (mapTest.DirectMapOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/MixedAnyOf.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/MixedAnyOf.cs
@@ -178,7 +178,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedAnyOf mixedAnyOf, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedAnyOf.ContentOption.IsSet && mixedAnyOf.Content == null)
-                throw new ArgumentNullException(nameof(mixedAnyOf.Content), "Property is required for class MixedAnyOf.");
+                throw new JsonException("Cannot write null property MixedAnyOf.Content to non-nullable JSON property 'content'.");
 
             if (mixedAnyOf.ContentOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/MixedOneOf.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/MixedOneOf.cs
@@ -178,7 +178,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedOneOf mixedOneOf, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedOneOf.ContentOption.IsSet && mixedOneOf.Content == null)
-                throw new ArgumentNullException(nameof(mixedOneOf.Content), "Property is required for class MixedOneOf.");
+                throw new JsonException("Cannot write null property MixedOneOf.Content to non-nullable JSON property 'content'.");
 
             if (mixedOneOf.ContentOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -258,8 +258,17 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, MixedPropertiesAndAdditionalPropertiesClass mixedPropertiesAndAdditionalPropertiesClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.DateTime == null)
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.DateTime to non-nullable JSON property 'dateTime'.");
+
             if (mixedPropertiesAndAdditionalPropertiesClass.MapOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.Map == null)
                 throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.Map to non-nullable JSON property 'map'.");
+
+            if (mixedPropertiesAndAdditionalPropertiesClass.UuidOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.Uuid == null)
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.Uuid to non-nullable JSON property 'uuid'.");
+
+            if (mixedPropertiesAndAdditionalPropertiesClass.UuidWithPatternOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.UuidWithPattern == null)
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.UuidWithPattern to non-nullable JSON property 'uuid_with_pattern'.");
 
             if (mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.IsSet)
                 writer.WriteString("dateTime", mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.Value!.Value.ToString(DateTimeFormat));

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -259,7 +259,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedPropertiesAndAdditionalPropertiesClass mixedPropertiesAndAdditionalPropertiesClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedPropertiesAndAdditionalPropertiesClass.MapOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.Map == null)
-                throw new ArgumentNullException(nameof(mixedPropertiesAndAdditionalPropertiesClass.Map), "Property is required for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.Map to non-nullable JSON property 'map'.");
 
             if (mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.IsSet)
                 writer.WriteString("dateTime", mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.Value!.Value.ToString(DateTimeFormat));

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/MixedSubId.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/MixedSubId.cs
@@ -178,7 +178,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedSubId mixedSubId, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedSubId.IdOption.IsSet && mixedSubId.Id == null)
-                throw new ArgumentNullException(nameof(mixedSubId.Id), "Property is required for class MixedSubId.");
+                throw new JsonException("Cannot write null property MixedSubId.Id to non-nullable JSON property 'id'.");
 
             if (mixedSubId.IdOption.IsSet)
                 writer.WriteString("id", mixedSubId.Id);

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -201,7 +201,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Model200Response model200Response, JsonSerializerOptions jsonSerializerOptions)
         {
             if (model200Response.ClassOption.IsSet && model200Response.Class == null)
-                throw new ArgumentNullException(nameof(model200Response.Class), "Property is required for class Model200Response.");
+                throw new JsonException("Cannot write null property Model200Response.Class to non-nullable JSON property 'class'.");
 
             if (model200Response.ClassOption.IsSet)
                 writer.WriteString("class", model200Response.Class);

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -203,6 +203,9 @@ namespace Org.OpenAPITools.Model
             if (model200Response.ClassOption.IsSet && model200Response.Class == null)
                 throw new JsonException("Cannot write null property Model200Response.Class to non-nullable JSON property 'class'.");
 
+            if (model200Response.NameOption.IsSet && model200Response.Name == null)
+                throw new JsonException("Cannot write null property Model200Response.Name to non-nullable JSON property 'name'.");
+
             if (model200Response.ClassOption.IsSet)
                 writer.WriteString("class", model200Response.Class);
 

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -178,7 +178,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ModelClient modelClient, JsonSerializerOptions jsonSerializerOptions)
         {
             if (modelClient.VarClientOption.IsSet && modelClient.VarClient == null)
-                throw new ArgumentNullException(nameof(modelClient.VarClient), "Property is required for class ModelClient.");
+                throw new JsonException("Cannot write null property ModelClient.VarClient to non-nullable JSON property 'client'.");
 
             if (modelClient.VarClientOption.IsSet)
                 writer.WriteString("client", modelClient.VarClient);

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Name.cs
@@ -284,7 +284,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Name name, JsonSerializerOptions jsonSerializerOptions)
         {
             if (name.PropertyOption.IsSet && name.Property == null)
-                throw new ArgumentNullException(nameof(name.Property), "Property is required for class Name.");
+                throw new JsonException("Cannot write null property Name.Property to non-nullable JSON property 'property'.");
 
             writer.WriteNumber("name", name.VarName);
 

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Name.cs
@@ -286,6 +286,12 @@ namespace Org.OpenAPITools.Model
             if (name.PropertyOption.IsSet && name.Property == null)
                 throw new JsonException("Cannot write null property Name.Property to non-nullable JSON property 'property'.");
 
+            if (name.SnakeCaseOption.IsSet && name.SnakeCase == null)
+                throw new JsonException("Cannot write null property Name.SnakeCase to non-nullable JSON property 'snake_case'.");
+
+            if (name.Var123NumberOption.IsSet && name.Var123Number == null)
+                throw new JsonException("Cannot write null property Name.Var123Number to non-nullable JSON property '123Number'.");
+
             writer.WriteNumber("name", name.VarName);
 
             if (name.PropertyOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
@@ -192,9 +192,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, NotificationtestGetElementsV1ResponseMPayload notificationtestGetElementsV1ResponseMPayload, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (notificationtestGetElementsV1ResponseMPayload.AObjVariableobject == null)
-                throw new ArgumentNullException(nameof(notificationtestGetElementsV1ResponseMPayload.AObjVariableobject), "Property is required for class NotificationtestGetElementsV1ResponseMPayload.");
-
             writer.WritePropertyName("a_objVariableobject");
             JsonSerializer.Serialize(writer, notificationtestGetElementsV1ResponseMPayload.AObjVariableobject, jsonSerializerOptions);
             writer.WriteNumber("pkiNotificationtestID", notificationtestGetElementsV1ResponseMPayload.PkiNotificationtestID);

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -411,10 +411,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, NullableClass nullableClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (nullableClass.ArrayItemsNullableOption.IsSet && nullableClass.ArrayItemsNullable == null)
-                throw new ArgumentNullException(nameof(nullableClass.ArrayItemsNullable), "Property is required for class NullableClass.");
+                throw new JsonException("Cannot write null property NullableClass.ArrayItemsNullable to non-nullable JSON property 'array_items_nullable'.");
 
             if (nullableClass.ObjectItemsNullableOption.IsSet && nullableClass.ObjectItemsNullable == null)
-                throw new ArgumentNullException(nameof(nullableClass.ObjectItemsNullable), "Property is required for class NullableClass.");
+                throw new JsonException("Cannot write null property NullableClass.ObjectItemsNullable to non-nullable JSON property 'object_items_nullable'.");
 
             if (nullableClass.ArrayAndItemsNullablePropOption.IsSet)
                 if (nullableClass.ArrayAndItemsNullablePropOption.Value != null)

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -177,6 +177,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, NumberOnly numberOnly, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (numberOnly.JustNumberOption.IsSet && numberOnly.JustNumber == null)
+                throw new JsonException("Cannot write null property NumberOnly.JustNumber to non-nullable JSON property 'JustNumber'.");
+
             if (numberOnly.JustNumberOption.IsSet)
                 writer.WriteNumber("JustNumber", numberOnly.JustNumberOption.Value!.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -250,13 +250,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ObjectWithDeprecatedFields objectWithDeprecatedFields, JsonSerializerOptions jsonSerializerOptions)
         {
             if (objectWithDeprecatedFields.BarsOption.IsSet && objectWithDeprecatedFields.Bars == null)
-                throw new ArgumentNullException(nameof(objectWithDeprecatedFields.Bars), "Property is required for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Bars to non-nullable JSON property 'bars'.");
 
             if (objectWithDeprecatedFields.DeprecatedRefOption.IsSet && objectWithDeprecatedFields.DeprecatedRef == null)
-                throw new ArgumentNullException(nameof(objectWithDeprecatedFields.DeprecatedRef), "Property is required for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.DeprecatedRef to non-nullable JSON property 'deprecatedRef'.");
 
             if (objectWithDeprecatedFields.UuidOption.IsSet && objectWithDeprecatedFields.Uuid == null)
-                throw new ArgumentNullException(nameof(objectWithDeprecatedFields.Uuid), "Property is required for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Uuid to non-nullable JSON property 'uuid'.");
 
             if (objectWithDeprecatedFields.BarsOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -255,6 +255,9 @@ namespace Org.OpenAPITools.Model
             if (objectWithDeprecatedFields.DeprecatedRefOption.IsSet && objectWithDeprecatedFields.DeprecatedRef == null)
                 throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.DeprecatedRef to non-nullable JSON property 'deprecatedRef'.");
 
+            if (objectWithDeprecatedFields.IdOption.IsSet && objectWithDeprecatedFields.Id == null)
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Id to non-nullable JSON property 'id'.");
+
             if (objectWithDeprecatedFields.UuidOption.IsSet && objectWithDeprecatedFields.Uuid == null)
                 throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Uuid to non-nullable JSON property 'uuid'.");
 

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Order.cs
@@ -387,6 +387,24 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Order order, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (order.CompleteOption.IsSet && order.Complete == null)
+                throw new JsonException("Cannot write null property Order.Complete to non-nullable JSON property 'complete'.");
+
+            if (order.IdOption.IsSet && order.Id == null)
+                throw new JsonException("Cannot write null property Order.Id to non-nullable JSON property 'id'.");
+
+            if (order.PetIdOption.IsSet && order.PetId == null)
+                throw new JsonException("Cannot write null property Order.PetId to non-nullable JSON property 'petId'.");
+
+            if (order.QuantityOption.IsSet && order.Quantity == null)
+                throw new JsonException("Cannot write null property Order.Quantity to non-nullable JSON property 'quantity'.");
+
+            if (order.ShipDateOption.IsSet && order.ShipDate == null)
+                throw new JsonException("Cannot write null property Order.ShipDate to non-nullable JSON property 'shipDate'.");
+
+            if (order.StatusOption.IsSet && order.Status == null)
+                throw new JsonException("Cannot write null property Order.Status to non-nullable JSON property 'status'.");
+
             if (order.CompleteOption.IsSet)
                 writer.WriteBoolean("complete", order.CompleteOption.Value!.Value);
 

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -224,7 +224,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, OuterComposite outerComposite, JsonSerializerOptions jsonSerializerOptions)
         {
             if (outerComposite.MyStringOption.IsSet && outerComposite.MyString == null)
-                throw new ArgumentNullException(nameof(outerComposite.MyString), "Property is required for class OuterComposite.");
+                throw new JsonException("Cannot write null property OuterComposite.MyString to non-nullable JSON property 'my_string'.");
 
             if (outerComposite.MyBooleanOption.IsSet)
                 writer.WriteBoolean("my_boolean", outerComposite.MyBooleanOption.Value!.Value);

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -223,6 +223,12 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, OuterComposite outerComposite, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (outerComposite.MyBooleanOption.IsSet && outerComposite.MyBoolean == null)
+                throw new JsonException("Cannot write null property OuterComposite.MyBoolean to non-nullable JSON property 'my_boolean'.");
+
+            if (outerComposite.MyNumberOption.IsSet && outerComposite.MyNumber == null)
+                throw new JsonException("Cannot write null property OuterComposite.MyNumber to non-nullable JSON property 'my_number'.");
+
             if (outerComposite.MyStringOption.IsSet && outerComposite.MyString == null)
                 throw new JsonException("Cannot write null property OuterComposite.MyString to non-nullable JSON property 'my_string'.");
 

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Pet.cs
@@ -374,17 +374,11 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Pet pet, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (pet.Name == null)
-                throw new ArgumentNullException(nameof(pet.Name), "Property is required for class Pet.");
-
-            if (pet.PhotoUrls == null)
-                throw new ArgumentNullException(nameof(pet.PhotoUrls), "Property is required for class Pet.");
-
             if (pet.CategoryOption.IsSet && pet.Category == null)
-                throw new ArgumentNullException(nameof(pet.Category), "Property is required for class Pet.");
+                throw new JsonException("Cannot write null property Pet.Category to non-nullable JSON property 'category'.");
 
             if (pet.TagsOption.IsSet && pet.Tags == null)
-                throw new ArgumentNullException(nameof(pet.Tags), "Property is required for class Pet.");
+                throw new JsonException("Cannot write null property Pet.Tags to non-nullable JSON property 'tags'.");
 
             writer.WriteString("name", pet.Name);
 

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Pet.cs
@@ -377,6 +377,12 @@ namespace Org.OpenAPITools.Model
             if (pet.CategoryOption.IsSet && pet.Category == null)
                 throw new JsonException("Cannot write null property Pet.Category to non-nullable JSON property 'category'.");
 
+            if (pet.IdOption.IsSet && pet.Id == null)
+                throw new JsonException("Cannot write null property Pet.Id to non-nullable JSON property 'id'.");
+
+            if (pet.StatusOption.IsSet && pet.Status == null)
+                throw new JsonException("Cannot write null property Pet.Status to non-nullable JSON property 'status'.");
+
             if (pet.TagsOption.IsSet && pet.Tags == null)
                 throw new JsonException("Cannot write null property Pet.Tags to non-nullable JSON property 'tags'.");
 

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
@@ -173,9 +173,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, QuadrilateralInterface quadrilateralInterface, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (quadrilateralInterface.QuadrilateralType == null)
-                throw new ArgumentNullException(nameof(quadrilateralInterface.QuadrilateralType), "Property is required for class QuadrilateralInterface.");
-
             writer.WriteString("quadrilateralType", quadrilateralInterface.QuadrilateralType);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -239,10 +239,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ReadOnlyFirst readOnlyFirst, JsonSerializerOptions jsonSerializerOptions)
         {
             if (readOnlyFirst.BarOption.IsSet && readOnlyFirst.Bar == null)
-                throw new ArgumentNullException(nameof(readOnlyFirst.Bar), "Property is required for class ReadOnlyFirst.");
+                throw new JsonException("Cannot write null property ReadOnlyFirst.Bar to non-nullable JSON property 'bar'.");
 
             if (readOnlyFirst.BazOption.IsSet && readOnlyFirst.Baz == null)
-                throw new ArgumentNullException(nameof(readOnlyFirst.Baz), "Property is required for class ReadOnlyFirst.");
+                throw new JsonException("Cannot write null property ReadOnlyFirst.Baz to non-nullable JSON property 'baz'.");
 
             if (readOnlyFirst.BarOption.IsSet)
                 writer.WriteString("bar", readOnlyFirst.Bar);

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -2238,11 +2238,38 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, RequiredClass requiredClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (requiredClass.NotRequiredNotnullableDatePropOption.IsSet && requiredClass.NotRequiredNotnullableDateProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotRequiredNotnullableDateProp to non-nullable JSON property 'not_required_notnullable_date_prop'.");
+
+            if (requiredClass.NotRequiredNotnullableintegerPropOption.IsSet && requiredClass.NotRequiredNotnullableintegerProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotRequiredNotnullableintegerProp to non-nullable JSON property 'not_required_notnullableinteger_prop'.");
+
             if (requiredClass.NotrequiredNotnullableArrayOfStringOption.IsSet && requiredClass.NotrequiredNotnullableArrayOfString == null)
                 throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableArrayOfString to non-nullable JSON property 'notrequired_notnullable_array_of_string'.");
 
+            if (requiredClass.NotrequiredNotnullableBooleanPropOption.IsSet && requiredClass.NotrequiredNotnullableBooleanProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableBooleanProp to non-nullable JSON property 'notrequired_notnullable_boolean_prop'.");
+
+            if (requiredClass.NotrequiredNotnullableDatetimePropOption.IsSet && requiredClass.NotrequiredNotnullableDatetimeProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableDatetimeProp to non-nullable JSON property 'notrequired_notnullable_datetime_prop'.");
+
+            if (requiredClass.NotrequiredNotnullableEnumIntegerOption.IsSet && requiredClass.NotrequiredNotnullableEnumInteger == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableEnumInteger to non-nullable JSON property 'notrequired_notnullable_enum_integer'.");
+
+            if (requiredClass.NotrequiredNotnullableEnumIntegerOnlyOption.IsSet && requiredClass.NotrequiredNotnullableEnumIntegerOnly == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableEnumIntegerOnly to non-nullable JSON property 'notrequired_notnullable_enum_integer_only'.");
+
+            if (requiredClass.NotrequiredNotnullableEnumStringOption.IsSet && requiredClass.NotrequiredNotnullableEnumString == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableEnumString to non-nullable JSON property 'notrequired_notnullable_enum_string'.");
+
+            if (requiredClass.NotrequiredNotnullableOuterEnumDefaultValueOption.IsSet && requiredClass.NotrequiredNotnullableOuterEnumDefaultValue == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableOuterEnumDefaultValue to non-nullable JSON property 'notrequired_notnullable_outerEnumDefaultValue'.");
+
             if (requiredClass.NotrequiredNotnullableStringPropOption.IsSet && requiredClass.NotrequiredNotnullableStringProp == null)
                 throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableStringProp to non-nullable JSON property 'notrequired_notnullable_string_prop'.");
+
+            if (requiredClass.NotrequiredNotnullableUuidOption.IsSet && requiredClass.NotrequiredNotnullableUuid == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableUuid to non-nullable JSON property 'notrequired_notnullable_uuid'.");
 
             writer.WriteString("required_not_nullable_date_prop", requiredClass.RequiredNotNullableDateProp.ToString(RequiredNotNullableDatePropFormat));
 

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -2238,17 +2238,11 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, RequiredClass requiredClass, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (requiredClass.RequiredNotnullableArrayOfString == null)
-                throw new ArgumentNullException(nameof(requiredClass.RequiredNotnullableArrayOfString), "Property is required for class RequiredClass.");
-
-            if (requiredClass.RequiredNotnullableStringProp == null)
-                throw new ArgumentNullException(nameof(requiredClass.RequiredNotnullableStringProp), "Property is required for class RequiredClass.");
-
             if (requiredClass.NotrequiredNotnullableArrayOfStringOption.IsSet && requiredClass.NotrequiredNotnullableArrayOfString == null)
-                throw new ArgumentNullException(nameof(requiredClass.NotrequiredNotnullableArrayOfString), "Property is required for class RequiredClass.");
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableArrayOfString to non-nullable JSON property 'notrequired_notnullable_array_of_string'.");
 
             if (requiredClass.NotrequiredNotnullableStringPropOption.IsSet && requiredClass.NotrequiredNotnullableStringProp == null)
-                throw new ArgumentNullException(nameof(requiredClass.NotrequiredNotnullableStringProp), "Property is required for class RequiredClass.");
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableStringProp to non-nullable JSON property 'notrequired_notnullable_string_prop'.");
 
             writer.WriteString("required_not_nullable_date_prop", requiredClass.RequiredNotNullableDateProp.ToString(RequiredNotNullableDatePropFormat));
 

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Result.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Result.cs
@@ -227,13 +227,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Result result, JsonSerializerOptions jsonSerializerOptions)
         {
             if (result.CodeOption.IsSet && result.Code == null)
-                throw new ArgumentNullException(nameof(result.Code), "Property is required for class Result.");
+                throw new JsonException("Cannot write null property Result.Code to non-nullable JSON property 'code'.");
 
             if (result.DataOption.IsSet && result.Data == null)
-                throw new ArgumentNullException(nameof(result.Data), "Property is required for class Result.");
+                throw new JsonException("Cannot write null property Result.Data to non-nullable JSON property 'data'.");
 
             if (result.UuidOption.IsSet && result.Uuid == null)
-                throw new ArgumentNullException(nameof(result.Uuid), "Property is required for class Result.");
+                throw new JsonException("Cannot write null property Result.Uuid to non-nullable JSON property 'uuid'.");
 
             if (result.CodeOption.IsSet)
                 writer.WriteString("code", result.Code);

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Return.cs
@@ -235,11 +235,8 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Return varReturn, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (varReturn.Lock == null)
-                throw new ArgumentNullException(nameof(varReturn.Lock), "Property is required for class Return.");
-
             if (varReturn.UnsafeOption.IsSet && varReturn.Unsafe == null)
-                throw new ArgumentNullException(nameof(varReturn.Unsafe), "Property is required for class Return.");
+                throw new JsonException("Cannot write null property Return.Unsafe to non-nullable JSON property 'unsafe'.");
 
             writer.WriteString("lock", varReturn.Lock);
 

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Return.cs
@@ -235,6 +235,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Return varReturn, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (varReturn.VarReturnOption.IsSet && varReturn.VarReturn == null)
+                throw new JsonException("Cannot write null property Return.VarReturn to non-nullable JSON property 'return'.");
+
             if (varReturn.UnsafeOption.IsSet && varReturn.Unsafe == null)
                 throw new JsonException("Cannot write null property Return.Unsafe to non-nullable JSON property 'unsafe'.");
 

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -203,6 +203,9 @@ namespace Org.OpenAPITools.Model
             if (rolesReportsHash.RoleOption.IsSet && rolesReportsHash.Role == null)
                 throw new JsonException("Cannot write null property RolesReportsHash.Role to non-nullable JSON property 'role'.");
 
+            if (rolesReportsHash.RoleUuidOption.IsSet && rolesReportsHash.RoleUuid == null)
+                throw new JsonException("Cannot write null property RolesReportsHash.RoleUuid to non-nullable JSON property 'role_uuid'.");
+
             if (rolesReportsHash.RoleOption.IsSet)
             {
                 writer.WritePropertyName("role");

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -201,7 +201,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, RolesReportsHash rolesReportsHash, JsonSerializerOptions jsonSerializerOptions)
         {
             if (rolesReportsHash.RoleOption.IsSet && rolesReportsHash.Role == null)
-                throw new ArgumentNullException(nameof(rolesReportsHash.Role), "Property is required for class RolesReportsHash.");
+                throw new JsonException("Cannot write null property RolesReportsHash.Role to non-nullable JSON property 'role'.");
 
             if (rolesReportsHash.RoleOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
@@ -178,7 +178,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, RolesReportsHashRole rolesReportsHashRole, JsonSerializerOptions jsonSerializerOptions)
         {
             if (rolesReportsHashRole.NameOption.IsSet && rolesReportsHashRole.Name == null)
-                throw new ArgumentNullException(nameof(rolesReportsHashRole.Name), "Property is required for class RolesReportsHashRole.");
+                throw new JsonException("Cannot write null property RolesReportsHashRole.Name to non-nullable JSON property 'name'.");
 
             if (rolesReportsHashRole.NameOption.IsSet)
                 writer.WriteString("name", rolesReportsHashRole.Name);

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
@@ -192,12 +192,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ScaleneTriangle scaleneTriangle, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (scaleneTriangle.ShapeType == null)
-                throw new ArgumentNullException(nameof(scaleneTriangle.ShapeType), "Property is required for class ScaleneTriangle.");
-
-            if (scaleneTriangle.TriangleType == null)
-                throw new ArgumentNullException(nameof(scaleneTriangle.TriangleType), "Property is required for class ScaleneTriangle.");
-
             writer.WriteString("shapeType", scaleneTriangle.ShapeType);
 
             writer.WriteString("triangleType", scaleneTriangle.TriangleType);

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ShapeInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ShapeInterface.cs
@@ -173,9 +173,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ShapeInterface shapeInterface, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (shapeInterface.ShapeType == null)
-                throw new ArgumentNullException(nameof(shapeInterface.ShapeType), "Property is required for class ShapeInterface.");
-
             writer.WriteString("shapeType", shapeInterface.ShapeType);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
@@ -192,12 +192,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, SimpleQuadrilateral simpleQuadrilateral, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (simpleQuadrilateral.QuadrilateralType == null)
-                throw new ArgumentNullException(nameof(simpleQuadrilateral.QuadrilateralType), "Property is required for class SimpleQuadrilateral.");
-
-            if (simpleQuadrilateral.ShapeType == null)
-                throw new ArgumentNullException(nameof(simpleQuadrilateral.ShapeType), "Property is required for class SimpleQuadrilateral.");
-
             writer.WriteString("quadrilateralType", simpleQuadrilateral.QuadrilateralType);
 
             writer.WriteString("shapeType", simpleQuadrilateral.ShapeType);

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -203,6 +203,9 @@ namespace Org.OpenAPITools.Model
             if (specialModelName.VarSpecialModelNameOption.IsSet && specialModelName.VarSpecialModelName == null)
                 throw new JsonException("Cannot write null property SpecialModelName.VarSpecialModelName to non-nullable JSON property '_special_model.name_'.");
 
+            if (specialModelName.SpecialPropertyNameOption.IsSet && specialModelName.SpecialPropertyName == null)
+                throw new JsonException("Cannot write null property SpecialModelName.SpecialPropertyName to non-nullable JSON property '$special[property.name]'.");
+
             if (specialModelName.VarSpecialModelNameOption.IsSet)
                 writer.WriteString("_special_model.name_", specialModelName.VarSpecialModelName);
 

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -201,7 +201,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, SpecialModelName specialModelName, JsonSerializerOptions jsonSerializerOptions)
         {
             if (specialModelName.VarSpecialModelNameOption.IsSet && specialModelName.VarSpecialModelName == null)
-                throw new ArgumentNullException(nameof(specialModelName.VarSpecialModelName), "Property is required for class SpecialModelName.");
+                throw new JsonException("Cannot write null property SpecialModelName.VarSpecialModelName to non-nullable JSON property '_special_model.name_'.");
 
             if (specialModelName.VarSpecialModelNameOption.IsSet)
                 writer.WriteString("_special_model.name_", specialModelName.VarSpecialModelName);

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Tag.cs
@@ -200,6 +200,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Tag tag, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (tag.IdOption.IsSet && tag.Id == null)
+                throw new JsonException("Cannot write null property Tag.Id to non-nullable JSON property 'id'.");
+
             if (tag.NameOption.IsSet && tag.Name == null)
                 throw new JsonException("Cannot write null property Tag.Name to non-nullable JSON property 'name'.");
 

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Tag.cs
@@ -201,7 +201,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Tag tag, JsonSerializerOptions jsonSerializerOptions)
         {
             if (tag.NameOption.IsSet && tag.Name == null)
-                throw new ArgumentNullException(nameof(tag.Name), "Property is required for class Tag.");
+                throw new JsonException("Cannot write null property Tag.Name to non-nullable JSON property 'name'.");
 
             if (tag.IdOption.IsSet)
                 writer.WriteNumber("id", tag.IdOption.Value!.Value);

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -178,7 +178,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestCollectionEndingWithWordList testCollectionEndingWithWordList, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testCollectionEndingWithWordList.ValueOption.IsSet && testCollectionEndingWithWordList.Value == null)
-                throw new ArgumentNullException(nameof(testCollectionEndingWithWordList.Value), "Property is required for class TestCollectionEndingWithWordList.");
+                throw new JsonException("Cannot write null property TestCollectionEndingWithWordList.Value to non-nullable JSON property 'value'.");
 
             if (testCollectionEndingWithWordList.ValueOption.IsSet)
                 writer.WriteString("value", testCollectionEndingWithWordList.Value);

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -178,7 +178,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestCollectionEndingWithWordListObject testCollectionEndingWithWordListObject, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testCollectionEndingWithWordListObject.TestCollectionEndingWithWordListOption.IsSet && testCollectionEndingWithWordListObject.TestCollectionEndingWithWordList == null)
-                throw new ArgumentNullException(nameof(testCollectionEndingWithWordListObject.TestCollectionEndingWithWordList), "Property is required for class TestCollectionEndingWithWordListObject.");
+                throw new JsonException("Cannot write null property TestCollectionEndingWithWordListObject.TestCollectionEndingWithWordList to non-nullable JSON property 'TestCollectionEndingWithWordList'.");
 
             if (testCollectionEndingWithWordListObject.TestCollectionEndingWithWordListOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/TestDescendants.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/TestDescendants.cs
@@ -292,9 +292,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, TestDescendants testDescendants, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (testDescendants.AlternativeName == null)
-                throw new ArgumentNullException(nameof(testDescendants.AlternativeName), "Property is required for class TestDescendants.");
-
             writer.WriteString("alternativeName", testDescendants.AlternativeName);
 
             writer.WriteString("objectType", TestDescendants.ObjectTypeEnumToJsonValue(testDescendants.ObjectType));

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
@@ -178,7 +178,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestInlineFreeformAdditionalPropertiesRequest testInlineFreeformAdditionalPropertiesRequest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testInlineFreeformAdditionalPropertiesRequest.SomePropertyOption.IsSet && testInlineFreeformAdditionalPropertiesRequest.SomeProperty == null)
-                throw new ArgumentNullException(nameof(testInlineFreeformAdditionalPropertiesRequest.SomeProperty), "Property is required for class TestInlineFreeformAdditionalPropertiesRequest.");
+                throw new JsonException("Cannot write null property TestInlineFreeformAdditionalPropertiesRequest.SomeProperty to non-nullable JSON property 'someProperty'.");
 
             if (testInlineFreeformAdditionalPropertiesRequest.SomePropertyOption.IsSet)
                 writer.WriteString("someProperty", testInlineFreeformAdditionalPropertiesRequest.SomeProperty);

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/TestResult.cs
@@ -225,6 +225,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, TestResult testResult, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (testResult.CodeOption.IsSet && testResult.Code == null)
+                throw new JsonException("Cannot write null property TestResult.Code to non-nullable JSON property 'code'.");
+
             if (testResult.DataOption.IsSet && testResult.Data == null)
                 throw new JsonException("Cannot write null property TestResult.Data to non-nullable JSON property 'data'.");
 

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/TestResult.cs
@@ -226,10 +226,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestResult testResult, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testResult.DataOption.IsSet && testResult.Data == null)
-                throw new ArgumentNullException(nameof(testResult.Data), "Property is required for class TestResult.");
+                throw new JsonException("Cannot write null property TestResult.Data to non-nullable JSON property 'data'.");
 
             if (testResult.UuidOption.IsSet && testResult.Uuid == null)
-                throw new ArgumentNullException(nameof(testResult.Uuid), "Property is required for class TestResult.");
+                throw new JsonException("Cannot write null property TestResult.Uuid to non-nullable JSON property 'uuid'.");
 
             if (testResult.CodeOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/TriangleInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/TriangleInterface.cs
@@ -173,9 +173,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, TriangleInterface triangleInterface, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (triangleInterface.TriangleType == null)
-                throw new ArgumentNullException(nameof(triangleInterface.TriangleType), "Property is required for class TriangleInterface.");
-
             writer.WriteString("triangleType", triangleInterface.TriangleType);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/User.cs
@@ -427,25 +427,25 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, User user, JsonSerializerOptions jsonSerializerOptions)
         {
             if (user.EmailOption.IsSet && user.Email == null)
-                throw new ArgumentNullException(nameof(user.Email), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Email to non-nullable JSON property 'email'.");
 
             if (user.FirstNameOption.IsSet && user.FirstName == null)
-                throw new ArgumentNullException(nameof(user.FirstName), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.FirstName to non-nullable JSON property 'firstName'.");
 
             if (user.LastNameOption.IsSet && user.LastName == null)
-                throw new ArgumentNullException(nameof(user.LastName), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.LastName to non-nullable JSON property 'lastName'.");
 
             if (user.ObjectWithNoDeclaredPropsOption.IsSet && user.ObjectWithNoDeclaredProps == null)
-                throw new ArgumentNullException(nameof(user.ObjectWithNoDeclaredProps), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.ObjectWithNoDeclaredProps to non-nullable JSON property 'objectWithNoDeclaredProps'.");
 
             if (user.PasswordOption.IsSet && user.Password == null)
-                throw new ArgumentNullException(nameof(user.Password), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Password to non-nullable JSON property 'password'.");
 
             if (user.PhoneOption.IsSet && user.Phone == null)
-                throw new ArgumentNullException(nameof(user.Phone), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Phone to non-nullable JSON property 'phone'.");
 
             if (user.UsernameOption.IsSet && user.Username == null)
-                throw new ArgumentNullException(nameof(user.Username), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Username to non-nullable JSON property 'username'.");
 
             if (user.AnyTypePropOption.IsSet)
                 if (user.AnyTypePropOption.Value != null)

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/User.cs
@@ -432,6 +432,9 @@ namespace Org.OpenAPITools.Model
             if (user.FirstNameOption.IsSet && user.FirstName == null)
                 throw new JsonException("Cannot write null property User.FirstName to non-nullable JSON property 'firstName'.");
 
+            if (user.IdOption.IsSet && user.Id == null)
+                throw new JsonException("Cannot write null property User.Id to non-nullable JSON property 'id'.");
+
             if (user.LastNameOption.IsSet && user.LastName == null)
                 throw new JsonException("Cannot write null property User.LastName to non-nullable JSON property 'lastName'.");
 
@@ -443,6 +446,9 @@ namespace Org.OpenAPITools.Model
 
             if (user.PhoneOption.IsSet && user.Phone == null)
                 throw new JsonException("Cannot write null property User.Phone to non-nullable JSON property 'phone'.");
+
+            if (user.UserStatusOption.IsSet && user.UserStatus == null)
+                throw new JsonException("Cannot write null property User.UserStatus to non-nullable JSON property 'userStatus'.");
 
             if (user.UsernameOption.IsSet && user.Username == null)
                 throw new JsonException("Cannot write null property User.Username to non-nullable JSON property 'username'.");

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Whale.cs
@@ -219,9 +219,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Whale whale, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (whale.ClassName == null)
-                throw new ArgumentNullException(nameof(whale.ClassName), "Property is required for class Whale.");
-
             writer.WriteString("className", whale.ClassName);
 
             if (whale.HasBaleenOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Whale.cs
@@ -219,6 +219,12 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Whale whale, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (whale.HasBaleenOption.IsSet && whale.HasBaleen == null)
+                throw new JsonException("Cannot write null property Whale.HasBaleen to non-nullable JSON property 'hasBaleen'.");
+
+            if (whale.HasTeethOption.IsSet && whale.HasTeeth == null)
+                throw new JsonException("Cannot write null property Whale.HasTeeth to non-nullable JSON property 'hasTeeth'.");
+
             writer.WriteString("className", whale.ClassName);
 
             if (whale.HasBaleenOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Zebra.cs
@@ -283,9 +283,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Zebra zebra, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (zebra.ClassName == null)
-                throw new ArgumentNullException(nameof(zebra.ClassName), "Property is required for class Zebra.");
-
             writer.WriteString("className", zebra.ClassName);
 
             var typeRawValue = Zebra.TypeEnumToJsonValue(zebra.TypeOption.Value!.Value);

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Zebra.cs
@@ -283,6 +283,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Zebra zebra, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (zebra.TypeOption.IsSet && zebra.Type == null)
+                throw new JsonException("Cannot write null property Zebra.Type to non-nullable JSON property 'type'.");
+
             writer.WriteString("className", zebra.ClassName);
 
             var typeRawValue = Zebra.TypeEnumToJsonValue(zebra.TypeOption.Value!.Value);

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
@@ -250,6 +250,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ZeroBasedEnumClass zeroBasedEnumClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (zeroBasedEnumClass.ZeroBasedEnumOption.IsSet && zeroBasedEnumClass.ZeroBasedEnum == null)
+                throw new JsonException("Cannot write null property ZeroBasedEnumClass.ZeroBasedEnum to non-nullable JSON property 'ZeroBasedEnum'.");
+
             var zeroBasedEnumRawValue = ZeroBasedEnumClass.ZeroBasedEnumEnumToJsonValue(zeroBasedEnumClass.ZeroBasedEnumOption.Value!.Value);
             writer.WriteString("ZeroBasedEnum", zeroBasedEnumRawValue);
         }

--- a/samples/client/petstore/csharp/generichost/net8/UseDateTimeForDate/src/Org.OpenAPITools/Model/NowGet200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net8/UseDateTimeForDate/src/Org.OpenAPITools/Model/NowGet200Response.cs
@@ -201,6 +201,12 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, NowGet200Response nowGet200Response, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (nowGet200Response.NowOption.IsSet && nowGet200Response.Now == null)
+                throw new JsonException("Cannot write null property NowGet200Response.Now to non-nullable JSON property 'now'.");
+
+            if (nowGet200Response.TodayOption.IsSet && nowGet200Response.Today == null)
+                throw new JsonException("Cannot write null property NowGet200Response.Today to non-nullable JSON property 'today'.");
+
             if (nowGet200Response.NowOption.IsSet)
                 writer.WriteString("now", nowGet200Response.NowOption.Value!.Value.ToString(NowFormat));
 

--- a/samples/client/petstore/csharp/generichost/net9/AllOf/src/Org.OpenAPITools/Model/Adult.cs
+++ b/samples/client/petstore/csharp/generichost/net9/AllOf/src/Org.OpenAPITools/Model/Adult.cs
@@ -184,13 +184,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Adult adult, JsonSerializerOptions jsonSerializerOptions)
         {
             if (adult.ChildrenOption.IsSet && adult.Children == null)
-                throw new ArgumentNullException(nameof(adult.Children), "Property is required for class Adult.");
+                throw new JsonException("Cannot write null property Adult.Children to non-nullable JSON property 'children'.");
 
             if (adult.FirstNameOption.IsSet && adult.FirstName == null)
-                throw new ArgumentNullException(nameof(adult.FirstName), "Property is required for class Adult.");
+                throw new JsonException("Cannot write null property Adult.FirstName to non-nullable JSON property 'firstName'.");
 
             if (adult.LastNameOption.IsSet && adult.LastName == null)
-                throw new ArgumentNullException(nameof(adult.LastName), "Property is required for class Adult.");
+                throw new JsonException("Cannot write null property Adult.LastName to non-nullable JSON property 'lastName'.");
 
             if (adult.ChildrenOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net9/AllOf/src/Org.OpenAPITools/Model/Child.cs
+++ b/samples/client/petstore/csharp/generichost/net9/AllOf/src/Org.OpenAPITools/Model/Child.cs
@@ -206,6 +206,12 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Child child, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (child.AgeOption.IsSet && child.Age == null)
+                throw new JsonException("Cannot write null property Child.Age to non-nullable JSON property 'age'.");
+
+            if (child.BoosterSeatOption.IsSet && child.BoosterSeat == null)
+                throw new JsonException("Cannot write null property Child.BoosterSeat to non-nullable JSON property 'boosterSeat'.");
+
             if (child.FirstNameOption.IsSet && child.FirstName == null)
                 throw new JsonException("Cannot write null property Child.FirstName to non-nullable JSON property 'firstName'.");
 

--- a/samples/client/petstore/csharp/generichost/net9/AllOf/src/Org.OpenAPITools/Model/Child.cs
+++ b/samples/client/petstore/csharp/generichost/net9/AllOf/src/Org.OpenAPITools/Model/Child.cs
@@ -207,10 +207,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Child child, JsonSerializerOptions jsonSerializerOptions)
         {
             if (child.FirstNameOption.IsSet && child.FirstName == null)
-                throw new ArgumentNullException(nameof(child.FirstName), "Property is required for class Child.");
+                throw new JsonException("Cannot write null property Child.FirstName to non-nullable JSON property 'firstName'.");
 
             if (child.LastNameOption.IsSet && child.LastName == null)
-                throw new ArgumentNullException(nameof(child.LastName), "Property is required for class Child.");
+                throw new JsonException("Cannot write null property Child.LastName to non-nullable JSON property 'lastName'.");
 
             if (child.AgeOption.IsSet)
                 writer.WriteNumber("age", child.AgeOption.Value!.Value);

--- a/samples/client/petstore/csharp/generichost/net9/AllOf/src/Org.OpenAPITools/Model/Person.cs
+++ b/samples/client/petstore/csharp/generichost/net9/AllOf/src/Org.OpenAPITools/Model/Person.cs
@@ -243,10 +243,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Person person, JsonSerializerOptions jsonSerializerOptions)
         {
             if (person.FirstNameOption.IsSet && person.FirstName == null)
-                throw new ArgumentNullException(nameof(person.FirstName), "Property is required for class Person.");
+                throw new JsonException("Cannot write null property Person.FirstName to non-nullable JSON property 'firstName'.");
 
             if (person.LastNameOption.IsSet && person.LastName == null)
-                throw new ArgumentNullException(nameof(person.LastName), "Property is required for class Person.");
+                throw new JsonException("Cannot write null property Person.LastName to non-nullable JSON property 'lastName'.");
 
             if (person.FirstNameOption.IsSet)
                 writer.WriteString("firstName", person.FirstName);

--- a/samples/client/petstore/csharp/generichost/net9/AnyOf/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net9/AnyOf/src/Org.OpenAPITools/Model/Apple.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Apple apple, JsonSerializerOptions jsonSerializerOptions)
         {
             if (apple.KindOption.IsSet && apple.Kind == null)
-                throw new ArgumentNullException(nameof(apple.Kind), "Property is required for class Apple.");
+                throw new JsonException("Cannot write null property Apple.Kind to non-nullable JSON property 'kind'.");
 
             if (apple.KindOption.IsSet)
                 writer.WriteString("kind", apple.Kind);

--- a/samples/client/petstore/csharp/generichost/net9/AnyOf/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net9/AnyOf/src/Org.OpenAPITools/Model/Banana.cs
@@ -176,6 +176,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Banana banana, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (banana.CountOption.IsSet && banana.Count == null)
+                throw new JsonException("Cannot write null property Banana.Count to non-nullable JSON property 'count'.");
+
             if (banana.CountOption.IsSet)
                 writer.WriteNumber("count", banana.CountOption.Value!.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net9/AnyOf/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net9/AnyOf/src/Org.OpenAPITools/Model/Fruit.cs
@@ -245,7 +245,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Fruit fruit, JsonSerializerOptions jsonSerializerOptions)
         {
             if (fruit.ColorOption.IsSet && fruit.Color == null)
-                throw new ArgumentNullException(nameof(fruit.Color), "Property is required for class Fruit.");
+                throw new JsonException("Cannot write null property Fruit.Color to non-nullable JSON property 'color'.");
 
             if (fruit.ColorOption.IsSet)
                 writer.WriteString("color", fruit.Color);

--- a/samples/client/petstore/csharp/generichost/net9/AnyOfNoCompare/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net9/AnyOfNoCompare/src/Org.OpenAPITools/Model/Apple.cs
@@ -176,7 +176,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Apple apple, JsonSerializerOptions jsonSerializerOptions)
         {
             if (apple.KindOption.IsSet && apple.Kind == null)
-                throw new ArgumentNullException(nameof(apple.Kind), "Property is required for class Apple.");
+                throw new JsonException("Cannot write null property Apple.Kind to non-nullable JSON property 'kind'.");
 
             if (apple.KindOption.IsSet)
                 writer.WriteString("kind", apple.Kind);

--- a/samples/client/petstore/csharp/generichost/net9/AnyOfNoCompare/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net9/AnyOfNoCompare/src/Org.OpenAPITools/Model/Banana.cs
@@ -175,6 +175,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Banana banana, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (banana.CountOption.IsSet && banana.Count == null)
+                throw new JsonException("Cannot write null property Banana.Count to non-nullable JSON property 'count'.");
+
             if (banana.CountOption.IsSet)
                 writer.WriteNumber("count", banana.CountOption.Value!.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net9/AnyOfNoCompare/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net9/AnyOfNoCompare/src/Org.OpenAPITools/Model/Fruit.cs
@@ -244,7 +244,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Fruit fruit, JsonSerializerOptions jsonSerializerOptions)
         {
             if (fruit.ColorOption.IsSet && fruit.Color == null)
-                throw new ArgumentNullException(nameof(fruit.Color), "Property is required for class Fruit.");
+                throw new JsonException("Cannot write null property Fruit.Color to non-nullable JSON property 'color'.");
 
             if (fruit.ColorOption.IsSet)
                 writer.WriteString("color", fruit.Color);

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Activity.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Activity activity, JsonSerializerOptions jsonSerializerOptions)
         {
             if (activity.ActivityOutputsOption.IsSet && activity.ActivityOutputs == null)
-                throw new ArgumentNullException(nameof(activity.ActivityOutputs), "Property is required for class Activity.");
+                throw new JsonException("Cannot write null property Activity.ActivityOutputs to non-nullable JSON property 'activity_outputs'.");
 
             if (activity.ActivityOutputsOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -198,10 +198,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ActivityOutputElementRepresentation activityOutputElementRepresentation, JsonSerializerOptions jsonSerializerOptions)
         {
             if (activityOutputElementRepresentation.Prop1Option.IsSet && activityOutputElementRepresentation.Prop1 == null)
-                throw new ArgumentNullException(nameof(activityOutputElementRepresentation.Prop1), "Property is required for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Cannot write null property ActivityOutputElementRepresentation.Prop1 to non-nullable JSON property 'prop1'.");
 
             if (activityOutputElementRepresentation.Prop2Option.IsSet && activityOutputElementRepresentation.Prop2 == null)
-                throw new ArgumentNullException(nameof(activityOutputElementRepresentation.Prop2), "Property is required for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Cannot write null property ActivityOutputElementRepresentation.Prop2 to non-nullable JSON property 'prop2'.");
 
             if (activityOutputElementRepresentation.Prop1Option.IsSet)
                 writer.WriteString("prop1", activityOutputElementRepresentation.Prop1);

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -334,25 +334,25 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, AdditionalPropertiesClass additionalPropertiesClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (additionalPropertiesClass.EmptyMapOption.IsSet && additionalPropertiesClass.EmptyMap == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.EmptyMap), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.EmptyMap to non-nullable JSON property 'empty_map'.");
 
             if (additionalPropertiesClass.MapOfMapPropertyOption.IsSet && additionalPropertiesClass.MapOfMapProperty == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapOfMapProperty), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapOfMapProperty to non-nullable JSON property 'map_of_map_property'.");
 
             if (additionalPropertiesClass.MapPropertyOption.IsSet && additionalPropertiesClass.MapProperty == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapProperty), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapProperty to non-nullable JSON property 'map_property'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1Option.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1 == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1 to non-nullable JSON property 'map_with_undeclared_properties_anytype_1'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2Option.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2 == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2 to non-nullable JSON property 'map_with_undeclared_properties_anytype_2'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3Option.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3 == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3 to non-nullable JSON property 'map_with_undeclared_properties_anytype_3'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesStringOption.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesString == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesString), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesString to non-nullable JSON property 'map_with_undeclared_properties_string'.");
 
             if (additionalPropertiesClass.Anytype1Option.IsSet)
                 if (additionalPropertiesClass.Anytype1Option.Value != null)

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Animal.cs
@@ -221,7 +221,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Animal animal, JsonSerializerOptions jsonSerializerOptions)
         {
             if (animal.ColorOption.IsSet && animal.Color == null)
-                throw new ArgumentNullException(nameof(animal.Color), "Property is required for class Animal.");
+                throw new JsonException("Cannot write null property Animal.Color to non-nullable JSON property 'color'.");
 
             writer.WriteString("className", animal.ClassName);
 

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -221,10 +221,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ApiResponse apiResponse, JsonSerializerOptions jsonSerializerOptions)
         {
             if (apiResponse.MessageOption.IsSet && apiResponse.Message == null)
-                throw new ArgumentNullException(nameof(apiResponse.Message), "Property is required for class ApiResponse.");
+                throw new JsonException("Cannot write null property ApiResponse.Message to non-nullable JSON property 'message'.");
 
             if (apiResponse.TypeOption.IsSet && apiResponse.Type == null)
-                throw new ArgumentNullException(nameof(apiResponse.Type), "Property is required for class ApiResponse.");
+                throw new JsonException("Cannot write null property ApiResponse.Type to non-nullable JSON property 'type'.");
 
             if (apiResponse.CodeOption.IsSet)
                 writer.WriteNumber("code", apiResponse.CodeOption.Value.Value);

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -220,6 +220,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ApiResponse apiResponse, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (apiResponse.CodeOption.IsSet && apiResponse.Code == null)
+                throw new JsonException("Cannot write null property ApiResponse.Code to non-nullable JSON property 'code'.");
+
             if (apiResponse.MessageOption.IsSet && apiResponse.Message == null)
                 throw new JsonException("Cannot write null property ApiResponse.Message to non-nullable JSON property 'message'.");
 

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Apple.cs
@@ -251,13 +251,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Apple apple, JsonSerializerOptions jsonSerializerOptions)
         {
             if (apple.ColorCodeOption.IsSet && apple.ColorCode == null)
-                throw new ArgumentNullException(nameof(apple.ColorCode), "Property is required for class Apple.");
+                throw new JsonException("Cannot write null property Apple.ColorCode to non-nullable JSON property 'color_code'.");
 
             if (apple.CultivarOption.IsSet && apple.Cultivar == null)
-                throw new ArgumentNullException(nameof(apple.Cultivar), "Property is required for class Apple.");
+                throw new JsonException("Cannot write null property Apple.Cultivar to non-nullable JSON property 'cultivar'.");
 
             if (apple.OriginOption.IsSet && apple.Origin == null)
-                throw new ArgumentNullException(nameof(apple.Origin), "Property is required for class Apple.");
+                throw new JsonException("Cannot write null property Apple.Origin to non-nullable JSON property 'origin'.");
 
             if (apple.ColorCodeOption.IsSet)
                 writer.WriteString("color_code", apple.ColorCode);

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -186,9 +186,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, AppleReq appleReq, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (appleReq.Cultivar == null)
-                throw new ArgumentNullException(nameof(appleReq.Cultivar), "Property is required for class AppleReq.");
-
             writer.WriteString("cultivar", appleReq.Cultivar);
 
             if (appleReq.MealyOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -186,6 +186,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, AppleReq appleReq, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (appleReq.MealyOption.IsSet && appleReq.Mealy == null)
+                throw new JsonException("Cannot write null property AppleReq.Mealy to non-nullable JSON property 'mealy'.");
+
             writer.WriteString("cultivar", appleReq.Cultivar);
 
             if (appleReq.MealyOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ArrayOfArrayOfNumberOnly arrayOfArrayOfNumberOnly, JsonSerializerOptions jsonSerializerOptions)
         {
             if (arrayOfArrayOfNumberOnly.ArrayArrayNumberOption.IsSet && arrayOfArrayOfNumberOnly.ArrayArrayNumber == null)
-                throw new ArgumentNullException(nameof(arrayOfArrayOfNumberOnly.ArrayArrayNumber), "Property is required for class ArrayOfArrayOfNumberOnly.");
+                throw new JsonException("Cannot write null property ArrayOfArrayOfNumberOnly.ArrayArrayNumber to non-nullable JSON property 'ArrayArrayNumber'.");
 
             if (arrayOfArrayOfNumberOnly.ArrayArrayNumberOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ArrayOfNumberOnly arrayOfNumberOnly, JsonSerializerOptions jsonSerializerOptions)
         {
             if (arrayOfNumberOnly.ArrayNumberOption.IsSet && arrayOfNumberOnly.ArrayNumber == null)
-                throw new ArgumentNullException(nameof(arrayOfNumberOnly.ArrayNumber), "Property is required for class ArrayOfNumberOnly.");
+                throw new JsonException("Cannot write null property ArrayOfNumberOnly.ArrayNumber to non-nullable JSON property 'ArrayNumber'.");
 
             if (arrayOfNumberOnly.ArrayNumberOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -221,13 +221,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ArrayTest arrayTest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (arrayTest.ArrayArrayOfIntegerOption.IsSet && arrayTest.ArrayArrayOfInteger == null)
-                throw new ArgumentNullException(nameof(arrayTest.ArrayArrayOfInteger), "Property is required for class ArrayTest.");
+                throw new JsonException("Cannot write null property ArrayTest.ArrayArrayOfInteger to non-nullable JSON property 'array_array_of_integer'.");
 
             if (arrayTest.ArrayArrayOfModelOption.IsSet && arrayTest.ArrayArrayOfModel == null)
-                throw new ArgumentNullException(nameof(arrayTest.ArrayArrayOfModel), "Property is required for class ArrayTest.");
+                throw new JsonException("Cannot write null property ArrayTest.ArrayArrayOfModel to non-nullable JSON property 'array_array_of_model'.");
 
             if (arrayTest.ArrayOfStringOption.IsSet && arrayTest.ArrayOfString == null)
-                throw new ArgumentNullException(nameof(arrayTest.ArrayOfString), "Property is required for class ArrayTest.");
+                throw new JsonException("Cannot write null property ArrayTest.ArrayOfString to non-nullable JSON property 'array_of_string'.");
 
             if (arrayTest.ArrayArrayOfIntegerOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Banana.cs
@@ -174,6 +174,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Banana banana, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (banana.LengthCmOption.IsSet && banana.LengthCm == null)
+                throw new JsonException("Cannot write null property Banana.LengthCm to non-nullable JSON property 'lengthCm'.");
+
             if (banana.LengthCmOption.IsSet)
                 writer.WriteNumber("lengthCm", banana.LengthCmOption.Value.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -186,6 +186,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, BananaReq bananaReq, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (bananaReq.SweetOption.IsSet && bananaReq.Sweet == null)
+                throw new JsonException("Cannot write null property BananaReq.Sweet to non-nullable JSON property 'sweet'.");
+
             writer.WriteNumber("lengthCm", bananaReq.LengthCm);
 
             if (bananaReq.SweetOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/BasquePig.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/BasquePig.cs
@@ -170,9 +170,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, BasquePig basquePig, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (basquePig.ClassName == null)
-                throw new ArgumentNullException(nameof(basquePig.ClassName), "Property is required for class BasquePig.");
-
             writer.WriteString("className", basquePig.ClassName);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -291,22 +291,22 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Capitalization capitalization, JsonSerializerOptions jsonSerializerOptions)
         {
             if (capitalization.ATT_NAMEOption.IsSet && capitalization.ATT_NAME == null)
-                throw new ArgumentNullException(nameof(capitalization.ATT_NAME), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.ATT_NAME to non-nullable JSON property 'ATT_NAME'.");
 
             if (capitalization.CapitalCamelOption.IsSet && capitalization.CapitalCamel == null)
-                throw new ArgumentNullException(nameof(capitalization.CapitalCamel), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.CapitalCamel to non-nullable JSON property 'CapitalCamel'.");
 
             if (capitalization.CapitalSnakeOption.IsSet && capitalization.CapitalSnake == null)
-                throw new ArgumentNullException(nameof(capitalization.CapitalSnake), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.CapitalSnake to non-nullable JSON property 'Capital_Snake'.");
 
             if (capitalization.SCAETHFlowPointsOption.IsSet && capitalization.SCAETHFlowPoints == null)
-                throw new ArgumentNullException(nameof(capitalization.SCAETHFlowPoints), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.SCAETHFlowPoints to non-nullable JSON property 'SCA_ETH_Flow_Points'.");
 
             if (capitalization.SmallCamelOption.IsSet && capitalization.SmallCamel == null)
-                throw new ArgumentNullException(nameof(capitalization.SmallCamel), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.SmallCamel to non-nullable JSON property 'smallCamel'.");
 
             if (capitalization.SmallSnakeOption.IsSet && capitalization.SmallSnake == null)
-                throw new ArgumentNullException(nameof(capitalization.SmallSnake), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.SmallSnake to non-nullable JSON property 'small_Snake'.");
 
             if (capitalization.ATT_NAMEOption.IsSet)
                 writer.WriteString("ATT_NAME", capitalization.ATT_NAME);

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Cat.cs
@@ -179,6 +179,9 @@ namespace Org.OpenAPITools.Model
             if (cat.ColorOption.IsSet && cat.Color == null)
                 throw new JsonException("Cannot write null property Cat.Color to non-nullable JSON property 'color'.");
 
+            if (cat.DeclawedOption.IsSet && cat.Declawed == null)
+                throw new JsonException("Cannot write null property Cat.Declawed to non-nullable JSON property 'declawed'.");
+
             writer.WriteString("className", cat.ClassName);
 
             if (cat.ColorOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Cat.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Cat cat, JsonSerializerOptions jsonSerializerOptions)
         {
             if (cat.ColorOption.IsSet && cat.Color == null)
-                throw new ArgumentNullException(nameof(cat.Color), "Property is required for class Cat.");
+                throw new JsonException("Cannot write null property Cat.Color to non-nullable JSON property 'color'.");
 
             writer.WriteString("className", cat.ClassName);
 

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Category.cs
@@ -193,9 +193,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Category category, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (category.Name == null)
-                throw new ArgumentNullException(nameof(category.Name), "Property is required for class Category.");
-
             if (category.IdOption.IsSet)
                 writer.WriteNumber("id", category.IdOption.Value.Value);
 

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Category.cs
@@ -193,6 +193,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Category category, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (category.IdOption.IsSet && category.Id == null)
+                throw new JsonException("Cannot write null property Category.Id to non-nullable JSON property 'id'.");
+
             if (category.IdOption.IsSet)
                 writer.WriteNumber("id", category.IdOption.Value.Value);
 

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ChildCat childCat, JsonSerializerOptions jsonSerializerOptions)
         {
             if (childCat.NameOption.IsSet && childCat.Name == null)
-                throw new ArgumentNullException(nameof(childCat.Name), "Property is required for class ChildCat.");
+                throw new JsonException("Cannot write null property ChildCat.Name to non-nullable JSON property 'name'.");
 
             writer.WriteString("pet_type", ChildCatAllOfPetTypeValueConverter.ToJsonValue(childCat.PetType));
 

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ClassModel classModel, JsonSerializerOptions jsonSerializerOptions)
         {
             if (classModel.ClassOption.IsSet && classModel.Class == null)
-                throw new ArgumentNullException(nameof(classModel.Class), "Property is required for class ClassModel.");
+                throw new JsonException("Cannot write null property ClassModel.Class to non-nullable JSON property '_class'.");
 
             if (classModel.ClassOption.IsSet)
                 writer.WriteString("_class", classModel.Class);

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
@@ -189,12 +189,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ComplexQuadrilateral complexQuadrilateral, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (complexQuadrilateral.QuadrilateralType == null)
-                throw new ArgumentNullException(nameof(complexQuadrilateral.QuadrilateralType), "Property is required for class ComplexQuadrilateral.");
-
-            if (complexQuadrilateral.ShapeType == null)
-                throw new ArgumentNullException(nameof(complexQuadrilateral.ShapeType), "Property is required for class ComplexQuadrilateral.");
-
             writer.WriteString("quadrilateralType", complexQuadrilateral.QuadrilateralType);
 
             writer.WriteString("shapeType", complexQuadrilateral.ShapeType);

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/CopyActivity.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/CopyActivity.cs
@@ -172,9 +172,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, CopyActivity copyActivity, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (copyActivity.CopyActivitytt == null)
-                throw new ArgumentNullException(nameof(copyActivity.CopyActivitytt), "Property is required for class CopyActivity.");
-
             writer.WriteString("copyActivitytt", copyActivity.CopyActivitytt);
 
             writer.WriteString("$schema", CopyActivityAllOfSchemaValueConverter.ToJsonValue(copyActivity.Schema));

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/DanishPig.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/DanishPig.cs
@@ -170,9 +170,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, DanishPig danishPig, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (danishPig.ClassName == null)
-                throw new ArgumentNullException(nameof(danishPig.ClassName), "Property is required for class DanishPig.");
-
             writer.WriteString("className", danishPig.ClassName);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -180,6 +180,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, DateOnlyClass dateOnlyClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (dateOnlyClass.DateOnlyPropertyOption.IsSet && dateOnlyClass.DateOnlyProperty == null)
+                throw new JsonException("Cannot write null property DateOnlyClass.DateOnlyProperty to non-nullable JSON property 'dateOnlyProperty'.");
+
             if (dateOnlyClass.DateOnlyPropertyOption.IsSet)
                 writer.WriteString("dateOnlyProperty", dateOnlyClass.DateOnlyPropertyOption.Value.Value.ToString(DateOnlyPropertyFormat));
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, DeprecatedObject deprecatedObject, JsonSerializerOptions jsonSerializerOptions)
         {
             if (deprecatedObject.NameOption.IsSet && deprecatedObject.Name == null)
-                throw new ArgumentNullException(nameof(deprecatedObject.Name), "Property is required for class DeprecatedObject.");
+                throw new JsonException("Cannot write null property DeprecatedObject.Name to non-nullable JSON property 'name'.");
 
             if (deprecatedObject.NameOption.IsSet)
                 writer.WriteString("name", deprecatedObject.Name);

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Descendant1.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Descendant1.cs
@@ -175,12 +175,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Descendant1 descendant1, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (descendant1.AlternativeName == null)
-                throw new ArgumentNullException(nameof(descendant1.AlternativeName), "Property is required for class Descendant1.");
-
-            if (descendant1.DescendantName == null)
-                throw new ArgumentNullException(nameof(descendant1.DescendantName), "Property is required for class Descendant1.");
-
             writer.WriteString("alternativeName", descendant1.AlternativeName);
 
             writer.WriteString("descendantName", descendant1.DescendantName);

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Descendant2.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Descendant2.cs
@@ -175,12 +175,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Descendant2 descendant2, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (descendant2.AlternativeName == null)
-                throw new ArgumentNullException(nameof(descendant2.AlternativeName), "Property is required for class Descendant2.");
-
-            if (descendant2.Confidentiality == null)
-                throw new ArgumentNullException(nameof(descendant2.Confidentiality), "Property is required for class Descendant2.");
-
             writer.WriteString("alternativeName", descendant2.AlternativeName);
 
             writer.WriteString("confidentiality", descendant2.Confidentiality);

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Dog.cs
@@ -177,10 +177,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Dog dog, JsonSerializerOptions jsonSerializerOptions)
         {
             if (dog.BreedOption.IsSet && dog.Breed == null)
-                throw new ArgumentNullException(nameof(dog.Breed), "Property is required for class Dog.");
+                throw new JsonException("Cannot write null property Dog.Breed to non-nullable JSON property 'breed'.");
 
             if (dog.ColorOption.IsSet && dog.Color == null)
-                throw new ArgumentNullException(nameof(dog.Color), "Property is required for class Dog.");
+                throw new JsonException("Cannot write null property Dog.Color to non-nullable JSON property 'color'.");
 
             writer.WriteString("className", dog.ClassName);
 

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Drawing.cs
@@ -238,10 +238,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Drawing drawing, JsonSerializerOptions jsonSerializerOptions)
         {
             if (drawing.MainShapeOption.IsSet && drawing.MainShape == null)
-                throw new ArgumentNullException(nameof(drawing.MainShape), "Property is required for class Drawing.");
+                throw new JsonException("Cannot write null property Drawing.MainShape to non-nullable JSON property 'mainShape'.");
 
             if (drawing.ShapesOption.IsSet && drawing.Shapes == null)
-                throw new ArgumentNullException(nameof(drawing.Shapes), "Property is required for class Drawing.");
+                throw new JsonException("Cannot write null property Drawing.Shapes to non-nullable JSON property 'shapes'.");
 
             if (drawing.MainShapeOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -200,6 +200,9 @@ namespace Org.OpenAPITools.Model
             if (enumArrays.ArrayEnumOption.IsSet && enumArrays.ArrayEnum == null)
                 throw new JsonException("Cannot write null property EnumArrays.ArrayEnum to non-nullable JSON property 'array_enum'.");
 
+            if (enumArrays.JustSymbolOption.IsSet && enumArrays.JustSymbol == null)
+                throw new JsonException("Cannot write null property EnumArrays.JustSymbol to non-nullable JSON property 'just_symbol'.");
+
             if (enumArrays.ArrayEnumOption.IsSet)
             {
                 writer.WritePropertyName("array_enum");

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -198,7 +198,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, EnumArrays enumArrays, JsonSerializerOptions jsonSerializerOptions)
         {
             if (enumArrays.ArrayEnumOption.IsSet && enumArrays.ArrayEnum == null)
-                throw new ArgumentNullException(nameof(enumArrays.ArrayEnum), "Property is required for class EnumArrays.");
+                throw new JsonException("Cannot write null property EnumArrays.ArrayEnum to non-nullable JSON property 'array_enum'.");
 
             if (enumArrays.ArrayEnumOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -351,6 +351,27 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, EnumTest enumTest, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (enumTest.EnumIntegerOption.IsSet && enumTest.EnumInteger == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumInteger to non-nullable JSON property 'enum_integer'.");
+
+            if (enumTest.EnumIntegerOnlyOption.IsSet && enumTest.EnumIntegerOnly == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumIntegerOnly to non-nullable JSON property 'enum_integer_only'.");
+
+            if (enumTest.EnumNumberOption.IsSet && enumTest.EnumNumber == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumNumber to non-nullable JSON property 'enum_number'.");
+
+            if (enumTest.EnumStringOption.IsSet && enumTest.EnumString == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumString to non-nullable JSON property 'enum_string'.");
+
+            if (enumTest.OuterEnumDefaultValueOption.IsSet && enumTest.OuterEnumDefaultValue == null)
+                throw new JsonException("Cannot write null property EnumTest.OuterEnumDefaultValue to non-nullable JSON property 'outerEnumDefaultValue'.");
+
+            if (enumTest.OuterEnumIntegerOption.IsSet && enumTest.OuterEnumInteger == null)
+                throw new JsonException("Cannot write null property EnumTest.OuterEnumInteger to non-nullable JSON property 'outerEnumInteger'.");
+
+            if (enumTest.OuterEnumIntegerDefaultValueOption.IsSet && enumTest.OuterEnumIntegerDefaultValue == null)
+                throw new JsonException("Cannot write null property EnumTest.OuterEnumIntegerDefaultValue to non-nullable JSON property 'outerEnumIntegerDefaultValue'.");
+
             var enumStringRequiredRawValue = EnumTestEnumStringValueConverter.ToJsonValue(enumTest.EnumStringRequired);
             writer.WriteString("enum_string_required", enumStringRequiredRawValue);
 

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
@@ -189,12 +189,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, EquilateralTriangle equilateralTriangle, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (equilateralTriangle.ShapeType == null)
-                throw new ArgumentNullException(nameof(equilateralTriangle.ShapeType), "Property is required for class EquilateralTriangle.");
-
-            if (equilateralTriangle.TriangleType == null)
-                throw new ArgumentNullException(nameof(equilateralTriangle.TriangleType), "Property is required for class EquilateralTriangle.");
-
             writer.WriteString("shapeType", equilateralTriangle.ShapeType);
 
             writer.WriteString("triangleType", equilateralTriangle.TriangleType);

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/File.cs
@@ -176,7 +176,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, File file, JsonSerializerOptions jsonSerializerOptions)
         {
             if (file.SourceURIOption.IsSet && file.SourceURI == null)
-                throw new ArgumentNullException(nameof(file.SourceURI), "Property is required for class File.");
+                throw new JsonException("Cannot write null property File.SourceURI to non-nullable JSON property 'sourceURI'.");
 
             if (file.SourceURIOption.IsSet)
                 writer.WriteString("sourceURI", file.SourceURI);

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -198,10 +198,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, FileSchemaTestClass fileSchemaTestClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (fileSchemaTestClass.FileOption.IsSet && fileSchemaTestClass.File == null)
-                throw new ArgumentNullException(nameof(fileSchemaTestClass.File), "Property is required for class FileSchemaTestClass.");
+                throw new JsonException("Cannot write null property FileSchemaTestClass.File to non-nullable JSON property 'file'.");
 
             if (fileSchemaTestClass.FilesOption.IsSet && fileSchemaTestClass.Files == null)
-                throw new ArgumentNullException(nameof(fileSchemaTestClass.Files), "Property is required for class FileSchemaTestClass.");
+                throw new JsonException("Cannot write null property FileSchemaTestClass.Files to non-nullable JSON property 'files'.");
 
             if (fileSchemaTestClass.FileOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Foo.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Foo foo, JsonSerializerOptions jsonSerializerOptions)
         {
             if (foo.BarOption.IsSet && foo.Bar == null)
-                throw new ArgumentNullException(nameof(foo.Bar), "Property is required for class Foo.");
+                throw new JsonException("Cannot write null property Foo.Bar to non-nullable JSON property 'bar'.");
 
             if (foo.BarOption.IsSet)
                 writer.WriteString("bar", foo.Bar);

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, FooGetDefaultResponse fooGetDefaultResponse, JsonSerializerOptions jsonSerializerOptions)
         {
             if (fooGetDefaultResponse.StringOption.IsSet && fooGetDefaultResponse.String == null)
-                throw new ArgumentNullException(nameof(fooGetDefaultResponse.String), "Property is required for class FooGetDefaultResponse.");
+                throw new JsonException("Cannot write null property FooGetDefaultResponse.String to non-nullable JSON property 'string'.");
 
             if (fooGetDefaultResponse.StringOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -954,11 +954,47 @@ namespace Org.OpenAPITools.Model
             if (formatTest.BinaryOption.IsSet && formatTest.Binary == null)
                 throw new JsonException("Cannot write null property FormatTest.Binary to non-nullable JSON property 'binary'.");
 
+            if (formatTest.DateTimeOption.IsSet && formatTest.DateTime == null)
+                throw new JsonException("Cannot write null property FormatTest.DateTime to non-nullable JSON property 'dateTime'.");
+
+            if (formatTest.DecimalOption.IsSet && formatTest.Decimal == null)
+                throw new JsonException("Cannot write null property FormatTest.Decimal to non-nullable JSON property 'decimal'.");
+
+            if (formatTest.DoubleOption.IsSet && formatTest.Double == null)
+                throw new JsonException("Cannot write null property FormatTest.Double to non-nullable JSON property 'double'.");
+
             if (formatTest.DuplicatePropertyName2Option.IsSet && formatTest.DuplicatePropertyName2 == null)
                 throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName2 to non-nullable JSON property 'duplicate_property_name'.");
 
             if (formatTest.DuplicatePropertyNameOption.IsSet && formatTest.DuplicatePropertyName == null)
                 throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName to non-nullable JSON property '@duplicate_property_name'.");
+
+            if (formatTest.FloatOption.IsSet && formatTest.Float == null)
+                throw new JsonException("Cannot write null property FormatTest.Float to non-nullable JSON property 'float'.");
+
+            if (formatTest.Int32Option.IsSet && formatTest.Int32 == null)
+                throw new JsonException("Cannot write null property FormatTest.Int32 to non-nullable JSON property 'int32'.");
+
+            if (formatTest.Int32RangeOption.IsSet && formatTest.Int32Range == null)
+                throw new JsonException("Cannot write null property FormatTest.Int32Range to non-nullable JSON property 'int32Range'.");
+
+            if (formatTest.Int64Option.IsSet && formatTest.Int64 == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64 to non-nullable JSON property 'int64'.");
+
+            if (formatTest.Int64NegativeOption.IsSet && formatTest.Int64Negative == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64Negative to non-nullable JSON property 'int64Negative'.");
+
+            if (formatTest.Int64NegativeExclusiveOption.IsSet && formatTest.Int64NegativeExclusive == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64NegativeExclusive to non-nullable JSON property 'int64NegativeExclusive'.");
+
+            if (formatTest.Int64PositiveOption.IsSet && formatTest.Int64Positive == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64Positive to non-nullable JSON property 'int64Positive'.");
+
+            if (formatTest.Int64PositiveExclusiveOption.IsSet && formatTest.Int64PositiveExclusive == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64PositiveExclusive to non-nullable JSON property 'int64PositiveExclusive'.");
+
+            if (formatTest.IntegerOption.IsSet && formatTest.Integer == null)
+                throw new JsonException("Cannot write null property FormatTest.Integer to non-nullable JSON property 'integer'.");
 
             if (formatTest.PatternWithBackslashOption.IsSet && formatTest.PatternWithBackslash == null)
                 throw new JsonException("Cannot write null property FormatTest.PatternWithBackslash to non-nullable JSON property 'pattern_with_backslash'.");
@@ -971,6 +1007,18 @@ namespace Org.OpenAPITools.Model
 
             if (formatTest.StringOption.IsSet && formatTest.String == null)
                 throw new JsonException("Cannot write null property FormatTest.String to non-nullable JSON property 'string'.");
+
+            if (formatTest.StringFormattedAsDecimalOption.IsSet && formatTest.StringFormattedAsDecimal == null)
+                throw new JsonException("Cannot write null property FormatTest.StringFormattedAsDecimal to non-nullable JSON property 'string_formatted_as_decimal'.");
+
+            if (formatTest.UnsignedIntegerOption.IsSet && formatTest.UnsignedInteger == null)
+                throw new JsonException("Cannot write null property FormatTest.UnsignedInteger to non-nullable JSON property 'unsigned_integer'.");
+
+            if (formatTest.UnsignedLongOption.IsSet && formatTest.UnsignedLong == null)
+                throw new JsonException("Cannot write null property FormatTest.UnsignedLong to non-nullable JSON property 'unsigned_long'.");
+
+            if (formatTest.UuidOption.IsSet && formatTest.Uuid == null)
+                throw new JsonException("Cannot write null property FormatTest.Uuid to non-nullable JSON property 'uuid'.");
 
             writer.WritePropertyName("byte");
             JsonSerializer.Serialize(writer, formatTest.Byte, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -951,32 +951,26 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, FormatTest formatTest, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (formatTest.Byte == null)
-                throw new ArgumentNullException(nameof(formatTest.Byte), "Property is required for class FormatTest.");
-
-            if (formatTest.Password == null)
-                throw new ArgumentNullException(nameof(formatTest.Password), "Property is required for class FormatTest.");
-
             if (formatTest.BinaryOption.IsSet && formatTest.Binary == null)
-                throw new ArgumentNullException(nameof(formatTest.Binary), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.Binary to non-nullable JSON property 'binary'.");
 
             if (formatTest.DuplicatePropertyName2Option.IsSet && formatTest.DuplicatePropertyName2 == null)
-                throw new ArgumentNullException(nameof(formatTest.DuplicatePropertyName2), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName2 to non-nullable JSON property 'duplicate_property_name'.");
 
             if (formatTest.DuplicatePropertyNameOption.IsSet && formatTest.DuplicatePropertyName == null)
-                throw new ArgumentNullException(nameof(formatTest.DuplicatePropertyName), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName to non-nullable JSON property '@duplicate_property_name'.");
 
             if (formatTest.PatternWithBackslashOption.IsSet && formatTest.PatternWithBackslash == null)
-                throw new ArgumentNullException(nameof(formatTest.PatternWithBackslash), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.PatternWithBackslash to non-nullable JSON property 'pattern_with_backslash'.");
 
             if (formatTest.PatternWithDigitsOption.IsSet && formatTest.PatternWithDigits == null)
-                throw new ArgumentNullException(nameof(formatTest.PatternWithDigits), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.PatternWithDigits to non-nullable JSON property 'pattern_with_digits'.");
 
             if (formatTest.PatternWithDigitsAndDelimiterOption.IsSet && formatTest.PatternWithDigitsAndDelimiter == null)
-                throw new ArgumentNullException(nameof(formatTest.PatternWithDigitsAndDelimiter), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.PatternWithDigitsAndDelimiter to non-nullable JSON property 'pattern_with_digits_and_delimiter'.");
 
             if (formatTest.StringOption.IsSet && formatTest.String == null)
-                throw new ArgumentNullException(nameof(formatTest.String), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.String to non-nullable JSON property 'string'.");
 
             writer.WritePropertyName("byte");
             JsonSerializer.Serialize(writer, formatTest.Byte, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Fruit.cs
@@ -219,7 +219,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Fruit fruit, JsonSerializerOptions jsonSerializerOptions)
         {
             if (fruit.ColorOption.IsSet && fruit.Color == null)
-                throw new ArgumentNullException(nameof(fruit.Color), "Property is required for class Fruit.");
+                throw new JsonException("Cannot write null property Fruit.Color to non-nullable JSON property 'color'.");
 
             if (fruit.ColorOption.IsSet)
                 writer.WriteString("color", fruit.Color);

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -236,7 +236,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, GmFruit gmFruit, JsonSerializerOptions jsonSerializerOptions)
         {
             if (gmFruit.ColorOption.IsSet && gmFruit.Color == null)
-                throw new ArgumentNullException(nameof(gmFruit.Color), "Property is required for class GmFruit.");
+                throw new JsonException("Cannot write null property GmFruit.Color to non-nullable JSON property 'color'.");
 
             if (gmFruit.ColorOption.IsSet)
                 writer.WriteString("color", gmFruit.Color);

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -239,10 +239,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, HasOnlyReadOnly hasOnlyReadOnly, JsonSerializerOptions jsonSerializerOptions)
         {
             if (hasOnlyReadOnly.BarOption.IsSet && hasOnlyReadOnly.Bar == null)
-                throw new ArgumentNullException(nameof(hasOnlyReadOnly.Bar), "Property is required for class HasOnlyReadOnly.");
+                throw new JsonException("Cannot write null property HasOnlyReadOnly.Bar to non-nullable JSON property 'bar'.");
 
             if (hasOnlyReadOnly.FooOption.IsSet && hasOnlyReadOnly.Foo == null)
-                throw new ArgumentNullException(nameof(hasOnlyReadOnly.Foo), "Property is required for class HasOnlyReadOnly.");
+                throw new JsonException("Cannot write null property HasOnlyReadOnly.Foo to non-nullable JSON property 'foo'.");
 
             if (hasOnlyReadOnly.BarOption.IsSet)
                 writer.WriteString("bar", hasOnlyReadOnly.Bar);

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
@@ -337,22 +337,22 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, InjectedVendorExtensionsTest injectedVendorExtensionsTest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessorOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor to non-nullable JSON property 'potentiallyOverriddenPropertyAccessor'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternalOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternal == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternal), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternal to non-nullable JSON property 'potentiallyOverriddenPropertyToInternal'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivateOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivate == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivate), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivate to non-nullable JSON property 'potentiallyOverriddenPropertyToPrivate'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublicOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublic == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublic), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublic to non-nullable JSON property 'potentiallyOverriddenPropertyToPublic'.");
 
             if (injectedVendorExtensionsTest.UnalteredPropertyOption.IsSet && injectedVendorExtensionsTest.UnalteredProperty == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.UnalteredProperty), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.UnalteredProperty to non-nullable JSON property 'unalteredProperty'.");
 
             if (injectedVendorExtensionsTest.UnalteredPropertyAccessorOption.IsSet && injectedVendorExtensionsTest.UnalteredPropertyAccessor == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.UnalteredPropertyAccessor), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.UnalteredPropertyAccessor to non-nullable JSON property 'unalteredPropertyAccessor'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessorOption.IsSet)
                 writer.WriteString("potentiallyOverriddenPropertyAccessor", injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor);

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
@@ -182,12 +182,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, IsoscelesTriangle isoscelesTriangle, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (isoscelesTriangle.ShapeType == null)
-                throw new ArgumentNullException(nameof(isoscelesTriangle.ShapeType), "Property is required for class IsoscelesTriangle.");
-
-            if (isoscelesTriangle.TriangleType == null)
-                throw new ArgumentNullException(nameof(isoscelesTriangle.TriangleType), "Property is required for class IsoscelesTriangle.");
-
             writer.WriteString("shapeType", isoscelesTriangle.ShapeType);
 
             writer.WriteString("triangleType", isoscelesTriangle.TriangleType);

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/List.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, List list, JsonSerializerOptions jsonSerializerOptions)
         {
             if (list.Var123ListOption.IsSet && list.Var123List == null)
-                throw new ArgumentNullException(nameof(list.Var123List), "Property is required for class List.");
+                throw new JsonException("Cannot write null property List.Var123List to non-nullable JSON property '123-list'.");
 
             if (list.Var123ListOption.IsSet)
                 writer.WriteString("123-list", list.Var123List);

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -198,10 +198,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, LiteralStringClass literalStringClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (literalStringClass.EscapedLiteralStringOption.IsSet && literalStringClass.EscapedLiteralString == null)
-                throw new ArgumentNullException(nameof(literalStringClass.EscapedLiteralString), "Property is required for class LiteralStringClass.");
+                throw new JsonException("Cannot write null property LiteralStringClass.EscapedLiteralString to non-nullable JSON property 'escapedLiteralString'.");
 
             if (literalStringClass.UnescapedLiteralStringOption.IsSet && literalStringClass.UnescapedLiteralString == null)
-                throw new ArgumentNullException(nameof(literalStringClass.UnescapedLiteralString), "Property is required for class LiteralStringClass.");
+                throw new JsonException("Cannot write null property LiteralStringClass.UnescapedLiteralString to non-nullable JSON property 'unescapedLiteralString'.");
 
             if (literalStringClass.EscapedLiteralStringOption.IsSet)
                 writer.WriteString("escapedLiteralString", literalStringClass.EscapedLiteralString);

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/MapTest.cs
@@ -244,16 +244,16 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MapTest mapTest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mapTest.DirectMapOption.IsSet && mapTest.DirectMap == null)
-                throw new ArgumentNullException(nameof(mapTest.DirectMap), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.DirectMap to non-nullable JSON property 'direct_map'.");
 
             if (mapTest.IndirectMapOption.IsSet && mapTest.IndirectMap == null)
-                throw new ArgumentNullException(nameof(mapTest.IndirectMap), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.IndirectMap to non-nullable JSON property 'indirect_map'.");
 
             if (mapTest.MapMapOfStringOption.IsSet && mapTest.MapMapOfString == null)
-                throw new ArgumentNullException(nameof(mapTest.MapMapOfString), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.MapMapOfString to non-nullable JSON property 'map_map_of_string'.");
 
             if (mapTest.MapOfEnumStringOption.IsSet && mapTest.MapOfEnumString == null)
-                throw new ArgumentNullException(nameof(mapTest.MapOfEnumString), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.MapOfEnumString to non-nullable JSON property 'map_of_enum_string'.");
 
             if (mapTest.DirectMapOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/MixedAnyOf.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/MixedAnyOf.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedAnyOf mixedAnyOf, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedAnyOf.ContentOption.IsSet && mixedAnyOf.Content == null)
-                throw new ArgumentNullException(nameof(mixedAnyOf.Content), "Property is required for class MixedAnyOf.");
+                throw new JsonException("Cannot write null property MixedAnyOf.Content to non-nullable JSON property 'content'.");
 
             if (mixedAnyOf.ContentOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/MixedOneOf.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/MixedOneOf.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedOneOf mixedOneOf, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedOneOf.ContentOption.IsSet && mixedOneOf.Content == null)
-                throw new ArgumentNullException(nameof(mixedOneOf.Content), "Property is required for class MixedOneOf.");
+                throw new JsonException("Cannot write null property MixedOneOf.Content to non-nullable JSON property 'content'.");
 
             if (mixedOneOf.ContentOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -255,8 +255,17 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, MixedPropertiesAndAdditionalPropertiesClass mixedPropertiesAndAdditionalPropertiesClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.DateTime == null)
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.DateTime to non-nullable JSON property 'dateTime'.");
+
             if (mixedPropertiesAndAdditionalPropertiesClass.MapOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.Map == null)
                 throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.Map to non-nullable JSON property 'map'.");
+
+            if (mixedPropertiesAndAdditionalPropertiesClass.UuidOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.Uuid == null)
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.Uuid to non-nullable JSON property 'uuid'.");
+
+            if (mixedPropertiesAndAdditionalPropertiesClass.UuidWithPatternOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.UuidWithPattern == null)
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.UuidWithPattern to non-nullable JSON property 'uuid_with_pattern'.");
 
             if (mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.IsSet)
                 writer.WriteString("dateTime", mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.Value.Value.ToString(DateTimeFormat));

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -256,7 +256,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedPropertiesAndAdditionalPropertiesClass mixedPropertiesAndAdditionalPropertiesClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedPropertiesAndAdditionalPropertiesClass.MapOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.Map == null)
-                throw new ArgumentNullException(nameof(mixedPropertiesAndAdditionalPropertiesClass.Map), "Property is required for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.Map to non-nullable JSON property 'map'.");
 
             if (mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.IsSet)
                 writer.WriteString("dateTime", mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.Value.Value.ToString(DateTimeFormat));

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/MixedSubId.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/MixedSubId.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedSubId mixedSubId, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedSubId.IdOption.IsSet && mixedSubId.Id == null)
-                throw new ArgumentNullException(nameof(mixedSubId.Id), "Property is required for class MixedSubId.");
+                throw new JsonException("Cannot write null property MixedSubId.Id to non-nullable JSON property 'id'.");
 
             if (mixedSubId.IdOption.IsSet)
                 writer.WriteString("id", mixedSubId.Id);

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -198,7 +198,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Model200Response model200Response, JsonSerializerOptions jsonSerializerOptions)
         {
             if (model200Response.ClassOption.IsSet && model200Response.Class == null)
-                throw new ArgumentNullException(nameof(model200Response.Class), "Property is required for class Model200Response.");
+                throw new JsonException("Cannot write null property Model200Response.Class to non-nullable JSON property 'class'.");
 
             if (model200Response.ClassOption.IsSet)
                 writer.WriteString("class", model200Response.Class);

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -200,6 +200,9 @@ namespace Org.OpenAPITools.Model
             if (model200Response.ClassOption.IsSet && model200Response.Class == null)
                 throw new JsonException("Cannot write null property Model200Response.Class to non-nullable JSON property 'class'.");
 
+            if (model200Response.NameOption.IsSet && model200Response.Name == null)
+                throw new JsonException("Cannot write null property Model200Response.Name to non-nullable JSON property 'name'.");
+
             if (model200Response.ClassOption.IsSet)
                 writer.WriteString("class", model200Response.Class);
 

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ModelClient modelClient, JsonSerializerOptions jsonSerializerOptions)
         {
             if (modelClient.VarClientOption.IsSet && modelClient.VarClient == null)
-                throw new ArgumentNullException(nameof(modelClient.VarClient), "Property is required for class ModelClient.");
+                throw new JsonException("Cannot write null property ModelClient.VarClient to non-nullable JSON property 'client'.");
 
             if (modelClient.VarClientOption.IsSet)
                 writer.WriteString("client", modelClient.VarClient);

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Name.cs
@@ -281,7 +281,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Name name, JsonSerializerOptions jsonSerializerOptions)
         {
             if (name.PropertyOption.IsSet && name.Property == null)
-                throw new ArgumentNullException(nameof(name.Property), "Property is required for class Name.");
+                throw new JsonException("Cannot write null property Name.Property to non-nullable JSON property 'property'.");
 
             writer.WriteNumber("name", name.VarName);
 

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Name.cs
@@ -283,6 +283,12 @@ namespace Org.OpenAPITools.Model
             if (name.PropertyOption.IsSet && name.Property == null)
                 throw new JsonException("Cannot write null property Name.Property to non-nullable JSON property 'property'.");
 
+            if (name.SnakeCaseOption.IsSet && name.SnakeCase == null)
+                throw new JsonException("Cannot write null property Name.SnakeCase to non-nullable JSON property 'snake_case'.");
+
+            if (name.Var123NumberOption.IsSet && name.Var123Number == null)
+                throw new JsonException("Cannot write null property Name.Var123Number to non-nullable JSON property '123Number'.");
+
             writer.WriteNumber("name", name.VarName);
 
             if (name.PropertyOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
@@ -189,9 +189,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, NotificationtestGetElementsV1ResponseMPayload notificationtestGetElementsV1ResponseMPayload, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (notificationtestGetElementsV1ResponseMPayload.AObjVariableobject == null)
-                throw new ArgumentNullException(nameof(notificationtestGetElementsV1ResponseMPayload.AObjVariableobject), "Property is required for class NotificationtestGetElementsV1ResponseMPayload.");
-
             writer.WritePropertyName("a_objVariableobject");
             JsonSerializer.Serialize(writer, notificationtestGetElementsV1ResponseMPayload.AObjVariableobject, jsonSerializerOptions);
             writer.WriteNumber("pkiNotificationtestID", notificationtestGetElementsV1ResponseMPayload.PkiNotificationtestID);

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -408,10 +408,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, NullableClass nullableClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (nullableClass.ArrayItemsNullableOption.IsSet && nullableClass.ArrayItemsNullable == null)
-                throw new ArgumentNullException(nameof(nullableClass.ArrayItemsNullable), "Property is required for class NullableClass.");
+                throw new JsonException("Cannot write null property NullableClass.ArrayItemsNullable to non-nullable JSON property 'array_items_nullable'.");
 
             if (nullableClass.ObjectItemsNullableOption.IsSet && nullableClass.ObjectItemsNullable == null)
-                throw new ArgumentNullException(nameof(nullableClass.ObjectItemsNullable), "Property is required for class NullableClass.");
+                throw new JsonException("Cannot write null property NullableClass.ObjectItemsNullable to non-nullable JSON property 'object_items_nullable'.");
 
             if (nullableClass.ArrayAndItemsNullablePropOption.IsSet)
                 if (nullableClass.ArrayAndItemsNullablePropOption.Value != null)

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -174,6 +174,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, NumberOnly numberOnly, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (numberOnly.JustNumberOption.IsSet && numberOnly.JustNumber == null)
+                throw new JsonException("Cannot write null property NumberOnly.JustNumber to non-nullable JSON property 'JustNumber'.");
+
             if (numberOnly.JustNumberOption.IsSet)
                 writer.WriteNumber("JustNumber", numberOnly.JustNumberOption.Value.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -247,13 +247,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ObjectWithDeprecatedFields objectWithDeprecatedFields, JsonSerializerOptions jsonSerializerOptions)
         {
             if (objectWithDeprecatedFields.BarsOption.IsSet && objectWithDeprecatedFields.Bars == null)
-                throw new ArgumentNullException(nameof(objectWithDeprecatedFields.Bars), "Property is required for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Bars to non-nullable JSON property 'bars'.");
 
             if (objectWithDeprecatedFields.DeprecatedRefOption.IsSet && objectWithDeprecatedFields.DeprecatedRef == null)
-                throw new ArgumentNullException(nameof(objectWithDeprecatedFields.DeprecatedRef), "Property is required for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.DeprecatedRef to non-nullable JSON property 'deprecatedRef'.");
 
             if (objectWithDeprecatedFields.UuidOption.IsSet && objectWithDeprecatedFields.Uuid == null)
-                throw new ArgumentNullException(nameof(objectWithDeprecatedFields.Uuid), "Property is required for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Uuid to non-nullable JSON property 'uuid'.");
 
             if (objectWithDeprecatedFields.BarsOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -252,6 +252,9 @@ namespace Org.OpenAPITools.Model
             if (objectWithDeprecatedFields.DeprecatedRefOption.IsSet && objectWithDeprecatedFields.DeprecatedRef == null)
                 throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.DeprecatedRef to non-nullable JSON property 'deprecatedRef'.");
 
+            if (objectWithDeprecatedFields.IdOption.IsSet && objectWithDeprecatedFields.Id == null)
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Id to non-nullable JSON property 'id'.");
+
             if (objectWithDeprecatedFields.UuidOption.IsSet && objectWithDeprecatedFields.Uuid == null)
                 throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Uuid to non-nullable JSON property 'uuid'.");
 

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Order.cs
@@ -295,6 +295,24 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Order order, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (order.CompleteOption.IsSet && order.Complete == null)
+                throw new JsonException("Cannot write null property Order.Complete to non-nullable JSON property 'complete'.");
+
+            if (order.IdOption.IsSet && order.Id == null)
+                throw new JsonException("Cannot write null property Order.Id to non-nullable JSON property 'id'.");
+
+            if (order.PetIdOption.IsSet && order.PetId == null)
+                throw new JsonException("Cannot write null property Order.PetId to non-nullable JSON property 'petId'.");
+
+            if (order.QuantityOption.IsSet && order.Quantity == null)
+                throw new JsonException("Cannot write null property Order.Quantity to non-nullable JSON property 'quantity'.");
+
+            if (order.ShipDateOption.IsSet && order.ShipDate == null)
+                throw new JsonException("Cannot write null property Order.ShipDate to non-nullable JSON property 'shipDate'.");
+
+            if (order.StatusOption.IsSet && order.Status == null)
+                throw new JsonException("Cannot write null property Order.Status to non-nullable JSON property 'status'.");
+
             if (order.CompleteOption.IsSet)
                 writer.WriteBoolean("complete", order.CompleteOption.Value.Value);
 

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -220,6 +220,12 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, OuterComposite outerComposite, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (outerComposite.MyBooleanOption.IsSet && outerComposite.MyBoolean == null)
+                throw new JsonException("Cannot write null property OuterComposite.MyBoolean to non-nullable JSON property 'my_boolean'.");
+
+            if (outerComposite.MyNumberOption.IsSet && outerComposite.MyNumber == null)
+                throw new JsonException("Cannot write null property OuterComposite.MyNumber to non-nullable JSON property 'my_number'.");
+
             if (outerComposite.MyStringOption.IsSet && outerComposite.MyString == null)
                 throw new JsonException("Cannot write null property OuterComposite.MyString to non-nullable JSON property 'my_string'.");
 

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -221,7 +221,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, OuterComposite outerComposite, JsonSerializerOptions jsonSerializerOptions)
         {
             if (outerComposite.MyStringOption.IsSet && outerComposite.MyString == null)
-                throw new ArgumentNullException(nameof(outerComposite.MyString), "Property is required for class OuterComposite.");
+                throw new JsonException("Cannot write null property OuterComposite.MyString to non-nullable JSON property 'my_string'.");
 
             if (outerComposite.MyBooleanOption.IsSet)
                 writer.WriteBoolean("my_boolean", outerComposite.MyBooleanOption.Value.Value);

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Pet.cs
@@ -282,17 +282,11 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Pet pet, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (pet.Name == null)
-                throw new ArgumentNullException(nameof(pet.Name), "Property is required for class Pet.");
-
-            if (pet.PhotoUrls == null)
-                throw new ArgumentNullException(nameof(pet.PhotoUrls), "Property is required for class Pet.");
-
             if (pet.CategoryOption.IsSet && pet.Category == null)
-                throw new ArgumentNullException(nameof(pet.Category), "Property is required for class Pet.");
+                throw new JsonException("Cannot write null property Pet.Category to non-nullable JSON property 'category'.");
 
             if (pet.TagsOption.IsSet && pet.Tags == null)
-                throw new ArgumentNullException(nameof(pet.Tags), "Property is required for class Pet.");
+                throw new JsonException("Cannot write null property Pet.Tags to non-nullable JSON property 'tags'.");
 
             writer.WriteString("name", pet.Name);
 

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Pet.cs
@@ -285,6 +285,12 @@ namespace Org.OpenAPITools.Model
             if (pet.CategoryOption.IsSet && pet.Category == null)
                 throw new JsonException("Cannot write null property Pet.Category to non-nullable JSON property 'category'.");
 
+            if (pet.IdOption.IsSet && pet.Id == null)
+                throw new JsonException("Cannot write null property Pet.Id to non-nullable JSON property 'id'.");
+
+            if (pet.StatusOption.IsSet && pet.Status == null)
+                throw new JsonException("Cannot write null property Pet.Status to non-nullable JSON property 'status'.");
+
             if (pet.TagsOption.IsSet && pet.Tags == null)
                 throw new JsonException("Cannot write null property Pet.Tags to non-nullable JSON property 'tags'.");
 

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
@@ -170,9 +170,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, QuadrilateralInterface quadrilateralInterface, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (quadrilateralInterface.QuadrilateralType == null)
-                throw new ArgumentNullException(nameof(quadrilateralInterface.QuadrilateralType), "Property is required for class QuadrilateralInterface.");
-
             writer.WriteString("quadrilateralType", quadrilateralInterface.QuadrilateralType);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -236,10 +236,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ReadOnlyFirst readOnlyFirst, JsonSerializerOptions jsonSerializerOptions)
         {
             if (readOnlyFirst.BarOption.IsSet && readOnlyFirst.Bar == null)
-                throw new ArgumentNullException(nameof(readOnlyFirst.Bar), "Property is required for class ReadOnlyFirst.");
+                throw new JsonException("Cannot write null property ReadOnlyFirst.Bar to non-nullable JSON property 'bar'.");
 
             if (readOnlyFirst.BazOption.IsSet && readOnlyFirst.Baz == null)
-                throw new ArgumentNullException(nameof(readOnlyFirst.Baz), "Property is required for class ReadOnlyFirst.");
+                throw new JsonException("Cannot write null property ReadOnlyFirst.Baz to non-nullable JSON property 'baz'.");
 
             if (readOnlyFirst.BarOption.IsSet)
                 writer.WriteString("bar", readOnlyFirst.Bar);

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -1053,11 +1053,38 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, RequiredClass requiredClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (requiredClass.NotRequiredNotnullableDatePropOption.IsSet && requiredClass.NotRequiredNotnullableDateProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotRequiredNotnullableDateProp to non-nullable JSON property 'not_required_notnullable_date_prop'.");
+
+            if (requiredClass.NotRequiredNotnullableintegerPropOption.IsSet && requiredClass.NotRequiredNotnullableintegerProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotRequiredNotnullableintegerProp to non-nullable JSON property 'not_required_notnullableinteger_prop'.");
+
             if (requiredClass.NotrequiredNotnullableArrayOfStringOption.IsSet && requiredClass.NotrequiredNotnullableArrayOfString == null)
                 throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableArrayOfString to non-nullable JSON property 'notrequired_notnullable_array_of_string'.");
 
+            if (requiredClass.NotrequiredNotnullableBooleanPropOption.IsSet && requiredClass.NotrequiredNotnullableBooleanProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableBooleanProp to non-nullable JSON property 'notrequired_notnullable_boolean_prop'.");
+
+            if (requiredClass.NotrequiredNotnullableDatetimePropOption.IsSet && requiredClass.NotrequiredNotnullableDatetimeProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableDatetimeProp to non-nullable JSON property 'notrequired_notnullable_datetime_prop'.");
+
+            if (requiredClass.NotrequiredNotnullableEnumIntegerOption.IsSet && requiredClass.NotrequiredNotnullableEnumInteger == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableEnumInteger to non-nullable JSON property 'notrequired_notnullable_enum_integer'.");
+
+            if (requiredClass.NotrequiredNotnullableEnumIntegerOnlyOption.IsSet && requiredClass.NotrequiredNotnullableEnumIntegerOnly == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableEnumIntegerOnly to non-nullable JSON property 'notrequired_notnullable_enum_integer_only'.");
+
+            if (requiredClass.NotrequiredNotnullableEnumStringOption.IsSet && requiredClass.NotrequiredNotnullableEnumString == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableEnumString to non-nullable JSON property 'notrequired_notnullable_enum_string'.");
+
+            if (requiredClass.NotrequiredNotnullableOuterEnumDefaultValueOption.IsSet && requiredClass.NotrequiredNotnullableOuterEnumDefaultValue == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableOuterEnumDefaultValue to non-nullable JSON property 'notrequired_notnullable_outerEnumDefaultValue'.");
+
             if (requiredClass.NotrequiredNotnullableStringPropOption.IsSet && requiredClass.NotrequiredNotnullableStringProp == null)
                 throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableStringProp to non-nullable JSON property 'notrequired_notnullable_string_prop'.");
+
+            if (requiredClass.NotrequiredNotnullableUuidOption.IsSet && requiredClass.NotrequiredNotnullableUuid == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableUuid to non-nullable JSON property 'notrequired_notnullable_uuid'.");
 
             writer.WriteString("required_not_nullable_date_prop", requiredClass.RequiredNotNullableDateProp.ToString(RequiredNotNullableDatePropFormat));
 

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -1053,17 +1053,11 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, RequiredClass requiredClass, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (requiredClass.RequiredNotnullableArrayOfString == null)
-                throw new ArgumentNullException(nameof(requiredClass.RequiredNotnullableArrayOfString), "Property is required for class RequiredClass.");
-
-            if (requiredClass.RequiredNotnullableStringProp == null)
-                throw new ArgumentNullException(nameof(requiredClass.RequiredNotnullableStringProp), "Property is required for class RequiredClass.");
-
             if (requiredClass.NotrequiredNotnullableArrayOfStringOption.IsSet && requiredClass.NotrequiredNotnullableArrayOfString == null)
-                throw new ArgumentNullException(nameof(requiredClass.NotrequiredNotnullableArrayOfString), "Property is required for class RequiredClass.");
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableArrayOfString to non-nullable JSON property 'notrequired_notnullable_array_of_string'.");
 
             if (requiredClass.NotrequiredNotnullableStringPropOption.IsSet && requiredClass.NotrequiredNotnullableStringProp == null)
-                throw new ArgumentNullException(nameof(requiredClass.NotrequiredNotnullableStringProp), "Property is required for class RequiredClass.");
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableStringProp to non-nullable JSON property 'notrequired_notnullable_string_prop'.");
 
             writer.WriteString("required_not_nullable_date_prop", requiredClass.RequiredNotNullableDateProp.ToString(RequiredNotNullableDatePropFormat));
 

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Result.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Result.cs
@@ -224,13 +224,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Result result, JsonSerializerOptions jsonSerializerOptions)
         {
             if (result.CodeOption.IsSet && result.Code == null)
-                throw new ArgumentNullException(nameof(result.Code), "Property is required for class Result.");
+                throw new JsonException("Cannot write null property Result.Code to non-nullable JSON property 'code'.");
 
             if (result.DataOption.IsSet && result.Data == null)
-                throw new ArgumentNullException(nameof(result.Data), "Property is required for class Result.");
+                throw new JsonException("Cannot write null property Result.Data to non-nullable JSON property 'data'.");
 
             if (result.UuidOption.IsSet && result.Uuid == null)
-                throw new ArgumentNullException(nameof(result.Uuid), "Property is required for class Result.");
+                throw new JsonException("Cannot write null property Result.Uuid to non-nullable JSON property 'uuid'.");
 
             if (result.CodeOption.IsSet)
                 writer.WriteString("code", result.Code);

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Return.cs
@@ -232,11 +232,8 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Return varReturn, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (varReturn.Lock == null)
-                throw new ArgumentNullException(nameof(varReturn.Lock), "Property is required for class Return.");
-
             if (varReturn.UnsafeOption.IsSet && varReturn.Unsafe == null)
-                throw new ArgumentNullException(nameof(varReturn.Unsafe), "Property is required for class Return.");
+                throw new JsonException("Cannot write null property Return.Unsafe to non-nullable JSON property 'unsafe'.");
 
             writer.WriteString("lock", varReturn.Lock);
 

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Return.cs
@@ -232,6 +232,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Return varReturn, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (varReturn.VarReturnOption.IsSet && varReturn.VarReturn == null)
+                throw new JsonException("Cannot write null property Return.VarReturn to non-nullable JSON property 'return'.");
+
             if (varReturn.UnsafeOption.IsSet && varReturn.Unsafe == null)
                 throw new JsonException("Cannot write null property Return.Unsafe to non-nullable JSON property 'unsafe'.");
 

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -198,7 +198,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, RolesReportsHash rolesReportsHash, JsonSerializerOptions jsonSerializerOptions)
         {
             if (rolesReportsHash.RoleOption.IsSet && rolesReportsHash.Role == null)
-                throw new ArgumentNullException(nameof(rolesReportsHash.Role), "Property is required for class RolesReportsHash.");
+                throw new JsonException("Cannot write null property RolesReportsHash.Role to non-nullable JSON property 'role'.");
 
             if (rolesReportsHash.RoleOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -200,6 +200,9 @@ namespace Org.OpenAPITools.Model
             if (rolesReportsHash.RoleOption.IsSet && rolesReportsHash.Role == null)
                 throw new JsonException("Cannot write null property RolesReportsHash.Role to non-nullable JSON property 'role'.");
 
+            if (rolesReportsHash.RoleUuidOption.IsSet && rolesReportsHash.RoleUuid == null)
+                throw new JsonException("Cannot write null property RolesReportsHash.RoleUuid to non-nullable JSON property 'role_uuid'.");
+
             if (rolesReportsHash.RoleOption.IsSet)
             {
                 writer.WritePropertyName("role");

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, RolesReportsHashRole rolesReportsHashRole, JsonSerializerOptions jsonSerializerOptions)
         {
             if (rolesReportsHashRole.NameOption.IsSet && rolesReportsHashRole.Name == null)
-                throw new ArgumentNullException(nameof(rolesReportsHashRole.Name), "Property is required for class RolesReportsHashRole.");
+                throw new JsonException("Cannot write null property RolesReportsHashRole.Name to non-nullable JSON property 'name'.");
 
             if (rolesReportsHashRole.NameOption.IsSet)
                 writer.WriteString("name", rolesReportsHashRole.Name);

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
@@ -189,12 +189,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ScaleneTriangle scaleneTriangle, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (scaleneTriangle.ShapeType == null)
-                throw new ArgumentNullException(nameof(scaleneTriangle.ShapeType), "Property is required for class ScaleneTriangle.");
-
-            if (scaleneTriangle.TriangleType == null)
-                throw new ArgumentNullException(nameof(scaleneTriangle.TriangleType), "Property is required for class ScaleneTriangle.");
-
             writer.WriteString("shapeType", scaleneTriangle.ShapeType);
 
             writer.WriteString("triangleType", scaleneTriangle.TriangleType);

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ShapeInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ShapeInterface.cs
@@ -170,9 +170,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ShapeInterface shapeInterface, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (shapeInterface.ShapeType == null)
-                throw new ArgumentNullException(nameof(shapeInterface.ShapeType), "Property is required for class ShapeInterface.");
-
             writer.WriteString("shapeType", shapeInterface.ShapeType);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
@@ -189,12 +189,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, SimpleQuadrilateral simpleQuadrilateral, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (simpleQuadrilateral.QuadrilateralType == null)
-                throw new ArgumentNullException(nameof(simpleQuadrilateral.QuadrilateralType), "Property is required for class SimpleQuadrilateral.");
-
-            if (simpleQuadrilateral.ShapeType == null)
-                throw new ArgumentNullException(nameof(simpleQuadrilateral.ShapeType), "Property is required for class SimpleQuadrilateral.");
-
             writer.WriteString("quadrilateralType", simpleQuadrilateral.QuadrilateralType);
 
             writer.WriteString("shapeType", simpleQuadrilateral.ShapeType);

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -200,6 +200,9 @@ namespace Org.OpenAPITools.Model
             if (specialModelName.VarSpecialModelNameOption.IsSet && specialModelName.VarSpecialModelName == null)
                 throw new JsonException("Cannot write null property SpecialModelName.VarSpecialModelName to non-nullable JSON property '_special_model.name_'.");
 
+            if (specialModelName.SpecialPropertyNameOption.IsSet && specialModelName.SpecialPropertyName == null)
+                throw new JsonException("Cannot write null property SpecialModelName.SpecialPropertyName to non-nullable JSON property '$special[property.name]'.");
+
             if (specialModelName.VarSpecialModelNameOption.IsSet)
                 writer.WriteString("_special_model.name_", specialModelName.VarSpecialModelName);
 

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -198,7 +198,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, SpecialModelName specialModelName, JsonSerializerOptions jsonSerializerOptions)
         {
             if (specialModelName.VarSpecialModelNameOption.IsSet && specialModelName.VarSpecialModelName == null)
-                throw new ArgumentNullException(nameof(specialModelName.VarSpecialModelName), "Property is required for class SpecialModelName.");
+                throw new JsonException("Cannot write null property SpecialModelName.VarSpecialModelName to non-nullable JSON property '_special_model.name_'.");
 
             if (specialModelName.VarSpecialModelNameOption.IsSet)
                 writer.WriteString("_special_model.name_", specialModelName.VarSpecialModelName);

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Tag.cs
@@ -198,7 +198,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Tag tag, JsonSerializerOptions jsonSerializerOptions)
         {
             if (tag.NameOption.IsSet && tag.Name == null)
-                throw new ArgumentNullException(nameof(tag.Name), "Property is required for class Tag.");
+                throw new JsonException("Cannot write null property Tag.Name to non-nullable JSON property 'name'.");
 
             if (tag.IdOption.IsSet)
                 writer.WriteNumber("id", tag.IdOption.Value.Value);

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Tag.cs
@@ -197,6 +197,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Tag tag, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (tag.IdOption.IsSet && tag.Id == null)
+                throw new JsonException("Cannot write null property Tag.Id to non-nullable JSON property 'id'.");
+
             if (tag.NameOption.IsSet && tag.Name == null)
                 throw new JsonException("Cannot write null property Tag.Name to non-nullable JSON property 'name'.");
 

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestCollectionEndingWithWordList testCollectionEndingWithWordList, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testCollectionEndingWithWordList.ValueOption.IsSet && testCollectionEndingWithWordList.Value == null)
-                throw new ArgumentNullException(nameof(testCollectionEndingWithWordList.Value), "Property is required for class TestCollectionEndingWithWordList.");
+                throw new JsonException("Cannot write null property TestCollectionEndingWithWordList.Value to non-nullable JSON property 'value'.");
 
             if (testCollectionEndingWithWordList.ValueOption.IsSet)
                 writer.WriteString("value", testCollectionEndingWithWordList.Value);

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestCollectionEndingWithWordListObject testCollectionEndingWithWordListObject, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testCollectionEndingWithWordListObject.TestCollectionEndingWithWordListOption.IsSet && testCollectionEndingWithWordListObject.TestCollectionEndingWithWordList == null)
-                throw new ArgumentNullException(nameof(testCollectionEndingWithWordListObject.TestCollectionEndingWithWordList), "Property is required for class TestCollectionEndingWithWordListObject.");
+                throw new JsonException("Cannot write null property TestCollectionEndingWithWordListObject.TestCollectionEndingWithWordList to non-nullable JSON property 'TestCollectionEndingWithWordList'.");
 
             if (testCollectionEndingWithWordListObject.TestCollectionEndingWithWordListOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/TestDescendants.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/TestDescendants.cs
@@ -216,9 +216,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, TestDescendants testDescendants, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (testDescendants.AlternativeName == null)
-                throw new ArgumentNullException(nameof(testDescendants.AlternativeName), "Property is required for class TestDescendants.");
-
             writer.WriteString("alternativeName", testDescendants.AlternativeName);
 
             writer.WriteString("objectType", TestDescendantsObjectTypeValueConverter.ToJsonValue(testDescendants.ObjectType));

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestInlineFreeformAdditionalPropertiesRequest testInlineFreeformAdditionalPropertiesRequest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testInlineFreeformAdditionalPropertiesRequest.SomePropertyOption.IsSet && testInlineFreeformAdditionalPropertiesRequest.SomeProperty == null)
-                throw new ArgumentNullException(nameof(testInlineFreeformAdditionalPropertiesRequest.SomeProperty), "Property is required for class TestInlineFreeformAdditionalPropertiesRequest.");
+                throw new JsonException("Cannot write null property TestInlineFreeformAdditionalPropertiesRequest.SomeProperty to non-nullable JSON property 'someProperty'.");
 
             if (testInlineFreeformAdditionalPropertiesRequest.SomePropertyOption.IsSet)
                 writer.WriteString("someProperty", testInlineFreeformAdditionalPropertiesRequest.SomeProperty);

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/TestResult.cs
@@ -222,6 +222,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, TestResult testResult, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (testResult.CodeOption.IsSet && testResult.Code == null)
+                throw new JsonException("Cannot write null property TestResult.Code to non-nullable JSON property 'code'.");
+
             if (testResult.DataOption.IsSet && testResult.Data == null)
                 throw new JsonException("Cannot write null property TestResult.Data to non-nullable JSON property 'data'.");
 

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/TestResult.cs
@@ -223,10 +223,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestResult testResult, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testResult.DataOption.IsSet && testResult.Data == null)
-                throw new ArgumentNullException(nameof(testResult.Data), "Property is required for class TestResult.");
+                throw new JsonException("Cannot write null property TestResult.Data to non-nullable JSON property 'data'.");
 
             if (testResult.UuidOption.IsSet && testResult.Uuid == null)
-                throw new ArgumentNullException(nameof(testResult.Uuid), "Property is required for class TestResult.");
+                throw new JsonException("Cannot write null property TestResult.Uuid to non-nullable JSON property 'uuid'.");
 
             if (testResult.CodeOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/TriangleInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/TriangleInterface.cs
@@ -170,9 +170,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, TriangleInterface triangleInterface, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (triangleInterface.TriangleType == null)
-                throw new ArgumentNullException(nameof(triangleInterface.TriangleType), "Property is required for class TriangleInterface.");
-
             writer.WriteString("triangleType", triangleInterface.TriangleType);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/User.cs
@@ -429,6 +429,9 @@ namespace Org.OpenAPITools.Model
             if (user.FirstNameOption.IsSet && user.FirstName == null)
                 throw new JsonException("Cannot write null property User.FirstName to non-nullable JSON property 'firstName'.");
 
+            if (user.IdOption.IsSet && user.Id == null)
+                throw new JsonException("Cannot write null property User.Id to non-nullable JSON property 'id'.");
+
             if (user.LastNameOption.IsSet && user.LastName == null)
                 throw new JsonException("Cannot write null property User.LastName to non-nullable JSON property 'lastName'.");
 
@@ -440,6 +443,9 @@ namespace Org.OpenAPITools.Model
 
             if (user.PhoneOption.IsSet && user.Phone == null)
                 throw new JsonException("Cannot write null property User.Phone to non-nullable JSON property 'phone'.");
+
+            if (user.UserStatusOption.IsSet && user.UserStatus == null)
+                throw new JsonException("Cannot write null property User.UserStatus to non-nullable JSON property 'userStatus'.");
 
             if (user.UsernameOption.IsSet && user.Username == null)
                 throw new JsonException("Cannot write null property User.Username to non-nullable JSON property 'username'.");

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/User.cs
@@ -424,25 +424,25 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, User user, JsonSerializerOptions jsonSerializerOptions)
         {
             if (user.EmailOption.IsSet && user.Email == null)
-                throw new ArgumentNullException(nameof(user.Email), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Email to non-nullable JSON property 'email'.");
 
             if (user.FirstNameOption.IsSet && user.FirstName == null)
-                throw new ArgumentNullException(nameof(user.FirstName), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.FirstName to non-nullable JSON property 'firstName'.");
 
             if (user.LastNameOption.IsSet && user.LastName == null)
-                throw new ArgumentNullException(nameof(user.LastName), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.LastName to non-nullable JSON property 'lastName'.");
 
             if (user.ObjectWithNoDeclaredPropsOption.IsSet && user.ObjectWithNoDeclaredProps == null)
-                throw new ArgumentNullException(nameof(user.ObjectWithNoDeclaredProps), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.ObjectWithNoDeclaredProps to non-nullable JSON property 'objectWithNoDeclaredProps'.");
 
             if (user.PasswordOption.IsSet && user.Password == null)
-                throw new ArgumentNullException(nameof(user.Password), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Password to non-nullable JSON property 'password'.");
 
             if (user.PhoneOption.IsSet && user.Phone == null)
-                throw new ArgumentNullException(nameof(user.Phone), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Phone to non-nullable JSON property 'phone'.");
 
             if (user.UsernameOption.IsSet && user.Username == null)
-                throw new ArgumentNullException(nameof(user.Username), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Username to non-nullable JSON property 'username'.");
 
             if (user.AnyTypePropOption.IsSet)
                 if (user.AnyTypePropOption.Value != null)

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Whale.cs
@@ -216,9 +216,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Whale whale, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (whale.ClassName == null)
-                throw new ArgumentNullException(nameof(whale.ClassName), "Property is required for class Whale.");
-
             writer.WriteString("className", whale.ClassName);
 
             if (whale.HasBaleenOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Whale.cs
@@ -216,6 +216,12 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Whale whale, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (whale.HasBaleenOption.IsSet && whale.HasBaleen == null)
+                throw new JsonException("Cannot write null property Whale.HasBaleen to non-nullable JSON property 'hasBaleen'.");
+
+            if (whale.HasTeethOption.IsSet && whale.HasTeeth == null)
+                throw new JsonException("Cannot write null property Whale.HasTeeth to non-nullable JSON property 'hasTeeth'.");
+
             writer.WriteString("className", whale.ClassName);
 
             if (whale.HasBaleenOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Zebra.cs
@@ -193,6 +193,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Zebra zebra, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (zebra.TypeOption.IsSet && zebra.Type == null)
+                throw new JsonException("Cannot write null property Zebra.Type to non-nullable JSON property 'type'.");
+
             writer.WriteString("className", zebra.ClassName);
 
             if (zebra.TypeOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Zebra.cs
@@ -193,9 +193,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Zebra zebra, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (zebra.ClassName == null)
-                throw new ArgumentNullException(nameof(zebra.ClassName), "Property is required for class Zebra.");
-
             writer.WriteString("className", zebra.ClassName);
 
             if (zebra.TypeOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
@@ -174,6 +174,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ZeroBasedEnumClass zeroBasedEnumClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (zeroBasedEnumClass.ZeroBasedEnumOption.IsSet && zeroBasedEnumClass.ZeroBasedEnum == null)
+                throw new JsonException("Cannot write null property ZeroBasedEnumClass.ZeroBasedEnum to non-nullable JSON property 'ZeroBasedEnum'.");
+
             if (zeroBasedEnumClass.ZeroBasedEnumOption.IsSet)
             {
                 var zeroBasedEnumRawValue = ZeroBasedEnumClassZeroBasedEnumValueConverter.ToJsonValue(zeroBasedEnumClass.ZeroBasedEnum.Value);

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Activity.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Activity activity, JsonSerializerOptions jsonSerializerOptions)
         {
             if (activity.ActivityOutputsOption.IsSet && activity.ActivityOutputs == null)
-                throw new ArgumentNullException(nameof(activity.ActivityOutputs), "Property is required for class Activity.");
+                throw new JsonException("Cannot write null property Activity.ActivityOutputs to non-nullable JSON property 'activity_outputs'.");
 
             if (activity.ActivityOutputsOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -200,10 +200,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ActivityOutputElementRepresentation activityOutputElementRepresentation, JsonSerializerOptions jsonSerializerOptions)
         {
             if (activityOutputElementRepresentation.Prop1Option.IsSet && activityOutputElementRepresentation.Prop1 == null)
-                throw new ArgumentNullException(nameof(activityOutputElementRepresentation.Prop1), "Property is required for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Cannot write null property ActivityOutputElementRepresentation.Prop1 to non-nullable JSON property 'prop1'.");
 
             if (activityOutputElementRepresentation.Prop2Option.IsSet && activityOutputElementRepresentation.Prop2 == null)
-                throw new ArgumentNullException(nameof(activityOutputElementRepresentation.Prop2), "Property is required for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Cannot write null property ActivityOutputElementRepresentation.Prop2 to non-nullable JSON property 'prop2'.");
 
             if (activityOutputElementRepresentation.Prop1Option.IsSet)
                 writer.WriteString("prop1", activityOutputElementRepresentation.Prop1);

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -336,25 +336,25 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, AdditionalPropertiesClass additionalPropertiesClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (additionalPropertiesClass.EmptyMapOption.IsSet && additionalPropertiesClass.EmptyMap == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.EmptyMap), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.EmptyMap to non-nullable JSON property 'empty_map'.");
 
             if (additionalPropertiesClass.MapOfMapPropertyOption.IsSet && additionalPropertiesClass.MapOfMapProperty == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapOfMapProperty), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapOfMapProperty to non-nullable JSON property 'map_of_map_property'.");
 
             if (additionalPropertiesClass.MapPropertyOption.IsSet && additionalPropertiesClass.MapProperty == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapProperty), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapProperty to non-nullable JSON property 'map_property'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1Option.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1 == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1 to non-nullable JSON property 'map_with_undeclared_properties_anytype_1'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2Option.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2 == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2 to non-nullable JSON property 'map_with_undeclared_properties_anytype_2'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3Option.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3 == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3 to non-nullable JSON property 'map_with_undeclared_properties_anytype_3'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesStringOption.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesString == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesString), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesString to non-nullable JSON property 'map_with_undeclared_properties_string'.");
 
             if (additionalPropertiesClass.Anytype1Option.IsSet)
                 if (additionalPropertiesClass.Anytype1Option.Value != null)

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Animal.cs
@@ -223,7 +223,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Animal animal, JsonSerializerOptions jsonSerializerOptions)
         {
             if (animal.ColorOption.IsSet && animal.Color == null)
-                throw new ArgumentNullException(nameof(animal.Color), "Property is required for class Animal.");
+                throw new JsonException("Cannot write null property Animal.Color to non-nullable JSON property 'color'.");
 
             writer.WriteString("className", animal.ClassName);
 

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -223,10 +223,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ApiResponse apiResponse, JsonSerializerOptions jsonSerializerOptions)
         {
             if (apiResponse.MessageOption.IsSet && apiResponse.Message == null)
-                throw new ArgumentNullException(nameof(apiResponse.Message), "Property is required for class ApiResponse.");
+                throw new JsonException("Cannot write null property ApiResponse.Message to non-nullable JSON property 'message'.");
 
             if (apiResponse.TypeOption.IsSet && apiResponse.Type == null)
-                throw new ArgumentNullException(nameof(apiResponse.Type), "Property is required for class ApiResponse.");
+                throw new JsonException("Cannot write null property ApiResponse.Type to non-nullable JSON property 'type'.");
 
             if (apiResponse.CodeOption.IsSet)
                 writer.WriteNumber("code", apiResponse.CodeOption.Value!.Value);

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -222,6 +222,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ApiResponse apiResponse, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (apiResponse.CodeOption.IsSet && apiResponse.Code == null)
+                throw new JsonException("Cannot write null property ApiResponse.Code to non-nullable JSON property 'code'.");
+
             if (apiResponse.MessageOption.IsSet && apiResponse.Message == null)
                 throw new JsonException("Cannot write null property ApiResponse.Message to non-nullable JSON property 'message'.");
 

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Apple.cs
@@ -253,13 +253,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Apple apple, JsonSerializerOptions jsonSerializerOptions)
         {
             if (apple.ColorCodeOption.IsSet && apple.ColorCode == null)
-                throw new ArgumentNullException(nameof(apple.ColorCode), "Property is required for class Apple.");
+                throw new JsonException("Cannot write null property Apple.ColorCode to non-nullable JSON property 'color_code'.");
 
             if (apple.CultivarOption.IsSet && apple.Cultivar == null)
-                throw new ArgumentNullException(nameof(apple.Cultivar), "Property is required for class Apple.");
+                throw new JsonException("Cannot write null property Apple.Cultivar to non-nullable JSON property 'cultivar'.");
 
             if (apple.OriginOption.IsSet && apple.Origin == null)
-                throw new ArgumentNullException(nameof(apple.Origin), "Property is required for class Apple.");
+                throw new JsonException("Cannot write null property Apple.Origin to non-nullable JSON property 'origin'.");
 
             if (apple.ColorCodeOption.IsSet)
                 writer.WriteString("color_code", apple.ColorCode);

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -188,6 +188,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, AppleReq appleReq, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (appleReq.MealyOption.IsSet && appleReq.Mealy == null)
+                throw new JsonException("Cannot write null property AppleReq.Mealy to non-nullable JSON property 'mealy'.");
+
             writer.WriteString("cultivar", appleReq.Cultivar);
 
             if (appleReq.MealyOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -188,9 +188,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, AppleReq appleReq, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (appleReq.Cultivar == null)
-                throw new ArgumentNullException(nameof(appleReq.Cultivar), "Property is required for class AppleReq.");
-
             writer.WriteString("cultivar", appleReq.Cultivar);
 
             if (appleReq.MealyOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ArrayOfArrayOfNumberOnly arrayOfArrayOfNumberOnly, JsonSerializerOptions jsonSerializerOptions)
         {
             if (arrayOfArrayOfNumberOnly.ArrayArrayNumberOption.IsSet && arrayOfArrayOfNumberOnly.ArrayArrayNumber == null)
-                throw new ArgumentNullException(nameof(arrayOfArrayOfNumberOnly.ArrayArrayNumber), "Property is required for class ArrayOfArrayOfNumberOnly.");
+                throw new JsonException("Cannot write null property ArrayOfArrayOfNumberOnly.ArrayArrayNumber to non-nullable JSON property 'ArrayArrayNumber'.");
 
             if (arrayOfArrayOfNumberOnly.ArrayArrayNumberOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ArrayOfNumberOnly arrayOfNumberOnly, JsonSerializerOptions jsonSerializerOptions)
         {
             if (arrayOfNumberOnly.ArrayNumberOption.IsSet && arrayOfNumberOnly.ArrayNumber == null)
-                throw new ArgumentNullException(nameof(arrayOfNumberOnly.ArrayNumber), "Property is required for class ArrayOfNumberOnly.");
+                throw new JsonException("Cannot write null property ArrayOfNumberOnly.ArrayNumber to non-nullable JSON property 'ArrayNumber'.");
 
             if (arrayOfNumberOnly.ArrayNumberOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -223,13 +223,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ArrayTest arrayTest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (arrayTest.ArrayArrayOfIntegerOption.IsSet && arrayTest.ArrayArrayOfInteger == null)
-                throw new ArgumentNullException(nameof(arrayTest.ArrayArrayOfInteger), "Property is required for class ArrayTest.");
+                throw new JsonException("Cannot write null property ArrayTest.ArrayArrayOfInteger to non-nullable JSON property 'array_array_of_integer'.");
 
             if (arrayTest.ArrayArrayOfModelOption.IsSet && arrayTest.ArrayArrayOfModel == null)
-                throw new ArgumentNullException(nameof(arrayTest.ArrayArrayOfModel), "Property is required for class ArrayTest.");
+                throw new JsonException("Cannot write null property ArrayTest.ArrayArrayOfModel to non-nullable JSON property 'array_array_of_model'.");
 
             if (arrayTest.ArrayOfStringOption.IsSet && arrayTest.ArrayOfString == null)
-                throw new ArgumentNullException(nameof(arrayTest.ArrayOfString), "Property is required for class ArrayTest.");
+                throw new JsonException("Cannot write null property ArrayTest.ArrayOfString to non-nullable JSON property 'array_of_string'.");
 
             if (arrayTest.ArrayArrayOfIntegerOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Banana.cs
@@ -176,6 +176,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Banana banana, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (banana.LengthCmOption.IsSet && banana.LengthCm == null)
+                throw new JsonException("Cannot write null property Banana.LengthCm to non-nullable JSON property 'lengthCm'.");
+
             if (banana.LengthCmOption.IsSet)
                 writer.WriteNumber("lengthCm", banana.LengthCmOption.Value!.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -188,6 +188,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, BananaReq bananaReq, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (bananaReq.SweetOption.IsSet && bananaReq.Sweet == null)
+                throw new JsonException("Cannot write null property BananaReq.Sweet to non-nullable JSON property 'sweet'.");
+
             writer.WriteNumber("lengthCm", bananaReq.LengthCm);
 
             if (bananaReq.SweetOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/BasquePig.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/BasquePig.cs
@@ -172,9 +172,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, BasquePig basquePig, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (basquePig.ClassName == null)
-                throw new ArgumentNullException(nameof(basquePig.ClassName), "Property is required for class BasquePig.");
-
             writer.WriteString("className", basquePig.ClassName);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -293,22 +293,22 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Capitalization capitalization, JsonSerializerOptions jsonSerializerOptions)
         {
             if (capitalization.ATT_NAMEOption.IsSet && capitalization.ATT_NAME == null)
-                throw new ArgumentNullException(nameof(capitalization.ATT_NAME), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.ATT_NAME to non-nullable JSON property 'ATT_NAME'.");
 
             if (capitalization.CapitalCamelOption.IsSet && capitalization.CapitalCamel == null)
-                throw new ArgumentNullException(nameof(capitalization.CapitalCamel), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.CapitalCamel to non-nullable JSON property 'CapitalCamel'.");
 
             if (capitalization.CapitalSnakeOption.IsSet && capitalization.CapitalSnake == null)
-                throw new ArgumentNullException(nameof(capitalization.CapitalSnake), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.CapitalSnake to non-nullable JSON property 'Capital_Snake'.");
 
             if (capitalization.SCAETHFlowPointsOption.IsSet && capitalization.SCAETHFlowPoints == null)
-                throw new ArgumentNullException(nameof(capitalization.SCAETHFlowPoints), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.SCAETHFlowPoints to non-nullable JSON property 'SCA_ETH_Flow_Points'.");
 
             if (capitalization.SmallCamelOption.IsSet && capitalization.SmallCamel == null)
-                throw new ArgumentNullException(nameof(capitalization.SmallCamel), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.SmallCamel to non-nullable JSON property 'smallCamel'.");
 
             if (capitalization.SmallSnakeOption.IsSet && capitalization.SmallSnake == null)
-                throw new ArgumentNullException(nameof(capitalization.SmallSnake), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.SmallSnake to non-nullable JSON property 'small_Snake'.");
 
             if (capitalization.ATT_NAMEOption.IsSet)
                 writer.WriteString("ATT_NAME", capitalization.ATT_NAME);

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Cat.cs
@@ -179,7 +179,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Cat cat, JsonSerializerOptions jsonSerializerOptions)
         {
             if (cat.ColorOption.IsSet && cat.Color == null)
-                throw new ArgumentNullException(nameof(cat.Color), "Property is required for class Cat.");
+                throw new JsonException("Cannot write null property Cat.Color to non-nullable JSON property 'color'.");
 
             writer.WriteString("className", cat.ClassName);
 

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Cat.cs
@@ -181,6 +181,9 @@ namespace Org.OpenAPITools.Model
             if (cat.ColorOption.IsSet && cat.Color == null)
                 throw new JsonException("Cannot write null property Cat.Color to non-nullable JSON property 'color'.");
 
+            if (cat.DeclawedOption.IsSet && cat.Declawed == null)
+                throw new JsonException("Cannot write null property Cat.Declawed to non-nullable JSON property 'declawed'.");
+
             writer.WriteString("className", cat.ClassName);
 
             if (cat.ColorOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Category.cs
@@ -195,9 +195,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Category category, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (category.Name == null)
-                throw new ArgumentNullException(nameof(category.Name), "Property is required for class Category.");
-
             if (category.IdOption.IsSet)
                 writer.WriteNumber("id", category.IdOption.Value!.Value);
 

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Category.cs
@@ -195,6 +195,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Category category, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (category.IdOption.IsSet && category.Id == null)
+                throw new JsonException("Cannot write null property Category.Id to non-nullable JSON property 'id'.");
+
             if (category.IdOption.IsSet)
                 writer.WriteNumber("id", category.IdOption.Value!.Value);
 

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -238,7 +238,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ChildCat childCat, JsonSerializerOptions jsonSerializerOptions)
         {
             if (childCat.NameOption.IsSet && childCat.Name == null)
-                throw new ArgumentNullException(nameof(childCat.Name), "Property is required for class ChildCat.");
+                throw new JsonException("Cannot write null property ChildCat.Name to non-nullable JSON property 'name'.");
 
             if (childCat.NameOption.IsSet)
                 writer.WriteString("name", childCat.Name);

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ClassModel classModel, JsonSerializerOptions jsonSerializerOptions)
         {
             if (classModel.ClassOption.IsSet && classModel.Class == null)
-                throw new ArgumentNullException(nameof(classModel.Class), "Property is required for class ClassModel.");
+                throw new JsonException("Cannot write null property ClassModel.Class to non-nullable JSON property '_class'.");
 
             if (classModel.ClassOption.IsSet)
                 writer.WriteString("_class", classModel.Class);

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
@@ -191,12 +191,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ComplexQuadrilateral complexQuadrilateral, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (complexQuadrilateral.QuadrilateralType == null)
-                throw new ArgumentNullException(nameof(complexQuadrilateral.QuadrilateralType), "Property is required for class ComplexQuadrilateral.");
-
-            if (complexQuadrilateral.ShapeType == null)
-                throw new ArgumentNullException(nameof(complexQuadrilateral.ShapeType), "Property is required for class ComplexQuadrilateral.");
-
             writer.WriteString("quadrilateralType", complexQuadrilateral.QuadrilateralType);
 
             writer.WriteString("shapeType", complexQuadrilateral.ShapeType);

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/CopyActivity.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/CopyActivity.cs
@@ -233,9 +233,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, CopyActivity copyActivity, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (copyActivity.CopyActivitytt == null)
-                throw new ArgumentNullException(nameof(copyActivity.CopyActivitytt), "Property is required for class CopyActivity.");
-
             writer.WriteString("copyActivitytt", copyActivity.CopyActivitytt);
 
             writer.WriteString("$schema", CopyActivity.SchemaEnumToJsonValue(copyActivity.Schema));

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/DanishPig.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/DanishPig.cs
@@ -172,9 +172,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, DanishPig danishPig, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (danishPig.ClassName == null)
-                throw new ArgumentNullException(nameof(danishPig.ClassName), "Property is required for class DanishPig.");
-
             writer.WriteString("className", danishPig.ClassName);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -182,6 +182,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, DateOnlyClass dateOnlyClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (dateOnlyClass.DateOnlyPropertyOption.IsSet && dateOnlyClass.DateOnlyProperty == null)
+                throw new JsonException("Cannot write null property DateOnlyClass.DateOnlyProperty to non-nullable JSON property 'dateOnlyProperty'.");
+
             if (dateOnlyClass.DateOnlyPropertyOption.IsSet)
                 writer.WriteString("dateOnlyProperty", dateOnlyClass.DateOnlyPropertyOption.Value!.Value.ToString(DateOnlyPropertyFormat));
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, DeprecatedObject deprecatedObject, JsonSerializerOptions jsonSerializerOptions)
         {
             if (deprecatedObject.NameOption.IsSet && deprecatedObject.Name == null)
-                throw new ArgumentNullException(nameof(deprecatedObject.Name), "Property is required for class DeprecatedObject.");
+                throw new JsonException("Cannot write null property DeprecatedObject.Name to non-nullable JSON property 'name'.");
 
             if (deprecatedObject.NameOption.IsSet)
                 writer.WriteString("name", deprecatedObject.Name);

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Descendant1.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Descendant1.cs
@@ -184,12 +184,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Descendant1 descendant1, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (descendant1.AlternativeName == null)
-                throw new ArgumentNullException(nameof(descendant1.AlternativeName), "Property is required for class Descendant1.");
-
-            if (descendant1.DescendantName == null)
-                throw new ArgumentNullException(nameof(descendant1.DescendantName), "Property is required for class Descendant1.");
-
             writer.WriteString("alternativeName", descendant1.AlternativeName);
 
             writer.WriteString("descendantName", descendant1.DescendantName);

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Descendant2.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Descendant2.cs
@@ -184,12 +184,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Descendant2 descendant2, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (descendant2.AlternativeName == null)
-                throw new ArgumentNullException(nameof(descendant2.AlternativeName), "Property is required for class Descendant2.");
-
-            if (descendant2.Confidentiality == null)
-                throw new ArgumentNullException(nameof(descendant2.Confidentiality), "Property is required for class Descendant2.");
-
             writer.WriteString("alternativeName", descendant2.AlternativeName);
 
             writer.WriteString("confidentiality", descendant2.Confidentiality);

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Dog.cs
@@ -179,10 +179,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Dog dog, JsonSerializerOptions jsonSerializerOptions)
         {
             if (dog.BreedOption.IsSet && dog.Breed == null)
-                throw new ArgumentNullException(nameof(dog.Breed), "Property is required for class Dog.");
+                throw new JsonException("Cannot write null property Dog.Breed to non-nullable JSON property 'breed'.");
 
             if (dog.ColorOption.IsSet && dog.Color == null)
-                throw new ArgumentNullException(nameof(dog.Color), "Property is required for class Dog.");
+                throw new JsonException("Cannot write null property Dog.Color to non-nullable JSON property 'color'.");
 
             writer.WriteString("className", dog.ClassName);
 

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Drawing.cs
@@ -240,10 +240,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Drawing drawing, JsonSerializerOptions jsonSerializerOptions)
         {
             if (drawing.MainShapeOption.IsSet && drawing.MainShape == null)
-                throw new ArgumentNullException(nameof(drawing.MainShape), "Property is required for class Drawing.");
+                throw new JsonException("Cannot write null property Drawing.MainShape to non-nullable JSON property 'mainShape'.");
 
             if (drawing.ShapesOption.IsSet && drawing.Shapes == null)
-                throw new ArgumentNullException(nameof(drawing.Shapes), "Property is required for class Drawing.");
+                throw new JsonException("Cannot write null property Drawing.Shapes to non-nullable JSON property 'shapes'.");
 
             if (drawing.MainShapeOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -339,7 +339,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, EnumArrays enumArrays, JsonSerializerOptions jsonSerializerOptions)
         {
             if (enumArrays.ArrayEnumOption.IsSet && enumArrays.ArrayEnum == null)
-                throw new ArgumentNullException(nameof(enumArrays.ArrayEnum), "Property is required for class EnumArrays.");
+                throw new JsonException("Cannot write null property EnumArrays.ArrayEnum to non-nullable JSON property 'array_enum'.");
 
             if (enumArrays.ArrayEnumOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -341,6 +341,9 @@ namespace Org.OpenAPITools.Model
             if (enumArrays.ArrayEnumOption.IsSet && enumArrays.ArrayEnum == null)
                 throw new JsonException("Cannot write null property EnumArrays.ArrayEnum to non-nullable JSON property 'array_enum'.");
 
+            if (enumArrays.JustSymbolOption.IsSet && enumArrays.JustSymbol == null)
+                throw new JsonException("Cannot write null property EnumArrays.JustSymbol to non-nullable JSON property 'just_symbol'.");
+
             if (enumArrays.ArrayEnumOption.IsSet)
             {
                 writer.WritePropertyName("array_enum");

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -877,6 +877,27 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, EnumTest enumTest, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (enumTest.EnumIntegerOption.IsSet && enumTest.EnumInteger == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumInteger to non-nullable JSON property 'enum_integer'.");
+
+            if (enumTest.EnumIntegerOnlyOption.IsSet && enumTest.EnumIntegerOnly == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumIntegerOnly to non-nullable JSON property 'enum_integer_only'.");
+
+            if (enumTest.EnumNumberOption.IsSet && enumTest.EnumNumber == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumNumber to non-nullable JSON property 'enum_number'.");
+
+            if (enumTest.EnumStringOption.IsSet && enumTest.EnumString == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumString to non-nullable JSON property 'enum_string'.");
+
+            if (enumTest.OuterEnumDefaultValueOption.IsSet && enumTest.OuterEnumDefaultValue == null)
+                throw new JsonException("Cannot write null property EnumTest.OuterEnumDefaultValue to non-nullable JSON property 'outerEnumDefaultValue'.");
+
+            if (enumTest.OuterEnumIntegerOption.IsSet && enumTest.OuterEnumInteger == null)
+                throw new JsonException("Cannot write null property EnumTest.OuterEnumInteger to non-nullable JSON property 'outerEnumInteger'.");
+
+            if (enumTest.OuterEnumIntegerDefaultValueOption.IsSet && enumTest.OuterEnumIntegerDefaultValue == null)
+                throw new JsonException("Cannot write null property EnumTest.OuterEnumIntegerDefaultValue to non-nullable JSON property 'outerEnumIntegerDefaultValue'.");
+
             var enumStringRequiredRawValue = EnumTest.EnumStringRequiredEnumToJsonValue(enumTest.EnumStringRequired);
             writer.WriteString("enum_string_required", enumStringRequiredRawValue);
             if (enumTest.EnumIntegerOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
@@ -191,12 +191,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, EquilateralTriangle equilateralTriangle, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (equilateralTriangle.ShapeType == null)
-                throw new ArgumentNullException(nameof(equilateralTriangle.ShapeType), "Property is required for class EquilateralTriangle.");
-
-            if (equilateralTriangle.TriangleType == null)
-                throw new ArgumentNullException(nameof(equilateralTriangle.TriangleType), "Property is required for class EquilateralTriangle.");
-
             writer.WriteString("shapeType", equilateralTriangle.ShapeType);
 
             writer.WriteString("triangleType", equilateralTriangle.TriangleType);

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/File.cs
@@ -178,7 +178,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, File file, JsonSerializerOptions jsonSerializerOptions)
         {
             if (file.SourceURIOption.IsSet && file.SourceURI == null)
-                throw new ArgumentNullException(nameof(file.SourceURI), "Property is required for class File.");
+                throw new JsonException("Cannot write null property File.SourceURI to non-nullable JSON property 'sourceURI'.");
 
             if (file.SourceURIOption.IsSet)
                 writer.WriteString("sourceURI", file.SourceURI);

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -200,10 +200,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, FileSchemaTestClass fileSchemaTestClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (fileSchemaTestClass.FileOption.IsSet && fileSchemaTestClass.File == null)
-                throw new ArgumentNullException(nameof(fileSchemaTestClass.File), "Property is required for class FileSchemaTestClass.");
+                throw new JsonException("Cannot write null property FileSchemaTestClass.File to non-nullable JSON property 'file'.");
 
             if (fileSchemaTestClass.FilesOption.IsSet && fileSchemaTestClass.Files == null)
-                throw new ArgumentNullException(nameof(fileSchemaTestClass.Files), "Property is required for class FileSchemaTestClass.");
+                throw new JsonException("Cannot write null property FileSchemaTestClass.Files to non-nullable JSON property 'files'.");
 
             if (fileSchemaTestClass.FileOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Foo.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Foo foo, JsonSerializerOptions jsonSerializerOptions)
         {
             if (foo.BarOption.IsSet && foo.Bar == null)
-                throw new ArgumentNullException(nameof(foo.Bar), "Property is required for class Foo.");
+                throw new JsonException("Cannot write null property Foo.Bar to non-nullable JSON property 'bar'.");
 
             if (foo.BarOption.IsSet)
                 writer.WriteString("bar", foo.Bar);

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, FooGetDefaultResponse fooGetDefaultResponse, JsonSerializerOptions jsonSerializerOptions)
         {
             if (fooGetDefaultResponse.StringOption.IsSet && fooGetDefaultResponse.String == null)
-                throw new ArgumentNullException(nameof(fooGetDefaultResponse.String), "Property is required for class FooGetDefaultResponse.");
+                throw new JsonException("Cannot write null property FooGetDefaultResponse.String to non-nullable JSON property 'string'.");
 
             if (fooGetDefaultResponse.StringOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -956,11 +956,47 @@ namespace Org.OpenAPITools.Model
             if (formatTest.BinaryOption.IsSet && formatTest.Binary == null)
                 throw new JsonException("Cannot write null property FormatTest.Binary to non-nullable JSON property 'binary'.");
 
+            if (formatTest.DateTimeOption.IsSet && formatTest.DateTime == null)
+                throw new JsonException("Cannot write null property FormatTest.DateTime to non-nullable JSON property 'dateTime'.");
+
+            if (formatTest.DecimalOption.IsSet && formatTest.Decimal == null)
+                throw new JsonException("Cannot write null property FormatTest.Decimal to non-nullable JSON property 'decimal'.");
+
+            if (formatTest.DoubleOption.IsSet && formatTest.Double == null)
+                throw new JsonException("Cannot write null property FormatTest.Double to non-nullable JSON property 'double'.");
+
             if (formatTest.DuplicatePropertyName2Option.IsSet && formatTest.DuplicatePropertyName2 == null)
                 throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName2 to non-nullable JSON property 'duplicate_property_name'.");
 
             if (formatTest.DuplicatePropertyNameOption.IsSet && formatTest.DuplicatePropertyName == null)
                 throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName to non-nullable JSON property '@duplicate_property_name'.");
+
+            if (formatTest.FloatOption.IsSet && formatTest.Float == null)
+                throw new JsonException("Cannot write null property FormatTest.Float to non-nullable JSON property 'float'.");
+
+            if (formatTest.Int32Option.IsSet && formatTest.Int32 == null)
+                throw new JsonException("Cannot write null property FormatTest.Int32 to non-nullable JSON property 'int32'.");
+
+            if (formatTest.Int32RangeOption.IsSet && formatTest.Int32Range == null)
+                throw new JsonException("Cannot write null property FormatTest.Int32Range to non-nullable JSON property 'int32Range'.");
+
+            if (formatTest.Int64Option.IsSet && formatTest.Int64 == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64 to non-nullable JSON property 'int64'.");
+
+            if (formatTest.Int64NegativeOption.IsSet && formatTest.Int64Negative == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64Negative to non-nullable JSON property 'int64Negative'.");
+
+            if (formatTest.Int64NegativeExclusiveOption.IsSet && formatTest.Int64NegativeExclusive == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64NegativeExclusive to non-nullable JSON property 'int64NegativeExclusive'.");
+
+            if (formatTest.Int64PositiveOption.IsSet && formatTest.Int64Positive == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64Positive to non-nullable JSON property 'int64Positive'.");
+
+            if (formatTest.Int64PositiveExclusiveOption.IsSet && formatTest.Int64PositiveExclusive == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64PositiveExclusive to non-nullable JSON property 'int64PositiveExclusive'.");
+
+            if (formatTest.IntegerOption.IsSet && formatTest.Integer == null)
+                throw new JsonException("Cannot write null property FormatTest.Integer to non-nullable JSON property 'integer'.");
 
             if (formatTest.PatternWithBackslashOption.IsSet && formatTest.PatternWithBackslash == null)
                 throw new JsonException("Cannot write null property FormatTest.PatternWithBackslash to non-nullable JSON property 'pattern_with_backslash'.");
@@ -973,6 +1009,18 @@ namespace Org.OpenAPITools.Model
 
             if (formatTest.StringOption.IsSet && formatTest.String == null)
                 throw new JsonException("Cannot write null property FormatTest.String to non-nullable JSON property 'string'.");
+
+            if (formatTest.StringFormattedAsDecimalOption.IsSet && formatTest.StringFormattedAsDecimal == null)
+                throw new JsonException("Cannot write null property FormatTest.StringFormattedAsDecimal to non-nullable JSON property 'string_formatted_as_decimal'.");
+
+            if (formatTest.UnsignedIntegerOption.IsSet && formatTest.UnsignedInteger == null)
+                throw new JsonException("Cannot write null property FormatTest.UnsignedInteger to non-nullable JSON property 'unsigned_integer'.");
+
+            if (formatTest.UnsignedLongOption.IsSet && formatTest.UnsignedLong == null)
+                throw new JsonException("Cannot write null property FormatTest.UnsignedLong to non-nullable JSON property 'unsigned_long'.");
+
+            if (formatTest.UuidOption.IsSet && formatTest.Uuid == null)
+                throw new JsonException("Cannot write null property FormatTest.Uuid to non-nullable JSON property 'uuid'.");
 
             writer.WritePropertyName("byte");
             JsonSerializer.Serialize(writer, formatTest.Byte, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -953,32 +953,26 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, FormatTest formatTest, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (formatTest.Byte == null)
-                throw new ArgumentNullException(nameof(formatTest.Byte), "Property is required for class FormatTest.");
-
-            if (formatTest.Password == null)
-                throw new ArgumentNullException(nameof(formatTest.Password), "Property is required for class FormatTest.");
-
             if (formatTest.BinaryOption.IsSet && formatTest.Binary == null)
-                throw new ArgumentNullException(nameof(formatTest.Binary), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.Binary to non-nullable JSON property 'binary'.");
 
             if (formatTest.DuplicatePropertyName2Option.IsSet && formatTest.DuplicatePropertyName2 == null)
-                throw new ArgumentNullException(nameof(formatTest.DuplicatePropertyName2), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName2 to non-nullable JSON property 'duplicate_property_name'.");
 
             if (formatTest.DuplicatePropertyNameOption.IsSet && formatTest.DuplicatePropertyName == null)
-                throw new ArgumentNullException(nameof(formatTest.DuplicatePropertyName), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName to non-nullable JSON property '@duplicate_property_name'.");
 
             if (formatTest.PatternWithBackslashOption.IsSet && formatTest.PatternWithBackslash == null)
-                throw new ArgumentNullException(nameof(formatTest.PatternWithBackslash), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.PatternWithBackslash to non-nullable JSON property 'pattern_with_backslash'.");
 
             if (formatTest.PatternWithDigitsOption.IsSet && formatTest.PatternWithDigits == null)
-                throw new ArgumentNullException(nameof(formatTest.PatternWithDigits), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.PatternWithDigits to non-nullable JSON property 'pattern_with_digits'.");
 
             if (formatTest.PatternWithDigitsAndDelimiterOption.IsSet && formatTest.PatternWithDigitsAndDelimiter == null)
-                throw new ArgumentNullException(nameof(formatTest.PatternWithDigitsAndDelimiter), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.PatternWithDigitsAndDelimiter to non-nullable JSON property 'pattern_with_digits_and_delimiter'.");
 
             if (formatTest.StringOption.IsSet && formatTest.String == null)
-                throw new ArgumentNullException(nameof(formatTest.String), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.String to non-nullable JSON property 'string'.");
 
             writer.WritePropertyName("byte");
             JsonSerializer.Serialize(writer, formatTest.Byte, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Fruit.cs
@@ -221,7 +221,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Fruit fruit, JsonSerializerOptions jsonSerializerOptions)
         {
             if (fruit.ColorOption.IsSet && fruit.Color == null)
-                throw new ArgumentNullException(nameof(fruit.Color), "Property is required for class Fruit.");
+                throw new JsonException("Cannot write null property Fruit.Color to non-nullable JSON property 'color'.");
 
             if (fruit.ColorOption.IsSet)
                 writer.WriteString("color", fruit.Color);

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -238,7 +238,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, GmFruit gmFruit, JsonSerializerOptions jsonSerializerOptions)
         {
             if (gmFruit.ColorOption.IsSet && gmFruit.Color == null)
-                throw new ArgumentNullException(nameof(gmFruit.Color), "Property is required for class GmFruit.");
+                throw new JsonException("Cannot write null property GmFruit.Color to non-nullable JSON property 'color'.");
 
             if (gmFruit.ColorOption.IsSet)
                 writer.WriteString("color", gmFruit.Color);

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -241,10 +241,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, HasOnlyReadOnly hasOnlyReadOnly, JsonSerializerOptions jsonSerializerOptions)
         {
             if (hasOnlyReadOnly.BarOption.IsSet && hasOnlyReadOnly.Bar == null)
-                throw new ArgumentNullException(nameof(hasOnlyReadOnly.Bar), "Property is required for class HasOnlyReadOnly.");
+                throw new JsonException("Cannot write null property HasOnlyReadOnly.Bar to non-nullable JSON property 'bar'.");
 
             if (hasOnlyReadOnly.FooOption.IsSet && hasOnlyReadOnly.Foo == null)
-                throw new ArgumentNullException(nameof(hasOnlyReadOnly.Foo), "Property is required for class HasOnlyReadOnly.");
+                throw new JsonException("Cannot write null property HasOnlyReadOnly.Foo to non-nullable JSON property 'foo'.");
 
             if (hasOnlyReadOnly.BarOption.IsSet)
                 writer.WriteString("bar", hasOnlyReadOnly.Bar);

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
@@ -339,22 +339,22 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, InjectedVendorExtensionsTest injectedVendorExtensionsTest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessorOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor to non-nullable JSON property 'potentiallyOverriddenPropertyAccessor'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternalOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternal == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternal), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternal to non-nullable JSON property 'potentiallyOverriddenPropertyToInternal'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivateOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivate == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivate), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivate to non-nullable JSON property 'potentiallyOverriddenPropertyToPrivate'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublicOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublic == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublic), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublic to non-nullable JSON property 'potentiallyOverriddenPropertyToPublic'.");
 
             if (injectedVendorExtensionsTest.UnalteredPropertyOption.IsSet && injectedVendorExtensionsTest.UnalteredProperty == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.UnalteredProperty), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.UnalteredProperty to non-nullable JSON property 'unalteredProperty'.");
 
             if (injectedVendorExtensionsTest.UnalteredPropertyAccessorOption.IsSet && injectedVendorExtensionsTest.UnalteredPropertyAccessor == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.UnalteredPropertyAccessor), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.UnalteredPropertyAccessor to non-nullable JSON property 'unalteredPropertyAccessor'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessorOption.IsSet)
                 writer.WriteString("potentiallyOverriddenPropertyAccessor", injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor);

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
@@ -184,12 +184,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, IsoscelesTriangle isoscelesTriangle, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (isoscelesTriangle.ShapeType == null)
-                throw new ArgumentNullException(nameof(isoscelesTriangle.ShapeType), "Property is required for class IsoscelesTriangle.");
-
-            if (isoscelesTriangle.TriangleType == null)
-                throw new ArgumentNullException(nameof(isoscelesTriangle.TriangleType), "Property is required for class IsoscelesTriangle.");
-
             writer.WriteString("shapeType", isoscelesTriangle.ShapeType);
 
             writer.WriteString("triangleType", isoscelesTriangle.TriangleType);

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/List.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, List list, JsonSerializerOptions jsonSerializerOptions)
         {
             if (list.Var123ListOption.IsSet && list.Var123List == null)
-                throw new ArgumentNullException(nameof(list.Var123List), "Property is required for class List.");
+                throw new JsonException("Cannot write null property List.Var123List to non-nullable JSON property '123-list'.");
 
             if (list.Var123ListOption.IsSet)
                 writer.WriteString("123-list", list.Var123List);

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -200,10 +200,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, LiteralStringClass literalStringClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (literalStringClass.EscapedLiteralStringOption.IsSet && literalStringClass.EscapedLiteralString == null)
-                throw new ArgumentNullException(nameof(literalStringClass.EscapedLiteralString), "Property is required for class LiteralStringClass.");
+                throw new JsonException("Cannot write null property LiteralStringClass.EscapedLiteralString to non-nullable JSON property 'escapedLiteralString'.");
 
             if (literalStringClass.UnescapedLiteralStringOption.IsSet && literalStringClass.UnescapedLiteralString == null)
-                throw new ArgumentNullException(nameof(literalStringClass.UnescapedLiteralString), "Property is required for class LiteralStringClass.");
+                throw new JsonException("Cannot write null property LiteralStringClass.UnescapedLiteralString to non-nullable JSON property 'unescapedLiteralString'.");
 
             if (literalStringClass.EscapedLiteralStringOption.IsSet)
                 writer.WriteString("escapedLiteralString", literalStringClass.EscapedLiteralString);

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/MapTest.cs
@@ -312,16 +312,16 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MapTest mapTest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mapTest.DirectMapOption.IsSet && mapTest.DirectMap == null)
-                throw new ArgumentNullException(nameof(mapTest.DirectMap), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.DirectMap to non-nullable JSON property 'direct_map'.");
 
             if (mapTest.IndirectMapOption.IsSet && mapTest.IndirectMap == null)
-                throw new ArgumentNullException(nameof(mapTest.IndirectMap), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.IndirectMap to non-nullable JSON property 'indirect_map'.");
 
             if (mapTest.MapMapOfStringOption.IsSet && mapTest.MapMapOfString == null)
-                throw new ArgumentNullException(nameof(mapTest.MapMapOfString), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.MapMapOfString to non-nullable JSON property 'map_map_of_string'.");
 
             if (mapTest.MapOfEnumStringOption.IsSet && mapTest.MapOfEnumString == null)
-                throw new ArgumentNullException(nameof(mapTest.MapOfEnumString), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.MapOfEnumString to non-nullable JSON property 'map_of_enum_string'.");
 
             if (mapTest.DirectMapOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedAnyOf.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedAnyOf.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedAnyOf mixedAnyOf, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedAnyOf.ContentOption.IsSet && mixedAnyOf.Content == null)
-                throw new ArgumentNullException(nameof(mixedAnyOf.Content), "Property is required for class MixedAnyOf.");
+                throw new JsonException("Cannot write null property MixedAnyOf.Content to non-nullable JSON property 'content'.");
 
             if (mixedAnyOf.ContentOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedOneOf.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedOneOf.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedOneOf mixedOneOf, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedOneOf.ContentOption.IsSet && mixedOneOf.Content == null)
-                throw new ArgumentNullException(nameof(mixedOneOf.Content), "Property is required for class MixedOneOf.");
+                throw new JsonException("Cannot write null property MixedOneOf.Content to non-nullable JSON property 'content'.");
 
             if (mixedOneOf.ContentOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -257,8 +257,17 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, MixedPropertiesAndAdditionalPropertiesClass mixedPropertiesAndAdditionalPropertiesClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.DateTime == null)
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.DateTime to non-nullable JSON property 'dateTime'.");
+
             if (mixedPropertiesAndAdditionalPropertiesClass.MapOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.Map == null)
                 throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.Map to non-nullable JSON property 'map'.");
+
+            if (mixedPropertiesAndAdditionalPropertiesClass.UuidOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.Uuid == null)
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.Uuid to non-nullable JSON property 'uuid'.");
+
+            if (mixedPropertiesAndAdditionalPropertiesClass.UuidWithPatternOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.UuidWithPattern == null)
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.UuidWithPattern to non-nullable JSON property 'uuid_with_pattern'.");
 
             if (mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.IsSet)
                 writer.WriteString("dateTime", mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.Value!.Value.ToString(DateTimeFormat));

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -258,7 +258,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedPropertiesAndAdditionalPropertiesClass mixedPropertiesAndAdditionalPropertiesClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedPropertiesAndAdditionalPropertiesClass.MapOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.Map == null)
-                throw new ArgumentNullException(nameof(mixedPropertiesAndAdditionalPropertiesClass.Map), "Property is required for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.Map to non-nullable JSON property 'map'.");
 
             if (mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.IsSet)
                 writer.WriteString("dateTime", mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.Value!.Value.ToString(DateTimeFormat));

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedSubId.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedSubId.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedSubId mixedSubId, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedSubId.IdOption.IsSet && mixedSubId.Id == null)
-                throw new ArgumentNullException(nameof(mixedSubId.Id), "Property is required for class MixedSubId.");
+                throw new JsonException("Cannot write null property MixedSubId.Id to non-nullable JSON property 'id'.");
 
             if (mixedSubId.IdOption.IsSet)
                 writer.WriteString("id", mixedSubId.Id);

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -202,6 +202,9 @@ namespace Org.OpenAPITools.Model
             if (model200Response.ClassOption.IsSet && model200Response.Class == null)
                 throw new JsonException("Cannot write null property Model200Response.Class to non-nullable JSON property 'class'.");
 
+            if (model200Response.NameOption.IsSet && model200Response.Name == null)
+                throw new JsonException("Cannot write null property Model200Response.Name to non-nullable JSON property 'name'.");
+
             if (model200Response.ClassOption.IsSet)
                 writer.WriteString("class", model200Response.Class);
 

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -200,7 +200,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Model200Response model200Response, JsonSerializerOptions jsonSerializerOptions)
         {
             if (model200Response.ClassOption.IsSet && model200Response.Class == null)
-                throw new ArgumentNullException(nameof(model200Response.Class), "Property is required for class Model200Response.");
+                throw new JsonException("Cannot write null property Model200Response.Class to non-nullable JSON property 'class'.");
 
             if (model200Response.ClassOption.IsSet)
                 writer.WriteString("class", model200Response.Class);

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ModelClient modelClient, JsonSerializerOptions jsonSerializerOptions)
         {
             if (modelClient.VarClientOption.IsSet && modelClient.VarClient == null)
-                throw new ArgumentNullException(nameof(modelClient.VarClient), "Property is required for class ModelClient.");
+                throw new JsonException("Cannot write null property ModelClient.VarClient to non-nullable JSON property 'client'.");
 
             if (modelClient.VarClientOption.IsSet)
                 writer.WriteString("client", modelClient.VarClient);

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Name.cs
@@ -283,7 +283,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Name name, JsonSerializerOptions jsonSerializerOptions)
         {
             if (name.PropertyOption.IsSet && name.Property == null)
-                throw new ArgumentNullException(nameof(name.Property), "Property is required for class Name.");
+                throw new JsonException("Cannot write null property Name.Property to non-nullable JSON property 'property'.");
 
             writer.WriteNumber("name", name.VarName);
 

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Name.cs
@@ -285,6 +285,12 @@ namespace Org.OpenAPITools.Model
             if (name.PropertyOption.IsSet && name.Property == null)
                 throw new JsonException("Cannot write null property Name.Property to non-nullable JSON property 'property'.");
 
+            if (name.SnakeCaseOption.IsSet && name.SnakeCase == null)
+                throw new JsonException("Cannot write null property Name.SnakeCase to non-nullable JSON property 'snake_case'.");
+
+            if (name.Var123NumberOption.IsSet && name.Var123Number == null)
+                throw new JsonException("Cannot write null property Name.Var123Number to non-nullable JSON property '123Number'.");
+
             writer.WriteNumber("name", name.VarName);
 
             if (name.PropertyOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
@@ -191,9 +191,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, NotificationtestGetElementsV1ResponseMPayload notificationtestGetElementsV1ResponseMPayload, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (notificationtestGetElementsV1ResponseMPayload.AObjVariableobject == null)
-                throw new ArgumentNullException(nameof(notificationtestGetElementsV1ResponseMPayload.AObjVariableobject), "Property is required for class NotificationtestGetElementsV1ResponseMPayload.");
-
             writer.WritePropertyName("a_objVariableobject");
             JsonSerializer.Serialize(writer, notificationtestGetElementsV1ResponseMPayload.AObjVariableobject, jsonSerializerOptions);
             writer.WriteNumber("pkiNotificationtestID", notificationtestGetElementsV1ResponseMPayload.PkiNotificationtestID);

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -410,10 +410,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, NullableClass nullableClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (nullableClass.ArrayItemsNullableOption.IsSet && nullableClass.ArrayItemsNullable == null)
-                throw new ArgumentNullException(nameof(nullableClass.ArrayItemsNullable), "Property is required for class NullableClass.");
+                throw new JsonException("Cannot write null property NullableClass.ArrayItemsNullable to non-nullable JSON property 'array_items_nullable'.");
 
             if (nullableClass.ObjectItemsNullableOption.IsSet && nullableClass.ObjectItemsNullable == null)
-                throw new ArgumentNullException(nameof(nullableClass.ObjectItemsNullable), "Property is required for class NullableClass.");
+                throw new JsonException("Cannot write null property NullableClass.ObjectItemsNullable to non-nullable JSON property 'object_items_nullable'.");
 
             if (nullableClass.ArrayAndItemsNullablePropOption.IsSet)
                 if (nullableClass.ArrayAndItemsNullablePropOption.Value != null)

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -176,6 +176,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, NumberOnly numberOnly, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (numberOnly.JustNumberOption.IsSet && numberOnly.JustNumber == null)
+                throw new JsonException("Cannot write null property NumberOnly.JustNumber to non-nullable JSON property 'JustNumber'.");
+
             if (numberOnly.JustNumberOption.IsSet)
                 writer.WriteNumber("JustNumber", numberOnly.JustNumberOption.Value!.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -254,6 +254,9 @@ namespace Org.OpenAPITools.Model
             if (objectWithDeprecatedFields.DeprecatedRefOption.IsSet && objectWithDeprecatedFields.DeprecatedRef == null)
                 throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.DeprecatedRef to non-nullable JSON property 'deprecatedRef'.");
 
+            if (objectWithDeprecatedFields.IdOption.IsSet && objectWithDeprecatedFields.Id == null)
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Id to non-nullable JSON property 'id'.");
+
             if (objectWithDeprecatedFields.UuidOption.IsSet && objectWithDeprecatedFields.Uuid == null)
                 throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Uuid to non-nullable JSON property 'uuid'.");
 

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -249,13 +249,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ObjectWithDeprecatedFields objectWithDeprecatedFields, JsonSerializerOptions jsonSerializerOptions)
         {
             if (objectWithDeprecatedFields.BarsOption.IsSet && objectWithDeprecatedFields.Bars == null)
-                throw new ArgumentNullException(nameof(objectWithDeprecatedFields.Bars), "Property is required for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Bars to non-nullable JSON property 'bars'.");
 
             if (objectWithDeprecatedFields.DeprecatedRefOption.IsSet && objectWithDeprecatedFields.DeprecatedRef == null)
-                throw new ArgumentNullException(nameof(objectWithDeprecatedFields.DeprecatedRef), "Property is required for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.DeprecatedRef to non-nullable JSON property 'deprecatedRef'.");
 
             if (objectWithDeprecatedFields.UuidOption.IsSet && objectWithDeprecatedFields.Uuid == null)
-                throw new ArgumentNullException(nameof(objectWithDeprecatedFields.Uuid), "Property is required for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Uuid to non-nullable JSON property 'uuid'.");
 
             if (objectWithDeprecatedFields.BarsOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Order.cs
@@ -386,6 +386,24 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Order order, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (order.CompleteOption.IsSet && order.Complete == null)
+                throw new JsonException("Cannot write null property Order.Complete to non-nullable JSON property 'complete'.");
+
+            if (order.IdOption.IsSet && order.Id == null)
+                throw new JsonException("Cannot write null property Order.Id to non-nullable JSON property 'id'.");
+
+            if (order.PetIdOption.IsSet && order.PetId == null)
+                throw new JsonException("Cannot write null property Order.PetId to non-nullable JSON property 'petId'.");
+
+            if (order.QuantityOption.IsSet && order.Quantity == null)
+                throw new JsonException("Cannot write null property Order.Quantity to non-nullable JSON property 'quantity'.");
+
+            if (order.ShipDateOption.IsSet && order.ShipDate == null)
+                throw new JsonException("Cannot write null property Order.ShipDate to non-nullable JSON property 'shipDate'.");
+
+            if (order.StatusOption.IsSet && order.Status == null)
+                throw new JsonException("Cannot write null property Order.Status to non-nullable JSON property 'status'.");
+
             if (order.CompleteOption.IsSet)
                 writer.WriteBoolean("complete", order.CompleteOption.Value!.Value);
 

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -223,7 +223,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, OuterComposite outerComposite, JsonSerializerOptions jsonSerializerOptions)
         {
             if (outerComposite.MyStringOption.IsSet && outerComposite.MyString == null)
-                throw new ArgumentNullException(nameof(outerComposite.MyString), "Property is required for class OuterComposite.");
+                throw new JsonException("Cannot write null property OuterComposite.MyString to non-nullable JSON property 'my_string'.");
 
             if (outerComposite.MyBooleanOption.IsSet)
                 writer.WriteBoolean("my_boolean", outerComposite.MyBooleanOption.Value!.Value);

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -222,6 +222,12 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, OuterComposite outerComposite, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (outerComposite.MyBooleanOption.IsSet && outerComposite.MyBoolean == null)
+                throw new JsonException("Cannot write null property OuterComposite.MyBoolean to non-nullable JSON property 'my_boolean'.");
+
+            if (outerComposite.MyNumberOption.IsSet && outerComposite.MyNumber == null)
+                throw new JsonException("Cannot write null property OuterComposite.MyNumber to non-nullable JSON property 'my_number'.");
+
             if (outerComposite.MyStringOption.IsSet && outerComposite.MyString == null)
                 throw new JsonException("Cannot write null property OuterComposite.MyString to non-nullable JSON property 'my_string'.");
 

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Pet.cs
@@ -376,6 +376,12 @@ namespace Org.OpenAPITools.Model
             if (pet.CategoryOption.IsSet && pet.Category == null)
                 throw new JsonException("Cannot write null property Pet.Category to non-nullable JSON property 'category'.");
 
+            if (pet.IdOption.IsSet && pet.Id == null)
+                throw new JsonException("Cannot write null property Pet.Id to non-nullable JSON property 'id'.");
+
+            if (pet.StatusOption.IsSet && pet.Status == null)
+                throw new JsonException("Cannot write null property Pet.Status to non-nullable JSON property 'status'.");
+
             if (pet.TagsOption.IsSet && pet.Tags == null)
                 throw new JsonException("Cannot write null property Pet.Tags to non-nullable JSON property 'tags'.");
 

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Pet.cs
@@ -373,17 +373,11 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Pet pet, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (pet.Name == null)
-                throw new ArgumentNullException(nameof(pet.Name), "Property is required for class Pet.");
-
-            if (pet.PhotoUrls == null)
-                throw new ArgumentNullException(nameof(pet.PhotoUrls), "Property is required for class Pet.");
-
             if (pet.CategoryOption.IsSet && pet.Category == null)
-                throw new ArgumentNullException(nameof(pet.Category), "Property is required for class Pet.");
+                throw new JsonException("Cannot write null property Pet.Category to non-nullable JSON property 'category'.");
 
             if (pet.TagsOption.IsSet && pet.Tags == null)
-                throw new ArgumentNullException(nameof(pet.Tags), "Property is required for class Pet.");
+                throw new JsonException("Cannot write null property Pet.Tags to non-nullable JSON property 'tags'.");
 
             writer.WriteString("name", pet.Name);
 

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
@@ -172,9 +172,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, QuadrilateralInterface quadrilateralInterface, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (quadrilateralInterface.QuadrilateralType == null)
-                throw new ArgumentNullException(nameof(quadrilateralInterface.QuadrilateralType), "Property is required for class QuadrilateralInterface.");
-
             writer.WriteString("quadrilateralType", quadrilateralInterface.QuadrilateralType);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -238,10 +238,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ReadOnlyFirst readOnlyFirst, JsonSerializerOptions jsonSerializerOptions)
         {
             if (readOnlyFirst.BarOption.IsSet && readOnlyFirst.Bar == null)
-                throw new ArgumentNullException(nameof(readOnlyFirst.Bar), "Property is required for class ReadOnlyFirst.");
+                throw new JsonException("Cannot write null property ReadOnlyFirst.Bar to non-nullable JSON property 'bar'.");
 
             if (readOnlyFirst.BazOption.IsSet && readOnlyFirst.Baz == null)
-                throw new ArgumentNullException(nameof(readOnlyFirst.Baz), "Property is required for class ReadOnlyFirst.");
+                throw new JsonException("Cannot write null property ReadOnlyFirst.Baz to non-nullable JSON property 'baz'.");
 
             if (readOnlyFirst.BarOption.IsSet)
                 writer.WriteString("bar", readOnlyFirst.Bar);

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -2237,17 +2237,11 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, RequiredClass requiredClass, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (requiredClass.RequiredNotnullableArrayOfString == null)
-                throw new ArgumentNullException(nameof(requiredClass.RequiredNotnullableArrayOfString), "Property is required for class RequiredClass.");
-
-            if (requiredClass.RequiredNotnullableStringProp == null)
-                throw new ArgumentNullException(nameof(requiredClass.RequiredNotnullableStringProp), "Property is required for class RequiredClass.");
-
             if (requiredClass.NotrequiredNotnullableArrayOfStringOption.IsSet && requiredClass.NotrequiredNotnullableArrayOfString == null)
-                throw new ArgumentNullException(nameof(requiredClass.NotrequiredNotnullableArrayOfString), "Property is required for class RequiredClass.");
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableArrayOfString to non-nullable JSON property 'notrequired_notnullable_array_of_string'.");
 
             if (requiredClass.NotrequiredNotnullableStringPropOption.IsSet && requiredClass.NotrequiredNotnullableStringProp == null)
-                throw new ArgumentNullException(nameof(requiredClass.NotrequiredNotnullableStringProp), "Property is required for class RequiredClass.");
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableStringProp to non-nullable JSON property 'notrequired_notnullable_string_prop'.");
 
             writer.WriteString("required_not_nullable_date_prop", requiredClass.RequiredNotNullableDateProp.ToString(RequiredNotNullableDatePropFormat));
 

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -2237,11 +2237,38 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, RequiredClass requiredClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (requiredClass.NotRequiredNotnullableDatePropOption.IsSet && requiredClass.NotRequiredNotnullableDateProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotRequiredNotnullableDateProp to non-nullable JSON property 'not_required_notnullable_date_prop'.");
+
+            if (requiredClass.NotRequiredNotnullableintegerPropOption.IsSet && requiredClass.NotRequiredNotnullableintegerProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotRequiredNotnullableintegerProp to non-nullable JSON property 'not_required_notnullableinteger_prop'.");
+
             if (requiredClass.NotrequiredNotnullableArrayOfStringOption.IsSet && requiredClass.NotrequiredNotnullableArrayOfString == null)
                 throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableArrayOfString to non-nullable JSON property 'notrequired_notnullable_array_of_string'.");
 
+            if (requiredClass.NotrequiredNotnullableBooleanPropOption.IsSet && requiredClass.NotrequiredNotnullableBooleanProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableBooleanProp to non-nullable JSON property 'notrequired_notnullable_boolean_prop'.");
+
+            if (requiredClass.NotrequiredNotnullableDatetimePropOption.IsSet && requiredClass.NotrequiredNotnullableDatetimeProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableDatetimeProp to non-nullable JSON property 'notrequired_notnullable_datetime_prop'.");
+
+            if (requiredClass.NotrequiredNotnullableEnumIntegerOption.IsSet && requiredClass.NotrequiredNotnullableEnumInteger == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableEnumInteger to non-nullable JSON property 'notrequired_notnullable_enum_integer'.");
+
+            if (requiredClass.NotrequiredNotnullableEnumIntegerOnlyOption.IsSet && requiredClass.NotrequiredNotnullableEnumIntegerOnly == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableEnumIntegerOnly to non-nullable JSON property 'notrequired_notnullable_enum_integer_only'.");
+
+            if (requiredClass.NotrequiredNotnullableEnumStringOption.IsSet && requiredClass.NotrequiredNotnullableEnumString == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableEnumString to non-nullable JSON property 'notrequired_notnullable_enum_string'.");
+
+            if (requiredClass.NotrequiredNotnullableOuterEnumDefaultValueOption.IsSet && requiredClass.NotrequiredNotnullableOuterEnumDefaultValue == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableOuterEnumDefaultValue to non-nullable JSON property 'notrequired_notnullable_outerEnumDefaultValue'.");
+
             if (requiredClass.NotrequiredNotnullableStringPropOption.IsSet && requiredClass.NotrequiredNotnullableStringProp == null)
                 throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableStringProp to non-nullable JSON property 'notrequired_notnullable_string_prop'.");
+
+            if (requiredClass.NotrequiredNotnullableUuidOption.IsSet && requiredClass.NotrequiredNotnullableUuid == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableUuid to non-nullable JSON property 'notrequired_notnullable_uuid'.");
 
             writer.WriteString("required_not_nullable_date_prop", requiredClass.RequiredNotNullableDateProp.ToString(RequiredNotNullableDatePropFormat));
 

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Result.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Result.cs
@@ -226,13 +226,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Result result, JsonSerializerOptions jsonSerializerOptions)
         {
             if (result.CodeOption.IsSet && result.Code == null)
-                throw new ArgumentNullException(nameof(result.Code), "Property is required for class Result.");
+                throw new JsonException("Cannot write null property Result.Code to non-nullable JSON property 'code'.");
 
             if (result.DataOption.IsSet && result.Data == null)
-                throw new ArgumentNullException(nameof(result.Data), "Property is required for class Result.");
+                throw new JsonException("Cannot write null property Result.Data to non-nullable JSON property 'data'.");
 
             if (result.UuidOption.IsSet && result.Uuid == null)
-                throw new ArgumentNullException(nameof(result.Uuid), "Property is required for class Result.");
+                throw new JsonException("Cannot write null property Result.Uuid to non-nullable JSON property 'uuid'.");
 
             if (result.CodeOption.IsSet)
                 writer.WriteString("code", result.Code);

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Return.cs
@@ -234,11 +234,8 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Return varReturn, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (varReturn.Lock == null)
-                throw new ArgumentNullException(nameof(varReturn.Lock), "Property is required for class Return.");
-
             if (varReturn.UnsafeOption.IsSet && varReturn.Unsafe == null)
-                throw new ArgumentNullException(nameof(varReturn.Unsafe), "Property is required for class Return.");
+                throw new JsonException("Cannot write null property Return.Unsafe to non-nullable JSON property 'unsafe'.");
 
             writer.WriteString("lock", varReturn.Lock);
 

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Return.cs
@@ -234,6 +234,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Return varReturn, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (varReturn.VarReturnOption.IsSet && varReturn.VarReturn == null)
+                throw new JsonException("Cannot write null property Return.VarReturn to non-nullable JSON property 'return'.");
+
             if (varReturn.UnsafeOption.IsSet && varReturn.Unsafe == null)
                 throw new JsonException("Cannot write null property Return.Unsafe to non-nullable JSON property 'unsafe'.");
 

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -200,7 +200,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, RolesReportsHash rolesReportsHash, JsonSerializerOptions jsonSerializerOptions)
         {
             if (rolesReportsHash.RoleOption.IsSet && rolesReportsHash.Role == null)
-                throw new ArgumentNullException(nameof(rolesReportsHash.Role), "Property is required for class RolesReportsHash.");
+                throw new JsonException("Cannot write null property RolesReportsHash.Role to non-nullable JSON property 'role'.");
 
             if (rolesReportsHash.RoleOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -202,6 +202,9 @@ namespace Org.OpenAPITools.Model
             if (rolesReportsHash.RoleOption.IsSet && rolesReportsHash.Role == null)
                 throw new JsonException("Cannot write null property RolesReportsHash.Role to non-nullable JSON property 'role'.");
 
+            if (rolesReportsHash.RoleUuidOption.IsSet && rolesReportsHash.RoleUuid == null)
+                throw new JsonException("Cannot write null property RolesReportsHash.RoleUuid to non-nullable JSON property 'role_uuid'.");
+
             if (rolesReportsHash.RoleOption.IsSet)
             {
                 writer.WritePropertyName("role");

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, RolesReportsHashRole rolesReportsHashRole, JsonSerializerOptions jsonSerializerOptions)
         {
             if (rolesReportsHashRole.NameOption.IsSet && rolesReportsHashRole.Name == null)
-                throw new ArgumentNullException(nameof(rolesReportsHashRole.Name), "Property is required for class RolesReportsHashRole.");
+                throw new JsonException("Cannot write null property RolesReportsHashRole.Name to non-nullable JSON property 'name'.");
 
             if (rolesReportsHashRole.NameOption.IsSet)
                 writer.WriteString("name", rolesReportsHashRole.Name);

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
@@ -191,12 +191,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ScaleneTriangle scaleneTriangle, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (scaleneTriangle.ShapeType == null)
-                throw new ArgumentNullException(nameof(scaleneTriangle.ShapeType), "Property is required for class ScaleneTriangle.");
-
-            if (scaleneTriangle.TriangleType == null)
-                throw new ArgumentNullException(nameof(scaleneTriangle.TriangleType), "Property is required for class ScaleneTriangle.");
-
             writer.WriteString("shapeType", scaleneTriangle.ShapeType);
 
             writer.WriteString("triangleType", scaleneTriangle.TriangleType);

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ShapeInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ShapeInterface.cs
@@ -172,9 +172,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ShapeInterface shapeInterface, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (shapeInterface.ShapeType == null)
-                throw new ArgumentNullException(nameof(shapeInterface.ShapeType), "Property is required for class ShapeInterface.");
-
             writer.WriteString("shapeType", shapeInterface.ShapeType);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
@@ -191,12 +191,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, SimpleQuadrilateral simpleQuadrilateral, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (simpleQuadrilateral.QuadrilateralType == null)
-                throw new ArgumentNullException(nameof(simpleQuadrilateral.QuadrilateralType), "Property is required for class SimpleQuadrilateral.");
-
-            if (simpleQuadrilateral.ShapeType == null)
-                throw new ArgumentNullException(nameof(simpleQuadrilateral.ShapeType), "Property is required for class SimpleQuadrilateral.");
-
             writer.WriteString("quadrilateralType", simpleQuadrilateral.QuadrilateralType);
 
             writer.WriteString("shapeType", simpleQuadrilateral.ShapeType);

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -202,6 +202,9 @@ namespace Org.OpenAPITools.Model
             if (specialModelName.VarSpecialModelNameOption.IsSet && specialModelName.VarSpecialModelName == null)
                 throw new JsonException("Cannot write null property SpecialModelName.VarSpecialModelName to non-nullable JSON property '_special_model.name_'.");
 
+            if (specialModelName.SpecialPropertyNameOption.IsSet && specialModelName.SpecialPropertyName == null)
+                throw new JsonException("Cannot write null property SpecialModelName.SpecialPropertyName to non-nullable JSON property '$special[property.name]'.");
+
             if (specialModelName.VarSpecialModelNameOption.IsSet)
                 writer.WriteString("_special_model.name_", specialModelName.VarSpecialModelName);
 

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -200,7 +200,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, SpecialModelName specialModelName, JsonSerializerOptions jsonSerializerOptions)
         {
             if (specialModelName.VarSpecialModelNameOption.IsSet && specialModelName.VarSpecialModelName == null)
-                throw new ArgumentNullException(nameof(specialModelName.VarSpecialModelName), "Property is required for class SpecialModelName.");
+                throw new JsonException("Cannot write null property SpecialModelName.VarSpecialModelName to non-nullable JSON property '_special_model.name_'.");
 
             if (specialModelName.VarSpecialModelNameOption.IsSet)
                 writer.WriteString("_special_model.name_", specialModelName.VarSpecialModelName);

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Tag.cs
@@ -199,6 +199,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Tag tag, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (tag.IdOption.IsSet && tag.Id == null)
+                throw new JsonException("Cannot write null property Tag.Id to non-nullable JSON property 'id'.");
+
             if (tag.NameOption.IsSet && tag.Name == null)
                 throw new JsonException("Cannot write null property Tag.Name to non-nullable JSON property 'name'.");
 

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Tag.cs
@@ -200,7 +200,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Tag tag, JsonSerializerOptions jsonSerializerOptions)
         {
             if (tag.NameOption.IsSet && tag.Name == null)
-                throw new ArgumentNullException(nameof(tag.Name), "Property is required for class Tag.");
+                throw new JsonException("Cannot write null property Tag.Name to non-nullable JSON property 'name'.");
 
             if (tag.IdOption.IsSet)
                 writer.WriteNumber("id", tag.IdOption.Value!.Value);

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestCollectionEndingWithWordList testCollectionEndingWithWordList, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testCollectionEndingWithWordList.ValueOption.IsSet && testCollectionEndingWithWordList.Value == null)
-                throw new ArgumentNullException(nameof(testCollectionEndingWithWordList.Value), "Property is required for class TestCollectionEndingWithWordList.");
+                throw new JsonException("Cannot write null property TestCollectionEndingWithWordList.Value to non-nullable JSON property 'value'.");
 
             if (testCollectionEndingWithWordList.ValueOption.IsSet)
                 writer.WriteString("value", testCollectionEndingWithWordList.Value);

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestCollectionEndingWithWordListObject testCollectionEndingWithWordListObject, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testCollectionEndingWithWordListObject.TestCollectionEndingWithWordListOption.IsSet && testCollectionEndingWithWordListObject.TestCollectionEndingWithWordList == null)
-                throw new ArgumentNullException(nameof(testCollectionEndingWithWordListObject.TestCollectionEndingWithWordList), "Property is required for class TestCollectionEndingWithWordListObject.");
+                throw new JsonException("Cannot write null property TestCollectionEndingWithWordListObject.TestCollectionEndingWithWordList to non-nullable JSON property 'TestCollectionEndingWithWordList'.");
 
             if (testCollectionEndingWithWordListObject.TestCollectionEndingWithWordListOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/TestDescendants.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/TestDescendants.cs
@@ -291,9 +291,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, TestDescendants testDescendants, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (testDescendants.AlternativeName == null)
-                throw new ArgumentNullException(nameof(testDescendants.AlternativeName), "Property is required for class TestDescendants.");
-
             writer.WriteString("alternativeName", testDescendants.AlternativeName);
 
             writer.WriteString("objectType", TestDescendants.ObjectTypeEnumToJsonValue(testDescendants.ObjectType));

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestInlineFreeformAdditionalPropertiesRequest testInlineFreeformAdditionalPropertiesRequest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testInlineFreeformAdditionalPropertiesRequest.SomePropertyOption.IsSet && testInlineFreeformAdditionalPropertiesRequest.SomeProperty == null)
-                throw new ArgumentNullException(nameof(testInlineFreeformAdditionalPropertiesRequest.SomeProperty), "Property is required for class TestInlineFreeformAdditionalPropertiesRequest.");
+                throw new JsonException("Cannot write null property TestInlineFreeformAdditionalPropertiesRequest.SomeProperty to non-nullable JSON property 'someProperty'.");
 
             if (testInlineFreeformAdditionalPropertiesRequest.SomePropertyOption.IsSet)
                 writer.WriteString("someProperty", testInlineFreeformAdditionalPropertiesRequest.SomeProperty);

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/TestResult.cs
@@ -224,6 +224,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, TestResult testResult, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (testResult.CodeOption.IsSet && testResult.Code == null)
+                throw new JsonException("Cannot write null property TestResult.Code to non-nullable JSON property 'code'.");
+
             if (testResult.DataOption.IsSet && testResult.Data == null)
                 throw new JsonException("Cannot write null property TestResult.Data to non-nullable JSON property 'data'.");
 

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/TestResult.cs
@@ -225,10 +225,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestResult testResult, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testResult.DataOption.IsSet && testResult.Data == null)
-                throw new ArgumentNullException(nameof(testResult.Data), "Property is required for class TestResult.");
+                throw new JsonException("Cannot write null property TestResult.Data to non-nullable JSON property 'data'.");
 
             if (testResult.UuidOption.IsSet && testResult.Uuid == null)
-                throw new ArgumentNullException(nameof(testResult.Uuid), "Property is required for class TestResult.");
+                throw new JsonException("Cannot write null property TestResult.Uuid to non-nullable JSON property 'uuid'.");
 
             if (testResult.CodeOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/TriangleInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/TriangleInterface.cs
@@ -172,9 +172,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, TriangleInterface triangleInterface, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (triangleInterface.TriangleType == null)
-                throw new ArgumentNullException(nameof(triangleInterface.TriangleType), "Property is required for class TriangleInterface.");
-
             writer.WriteString("triangleType", triangleInterface.TriangleType);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/User.cs
@@ -431,6 +431,9 @@ namespace Org.OpenAPITools.Model
             if (user.FirstNameOption.IsSet && user.FirstName == null)
                 throw new JsonException("Cannot write null property User.FirstName to non-nullable JSON property 'firstName'.");
 
+            if (user.IdOption.IsSet && user.Id == null)
+                throw new JsonException("Cannot write null property User.Id to non-nullable JSON property 'id'.");
+
             if (user.LastNameOption.IsSet && user.LastName == null)
                 throw new JsonException("Cannot write null property User.LastName to non-nullable JSON property 'lastName'.");
 
@@ -442,6 +445,9 @@ namespace Org.OpenAPITools.Model
 
             if (user.PhoneOption.IsSet && user.Phone == null)
                 throw new JsonException("Cannot write null property User.Phone to non-nullable JSON property 'phone'.");
+
+            if (user.UserStatusOption.IsSet && user.UserStatus == null)
+                throw new JsonException("Cannot write null property User.UserStatus to non-nullable JSON property 'userStatus'.");
 
             if (user.UsernameOption.IsSet && user.Username == null)
                 throw new JsonException("Cannot write null property User.Username to non-nullable JSON property 'username'.");

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/User.cs
@@ -426,25 +426,25 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, User user, JsonSerializerOptions jsonSerializerOptions)
         {
             if (user.EmailOption.IsSet && user.Email == null)
-                throw new ArgumentNullException(nameof(user.Email), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Email to non-nullable JSON property 'email'.");
 
             if (user.FirstNameOption.IsSet && user.FirstName == null)
-                throw new ArgumentNullException(nameof(user.FirstName), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.FirstName to non-nullable JSON property 'firstName'.");
 
             if (user.LastNameOption.IsSet && user.LastName == null)
-                throw new ArgumentNullException(nameof(user.LastName), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.LastName to non-nullable JSON property 'lastName'.");
 
             if (user.ObjectWithNoDeclaredPropsOption.IsSet && user.ObjectWithNoDeclaredProps == null)
-                throw new ArgumentNullException(nameof(user.ObjectWithNoDeclaredProps), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.ObjectWithNoDeclaredProps to non-nullable JSON property 'objectWithNoDeclaredProps'.");
 
             if (user.PasswordOption.IsSet && user.Password == null)
-                throw new ArgumentNullException(nameof(user.Password), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Password to non-nullable JSON property 'password'.");
 
             if (user.PhoneOption.IsSet && user.Phone == null)
-                throw new ArgumentNullException(nameof(user.Phone), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Phone to non-nullable JSON property 'phone'.");
 
             if (user.UsernameOption.IsSet && user.Username == null)
-                throw new ArgumentNullException(nameof(user.Username), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Username to non-nullable JSON property 'username'.");
 
             if (user.AnyTypePropOption.IsSet)
                 if (user.AnyTypePropOption.Value != null)

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Whale.cs
@@ -218,6 +218,12 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Whale whale, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (whale.HasBaleenOption.IsSet && whale.HasBaleen == null)
+                throw new JsonException("Cannot write null property Whale.HasBaleen to non-nullable JSON property 'hasBaleen'.");
+
+            if (whale.HasTeethOption.IsSet && whale.HasTeeth == null)
+                throw new JsonException("Cannot write null property Whale.HasTeeth to non-nullable JSON property 'hasTeeth'.");
+
             writer.WriteString("className", whale.ClassName);
 
             if (whale.HasBaleenOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Whale.cs
@@ -218,9 +218,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Whale whale, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (whale.ClassName == null)
-                throw new ArgumentNullException(nameof(whale.ClassName), "Property is required for class Whale.");
-
             writer.WriteString("className", whale.ClassName);
 
             if (whale.HasBaleenOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Zebra.cs
@@ -282,6 +282,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Zebra zebra, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (zebra.TypeOption.IsSet && zebra.Type == null)
+                throw new JsonException("Cannot write null property Zebra.Type to non-nullable JSON property 'type'.");
+
             writer.WriteString("className", zebra.ClassName);
 
             var typeRawValue = Zebra.TypeEnumToJsonValue(zebra.TypeOption.Value!.Value);

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Zebra.cs
@@ -282,9 +282,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Zebra zebra, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (zebra.ClassName == null)
-                throw new ArgumentNullException(nameof(zebra.ClassName), "Property is required for class Zebra.");
-
             writer.WriteString("className", zebra.ClassName);
 
             var typeRawValue = Zebra.TypeEnumToJsonValue(zebra.TypeOption.Value!.Value);

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
@@ -249,6 +249,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ZeroBasedEnumClass zeroBasedEnumClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (zeroBasedEnumClass.ZeroBasedEnumOption.IsSet && zeroBasedEnumClass.ZeroBasedEnum == null)
+                throw new JsonException("Cannot write null property ZeroBasedEnumClass.ZeroBasedEnum to non-nullable JSON property 'ZeroBasedEnum'.");
+
             var zeroBasedEnumRawValue = ZeroBasedEnumClass.ZeroBasedEnumEnumToJsonValue(zeroBasedEnumClass.ZeroBasedEnumOption.Value!.Value);
             writer.WriteString("ZeroBasedEnum", zeroBasedEnumRawValue);
         }

--- a/samples/client/petstore/csharp/generichost/net9/OneOf/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net9/OneOf/src/Org.OpenAPITools/Model/Apple.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Apple apple, JsonSerializerOptions jsonSerializerOptions)
         {
             if (apple.KindOption.IsSet && apple.Kind == null)
-                throw new ArgumentNullException(nameof(apple.Kind), "Property is required for class Apple.");
+                throw new JsonException("Cannot write null property Apple.Kind to non-nullable JSON property 'kind'.");
 
             if (apple.KindOption.IsSet)
                 writer.WriteString("kind", apple.Kind);

--- a/samples/client/petstore/csharp/generichost/net9/OneOf/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net9/OneOf/src/Org.OpenAPITools/Model/Banana.cs
@@ -176,6 +176,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Banana banana, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (banana.CountOption.IsSet && banana.Count == null)
+                throw new JsonException("Cannot write null property Banana.Count to non-nullable JSON property 'count'.");
+
             if (banana.CountOption.IsSet)
                 writer.WriteNumber("count", banana.CountOption.Value!.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net9/OneOf/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net9/OneOf/src/Org.OpenAPITools/Model/Fruit.cs
@@ -252,7 +252,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Fruit fruit, JsonSerializerOptions jsonSerializerOptions)
         {
             if (fruit.ColorOption.IsSet && fruit.Color == null)
-                throw new ArgumentNullException(nameof(fruit.Color), "Property is required for class Fruit.");
+                throw new JsonException("Cannot write null property Fruit.Color to non-nullable JSON property 'color'.");
 
             if (fruit.ColorOption.IsSet)
                 writer.WriteString("color", fruit.Color);

--- a/samples/client/petstore/csharp/generichost/net9/OneOf/src/Org.OpenAPITools/Model/Orange.cs
+++ b/samples/client/petstore/csharp/generichost/net9/OneOf/src/Org.OpenAPITools/Model/Orange.cs
@@ -176,6 +176,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Orange orange, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (orange.SweetOption.IsSet && orange.Sweet == null)
+                throw new JsonException("Cannot write null property Orange.Sweet to non-nullable JSON property 'sweet'.");
+
             if (orange.SweetOption.IsSet)
                 writer.WriteBoolean("sweet", orange.SweetOption.Value!.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Activity.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Activity activity, JsonSerializerOptions jsonSerializerOptions)
         {
             if (activity.ActivityOutputsOption.IsSet && activity.ActivityOutputs == null)
-                throw new ArgumentNullException(nameof(activity.ActivityOutputs), "Property is required for class Activity.");
+                throw new JsonException("Cannot write null property Activity.ActivityOutputs to non-nullable JSON property 'activity_outputs'.");
 
             if (activity.ActivityOutputsOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -198,10 +198,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ActivityOutputElementRepresentation activityOutputElementRepresentation, JsonSerializerOptions jsonSerializerOptions)
         {
             if (activityOutputElementRepresentation.Prop1Option.IsSet && activityOutputElementRepresentation.Prop1 == null)
-                throw new ArgumentNullException(nameof(activityOutputElementRepresentation.Prop1), "Property is required for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Cannot write null property ActivityOutputElementRepresentation.Prop1 to non-nullable JSON property 'prop1'.");
 
             if (activityOutputElementRepresentation.Prop2Option.IsSet && activityOutputElementRepresentation.Prop2 == null)
-                throw new ArgumentNullException(nameof(activityOutputElementRepresentation.Prop2), "Property is required for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Cannot write null property ActivityOutputElementRepresentation.Prop2 to non-nullable JSON property 'prop2'.");
 
             if (activityOutputElementRepresentation.Prop1Option.IsSet)
                 writer.WriteString("prop1", activityOutputElementRepresentation.Prop1);

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -334,25 +334,25 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, AdditionalPropertiesClass additionalPropertiesClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (additionalPropertiesClass.EmptyMapOption.IsSet && additionalPropertiesClass.EmptyMap == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.EmptyMap), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.EmptyMap to non-nullable JSON property 'empty_map'.");
 
             if (additionalPropertiesClass.MapOfMapPropertyOption.IsSet && additionalPropertiesClass.MapOfMapProperty == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapOfMapProperty), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapOfMapProperty to non-nullable JSON property 'map_of_map_property'.");
 
             if (additionalPropertiesClass.MapPropertyOption.IsSet && additionalPropertiesClass.MapProperty == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapProperty), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapProperty to non-nullable JSON property 'map_property'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1Option.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1 == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1 to non-nullable JSON property 'map_with_undeclared_properties_anytype_1'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2Option.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2 == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2 to non-nullable JSON property 'map_with_undeclared_properties_anytype_2'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3Option.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3 == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3 to non-nullable JSON property 'map_with_undeclared_properties_anytype_3'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesStringOption.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesString == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesString), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesString to non-nullable JSON property 'map_with_undeclared_properties_string'.");
 
             if (additionalPropertiesClass.Anytype1Option.IsSet)
                 if (additionalPropertiesClass.Anytype1Option.Value != null)

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Animal.cs
@@ -221,7 +221,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Animal animal, JsonSerializerOptions jsonSerializerOptions)
         {
             if (animal.ColorOption.IsSet && animal.Color == null)
-                throw new ArgumentNullException(nameof(animal.Color), "Property is required for class Animal.");
+                throw new JsonException("Cannot write null property Animal.Color to non-nullable JSON property 'color'.");
 
             writer.WriteString("className", animal.ClassName);
 

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -221,10 +221,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ApiResponse apiResponse, JsonSerializerOptions jsonSerializerOptions)
         {
             if (apiResponse.MessageOption.IsSet && apiResponse.Message == null)
-                throw new ArgumentNullException(nameof(apiResponse.Message), "Property is required for class ApiResponse.");
+                throw new JsonException("Cannot write null property ApiResponse.Message to non-nullable JSON property 'message'.");
 
             if (apiResponse.TypeOption.IsSet && apiResponse.Type == null)
-                throw new ArgumentNullException(nameof(apiResponse.Type), "Property is required for class ApiResponse.");
+                throw new JsonException("Cannot write null property ApiResponse.Type to non-nullable JSON property 'type'.");
 
             if (apiResponse.CodeOption.IsSet)
                 writer.WriteNumber("code", apiResponse.CodeOption.Value.Value);

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -220,6 +220,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ApiResponse apiResponse, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (apiResponse.CodeOption.IsSet && apiResponse.Code == null)
+                throw new JsonException("Cannot write null property ApiResponse.Code to non-nullable JSON property 'code'.");
+
             if (apiResponse.MessageOption.IsSet && apiResponse.Message == null)
                 throw new JsonException("Cannot write null property ApiResponse.Message to non-nullable JSON property 'message'.");
 

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Apple.cs
@@ -251,13 +251,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Apple apple, JsonSerializerOptions jsonSerializerOptions)
         {
             if (apple.ColorCodeOption.IsSet && apple.ColorCode == null)
-                throw new ArgumentNullException(nameof(apple.ColorCode), "Property is required for class Apple.");
+                throw new JsonException("Cannot write null property Apple.ColorCode to non-nullable JSON property 'color_code'.");
 
             if (apple.CultivarOption.IsSet && apple.Cultivar == null)
-                throw new ArgumentNullException(nameof(apple.Cultivar), "Property is required for class Apple.");
+                throw new JsonException("Cannot write null property Apple.Cultivar to non-nullable JSON property 'cultivar'.");
 
             if (apple.OriginOption.IsSet && apple.Origin == null)
-                throw new ArgumentNullException(nameof(apple.Origin), "Property is required for class Apple.");
+                throw new JsonException("Cannot write null property Apple.Origin to non-nullable JSON property 'origin'.");
 
             if (apple.ColorCodeOption.IsSet)
                 writer.WriteString("color_code", apple.ColorCode);

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -186,9 +186,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, AppleReq appleReq, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (appleReq.Cultivar == null)
-                throw new ArgumentNullException(nameof(appleReq.Cultivar), "Property is required for class AppleReq.");
-
             writer.WriteString("cultivar", appleReq.Cultivar);
 
             if (appleReq.MealyOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -186,6 +186,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, AppleReq appleReq, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (appleReq.MealyOption.IsSet && appleReq.Mealy == null)
+                throw new JsonException("Cannot write null property AppleReq.Mealy to non-nullable JSON property 'mealy'.");
+
             writer.WriteString("cultivar", appleReq.Cultivar);
 
             if (appleReq.MealyOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ArrayOfArrayOfNumberOnly arrayOfArrayOfNumberOnly, JsonSerializerOptions jsonSerializerOptions)
         {
             if (arrayOfArrayOfNumberOnly.ArrayArrayNumberOption.IsSet && arrayOfArrayOfNumberOnly.ArrayArrayNumber == null)
-                throw new ArgumentNullException(nameof(arrayOfArrayOfNumberOnly.ArrayArrayNumber), "Property is required for class ArrayOfArrayOfNumberOnly.");
+                throw new JsonException("Cannot write null property ArrayOfArrayOfNumberOnly.ArrayArrayNumber to non-nullable JSON property 'ArrayArrayNumber'.");
 
             if (arrayOfArrayOfNumberOnly.ArrayArrayNumberOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ArrayOfNumberOnly arrayOfNumberOnly, JsonSerializerOptions jsonSerializerOptions)
         {
             if (arrayOfNumberOnly.ArrayNumberOption.IsSet && arrayOfNumberOnly.ArrayNumber == null)
-                throw new ArgumentNullException(nameof(arrayOfNumberOnly.ArrayNumber), "Property is required for class ArrayOfNumberOnly.");
+                throw new JsonException("Cannot write null property ArrayOfNumberOnly.ArrayNumber to non-nullable JSON property 'ArrayNumber'.");
 
             if (arrayOfNumberOnly.ArrayNumberOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -221,13 +221,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ArrayTest arrayTest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (arrayTest.ArrayArrayOfIntegerOption.IsSet && arrayTest.ArrayArrayOfInteger == null)
-                throw new ArgumentNullException(nameof(arrayTest.ArrayArrayOfInteger), "Property is required for class ArrayTest.");
+                throw new JsonException("Cannot write null property ArrayTest.ArrayArrayOfInteger to non-nullable JSON property 'array_array_of_integer'.");
 
             if (arrayTest.ArrayArrayOfModelOption.IsSet && arrayTest.ArrayArrayOfModel == null)
-                throw new ArgumentNullException(nameof(arrayTest.ArrayArrayOfModel), "Property is required for class ArrayTest.");
+                throw new JsonException("Cannot write null property ArrayTest.ArrayArrayOfModel to non-nullable JSON property 'array_array_of_model'.");
 
             if (arrayTest.ArrayOfStringOption.IsSet && arrayTest.ArrayOfString == null)
-                throw new ArgumentNullException(nameof(arrayTest.ArrayOfString), "Property is required for class ArrayTest.");
+                throw new JsonException("Cannot write null property ArrayTest.ArrayOfString to non-nullable JSON property 'array_of_string'.");
 
             if (arrayTest.ArrayArrayOfIntegerOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Banana.cs
@@ -174,6 +174,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Banana banana, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (banana.LengthCmOption.IsSet && banana.LengthCm == null)
+                throw new JsonException("Cannot write null property Banana.LengthCm to non-nullable JSON property 'lengthCm'.");
+
             if (banana.LengthCmOption.IsSet)
                 writer.WriteNumber("lengthCm", banana.LengthCmOption.Value.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -186,6 +186,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, BananaReq bananaReq, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (bananaReq.SweetOption.IsSet && bananaReq.Sweet == null)
+                throw new JsonException("Cannot write null property BananaReq.Sweet to non-nullable JSON property 'sweet'.");
+
             writer.WriteNumber("lengthCm", bananaReq.LengthCm);
 
             if (bananaReq.SweetOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/BasquePig.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/BasquePig.cs
@@ -170,9 +170,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, BasquePig basquePig, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (basquePig.ClassName == null)
-                throw new ArgumentNullException(nameof(basquePig.ClassName), "Property is required for class BasquePig.");
-
             writer.WriteString("className", basquePig.ClassName);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -291,22 +291,22 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Capitalization capitalization, JsonSerializerOptions jsonSerializerOptions)
         {
             if (capitalization.ATT_NAMEOption.IsSet && capitalization.ATT_NAME == null)
-                throw new ArgumentNullException(nameof(capitalization.ATT_NAME), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.ATT_NAME to non-nullable JSON property 'ATT_NAME'.");
 
             if (capitalization.CapitalCamelOption.IsSet && capitalization.CapitalCamel == null)
-                throw new ArgumentNullException(nameof(capitalization.CapitalCamel), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.CapitalCamel to non-nullable JSON property 'CapitalCamel'.");
 
             if (capitalization.CapitalSnakeOption.IsSet && capitalization.CapitalSnake == null)
-                throw new ArgumentNullException(nameof(capitalization.CapitalSnake), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.CapitalSnake to non-nullable JSON property 'Capital_Snake'.");
 
             if (capitalization.SCAETHFlowPointsOption.IsSet && capitalization.SCAETHFlowPoints == null)
-                throw new ArgumentNullException(nameof(capitalization.SCAETHFlowPoints), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.SCAETHFlowPoints to non-nullable JSON property 'SCA_ETH_Flow_Points'.");
 
             if (capitalization.SmallCamelOption.IsSet && capitalization.SmallCamel == null)
-                throw new ArgumentNullException(nameof(capitalization.SmallCamel), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.SmallCamel to non-nullable JSON property 'smallCamel'.");
 
             if (capitalization.SmallSnakeOption.IsSet && capitalization.SmallSnake == null)
-                throw new ArgumentNullException(nameof(capitalization.SmallSnake), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.SmallSnake to non-nullable JSON property 'small_Snake'.");
 
             if (capitalization.ATT_NAMEOption.IsSet)
                 writer.WriteString("ATT_NAME", capitalization.ATT_NAME);

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Cat.cs
@@ -179,6 +179,9 @@ namespace Org.OpenAPITools.Model
             if (cat.ColorOption.IsSet && cat.Color == null)
                 throw new JsonException("Cannot write null property Cat.Color to non-nullable JSON property 'color'.");
 
+            if (cat.DeclawedOption.IsSet && cat.Declawed == null)
+                throw new JsonException("Cannot write null property Cat.Declawed to non-nullable JSON property 'declawed'.");
+
             writer.WriteString("className", cat.ClassName);
 
             if (cat.ColorOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Cat.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Cat cat, JsonSerializerOptions jsonSerializerOptions)
         {
             if (cat.ColorOption.IsSet && cat.Color == null)
-                throw new ArgumentNullException(nameof(cat.Color), "Property is required for class Cat.");
+                throw new JsonException("Cannot write null property Cat.Color to non-nullable JSON property 'color'.");
 
             writer.WriteString("className", cat.ClassName);
 

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Category.cs
@@ -193,9 +193,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Category category, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (category.Name == null)
-                throw new ArgumentNullException(nameof(category.Name), "Property is required for class Category.");
-
             if (category.IdOption.IsSet)
                 writer.WriteNumber("id", category.IdOption.Value.Value);
 

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Category.cs
@@ -193,6 +193,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Category category, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (category.IdOption.IsSet && category.Id == null)
+                throw new JsonException("Cannot write null property Category.Id to non-nullable JSON property 'id'.");
+
             if (category.IdOption.IsSet)
                 writer.WriteNumber("id", category.IdOption.Value.Value);
 

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -236,7 +236,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ChildCat childCat, JsonSerializerOptions jsonSerializerOptions)
         {
             if (childCat.NameOption.IsSet && childCat.Name == null)
-                throw new ArgumentNullException(nameof(childCat.Name), "Property is required for class ChildCat.");
+                throw new JsonException("Cannot write null property ChildCat.Name to non-nullable JSON property 'name'.");
 
             if (childCat.NameOption.IsSet)
                 writer.WriteString("name", childCat.Name);

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ClassModel classModel, JsonSerializerOptions jsonSerializerOptions)
         {
             if (classModel.ClassOption.IsSet && classModel.Class == null)
-                throw new ArgumentNullException(nameof(classModel.Class), "Property is required for class ClassModel.");
+                throw new JsonException("Cannot write null property ClassModel.Class to non-nullable JSON property '_class'.");
 
             if (classModel.ClassOption.IsSet)
                 writer.WriteString("_class", classModel.Class);

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
@@ -189,12 +189,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ComplexQuadrilateral complexQuadrilateral, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (complexQuadrilateral.QuadrilateralType == null)
-                throw new ArgumentNullException(nameof(complexQuadrilateral.QuadrilateralType), "Property is required for class ComplexQuadrilateral.");
-
-            if (complexQuadrilateral.ShapeType == null)
-                throw new ArgumentNullException(nameof(complexQuadrilateral.ShapeType), "Property is required for class ComplexQuadrilateral.");
-
             writer.WriteString("quadrilateralType", complexQuadrilateral.QuadrilateralType);
 
             writer.WriteString("shapeType", complexQuadrilateral.ShapeType);

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/CopyActivity.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/CopyActivity.cs
@@ -231,9 +231,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, CopyActivity copyActivity, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (copyActivity.CopyActivitytt == null)
-                throw new ArgumentNullException(nameof(copyActivity.CopyActivitytt), "Property is required for class CopyActivity.");
-
             writer.WriteString("copyActivitytt", copyActivity.CopyActivitytt);
 
             writer.WriteString("$schema", CopyActivity.SchemaEnumToJsonValue(copyActivity.Schema));

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/DanishPig.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/DanishPig.cs
@@ -170,9 +170,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, DanishPig danishPig, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (danishPig.ClassName == null)
-                throw new ArgumentNullException(nameof(danishPig.ClassName), "Property is required for class DanishPig.");
-
             writer.WriteString("className", danishPig.ClassName);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -180,6 +180,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, DateOnlyClass dateOnlyClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (dateOnlyClass.DateOnlyPropertyOption.IsSet && dateOnlyClass.DateOnlyProperty == null)
+                throw new JsonException("Cannot write null property DateOnlyClass.DateOnlyProperty to non-nullable JSON property 'dateOnlyProperty'.");
+
             if (dateOnlyClass.DateOnlyPropertyOption.IsSet)
                 writer.WriteString("dateOnlyProperty", dateOnlyClass.DateOnlyPropertyOption.Value.Value.ToString(DateOnlyPropertyFormat));
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, DeprecatedObject deprecatedObject, JsonSerializerOptions jsonSerializerOptions)
         {
             if (deprecatedObject.NameOption.IsSet && deprecatedObject.Name == null)
-                throw new ArgumentNullException(nameof(deprecatedObject.Name), "Property is required for class DeprecatedObject.");
+                throw new JsonException("Cannot write null property DeprecatedObject.Name to non-nullable JSON property 'name'.");
 
             if (deprecatedObject.NameOption.IsSet)
                 writer.WriteString("name", deprecatedObject.Name);

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Descendant1.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Descendant1.cs
@@ -182,12 +182,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Descendant1 descendant1, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (descendant1.AlternativeName == null)
-                throw new ArgumentNullException(nameof(descendant1.AlternativeName), "Property is required for class Descendant1.");
-
-            if (descendant1.DescendantName == null)
-                throw new ArgumentNullException(nameof(descendant1.DescendantName), "Property is required for class Descendant1.");
-
             writer.WriteString("alternativeName", descendant1.AlternativeName);
 
             writer.WriteString("descendantName", descendant1.DescendantName);

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Descendant2.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Descendant2.cs
@@ -182,12 +182,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Descendant2 descendant2, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (descendant2.AlternativeName == null)
-                throw new ArgumentNullException(nameof(descendant2.AlternativeName), "Property is required for class Descendant2.");
-
-            if (descendant2.Confidentiality == null)
-                throw new ArgumentNullException(nameof(descendant2.Confidentiality), "Property is required for class Descendant2.");
-
             writer.WriteString("alternativeName", descendant2.AlternativeName);
 
             writer.WriteString("confidentiality", descendant2.Confidentiality);

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Dog.cs
@@ -177,10 +177,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Dog dog, JsonSerializerOptions jsonSerializerOptions)
         {
             if (dog.BreedOption.IsSet && dog.Breed == null)
-                throw new ArgumentNullException(nameof(dog.Breed), "Property is required for class Dog.");
+                throw new JsonException("Cannot write null property Dog.Breed to non-nullable JSON property 'breed'.");
 
             if (dog.ColorOption.IsSet && dog.Color == null)
-                throw new ArgumentNullException(nameof(dog.Color), "Property is required for class Dog.");
+                throw new JsonException("Cannot write null property Dog.Color to non-nullable JSON property 'color'.");
 
             writer.WriteString("className", dog.ClassName);
 

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Drawing.cs
@@ -238,10 +238,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Drawing drawing, JsonSerializerOptions jsonSerializerOptions)
         {
             if (drawing.MainShapeOption.IsSet && drawing.MainShape == null)
-                throw new ArgumentNullException(nameof(drawing.MainShape), "Property is required for class Drawing.");
+                throw new JsonException("Cannot write null property Drawing.MainShape to non-nullable JSON property 'mainShape'.");
 
             if (drawing.ShapesOption.IsSet && drawing.Shapes == null)
-                throw new ArgumentNullException(nameof(drawing.Shapes), "Property is required for class Drawing.");
+                throw new JsonException("Cannot write null property Drawing.Shapes to non-nullable JSON property 'shapes'.");
 
             if (drawing.MainShapeOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -337,7 +337,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, EnumArrays enumArrays, JsonSerializerOptions jsonSerializerOptions)
         {
             if (enumArrays.ArrayEnumOption.IsSet && enumArrays.ArrayEnum == null)
-                throw new ArgumentNullException(nameof(enumArrays.ArrayEnum), "Property is required for class EnumArrays.");
+                throw new JsonException("Cannot write null property EnumArrays.ArrayEnum to non-nullable JSON property 'array_enum'.");
 
             if (enumArrays.ArrayEnumOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -339,6 +339,9 @@ namespace Org.OpenAPITools.Model
             if (enumArrays.ArrayEnumOption.IsSet && enumArrays.ArrayEnum == null)
                 throw new JsonException("Cannot write null property EnumArrays.ArrayEnum to non-nullable JSON property 'array_enum'.");
 
+            if (enumArrays.JustSymbolOption.IsSet && enumArrays.JustSymbol == null)
+                throw new JsonException("Cannot write null property EnumArrays.JustSymbol to non-nullable JSON property 'just_symbol'.");
+
             if (enumArrays.ArrayEnumOption.IsSet)
             {
                 writer.WritePropertyName("array_enum");

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -875,6 +875,27 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, EnumTest enumTest, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (enumTest.EnumIntegerOption.IsSet && enumTest.EnumInteger == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumInteger to non-nullable JSON property 'enum_integer'.");
+
+            if (enumTest.EnumIntegerOnlyOption.IsSet && enumTest.EnumIntegerOnly == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumIntegerOnly to non-nullable JSON property 'enum_integer_only'.");
+
+            if (enumTest.EnumNumberOption.IsSet && enumTest.EnumNumber == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumNumber to non-nullable JSON property 'enum_number'.");
+
+            if (enumTest.EnumStringOption.IsSet && enumTest.EnumString == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumString to non-nullable JSON property 'enum_string'.");
+
+            if (enumTest.OuterEnumDefaultValueOption.IsSet && enumTest.OuterEnumDefaultValue == null)
+                throw new JsonException("Cannot write null property EnumTest.OuterEnumDefaultValue to non-nullable JSON property 'outerEnumDefaultValue'.");
+
+            if (enumTest.OuterEnumIntegerOption.IsSet && enumTest.OuterEnumInteger == null)
+                throw new JsonException("Cannot write null property EnumTest.OuterEnumInteger to non-nullable JSON property 'outerEnumInteger'.");
+
+            if (enumTest.OuterEnumIntegerDefaultValueOption.IsSet && enumTest.OuterEnumIntegerDefaultValue == null)
+                throw new JsonException("Cannot write null property EnumTest.OuterEnumIntegerDefaultValue to non-nullable JSON property 'outerEnumIntegerDefaultValue'.");
+
             var enumStringRequiredRawValue = EnumTest.EnumStringRequiredEnumToJsonValue(enumTest.EnumStringRequired);
             writer.WriteString("enum_string_required", enumStringRequiredRawValue);
             if (enumTest.EnumIntegerOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
@@ -189,12 +189,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, EquilateralTriangle equilateralTriangle, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (equilateralTriangle.ShapeType == null)
-                throw new ArgumentNullException(nameof(equilateralTriangle.ShapeType), "Property is required for class EquilateralTriangle.");
-
-            if (equilateralTriangle.TriangleType == null)
-                throw new ArgumentNullException(nameof(equilateralTriangle.TriangleType), "Property is required for class EquilateralTriangle.");
-
             writer.WriteString("shapeType", equilateralTriangle.ShapeType);
 
             writer.WriteString("triangleType", equilateralTriangle.TriangleType);

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/File.cs
@@ -176,7 +176,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, File file, JsonSerializerOptions jsonSerializerOptions)
         {
             if (file.SourceURIOption.IsSet && file.SourceURI == null)
-                throw new ArgumentNullException(nameof(file.SourceURI), "Property is required for class File.");
+                throw new JsonException("Cannot write null property File.SourceURI to non-nullable JSON property 'sourceURI'.");
 
             if (file.SourceURIOption.IsSet)
                 writer.WriteString("sourceURI", file.SourceURI);

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -198,10 +198,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, FileSchemaTestClass fileSchemaTestClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (fileSchemaTestClass.FileOption.IsSet && fileSchemaTestClass.File == null)
-                throw new ArgumentNullException(nameof(fileSchemaTestClass.File), "Property is required for class FileSchemaTestClass.");
+                throw new JsonException("Cannot write null property FileSchemaTestClass.File to non-nullable JSON property 'file'.");
 
             if (fileSchemaTestClass.FilesOption.IsSet && fileSchemaTestClass.Files == null)
-                throw new ArgumentNullException(nameof(fileSchemaTestClass.Files), "Property is required for class FileSchemaTestClass.");
+                throw new JsonException("Cannot write null property FileSchemaTestClass.Files to non-nullable JSON property 'files'.");
 
             if (fileSchemaTestClass.FileOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Foo.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Foo foo, JsonSerializerOptions jsonSerializerOptions)
         {
             if (foo.BarOption.IsSet && foo.Bar == null)
-                throw new ArgumentNullException(nameof(foo.Bar), "Property is required for class Foo.");
+                throw new JsonException("Cannot write null property Foo.Bar to non-nullable JSON property 'bar'.");
 
             if (foo.BarOption.IsSet)
                 writer.WriteString("bar", foo.Bar);

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, FooGetDefaultResponse fooGetDefaultResponse, JsonSerializerOptions jsonSerializerOptions)
         {
             if (fooGetDefaultResponse.StringOption.IsSet && fooGetDefaultResponse.String == null)
-                throw new ArgumentNullException(nameof(fooGetDefaultResponse.String), "Property is required for class FooGetDefaultResponse.");
+                throw new JsonException("Cannot write null property FooGetDefaultResponse.String to non-nullable JSON property 'string'.");
 
             if (fooGetDefaultResponse.StringOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -954,11 +954,47 @@ namespace Org.OpenAPITools.Model
             if (formatTest.BinaryOption.IsSet && formatTest.Binary == null)
                 throw new JsonException("Cannot write null property FormatTest.Binary to non-nullable JSON property 'binary'.");
 
+            if (formatTest.DateTimeOption.IsSet && formatTest.DateTime == null)
+                throw new JsonException("Cannot write null property FormatTest.DateTime to non-nullable JSON property 'dateTime'.");
+
+            if (formatTest.DecimalOption.IsSet && formatTest.Decimal == null)
+                throw new JsonException("Cannot write null property FormatTest.Decimal to non-nullable JSON property 'decimal'.");
+
+            if (formatTest.DoubleOption.IsSet && formatTest.Double == null)
+                throw new JsonException("Cannot write null property FormatTest.Double to non-nullable JSON property 'double'.");
+
             if (formatTest.DuplicatePropertyName2Option.IsSet && formatTest.DuplicatePropertyName2 == null)
                 throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName2 to non-nullable JSON property 'duplicate_property_name'.");
 
             if (formatTest.DuplicatePropertyNameOption.IsSet && formatTest.DuplicatePropertyName == null)
                 throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName to non-nullable JSON property '@duplicate_property_name'.");
+
+            if (formatTest.FloatOption.IsSet && formatTest.Float == null)
+                throw new JsonException("Cannot write null property FormatTest.Float to non-nullable JSON property 'float'.");
+
+            if (formatTest.Int32Option.IsSet && formatTest.Int32 == null)
+                throw new JsonException("Cannot write null property FormatTest.Int32 to non-nullable JSON property 'int32'.");
+
+            if (formatTest.Int32RangeOption.IsSet && formatTest.Int32Range == null)
+                throw new JsonException("Cannot write null property FormatTest.Int32Range to non-nullable JSON property 'int32Range'.");
+
+            if (formatTest.Int64Option.IsSet && formatTest.Int64 == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64 to non-nullable JSON property 'int64'.");
+
+            if (formatTest.Int64NegativeOption.IsSet && formatTest.Int64Negative == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64Negative to non-nullable JSON property 'int64Negative'.");
+
+            if (formatTest.Int64NegativeExclusiveOption.IsSet && formatTest.Int64NegativeExclusive == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64NegativeExclusive to non-nullable JSON property 'int64NegativeExclusive'.");
+
+            if (formatTest.Int64PositiveOption.IsSet && formatTest.Int64Positive == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64Positive to non-nullable JSON property 'int64Positive'.");
+
+            if (formatTest.Int64PositiveExclusiveOption.IsSet && formatTest.Int64PositiveExclusive == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64PositiveExclusive to non-nullable JSON property 'int64PositiveExclusive'.");
+
+            if (formatTest.IntegerOption.IsSet && formatTest.Integer == null)
+                throw new JsonException("Cannot write null property FormatTest.Integer to non-nullable JSON property 'integer'.");
 
             if (formatTest.PatternWithBackslashOption.IsSet && formatTest.PatternWithBackslash == null)
                 throw new JsonException("Cannot write null property FormatTest.PatternWithBackslash to non-nullable JSON property 'pattern_with_backslash'.");
@@ -971,6 +1007,18 @@ namespace Org.OpenAPITools.Model
 
             if (formatTest.StringOption.IsSet && formatTest.String == null)
                 throw new JsonException("Cannot write null property FormatTest.String to non-nullable JSON property 'string'.");
+
+            if (formatTest.StringFormattedAsDecimalOption.IsSet && formatTest.StringFormattedAsDecimal == null)
+                throw new JsonException("Cannot write null property FormatTest.StringFormattedAsDecimal to non-nullable JSON property 'string_formatted_as_decimal'.");
+
+            if (formatTest.UnsignedIntegerOption.IsSet && formatTest.UnsignedInteger == null)
+                throw new JsonException("Cannot write null property FormatTest.UnsignedInteger to non-nullable JSON property 'unsigned_integer'.");
+
+            if (formatTest.UnsignedLongOption.IsSet && formatTest.UnsignedLong == null)
+                throw new JsonException("Cannot write null property FormatTest.UnsignedLong to non-nullable JSON property 'unsigned_long'.");
+
+            if (formatTest.UuidOption.IsSet && formatTest.Uuid == null)
+                throw new JsonException("Cannot write null property FormatTest.Uuid to non-nullable JSON property 'uuid'.");
 
             writer.WritePropertyName("byte");
             JsonSerializer.Serialize(writer, formatTest.Byte, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -951,32 +951,26 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, FormatTest formatTest, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (formatTest.Byte == null)
-                throw new ArgumentNullException(nameof(formatTest.Byte), "Property is required for class FormatTest.");
-
-            if (formatTest.Password == null)
-                throw new ArgumentNullException(nameof(formatTest.Password), "Property is required for class FormatTest.");
-
             if (formatTest.BinaryOption.IsSet && formatTest.Binary == null)
-                throw new ArgumentNullException(nameof(formatTest.Binary), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.Binary to non-nullable JSON property 'binary'.");
 
             if (formatTest.DuplicatePropertyName2Option.IsSet && formatTest.DuplicatePropertyName2 == null)
-                throw new ArgumentNullException(nameof(formatTest.DuplicatePropertyName2), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName2 to non-nullable JSON property 'duplicate_property_name'.");
 
             if (formatTest.DuplicatePropertyNameOption.IsSet && formatTest.DuplicatePropertyName == null)
-                throw new ArgumentNullException(nameof(formatTest.DuplicatePropertyName), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName to non-nullable JSON property '@duplicate_property_name'.");
 
             if (formatTest.PatternWithBackslashOption.IsSet && formatTest.PatternWithBackslash == null)
-                throw new ArgumentNullException(nameof(formatTest.PatternWithBackslash), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.PatternWithBackslash to non-nullable JSON property 'pattern_with_backslash'.");
 
             if (formatTest.PatternWithDigitsOption.IsSet && formatTest.PatternWithDigits == null)
-                throw new ArgumentNullException(nameof(formatTest.PatternWithDigits), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.PatternWithDigits to non-nullable JSON property 'pattern_with_digits'.");
 
             if (formatTest.PatternWithDigitsAndDelimiterOption.IsSet && formatTest.PatternWithDigitsAndDelimiter == null)
-                throw new ArgumentNullException(nameof(formatTest.PatternWithDigitsAndDelimiter), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.PatternWithDigitsAndDelimiter to non-nullable JSON property 'pattern_with_digits_and_delimiter'.");
 
             if (formatTest.StringOption.IsSet && formatTest.String == null)
-                throw new ArgumentNullException(nameof(formatTest.String), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.String to non-nullable JSON property 'string'.");
 
             writer.WritePropertyName("byte");
             JsonSerializer.Serialize(writer, formatTest.Byte, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
@@ -219,7 +219,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Fruit fruit, JsonSerializerOptions jsonSerializerOptions)
         {
             if (fruit.ColorOption.IsSet && fruit.Color == null)
-                throw new ArgumentNullException(nameof(fruit.Color), "Property is required for class Fruit.");
+                throw new JsonException("Cannot write null property Fruit.Color to non-nullable JSON property 'color'.");
 
             if (fruit.ColorOption.IsSet)
                 writer.WriteString("color", fruit.Color);

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -236,7 +236,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, GmFruit gmFruit, JsonSerializerOptions jsonSerializerOptions)
         {
             if (gmFruit.ColorOption.IsSet && gmFruit.Color == null)
-                throw new ArgumentNullException(nameof(gmFruit.Color), "Property is required for class GmFruit.");
+                throw new JsonException("Cannot write null property GmFruit.Color to non-nullable JSON property 'color'.");
 
             if (gmFruit.ColorOption.IsSet)
                 writer.WriteString("color", gmFruit.Color);

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -239,10 +239,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, HasOnlyReadOnly hasOnlyReadOnly, JsonSerializerOptions jsonSerializerOptions)
         {
             if (hasOnlyReadOnly.BarOption.IsSet && hasOnlyReadOnly.Bar == null)
-                throw new ArgumentNullException(nameof(hasOnlyReadOnly.Bar), "Property is required for class HasOnlyReadOnly.");
+                throw new JsonException("Cannot write null property HasOnlyReadOnly.Bar to non-nullable JSON property 'bar'.");
 
             if (hasOnlyReadOnly.FooOption.IsSet && hasOnlyReadOnly.Foo == null)
-                throw new ArgumentNullException(nameof(hasOnlyReadOnly.Foo), "Property is required for class HasOnlyReadOnly.");
+                throw new JsonException("Cannot write null property HasOnlyReadOnly.Foo to non-nullable JSON property 'foo'.");
 
             if (hasOnlyReadOnly.BarOption.IsSet)
                 writer.WriteString("bar", hasOnlyReadOnly.Bar);

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
@@ -337,22 +337,22 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, InjectedVendorExtensionsTest injectedVendorExtensionsTest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessorOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor to non-nullable JSON property 'potentiallyOverriddenPropertyAccessor'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternalOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternal == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternal), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternal to non-nullable JSON property 'potentiallyOverriddenPropertyToInternal'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivateOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivate == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivate), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivate to non-nullable JSON property 'potentiallyOverriddenPropertyToPrivate'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublicOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublic == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublic), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublic to non-nullable JSON property 'potentiallyOverriddenPropertyToPublic'.");
 
             if (injectedVendorExtensionsTest.UnalteredPropertyOption.IsSet && injectedVendorExtensionsTest.UnalteredProperty == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.UnalteredProperty), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.UnalteredProperty to non-nullable JSON property 'unalteredProperty'.");
 
             if (injectedVendorExtensionsTest.UnalteredPropertyAccessorOption.IsSet && injectedVendorExtensionsTest.UnalteredPropertyAccessor == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.UnalteredPropertyAccessor), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.UnalteredPropertyAccessor to non-nullable JSON property 'unalteredPropertyAccessor'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessorOption.IsSet)
                 writer.WriteString("potentiallyOverriddenPropertyAccessor", injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor);

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
@@ -182,12 +182,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, IsoscelesTriangle isoscelesTriangle, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (isoscelesTriangle.ShapeType == null)
-                throw new ArgumentNullException(nameof(isoscelesTriangle.ShapeType), "Property is required for class IsoscelesTriangle.");
-
-            if (isoscelesTriangle.TriangleType == null)
-                throw new ArgumentNullException(nameof(isoscelesTriangle.TriangleType), "Property is required for class IsoscelesTriangle.");
-
             writer.WriteString("shapeType", isoscelesTriangle.ShapeType);
 
             writer.WriteString("triangleType", isoscelesTriangle.TriangleType);

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/List.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, List list, JsonSerializerOptions jsonSerializerOptions)
         {
             if (list.Var123ListOption.IsSet && list.Var123List == null)
-                throw new ArgumentNullException(nameof(list.Var123List), "Property is required for class List.");
+                throw new JsonException("Cannot write null property List.Var123List to non-nullable JSON property '123-list'.");
 
             if (list.Var123ListOption.IsSet)
                 writer.WriteString("123-list", list.Var123List);

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -198,10 +198,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, LiteralStringClass literalStringClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (literalStringClass.EscapedLiteralStringOption.IsSet && literalStringClass.EscapedLiteralString == null)
-                throw new ArgumentNullException(nameof(literalStringClass.EscapedLiteralString), "Property is required for class LiteralStringClass.");
+                throw new JsonException("Cannot write null property LiteralStringClass.EscapedLiteralString to non-nullable JSON property 'escapedLiteralString'.");
 
             if (literalStringClass.UnescapedLiteralStringOption.IsSet && literalStringClass.UnescapedLiteralString == null)
-                throw new ArgumentNullException(nameof(literalStringClass.UnescapedLiteralString), "Property is required for class LiteralStringClass.");
+                throw new JsonException("Cannot write null property LiteralStringClass.UnescapedLiteralString to non-nullable JSON property 'unescapedLiteralString'.");
 
             if (literalStringClass.EscapedLiteralStringOption.IsSet)
                 writer.WriteString("escapedLiteralString", literalStringClass.EscapedLiteralString);

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/MapTest.cs
@@ -310,16 +310,16 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MapTest mapTest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mapTest.DirectMapOption.IsSet && mapTest.DirectMap == null)
-                throw new ArgumentNullException(nameof(mapTest.DirectMap), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.DirectMap to non-nullable JSON property 'direct_map'.");
 
             if (mapTest.IndirectMapOption.IsSet && mapTest.IndirectMap == null)
-                throw new ArgumentNullException(nameof(mapTest.IndirectMap), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.IndirectMap to non-nullable JSON property 'indirect_map'.");
 
             if (mapTest.MapMapOfStringOption.IsSet && mapTest.MapMapOfString == null)
-                throw new ArgumentNullException(nameof(mapTest.MapMapOfString), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.MapMapOfString to non-nullable JSON property 'map_map_of_string'.");
 
             if (mapTest.MapOfEnumStringOption.IsSet && mapTest.MapOfEnumString == null)
-                throw new ArgumentNullException(nameof(mapTest.MapOfEnumString), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.MapOfEnumString to non-nullable JSON property 'map_of_enum_string'.");
 
             if (mapTest.DirectMapOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/MixedAnyOf.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/MixedAnyOf.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedAnyOf mixedAnyOf, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedAnyOf.ContentOption.IsSet && mixedAnyOf.Content == null)
-                throw new ArgumentNullException(nameof(mixedAnyOf.Content), "Property is required for class MixedAnyOf.");
+                throw new JsonException("Cannot write null property MixedAnyOf.Content to non-nullable JSON property 'content'.");
 
             if (mixedAnyOf.ContentOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/MixedOneOf.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/MixedOneOf.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedOneOf mixedOneOf, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedOneOf.ContentOption.IsSet && mixedOneOf.Content == null)
-                throw new ArgumentNullException(nameof(mixedOneOf.Content), "Property is required for class MixedOneOf.");
+                throw new JsonException("Cannot write null property MixedOneOf.Content to non-nullable JSON property 'content'.");
 
             if (mixedOneOf.ContentOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -255,8 +255,17 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, MixedPropertiesAndAdditionalPropertiesClass mixedPropertiesAndAdditionalPropertiesClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.DateTime == null)
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.DateTime to non-nullable JSON property 'dateTime'.");
+
             if (mixedPropertiesAndAdditionalPropertiesClass.MapOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.Map == null)
                 throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.Map to non-nullable JSON property 'map'.");
+
+            if (mixedPropertiesAndAdditionalPropertiesClass.UuidOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.Uuid == null)
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.Uuid to non-nullable JSON property 'uuid'.");
+
+            if (mixedPropertiesAndAdditionalPropertiesClass.UuidWithPatternOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.UuidWithPattern == null)
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.UuidWithPattern to non-nullable JSON property 'uuid_with_pattern'.");
 
             if (mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.IsSet)
                 writer.WriteString("dateTime", mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.Value.Value.ToString(DateTimeFormat));

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -256,7 +256,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedPropertiesAndAdditionalPropertiesClass mixedPropertiesAndAdditionalPropertiesClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedPropertiesAndAdditionalPropertiesClass.MapOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.Map == null)
-                throw new ArgumentNullException(nameof(mixedPropertiesAndAdditionalPropertiesClass.Map), "Property is required for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.Map to non-nullable JSON property 'map'.");
 
             if (mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.IsSet)
                 writer.WriteString("dateTime", mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.Value.Value.ToString(DateTimeFormat));

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/MixedSubId.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/MixedSubId.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedSubId mixedSubId, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedSubId.IdOption.IsSet && mixedSubId.Id == null)
-                throw new ArgumentNullException(nameof(mixedSubId.Id), "Property is required for class MixedSubId.");
+                throw new JsonException("Cannot write null property MixedSubId.Id to non-nullable JSON property 'id'.");
 
             if (mixedSubId.IdOption.IsSet)
                 writer.WriteString("id", mixedSubId.Id);

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -198,7 +198,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Model200Response model200Response, JsonSerializerOptions jsonSerializerOptions)
         {
             if (model200Response.ClassOption.IsSet && model200Response.Class == null)
-                throw new ArgumentNullException(nameof(model200Response.Class), "Property is required for class Model200Response.");
+                throw new JsonException("Cannot write null property Model200Response.Class to non-nullable JSON property 'class'.");
 
             if (model200Response.ClassOption.IsSet)
                 writer.WriteString("class", model200Response.Class);

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -200,6 +200,9 @@ namespace Org.OpenAPITools.Model
             if (model200Response.ClassOption.IsSet && model200Response.Class == null)
                 throw new JsonException("Cannot write null property Model200Response.Class to non-nullable JSON property 'class'.");
 
+            if (model200Response.NameOption.IsSet && model200Response.Name == null)
+                throw new JsonException("Cannot write null property Model200Response.Name to non-nullable JSON property 'name'.");
+
             if (model200Response.ClassOption.IsSet)
                 writer.WriteString("class", model200Response.Class);
 

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ModelClient modelClient, JsonSerializerOptions jsonSerializerOptions)
         {
             if (modelClient.VarClientOption.IsSet && modelClient.VarClient == null)
-                throw new ArgumentNullException(nameof(modelClient.VarClient), "Property is required for class ModelClient.");
+                throw new JsonException("Cannot write null property ModelClient.VarClient to non-nullable JSON property 'client'.");
 
             if (modelClient.VarClientOption.IsSet)
                 writer.WriteString("client", modelClient.VarClient);

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Name.cs
@@ -281,7 +281,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Name name, JsonSerializerOptions jsonSerializerOptions)
         {
             if (name.PropertyOption.IsSet && name.Property == null)
-                throw new ArgumentNullException(nameof(name.Property), "Property is required for class Name.");
+                throw new JsonException("Cannot write null property Name.Property to non-nullable JSON property 'property'.");
 
             writer.WriteNumber("name", name.VarName);
 

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Name.cs
@@ -283,6 +283,12 @@ namespace Org.OpenAPITools.Model
             if (name.PropertyOption.IsSet && name.Property == null)
                 throw new JsonException("Cannot write null property Name.Property to non-nullable JSON property 'property'.");
 
+            if (name.SnakeCaseOption.IsSet && name.SnakeCase == null)
+                throw new JsonException("Cannot write null property Name.SnakeCase to non-nullable JSON property 'snake_case'.");
+
+            if (name.Var123NumberOption.IsSet && name.Var123Number == null)
+                throw new JsonException("Cannot write null property Name.Var123Number to non-nullable JSON property '123Number'.");
+
             writer.WriteNumber("name", name.VarName);
 
             if (name.PropertyOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
@@ -189,9 +189,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, NotificationtestGetElementsV1ResponseMPayload notificationtestGetElementsV1ResponseMPayload, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (notificationtestGetElementsV1ResponseMPayload.AObjVariableobject == null)
-                throw new ArgumentNullException(nameof(notificationtestGetElementsV1ResponseMPayload.AObjVariableobject), "Property is required for class NotificationtestGetElementsV1ResponseMPayload.");
-
             writer.WritePropertyName("a_objVariableobject");
             JsonSerializer.Serialize(writer, notificationtestGetElementsV1ResponseMPayload.AObjVariableobject, jsonSerializerOptions);
             writer.WriteNumber("pkiNotificationtestID", notificationtestGetElementsV1ResponseMPayload.PkiNotificationtestID);

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -408,10 +408,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, NullableClass nullableClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (nullableClass.ArrayItemsNullableOption.IsSet && nullableClass.ArrayItemsNullable == null)
-                throw new ArgumentNullException(nameof(nullableClass.ArrayItemsNullable), "Property is required for class NullableClass.");
+                throw new JsonException("Cannot write null property NullableClass.ArrayItemsNullable to non-nullable JSON property 'array_items_nullable'.");
 
             if (nullableClass.ObjectItemsNullableOption.IsSet && nullableClass.ObjectItemsNullable == null)
-                throw new ArgumentNullException(nameof(nullableClass.ObjectItemsNullable), "Property is required for class NullableClass.");
+                throw new JsonException("Cannot write null property NullableClass.ObjectItemsNullable to non-nullable JSON property 'object_items_nullable'.");
 
             if (nullableClass.ArrayAndItemsNullablePropOption.IsSet)
                 if (nullableClass.ArrayAndItemsNullablePropOption.Value != null)

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -174,6 +174,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, NumberOnly numberOnly, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (numberOnly.JustNumberOption.IsSet && numberOnly.JustNumber == null)
+                throw new JsonException("Cannot write null property NumberOnly.JustNumber to non-nullable JSON property 'JustNumber'.");
+
             if (numberOnly.JustNumberOption.IsSet)
                 writer.WriteNumber("JustNumber", numberOnly.JustNumberOption.Value.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -247,13 +247,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ObjectWithDeprecatedFields objectWithDeprecatedFields, JsonSerializerOptions jsonSerializerOptions)
         {
             if (objectWithDeprecatedFields.BarsOption.IsSet && objectWithDeprecatedFields.Bars == null)
-                throw new ArgumentNullException(nameof(objectWithDeprecatedFields.Bars), "Property is required for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Bars to non-nullable JSON property 'bars'.");
 
             if (objectWithDeprecatedFields.DeprecatedRefOption.IsSet && objectWithDeprecatedFields.DeprecatedRef == null)
-                throw new ArgumentNullException(nameof(objectWithDeprecatedFields.DeprecatedRef), "Property is required for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.DeprecatedRef to non-nullable JSON property 'deprecatedRef'.");
 
             if (objectWithDeprecatedFields.UuidOption.IsSet && objectWithDeprecatedFields.Uuid == null)
-                throw new ArgumentNullException(nameof(objectWithDeprecatedFields.Uuid), "Property is required for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Uuid to non-nullable JSON property 'uuid'.");
 
             if (objectWithDeprecatedFields.BarsOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -252,6 +252,9 @@ namespace Org.OpenAPITools.Model
             if (objectWithDeprecatedFields.DeprecatedRefOption.IsSet && objectWithDeprecatedFields.DeprecatedRef == null)
                 throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.DeprecatedRef to non-nullable JSON property 'deprecatedRef'.");
 
+            if (objectWithDeprecatedFields.IdOption.IsSet && objectWithDeprecatedFields.Id == null)
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Id to non-nullable JSON property 'id'.");
+
             if (objectWithDeprecatedFields.UuidOption.IsSet && objectWithDeprecatedFields.Uuid == null)
                 throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Uuid to non-nullable JSON property 'uuid'.");
 

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Order.cs
@@ -384,6 +384,24 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Order order, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (order.CompleteOption.IsSet && order.Complete == null)
+                throw new JsonException("Cannot write null property Order.Complete to non-nullable JSON property 'complete'.");
+
+            if (order.IdOption.IsSet && order.Id == null)
+                throw new JsonException("Cannot write null property Order.Id to non-nullable JSON property 'id'.");
+
+            if (order.PetIdOption.IsSet && order.PetId == null)
+                throw new JsonException("Cannot write null property Order.PetId to non-nullable JSON property 'petId'.");
+
+            if (order.QuantityOption.IsSet && order.Quantity == null)
+                throw new JsonException("Cannot write null property Order.Quantity to non-nullable JSON property 'quantity'.");
+
+            if (order.ShipDateOption.IsSet && order.ShipDate == null)
+                throw new JsonException("Cannot write null property Order.ShipDate to non-nullable JSON property 'shipDate'.");
+
+            if (order.StatusOption.IsSet && order.Status == null)
+                throw new JsonException("Cannot write null property Order.Status to non-nullable JSON property 'status'.");
+
             if (order.CompleteOption.IsSet)
                 writer.WriteBoolean("complete", order.CompleteOption.Value.Value);
 

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -220,6 +220,12 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, OuterComposite outerComposite, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (outerComposite.MyBooleanOption.IsSet && outerComposite.MyBoolean == null)
+                throw new JsonException("Cannot write null property OuterComposite.MyBoolean to non-nullable JSON property 'my_boolean'.");
+
+            if (outerComposite.MyNumberOption.IsSet && outerComposite.MyNumber == null)
+                throw new JsonException("Cannot write null property OuterComposite.MyNumber to non-nullable JSON property 'my_number'.");
+
             if (outerComposite.MyStringOption.IsSet && outerComposite.MyString == null)
                 throw new JsonException("Cannot write null property OuterComposite.MyString to non-nullable JSON property 'my_string'.");
 

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -221,7 +221,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, OuterComposite outerComposite, JsonSerializerOptions jsonSerializerOptions)
         {
             if (outerComposite.MyStringOption.IsSet && outerComposite.MyString == null)
-                throw new ArgumentNullException(nameof(outerComposite.MyString), "Property is required for class OuterComposite.");
+                throw new JsonException("Cannot write null property OuterComposite.MyString to non-nullable JSON property 'my_string'.");
 
             if (outerComposite.MyBooleanOption.IsSet)
                 writer.WriteBoolean("my_boolean", outerComposite.MyBooleanOption.Value.Value);

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Pet.cs
@@ -371,17 +371,11 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Pet pet, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (pet.Name == null)
-                throw new ArgumentNullException(nameof(pet.Name), "Property is required for class Pet.");
-
-            if (pet.PhotoUrls == null)
-                throw new ArgumentNullException(nameof(pet.PhotoUrls), "Property is required for class Pet.");
-
             if (pet.CategoryOption.IsSet && pet.Category == null)
-                throw new ArgumentNullException(nameof(pet.Category), "Property is required for class Pet.");
+                throw new JsonException("Cannot write null property Pet.Category to non-nullable JSON property 'category'.");
 
             if (pet.TagsOption.IsSet && pet.Tags == null)
-                throw new ArgumentNullException(nameof(pet.Tags), "Property is required for class Pet.");
+                throw new JsonException("Cannot write null property Pet.Tags to non-nullable JSON property 'tags'.");
 
             writer.WriteString("name", pet.Name);
 

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Pet.cs
@@ -374,6 +374,12 @@ namespace Org.OpenAPITools.Model
             if (pet.CategoryOption.IsSet && pet.Category == null)
                 throw new JsonException("Cannot write null property Pet.Category to non-nullable JSON property 'category'.");
 
+            if (pet.IdOption.IsSet && pet.Id == null)
+                throw new JsonException("Cannot write null property Pet.Id to non-nullable JSON property 'id'.");
+
+            if (pet.StatusOption.IsSet && pet.Status == null)
+                throw new JsonException("Cannot write null property Pet.Status to non-nullable JSON property 'status'.");
+
             if (pet.TagsOption.IsSet && pet.Tags == null)
                 throw new JsonException("Cannot write null property Pet.Tags to non-nullable JSON property 'tags'.");
 

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
@@ -170,9 +170,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, QuadrilateralInterface quadrilateralInterface, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (quadrilateralInterface.QuadrilateralType == null)
-                throw new ArgumentNullException(nameof(quadrilateralInterface.QuadrilateralType), "Property is required for class QuadrilateralInterface.");
-
             writer.WriteString("quadrilateralType", quadrilateralInterface.QuadrilateralType);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -236,10 +236,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ReadOnlyFirst readOnlyFirst, JsonSerializerOptions jsonSerializerOptions)
         {
             if (readOnlyFirst.BarOption.IsSet && readOnlyFirst.Bar == null)
-                throw new ArgumentNullException(nameof(readOnlyFirst.Bar), "Property is required for class ReadOnlyFirst.");
+                throw new JsonException("Cannot write null property ReadOnlyFirst.Bar to non-nullable JSON property 'bar'.");
 
             if (readOnlyFirst.BazOption.IsSet && readOnlyFirst.Baz == null)
-                throw new ArgumentNullException(nameof(readOnlyFirst.Baz), "Property is required for class ReadOnlyFirst.");
+                throw new JsonException("Cannot write null property ReadOnlyFirst.Baz to non-nullable JSON property 'baz'.");
 
             if (readOnlyFirst.BarOption.IsSet)
                 writer.WriteString("bar", readOnlyFirst.Bar);

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -2235,17 +2235,11 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, RequiredClass requiredClass, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (requiredClass.RequiredNotnullableArrayOfString == null)
-                throw new ArgumentNullException(nameof(requiredClass.RequiredNotnullableArrayOfString), "Property is required for class RequiredClass.");
-
-            if (requiredClass.RequiredNotnullableStringProp == null)
-                throw new ArgumentNullException(nameof(requiredClass.RequiredNotnullableStringProp), "Property is required for class RequiredClass.");
-
             if (requiredClass.NotrequiredNotnullableArrayOfStringOption.IsSet && requiredClass.NotrequiredNotnullableArrayOfString == null)
-                throw new ArgumentNullException(nameof(requiredClass.NotrequiredNotnullableArrayOfString), "Property is required for class RequiredClass.");
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableArrayOfString to non-nullable JSON property 'notrequired_notnullable_array_of_string'.");
 
             if (requiredClass.NotrequiredNotnullableStringPropOption.IsSet && requiredClass.NotrequiredNotnullableStringProp == null)
-                throw new ArgumentNullException(nameof(requiredClass.NotrequiredNotnullableStringProp), "Property is required for class RequiredClass.");
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableStringProp to non-nullable JSON property 'notrequired_notnullable_string_prop'.");
 
             writer.WriteString("required_not_nullable_date_prop", requiredClass.RequiredNotNullableDateProp.ToString(RequiredNotNullableDatePropFormat));
 

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -2235,11 +2235,38 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, RequiredClass requiredClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (requiredClass.NotRequiredNotnullableDatePropOption.IsSet && requiredClass.NotRequiredNotnullableDateProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotRequiredNotnullableDateProp to non-nullable JSON property 'not_required_notnullable_date_prop'.");
+
+            if (requiredClass.NotRequiredNotnullableintegerPropOption.IsSet && requiredClass.NotRequiredNotnullableintegerProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotRequiredNotnullableintegerProp to non-nullable JSON property 'not_required_notnullableinteger_prop'.");
+
             if (requiredClass.NotrequiredNotnullableArrayOfStringOption.IsSet && requiredClass.NotrequiredNotnullableArrayOfString == null)
                 throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableArrayOfString to non-nullable JSON property 'notrequired_notnullable_array_of_string'.");
 
+            if (requiredClass.NotrequiredNotnullableBooleanPropOption.IsSet && requiredClass.NotrequiredNotnullableBooleanProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableBooleanProp to non-nullable JSON property 'notrequired_notnullable_boolean_prop'.");
+
+            if (requiredClass.NotrequiredNotnullableDatetimePropOption.IsSet && requiredClass.NotrequiredNotnullableDatetimeProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableDatetimeProp to non-nullable JSON property 'notrequired_notnullable_datetime_prop'.");
+
+            if (requiredClass.NotrequiredNotnullableEnumIntegerOption.IsSet && requiredClass.NotrequiredNotnullableEnumInteger == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableEnumInteger to non-nullable JSON property 'notrequired_notnullable_enum_integer'.");
+
+            if (requiredClass.NotrequiredNotnullableEnumIntegerOnlyOption.IsSet && requiredClass.NotrequiredNotnullableEnumIntegerOnly == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableEnumIntegerOnly to non-nullable JSON property 'notrequired_notnullable_enum_integer_only'.");
+
+            if (requiredClass.NotrequiredNotnullableEnumStringOption.IsSet && requiredClass.NotrequiredNotnullableEnumString == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableEnumString to non-nullable JSON property 'notrequired_notnullable_enum_string'.");
+
+            if (requiredClass.NotrequiredNotnullableOuterEnumDefaultValueOption.IsSet && requiredClass.NotrequiredNotnullableOuterEnumDefaultValue == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableOuterEnumDefaultValue to non-nullable JSON property 'notrequired_notnullable_outerEnumDefaultValue'.");
+
             if (requiredClass.NotrequiredNotnullableStringPropOption.IsSet && requiredClass.NotrequiredNotnullableStringProp == null)
                 throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableStringProp to non-nullable JSON property 'notrequired_notnullable_string_prop'.");
+
+            if (requiredClass.NotrequiredNotnullableUuidOption.IsSet && requiredClass.NotrequiredNotnullableUuid == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableUuid to non-nullable JSON property 'notrequired_notnullable_uuid'.");
 
             writer.WriteString("required_not_nullable_date_prop", requiredClass.RequiredNotNullableDateProp.ToString(RequiredNotNullableDatePropFormat));
 

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Result.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Result.cs
@@ -224,13 +224,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Result result, JsonSerializerOptions jsonSerializerOptions)
         {
             if (result.CodeOption.IsSet && result.Code == null)
-                throw new ArgumentNullException(nameof(result.Code), "Property is required for class Result.");
+                throw new JsonException("Cannot write null property Result.Code to non-nullable JSON property 'code'.");
 
             if (result.DataOption.IsSet && result.Data == null)
-                throw new ArgumentNullException(nameof(result.Data), "Property is required for class Result.");
+                throw new JsonException("Cannot write null property Result.Data to non-nullable JSON property 'data'.");
 
             if (result.UuidOption.IsSet && result.Uuid == null)
-                throw new ArgumentNullException(nameof(result.Uuid), "Property is required for class Result.");
+                throw new JsonException("Cannot write null property Result.Uuid to non-nullable JSON property 'uuid'.");
 
             if (result.CodeOption.IsSet)
                 writer.WriteString("code", result.Code);

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Return.cs
@@ -232,11 +232,8 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Return varReturn, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (varReturn.Lock == null)
-                throw new ArgumentNullException(nameof(varReturn.Lock), "Property is required for class Return.");
-
             if (varReturn.UnsafeOption.IsSet && varReturn.Unsafe == null)
-                throw new ArgumentNullException(nameof(varReturn.Unsafe), "Property is required for class Return.");
+                throw new JsonException("Cannot write null property Return.Unsafe to non-nullable JSON property 'unsafe'.");
 
             writer.WriteString("lock", varReturn.Lock);
 

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Return.cs
@@ -232,6 +232,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Return varReturn, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (varReturn.VarReturnOption.IsSet && varReturn.VarReturn == null)
+                throw new JsonException("Cannot write null property Return.VarReturn to non-nullable JSON property 'return'.");
+
             if (varReturn.UnsafeOption.IsSet && varReturn.Unsafe == null)
                 throw new JsonException("Cannot write null property Return.Unsafe to non-nullable JSON property 'unsafe'.");
 

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -198,7 +198,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, RolesReportsHash rolesReportsHash, JsonSerializerOptions jsonSerializerOptions)
         {
             if (rolesReportsHash.RoleOption.IsSet && rolesReportsHash.Role == null)
-                throw new ArgumentNullException(nameof(rolesReportsHash.Role), "Property is required for class RolesReportsHash.");
+                throw new JsonException("Cannot write null property RolesReportsHash.Role to non-nullable JSON property 'role'.");
 
             if (rolesReportsHash.RoleOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -200,6 +200,9 @@ namespace Org.OpenAPITools.Model
             if (rolesReportsHash.RoleOption.IsSet && rolesReportsHash.Role == null)
                 throw new JsonException("Cannot write null property RolesReportsHash.Role to non-nullable JSON property 'role'.");
 
+            if (rolesReportsHash.RoleUuidOption.IsSet && rolesReportsHash.RoleUuid == null)
+                throw new JsonException("Cannot write null property RolesReportsHash.RoleUuid to non-nullable JSON property 'role_uuid'.");
+
             if (rolesReportsHash.RoleOption.IsSet)
             {
                 writer.WritePropertyName("role");

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, RolesReportsHashRole rolesReportsHashRole, JsonSerializerOptions jsonSerializerOptions)
         {
             if (rolesReportsHashRole.NameOption.IsSet && rolesReportsHashRole.Name == null)
-                throw new ArgumentNullException(nameof(rolesReportsHashRole.Name), "Property is required for class RolesReportsHashRole.");
+                throw new JsonException("Cannot write null property RolesReportsHashRole.Name to non-nullable JSON property 'name'.");
 
             if (rolesReportsHashRole.NameOption.IsSet)
                 writer.WriteString("name", rolesReportsHashRole.Name);

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
@@ -189,12 +189,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ScaleneTriangle scaleneTriangle, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (scaleneTriangle.ShapeType == null)
-                throw new ArgumentNullException(nameof(scaleneTriangle.ShapeType), "Property is required for class ScaleneTriangle.");
-
-            if (scaleneTriangle.TriangleType == null)
-                throw new ArgumentNullException(nameof(scaleneTriangle.TriangleType), "Property is required for class ScaleneTriangle.");
-
             writer.WriteString("shapeType", scaleneTriangle.ShapeType);
 
             writer.WriteString("triangleType", scaleneTriangle.TriangleType);

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ShapeInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ShapeInterface.cs
@@ -170,9 +170,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ShapeInterface shapeInterface, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (shapeInterface.ShapeType == null)
-                throw new ArgumentNullException(nameof(shapeInterface.ShapeType), "Property is required for class ShapeInterface.");
-
             writer.WriteString("shapeType", shapeInterface.ShapeType);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
@@ -189,12 +189,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, SimpleQuadrilateral simpleQuadrilateral, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (simpleQuadrilateral.QuadrilateralType == null)
-                throw new ArgumentNullException(nameof(simpleQuadrilateral.QuadrilateralType), "Property is required for class SimpleQuadrilateral.");
-
-            if (simpleQuadrilateral.ShapeType == null)
-                throw new ArgumentNullException(nameof(simpleQuadrilateral.ShapeType), "Property is required for class SimpleQuadrilateral.");
-
             writer.WriteString("quadrilateralType", simpleQuadrilateral.QuadrilateralType);
 
             writer.WriteString("shapeType", simpleQuadrilateral.ShapeType);

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -200,6 +200,9 @@ namespace Org.OpenAPITools.Model
             if (specialModelName.VarSpecialModelNameOption.IsSet && specialModelName.VarSpecialModelName == null)
                 throw new JsonException("Cannot write null property SpecialModelName.VarSpecialModelName to non-nullable JSON property '_special_model.name_'.");
 
+            if (specialModelName.SpecialPropertyNameOption.IsSet && specialModelName.SpecialPropertyName == null)
+                throw new JsonException("Cannot write null property SpecialModelName.SpecialPropertyName to non-nullable JSON property '$special[property.name]'.");
+
             if (specialModelName.VarSpecialModelNameOption.IsSet)
                 writer.WriteString("_special_model.name_", specialModelName.VarSpecialModelName);
 

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -198,7 +198,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, SpecialModelName specialModelName, JsonSerializerOptions jsonSerializerOptions)
         {
             if (specialModelName.VarSpecialModelNameOption.IsSet && specialModelName.VarSpecialModelName == null)
-                throw new ArgumentNullException(nameof(specialModelName.VarSpecialModelName), "Property is required for class SpecialModelName.");
+                throw new JsonException("Cannot write null property SpecialModelName.VarSpecialModelName to non-nullable JSON property '_special_model.name_'.");
 
             if (specialModelName.VarSpecialModelNameOption.IsSet)
                 writer.WriteString("_special_model.name_", specialModelName.VarSpecialModelName);

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Tag.cs
@@ -198,7 +198,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Tag tag, JsonSerializerOptions jsonSerializerOptions)
         {
             if (tag.NameOption.IsSet && tag.Name == null)
-                throw new ArgumentNullException(nameof(tag.Name), "Property is required for class Tag.");
+                throw new JsonException("Cannot write null property Tag.Name to non-nullable JSON property 'name'.");
 
             if (tag.IdOption.IsSet)
                 writer.WriteNumber("id", tag.IdOption.Value.Value);

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Tag.cs
@@ -197,6 +197,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Tag tag, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (tag.IdOption.IsSet && tag.Id == null)
+                throw new JsonException("Cannot write null property Tag.Id to non-nullable JSON property 'id'.");
+
             if (tag.NameOption.IsSet && tag.Name == null)
                 throw new JsonException("Cannot write null property Tag.Name to non-nullable JSON property 'name'.");
 

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestCollectionEndingWithWordList testCollectionEndingWithWordList, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testCollectionEndingWithWordList.ValueOption.IsSet && testCollectionEndingWithWordList.Value == null)
-                throw new ArgumentNullException(nameof(testCollectionEndingWithWordList.Value), "Property is required for class TestCollectionEndingWithWordList.");
+                throw new JsonException("Cannot write null property TestCollectionEndingWithWordList.Value to non-nullable JSON property 'value'.");
 
             if (testCollectionEndingWithWordList.ValueOption.IsSet)
                 writer.WriteString("value", testCollectionEndingWithWordList.Value);

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestCollectionEndingWithWordListObject testCollectionEndingWithWordListObject, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testCollectionEndingWithWordListObject.TestCollectionEndingWithWordListOption.IsSet && testCollectionEndingWithWordListObject.TestCollectionEndingWithWordList == null)
-                throw new ArgumentNullException(nameof(testCollectionEndingWithWordListObject.TestCollectionEndingWithWordList), "Property is required for class TestCollectionEndingWithWordListObject.");
+                throw new JsonException("Cannot write null property TestCollectionEndingWithWordListObject.TestCollectionEndingWithWordList to non-nullable JSON property 'TestCollectionEndingWithWordList'.");
 
             if (testCollectionEndingWithWordListObject.TestCollectionEndingWithWordListOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/TestDescendants.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/TestDescendants.cs
@@ -289,9 +289,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, TestDescendants testDescendants, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (testDescendants.AlternativeName == null)
-                throw new ArgumentNullException(nameof(testDescendants.AlternativeName), "Property is required for class TestDescendants.");
-
             writer.WriteString("alternativeName", testDescendants.AlternativeName);
 
             writer.WriteString("objectType", TestDescendants.ObjectTypeEnumToJsonValue(testDescendants.ObjectType));

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestInlineFreeformAdditionalPropertiesRequest testInlineFreeformAdditionalPropertiesRequest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testInlineFreeformAdditionalPropertiesRequest.SomePropertyOption.IsSet && testInlineFreeformAdditionalPropertiesRequest.SomeProperty == null)
-                throw new ArgumentNullException(nameof(testInlineFreeformAdditionalPropertiesRequest.SomeProperty), "Property is required for class TestInlineFreeformAdditionalPropertiesRequest.");
+                throw new JsonException("Cannot write null property TestInlineFreeformAdditionalPropertiesRequest.SomeProperty to non-nullable JSON property 'someProperty'.");
 
             if (testInlineFreeformAdditionalPropertiesRequest.SomePropertyOption.IsSet)
                 writer.WriteString("someProperty", testInlineFreeformAdditionalPropertiesRequest.SomeProperty);

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/TestResult.cs
@@ -222,6 +222,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, TestResult testResult, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (testResult.CodeOption.IsSet && testResult.Code == null)
+                throw new JsonException("Cannot write null property TestResult.Code to non-nullable JSON property 'code'.");
+
             if (testResult.DataOption.IsSet && testResult.Data == null)
                 throw new JsonException("Cannot write null property TestResult.Data to non-nullable JSON property 'data'.");
 

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/TestResult.cs
@@ -223,10 +223,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestResult testResult, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testResult.DataOption.IsSet && testResult.Data == null)
-                throw new ArgumentNullException(nameof(testResult.Data), "Property is required for class TestResult.");
+                throw new JsonException("Cannot write null property TestResult.Data to non-nullable JSON property 'data'.");
 
             if (testResult.UuidOption.IsSet && testResult.Uuid == null)
-                throw new ArgumentNullException(nameof(testResult.Uuid), "Property is required for class TestResult.");
+                throw new JsonException("Cannot write null property TestResult.Uuid to non-nullable JSON property 'uuid'.");
 
             if (testResult.CodeOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/TriangleInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/TriangleInterface.cs
@@ -170,9 +170,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, TriangleInterface triangleInterface, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (triangleInterface.TriangleType == null)
-                throw new ArgumentNullException(nameof(triangleInterface.TriangleType), "Property is required for class TriangleInterface.");
-
             writer.WriteString("triangleType", triangleInterface.TriangleType);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/User.cs
@@ -429,6 +429,9 @@ namespace Org.OpenAPITools.Model
             if (user.FirstNameOption.IsSet && user.FirstName == null)
                 throw new JsonException("Cannot write null property User.FirstName to non-nullable JSON property 'firstName'.");
 
+            if (user.IdOption.IsSet && user.Id == null)
+                throw new JsonException("Cannot write null property User.Id to non-nullable JSON property 'id'.");
+
             if (user.LastNameOption.IsSet && user.LastName == null)
                 throw new JsonException("Cannot write null property User.LastName to non-nullable JSON property 'lastName'.");
 
@@ -440,6 +443,9 @@ namespace Org.OpenAPITools.Model
 
             if (user.PhoneOption.IsSet && user.Phone == null)
                 throw new JsonException("Cannot write null property User.Phone to non-nullable JSON property 'phone'.");
+
+            if (user.UserStatusOption.IsSet && user.UserStatus == null)
+                throw new JsonException("Cannot write null property User.UserStatus to non-nullable JSON property 'userStatus'.");
 
             if (user.UsernameOption.IsSet && user.Username == null)
                 throw new JsonException("Cannot write null property User.Username to non-nullable JSON property 'username'.");

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/User.cs
@@ -424,25 +424,25 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, User user, JsonSerializerOptions jsonSerializerOptions)
         {
             if (user.EmailOption.IsSet && user.Email == null)
-                throw new ArgumentNullException(nameof(user.Email), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Email to non-nullable JSON property 'email'.");
 
             if (user.FirstNameOption.IsSet && user.FirstName == null)
-                throw new ArgumentNullException(nameof(user.FirstName), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.FirstName to non-nullable JSON property 'firstName'.");
 
             if (user.LastNameOption.IsSet && user.LastName == null)
-                throw new ArgumentNullException(nameof(user.LastName), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.LastName to non-nullable JSON property 'lastName'.");
 
             if (user.ObjectWithNoDeclaredPropsOption.IsSet && user.ObjectWithNoDeclaredProps == null)
-                throw new ArgumentNullException(nameof(user.ObjectWithNoDeclaredProps), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.ObjectWithNoDeclaredProps to non-nullable JSON property 'objectWithNoDeclaredProps'.");
 
             if (user.PasswordOption.IsSet && user.Password == null)
-                throw new ArgumentNullException(nameof(user.Password), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Password to non-nullable JSON property 'password'.");
 
             if (user.PhoneOption.IsSet && user.Phone == null)
-                throw new ArgumentNullException(nameof(user.Phone), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Phone to non-nullable JSON property 'phone'.");
 
             if (user.UsernameOption.IsSet && user.Username == null)
-                throw new ArgumentNullException(nameof(user.Username), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Username to non-nullable JSON property 'username'.");
 
             if (user.AnyTypePropOption.IsSet)
                 if (user.AnyTypePropOption.Value != null)

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Whale.cs
@@ -216,9 +216,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Whale whale, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (whale.ClassName == null)
-                throw new ArgumentNullException(nameof(whale.ClassName), "Property is required for class Whale.");
-
             writer.WriteString("className", whale.ClassName);
 
             if (whale.HasBaleenOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Whale.cs
@@ -216,6 +216,12 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Whale whale, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (whale.HasBaleenOption.IsSet && whale.HasBaleen == null)
+                throw new JsonException("Cannot write null property Whale.HasBaleen to non-nullable JSON property 'hasBaleen'.");
+
+            if (whale.HasTeethOption.IsSet && whale.HasTeeth == null)
+                throw new JsonException("Cannot write null property Whale.HasTeeth to non-nullable JSON property 'hasTeeth'.");
+
             writer.WriteString("className", whale.ClassName);
 
             if (whale.HasBaleenOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Zebra.cs
@@ -280,6 +280,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Zebra zebra, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (zebra.TypeOption.IsSet && zebra.Type == null)
+                throw new JsonException("Cannot write null property Zebra.Type to non-nullable JSON property 'type'.");
+
             writer.WriteString("className", zebra.ClassName);
 
             var typeRawValue = Zebra.TypeEnumToJsonValue(zebra.TypeOption.Value.Value);

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Zebra.cs
@@ -280,9 +280,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Zebra zebra, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (zebra.ClassName == null)
-                throw new ArgumentNullException(nameof(zebra.ClassName), "Property is required for class Zebra.");
-
             writer.WriteString("className", zebra.ClassName);
 
             var typeRawValue = Zebra.TypeEnumToJsonValue(zebra.TypeOption.Value.Value);

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
@@ -247,6 +247,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ZeroBasedEnumClass zeroBasedEnumClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (zeroBasedEnumClass.ZeroBasedEnumOption.IsSet && zeroBasedEnumClass.ZeroBasedEnum == null)
+                throw new JsonException("Cannot write null property ZeroBasedEnumClass.ZeroBasedEnum to non-nullable JSON property 'ZeroBasedEnum'.");
+
             var zeroBasedEnumRawValue = ZeroBasedEnumClass.ZeroBasedEnumEnumToJsonValue(zeroBasedEnumClass.ZeroBasedEnumOption.Value.Value);
             writer.WriteString("ZeroBasedEnum", zeroBasedEnumRawValue);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Activity.cs
@@ -178,7 +178,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Activity activity, JsonSerializerOptions jsonSerializerOptions)
         {
             if (activity.ActivityOutputsOption.IsSet && activity.ActivityOutputs == null)
-                throw new ArgumentNullException(nameof(activity.ActivityOutputs), "Property is required for class Activity.");
+                throw new JsonException("Cannot write null property Activity.ActivityOutputs to non-nullable JSON property 'activity_outputs'.");
 
             if (activity.ActivityOutputsOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -201,10 +201,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ActivityOutputElementRepresentation activityOutputElementRepresentation, JsonSerializerOptions jsonSerializerOptions)
         {
             if (activityOutputElementRepresentation.Prop1Option.IsSet && activityOutputElementRepresentation.Prop1 == null)
-                throw new ArgumentNullException(nameof(activityOutputElementRepresentation.Prop1), "Property is required for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Cannot write null property ActivityOutputElementRepresentation.Prop1 to non-nullable JSON property 'prop1'.");
 
             if (activityOutputElementRepresentation.Prop2Option.IsSet && activityOutputElementRepresentation.Prop2 == null)
-                throw new ArgumentNullException(nameof(activityOutputElementRepresentation.Prop2), "Property is required for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Cannot write null property ActivityOutputElementRepresentation.Prop2 to non-nullable JSON property 'prop2'.");
 
             if (activityOutputElementRepresentation.Prop1Option.IsSet)
                 writer.WriteString("prop1", activityOutputElementRepresentation.Prop1);

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -337,25 +337,25 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, AdditionalPropertiesClass additionalPropertiesClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (additionalPropertiesClass.EmptyMapOption.IsSet && additionalPropertiesClass.EmptyMap == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.EmptyMap), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.EmptyMap to non-nullable JSON property 'empty_map'.");
 
             if (additionalPropertiesClass.MapOfMapPropertyOption.IsSet && additionalPropertiesClass.MapOfMapProperty == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapOfMapProperty), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapOfMapProperty to non-nullable JSON property 'map_of_map_property'.");
 
             if (additionalPropertiesClass.MapPropertyOption.IsSet && additionalPropertiesClass.MapProperty == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapProperty), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapProperty to non-nullable JSON property 'map_property'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1Option.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1 == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1 to non-nullable JSON property 'map_with_undeclared_properties_anytype_1'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2Option.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2 == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2 to non-nullable JSON property 'map_with_undeclared_properties_anytype_2'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3Option.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3 == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3 to non-nullable JSON property 'map_with_undeclared_properties_anytype_3'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesStringOption.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesString == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesString), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesString to non-nullable JSON property 'map_with_undeclared_properties_string'.");
 
             if (additionalPropertiesClass.Anytype1Option.IsSet)
                 if (additionalPropertiesClass.Anytype1Option.Value != null)

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Animal.cs
@@ -224,7 +224,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Animal animal, JsonSerializerOptions jsonSerializerOptions)
         {
             if (animal.ColorOption.IsSet && animal.Color == null)
-                throw new ArgumentNullException(nameof(animal.Color), "Property is required for class Animal.");
+                throw new JsonException("Cannot write null property Animal.Color to non-nullable JSON property 'color'.");
 
             writer.WriteString("className", animal.ClassName);
 

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -224,10 +224,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ApiResponse apiResponse, JsonSerializerOptions jsonSerializerOptions)
         {
             if (apiResponse.MessageOption.IsSet && apiResponse.Message == null)
-                throw new ArgumentNullException(nameof(apiResponse.Message), "Property is required for class ApiResponse.");
+                throw new JsonException("Cannot write null property ApiResponse.Message to non-nullable JSON property 'message'.");
 
             if (apiResponse.TypeOption.IsSet && apiResponse.Type == null)
-                throw new ArgumentNullException(nameof(apiResponse.Type), "Property is required for class ApiResponse.");
+                throw new JsonException("Cannot write null property ApiResponse.Type to non-nullable JSON property 'type'.");
 
             if (apiResponse.CodeOption.IsSet)
                 writer.WriteNumber("code", apiResponse.CodeOption.Value!.Value);

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -223,6 +223,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ApiResponse apiResponse, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (apiResponse.CodeOption.IsSet && apiResponse.Code == null)
+                throw new JsonException("Cannot write null property ApiResponse.Code to non-nullable JSON property 'code'.");
+
             if (apiResponse.MessageOption.IsSet && apiResponse.Message == null)
                 throw new JsonException("Cannot write null property ApiResponse.Message to non-nullable JSON property 'message'.");
 

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Apple.cs
@@ -254,13 +254,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Apple apple, JsonSerializerOptions jsonSerializerOptions)
         {
             if (apple.ColorCodeOption.IsSet && apple.ColorCode == null)
-                throw new ArgumentNullException(nameof(apple.ColorCode), "Property is required for class Apple.");
+                throw new JsonException("Cannot write null property Apple.ColorCode to non-nullable JSON property 'color_code'.");
 
             if (apple.CultivarOption.IsSet && apple.Cultivar == null)
-                throw new ArgumentNullException(nameof(apple.Cultivar), "Property is required for class Apple.");
+                throw new JsonException("Cannot write null property Apple.Cultivar to non-nullable JSON property 'cultivar'.");
 
             if (apple.OriginOption.IsSet && apple.Origin == null)
-                throw new ArgumentNullException(nameof(apple.Origin), "Property is required for class Apple.");
+                throw new JsonException("Cannot write null property Apple.Origin to non-nullable JSON property 'origin'.");
 
             if (apple.ColorCodeOption.IsSet)
                 writer.WriteString("color_code", apple.ColorCode);

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -189,9 +189,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, AppleReq appleReq, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (appleReq.Cultivar == null)
-                throw new ArgumentNullException(nameof(appleReq.Cultivar), "Property is required for class AppleReq.");
-
             writer.WriteString("cultivar", appleReq.Cultivar);
 
             if (appleReq.MealyOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -189,6 +189,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, AppleReq appleReq, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (appleReq.MealyOption.IsSet && appleReq.Mealy == null)
+                throw new JsonException("Cannot write null property AppleReq.Mealy to non-nullable JSON property 'mealy'.");
+
             writer.WriteString("cultivar", appleReq.Cultivar);
 
             if (appleReq.MealyOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -178,7 +178,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ArrayOfArrayOfNumberOnly arrayOfArrayOfNumberOnly, JsonSerializerOptions jsonSerializerOptions)
         {
             if (arrayOfArrayOfNumberOnly.ArrayArrayNumberOption.IsSet && arrayOfArrayOfNumberOnly.ArrayArrayNumber == null)
-                throw new ArgumentNullException(nameof(arrayOfArrayOfNumberOnly.ArrayArrayNumber), "Property is required for class ArrayOfArrayOfNumberOnly.");
+                throw new JsonException("Cannot write null property ArrayOfArrayOfNumberOnly.ArrayArrayNumber to non-nullable JSON property 'ArrayArrayNumber'.");
 
             if (arrayOfArrayOfNumberOnly.ArrayArrayNumberOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -178,7 +178,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ArrayOfNumberOnly arrayOfNumberOnly, JsonSerializerOptions jsonSerializerOptions)
         {
             if (arrayOfNumberOnly.ArrayNumberOption.IsSet && arrayOfNumberOnly.ArrayNumber == null)
-                throw new ArgumentNullException(nameof(arrayOfNumberOnly.ArrayNumber), "Property is required for class ArrayOfNumberOnly.");
+                throw new JsonException("Cannot write null property ArrayOfNumberOnly.ArrayNumber to non-nullable JSON property 'ArrayNumber'.");
 
             if (arrayOfNumberOnly.ArrayNumberOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -224,13 +224,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ArrayTest arrayTest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (arrayTest.ArrayArrayOfIntegerOption.IsSet && arrayTest.ArrayArrayOfInteger == null)
-                throw new ArgumentNullException(nameof(arrayTest.ArrayArrayOfInteger), "Property is required for class ArrayTest.");
+                throw new JsonException("Cannot write null property ArrayTest.ArrayArrayOfInteger to non-nullable JSON property 'array_array_of_integer'.");
 
             if (arrayTest.ArrayArrayOfModelOption.IsSet && arrayTest.ArrayArrayOfModel == null)
-                throw new ArgumentNullException(nameof(arrayTest.ArrayArrayOfModel), "Property is required for class ArrayTest.");
+                throw new JsonException("Cannot write null property ArrayTest.ArrayArrayOfModel to non-nullable JSON property 'array_array_of_model'.");
 
             if (arrayTest.ArrayOfStringOption.IsSet && arrayTest.ArrayOfString == null)
-                throw new ArgumentNullException(nameof(arrayTest.ArrayOfString), "Property is required for class ArrayTest.");
+                throw new JsonException("Cannot write null property ArrayTest.ArrayOfString to non-nullable JSON property 'array_of_string'.");
 
             if (arrayTest.ArrayArrayOfIntegerOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Banana.cs
@@ -177,6 +177,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Banana banana, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (banana.LengthCmOption.IsSet && banana.LengthCm == null)
+                throw new JsonException("Cannot write null property Banana.LengthCm to non-nullable JSON property 'lengthCm'.");
+
             if (banana.LengthCmOption.IsSet)
                 writer.WriteNumber("lengthCm", banana.LengthCmOption.Value!.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -189,6 +189,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, BananaReq bananaReq, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (bananaReq.SweetOption.IsSet && bananaReq.Sweet == null)
+                throw new JsonException("Cannot write null property BananaReq.Sweet to non-nullable JSON property 'sweet'.");
+
             writer.WriteNumber("lengthCm", bananaReq.LengthCm);
 
             if (bananaReq.SweetOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/BasquePig.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/BasquePig.cs
@@ -173,9 +173,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, BasquePig basquePig, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (basquePig.ClassName == null)
-                throw new ArgumentNullException(nameof(basquePig.ClassName), "Property is required for class BasquePig.");
-
             writer.WriteString("className", basquePig.ClassName);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -294,22 +294,22 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Capitalization capitalization, JsonSerializerOptions jsonSerializerOptions)
         {
             if (capitalization.ATT_NAMEOption.IsSet && capitalization.ATT_NAME == null)
-                throw new ArgumentNullException(nameof(capitalization.ATT_NAME), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.ATT_NAME to non-nullable JSON property 'ATT_NAME'.");
 
             if (capitalization.CapitalCamelOption.IsSet && capitalization.CapitalCamel == null)
-                throw new ArgumentNullException(nameof(capitalization.CapitalCamel), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.CapitalCamel to non-nullable JSON property 'CapitalCamel'.");
 
             if (capitalization.CapitalSnakeOption.IsSet && capitalization.CapitalSnake == null)
-                throw new ArgumentNullException(nameof(capitalization.CapitalSnake), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.CapitalSnake to non-nullable JSON property 'Capital_Snake'.");
 
             if (capitalization.SCAETHFlowPointsOption.IsSet && capitalization.SCAETHFlowPoints == null)
-                throw new ArgumentNullException(nameof(capitalization.SCAETHFlowPoints), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.SCAETHFlowPoints to non-nullable JSON property 'SCA_ETH_Flow_Points'.");
 
             if (capitalization.SmallCamelOption.IsSet && capitalization.SmallCamel == null)
-                throw new ArgumentNullException(nameof(capitalization.SmallCamel), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.SmallCamel to non-nullable JSON property 'smallCamel'.");
 
             if (capitalization.SmallSnakeOption.IsSet && capitalization.SmallSnake == null)
-                throw new ArgumentNullException(nameof(capitalization.SmallSnake), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.SmallSnake to non-nullable JSON property 'small_Snake'.");
 
             if (capitalization.ATT_NAMEOption.IsSet)
                 writer.WriteString("ATT_NAME", capitalization.ATT_NAME);

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Cat.cs
@@ -182,6 +182,9 @@ namespace Org.OpenAPITools.Model
             if (cat.ColorOption.IsSet && cat.Color == null)
                 throw new JsonException("Cannot write null property Cat.Color to non-nullable JSON property 'color'.");
 
+            if (cat.DeclawedOption.IsSet && cat.Declawed == null)
+                throw new JsonException("Cannot write null property Cat.Declawed to non-nullable JSON property 'declawed'.");
+
             writer.WriteString("className", cat.ClassName);
 
             if (cat.ColorOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Cat.cs
@@ -180,7 +180,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Cat cat, JsonSerializerOptions jsonSerializerOptions)
         {
             if (cat.ColorOption.IsSet && cat.Color == null)
-                throw new ArgumentNullException(nameof(cat.Color), "Property is required for class Cat.");
+                throw new JsonException("Cannot write null property Cat.Color to non-nullable JSON property 'color'.");
 
             writer.WriteString("className", cat.ClassName);
 

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Category.cs
@@ -196,6 +196,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Category category, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (category.IdOption.IsSet && category.Id == null)
+                throw new JsonException("Cannot write null property Category.Id to non-nullable JSON property 'id'.");
+
             if (category.IdOption.IsSet)
                 writer.WriteNumber("id", category.IdOption.Value!.Value);
 

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Category.cs
@@ -196,9 +196,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Category category, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (category.Name == null)
-                throw new ArgumentNullException(nameof(category.Name), "Property is required for class Category.");
-
             if (category.IdOption.IsSet)
                 writer.WriteNumber("id", category.IdOption.Value!.Value);
 

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -239,7 +239,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ChildCat childCat, JsonSerializerOptions jsonSerializerOptions)
         {
             if (childCat.NameOption.IsSet && childCat.Name == null)
-                throw new ArgumentNullException(nameof(childCat.Name), "Property is required for class ChildCat.");
+                throw new JsonException("Cannot write null property ChildCat.Name to non-nullable JSON property 'name'.");
 
             if (childCat.NameOption.IsSet)
                 writer.WriteString("name", childCat.Name);

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -178,7 +178,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ClassModel classModel, JsonSerializerOptions jsonSerializerOptions)
         {
             if (classModel.ClassOption.IsSet && classModel.Class == null)
-                throw new ArgumentNullException(nameof(classModel.Class), "Property is required for class ClassModel.");
+                throw new JsonException("Cannot write null property ClassModel.Class to non-nullable JSON property '_class'.");
 
             if (classModel.ClassOption.IsSet)
                 writer.WriteString("_class", classModel.Class);

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
@@ -192,12 +192,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ComplexQuadrilateral complexQuadrilateral, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (complexQuadrilateral.QuadrilateralType == null)
-                throw new ArgumentNullException(nameof(complexQuadrilateral.QuadrilateralType), "Property is required for class ComplexQuadrilateral.");
-
-            if (complexQuadrilateral.ShapeType == null)
-                throw new ArgumentNullException(nameof(complexQuadrilateral.ShapeType), "Property is required for class ComplexQuadrilateral.");
-
             writer.WriteString("quadrilateralType", complexQuadrilateral.QuadrilateralType);
 
             writer.WriteString("shapeType", complexQuadrilateral.ShapeType);

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/CopyActivity.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/CopyActivity.cs
@@ -234,9 +234,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, CopyActivity copyActivity, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (copyActivity.CopyActivitytt == null)
-                throw new ArgumentNullException(nameof(copyActivity.CopyActivitytt), "Property is required for class CopyActivity.");
-
             writer.WriteString("copyActivitytt", copyActivity.CopyActivitytt);
 
             writer.WriteString("$schema", CopyActivity.SchemaEnumToJsonValue(copyActivity.Schema));

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/DanishPig.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/DanishPig.cs
@@ -173,9 +173,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, DanishPig danishPig, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (danishPig.ClassName == null)
-                throw new ArgumentNullException(nameof(danishPig.ClassName), "Property is required for class DanishPig.");
-
             writer.WriteString("className", danishPig.ClassName);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -183,6 +183,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, DateOnlyClass dateOnlyClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (dateOnlyClass.DateOnlyPropertyOption.IsSet && dateOnlyClass.DateOnlyProperty == null)
+                throw new JsonException("Cannot write null property DateOnlyClass.DateOnlyProperty to non-nullable JSON property 'dateOnlyProperty'.");
+
             if (dateOnlyClass.DateOnlyPropertyOption.IsSet)
                 writer.WriteString("dateOnlyProperty", dateOnlyClass.DateOnlyPropertyOption.Value!.Value.ToString(DateOnlyPropertyFormat));
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -178,7 +178,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, DeprecatedObject deprecatedObject, JsonSerializerOptions jsonSerializerOptions)
         {
             if (deprecatedObject.NameOption.IsSet && deprecatedObject.Name == null)
-                throw new ArgumentNullException(nameof(deprecatedObject.Name), "Property is required for class DeprecatedObject.");
+                throw new JsonException("Cannot write null property DeprecatedObject.Name to non-nullable JSON property 'name'.");
 
             if (deprecatedObject.NameOption.IsSet)
                 writer.WriteString("name", deprecatedObject.Name);

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Descendant1.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Descendant1.cs
@@ -185,12 +185,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Descendant1 descendant1, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (descendant1.AlternativeName == null)
-                throw new ArgumentNullException(nameof(descendant1.AlternativeName), "Property is required for class Descendant1.");
-
-            if (descendant1.DescendantName == null)
-                throw new ArgumentNullException(nameof(descendant1.DescendantName), "Property is required for class Descendant1.");
-
             writer.WriteString("alternativeName", descendant1.AlternativeName);
 
             writer.WriteString("descendantName", descendant1.DescendantName);

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Descendant2.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Descendant2.cs
@@ -185,12 +185,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Descendant2 descendant2, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (descendant2.AlternativeName == null)
-                throw new ArgumentNullException(nameof(descendant2.AlternativeName), "Property is required for class Descendant2.");
-
-            if (descendant2.Confidentiality == null)
-                throw new ArgumentNullException(nameof(descendant2.Confidentiality), "Property is required for class Descendant2.");
-
             writer.WriteString("alternativeName", descendant2.AlternativeName);
 
             writer.WriteString("confidentiality", descendant2.Confidentiality);

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Dog.cs
@@ -180,10 +180,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Dog dog, JsonSerializerOptions jsonSerializerOptions)
         {
             if (dog.BreedOption.IsSet && dog.Breed == null)
-                throw new ArgumentNullException(nameof(dog.Breed), "Property is required for class Dog.");
+                throw new JsonException("Cannot write null property Dog.Breed to non-nullable JSON property 'breed'.");
 
             if (dog.ColorOption.IsSet && dog.Color == null)
-                throw new ArgumentNullException(nameof(dog.Color), "Property is required for class Dog.");
+                throw new JsonException("Cannot write null property Dog.Color to non-nullable JSON property 'color'.");
 
             writer.WriteString("className", dog.ClassName);
 

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Drawing.cs
@@ -241,10 +241,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Drawing drawing, JsonSerializerOptions jsonSerializerOptions)
         {
             if (drawing.MainShapeOption.IsSet && drawing.MainShape == null)
-                throw new ArgumentNullException(nameof(drawing.MainShape), "Property is required for class Drawing.");
+                throw new JsonException("Cannot write null property Drawing.MainShape to non-nullable JSON property 'mainShape'.");
 
             if (drawing.ShapesOption.IsSet && drawing.Shapes == null)
-                throw new ArgumentNullException(nameof(drawing.Shapes), "Property is required for class Drawing.");
+                throw new JsonException("Cannot write null property Drawing.Shapes to non-nullable JSON property 'shapes'.");
 
             if (drawing.MainShapeOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -342,6 +342,9 @@ namespace Org.OpenAPITools.Model
             if (enumArrays.ArrayEnumOption.IsSet && enumArrays.ArrayEnum == null)
                 throw new JsonException("Cannot write null property EnumArrays.ArrayEnum to non-nullable JSON property 'array_enum'.");
 
+            if (enumArrays.JustSymbolOption.IsSet && enumArrays.JustSymbol == null)
+                throw new JsonException("Cannot write null property EnumArrays.JustSymbol to non-nullable JSON property 'just_symbol'.");
+
             if (enumArrays.ArrayEnumOption.IsSet)
             {
                 writer.WritePropertyName("array_enum");

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -340,7 +340,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, EnumArrays enumArrays, JsonSerializerOptions jsonSerializerOptions)
         {
             if (enumArrays.ArrayEnumOption.IsSet && enumArrays.ArrayEnum == null)
-                throw new ArgumentNullException(nameof(enumArrays.ArrayEnum), "Property is required for class EnumArrays.");
+                throw new JsonException("Cannot write null property EnumArrays.ArrayEnum to non-nullable JSON property 'array_enum'.");
 
             if (enumArrays.ArrayEnumOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -878,6 +878,27 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, EnumTest enumTest, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (enumTest.EnumIntegerOption.IsSet && enumTest.EnumInteger == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumInteger to non-nullable JSON property 'enum_integer'.");
+
+            if (enumTest.EnumIntegerOnlyOption.IsSet && enumTest.EnumIntegerOnly == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumIntegerOnly to non-nullable JSON property 'enum_integer_only'.");
+
+            if (enumTest.EnumNumberOption.IsSet && enumTest.EnumNumber == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumNumber to non-nullable JSON property 'enum_number'.");
+
+            if (enumTest.EnumStringOption.IsSet && enumTest.EnumString == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumString to non-nullable JSON property 'enum_string'.");
+
+            if (enumTest.OuterEnumDefaultValueOption.IsSet && enumTest.OuterEnumDefaultValue == null)
+                throw new JsonException("Cannot write null property EnumTest.OuterEnumDefaultValue to non-nullable JSON property 'outerEnumDefaultValue'.");
+
+            if (enumTest.OuterEnumIntegerOption.IsSet && enumTest.OuterEnumInteger == null)
+                throw new JsonException("Cannot write null property EnumTest.OuterEnumInteger to non-nullable JSON property 'outerEnumInteger'.");
+
+            if (enumTest.OuterEnumIntegerDefaultValueOption.IsSet && enumTest.OuterEnumIntegerDefaultValue == null)
+                throw new JsonException("Cannot write null property EnumTest.OuterEnumIntegerDefaultValue to non-nullable JSON property 'outerEnumIntegerDefaultValue'.");
+
             var enumStringRequiredRawValue = EnumTest.EnumStringRequiredEnumToJsonValue(enumTest.EnumStringRequired);
             writer.WriteString("enum_string_required", enumStringRequiredRawValue);
             if (enumTest.EnumIntegerOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
@@ -192,12 +192,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, EquilateralTriangle equilateralTriangle, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (equilateralTriangle.ShapeType == null)
-                throw new ArgumentNullException(nameof(equilateralTriangle.ShapeType), "Property is required for class EquilateralTriangle.");
-
-            if (equilateralTriangle.TriangleType == null)
-                throw new ArgumentNullException(nameof(equilateralTriangle.TriangleType), "Property is required for class EquilateralTriangle.");
-
             writer.WriteString("shapeType", equilateralTriangle.ShapeType);
 
             writer.WriteString("triangleType", equilateralTriangle.TriangleType);

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/File.cs
@@ -179,7 +179,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, File file, JsonSerializerOptions jsonSerializerOptions)
         {
             if (file.SourceURIOption.IsSet && file.SourceURI == null)
-                throw new ArgumentNullException(nameof(file.SourceURI), "Property is required for class File.");
+                throw new JsonException("Cannot write null property File.SourceURI to non-nullable JSON property 'sourceURI'.");
 
             if (file.SourceURIOption.IsSet)
                 writer.WriteString("sourceURI", file.SourceURI);

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -201,10 +201,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, FileSchemaTestClass fileSchemaTestClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (fileSchemaTestClass.FileOption.IsSet && fileSchemaTestClass.File == null)
-                throw new ArgumentNullException(nameof(fileSchemaTestClass.File), "Property is required for class FileSchemaTestClass.");
+                throw new JsonException("Cannot write null property FileSchemaTestClass.File to non-nullable JSON property 'file'.");
 
             if (fileSchemaTestClass.FilesOption.IsSet && fileSchemaTestClass.Files == null)
-                throw new ArgumentNullException(nameof(fileSchemaTestClass.Files), "Property is required for class FileSchemaTestClass.");
+                throw new JsonException("Cannot write null property FileSchemaTestClass.Files to non-nullable JSON property 'files'.");
 
             if (fileSchemaTestClass.FileOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Foo.cs
@@ -178,7 +178,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Foo foo, JsonSerializerOptions jsonSerializerOptions)
         {
             if (foo.BarOption.IsSet && foo.Bar == null)
-                throw new ArgumentNullException(nameof(foo.Bar), "Property is required for class Foo.");
+                throw new JsonException("Cannot write null property Foo.Bar to non-nullable JSON property 'bar'.");
 
             if (foo.BarOption.IsSet)
                 writer.WriteString("bar", foo.Bar);

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -178,7 +178,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, FooGetDefaultResponse fooGetDefaultResponse, JsonSerializerOptions jsonSerializerOptions)
         {
             if (fooGetDefaultResponse.StringOption.IsSet && fooGetDefaultResponse.String == null)
-                throw new ArgumentNullException(nameof(fooGetDefaultResponse.String), "Property is required for class FooGetDefaultResponse.");
+                throw new JsonException("Cannot write null property FooGetDefaultResponse.String to non-nullable JSON property 'string'.");
 
             if (fooGetDefaultResponse.StringOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -957,11 +957,47 @@ namespace Org.OpenAPITools.Model
             if (formatTest.BinaryOption.IsSet && formatTest.Binary == null)
                 throw new JsonException("Cannot write null property FormatTest.Binary to non-nullable JSON property 'binary'.");
 
+            if (formatTest.DateTimeOption.IsSet && formatTest.DateTime == null)
+                throw new JsonException("Cannot write null property FormatTest.DateTime to non-nullable JSON property 'dateTime'.");
+
+            if (formatTest.DecimalOption.IsSet && formatTest.Decimal == null)
+                throw new JsonException("Cannot write null property FormatTest.Decimal to non-nullable JSON property 'decimal'.");
+
+            if (formatTest.DoubleOption.IsSet && formatTest.Double == null)
+                throw new JsonException("Cannot write null property FormatTest.Double to non-nullable JSON property 'double'.");
+
             if (formatTest.DuplicatePropertyName2Option.IsSet && formatTest.DuplicatePropertyName2 == null)
                 throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName2 to non-nullable JSON property 'duplicate_property_name'.");
 
             if (formatTest.DuplicatePropertyNameOption.IsSet && formatTest.DuplicatePropertyName == null)
                 throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName to non-nullable JSON property '@duplicate_property_name'.");
+
+            if (formatTest.FloatOption.IsSet && formatTest.Float == null)
+                throw new JsonException("Cannot write null property FormatTest.Float to non-nullable JSON property 'float'.");
+
+            if (formatTest.Int32Option.IsSet && formatTest.Int32 == null)
+                throw new JsonException("Cannot write null property FormatTest.Int32 to non-nullable JSON property 'int32'.");
+
+            if (formatTest.Int32RangeOption.IsSet && formatTest.Int32Range == null)
+                throw new JsonException("Cannot write null property FormatTest.Int32Range to non-nullable JSON property 'int32Range'.");
+
+            if (formatTest.Int64Option.IsSet && formatTest.Int64 == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64 to non-nullable JSON property 'int64'.");
+
+            if (formatTest.Int64NegativeOption.IsSet && formatTest.Int64Negative == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64Negative to non-nullable JSON property 'int64Negative'.");
+
+            if (formatTest.Int64NegativeExclusiveOption.IsSet && formatTest.Int64NegativeExclusive == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64NegativeExclusive to non-nullable JSON property 'int64NegativeExclusive'.");
+
+            if (formatTest.Int64PositiveOption.IsSet && formatTest.Int64Positive == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64Positive to non-nullable JSON property 'int64Positive'.");
+
+            if (formatTest.Int64PositiveExclusiveOption.IsSet && formatTest.Int64PositiveExclusive == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64PositiveExclusive to non-nullable JSON property 'int64PositiveExclusive'.");
+
+            if (formatTest.IntegerOption.IsSet && formatTest.Integer == null)
+                throw new JsonException("Cannot write null property FormatTest.Integer to non-nullable JSON property 'integer'.");
 
             if (formatTest.PatternWithBackslashOption.IsSet && formatTest.PatternWithBackslash == null)
                 throw new JsonException("Cannot write null property FormatTest.PatternWithBackslash to non-nullable JSON property 'pattern_with_backslash'.");
@@ -974,6 +1010,18 @@ namespace Org.OpenAPITools.Model
 
             if (formatTest.StringOption.IsSet && formatTest.String == null)
                 throw new JsonException("Cannot write null property FormatTest.String to non-nullable JSON property 'string'.");
+
+            if (formatTest.StringFormattedAsDecimalOption.IsSet && formatTest.StringFormattedAsDecimal == null)
+                throw new JsonException("Cannot write null property FormatTest.StringFormattedAsDecimal to non-nullable JSON property 'string_formatted_as_decimal'.");
+
+            if (formatTest.UnsignedIntegerOption.IsSet && formatTest.UnsignedInteger == null)
+                throw new JsonException("Cannot write null property FormatTest.UnsignedInteger to non-nullable JSON property 'unsigned_integer'.");
+
+            if (formatTest.UnsignedLongOption.IsSet && formatTest.UnsignedLong == null)
+                throw new JsonException("Cannot write null property FormatTest.UnsignedLong to non-nullable JSON property 'unsigned_long'.");
+
+            if (formatTest.UuidOption.IsSet && formatTest.Uuid == null)
+                throw new JsonException("Cannot write null property FormatTest.Uuid to non-nullable JSON property 'uuid'.");
 
             writer.WritePropertyName("byte");
             JsonSerializer.Serialize(writer, formatTest.Byte, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -954,32 +954,26 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, FormatTest formatTest, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (formatTest.Byte == null)
-                throw new ArgumentNullException(nameof(formatTest.Byte), "Property is required for class FormatTest.");
-
-            if (formatTest.Password == null)
-                throw new ArgumentNullException(nameof(formatTest.Password), "Property is required for class FormatTest.");
-
             if (formatTest.BinaryOption.IsSet && formatTest.Binary == null)
-                throw new ArgumentNullException(nameof(formatTest.Binary), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.Binary to non-nullable JSON property 'binary'.");
 
             if (formatTest.DuplicatePropertyName2Option.IsSet && formatTest.DuplicatePropertyName2 == null)
-                throw new ArgumentNullException(nameof(formatTest.DuplicatePropertyName2), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName2 to non-nullable JSON property 'duplicate_property_name'.");
 
             if (formatTest.DuplicatePropertyNameOption.IsSet && formatTest.DuplicatePropertyName == null)
-                throw new ArgumentNullException(nameof(formatTest.DuplicatePropertyName), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName to non-nullable JSON property '@duplicate_property_name'.");
 
             if (formatTest.PatternWithBackslashOption.IsSet && formatTest.PatternWithBackslash == null)
-                throw new ArgumentNullException(nameof(formatTest.PatternWithBackslash), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.PatternWithBackslash to non-nullable JSON property 'pattern_with_backslash'.");
 
             if (formatTest.PatternWithDigitsOption.IsSet && formatTest.PatternWithDigits == null)
-                throw new ArgumentNullException(nameof(formatTest.PatternWithDigits), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.PatternWithDigits to non-nullable JSON property 'pattern_with_digits'.");
 
             if (formatTest.PatternWithDigitsAndDelimiterOption.IsSet && formatTest.PatternWithDigitsAndDelimiter == null)
-                throw new ArgumentNullException(nameof(formatTest.PatternWithDigitsAndDelimiter), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.PatternWithDigitsAndDelimiter to non-nullable JSON property 'pattern_with_digits_and_delimiter'.");
 
             if (formatTest.StringOption.IsSet && formatTest.String == null)
-                throw new ArgumentNullException(nameof(formatTest.String), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.String to non-nullable JSON property 'string'.");
 
             writer.WritePropertyName("byte");
             JsonSerializer.Serialize(writer, formatTest.Byte, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Fruit.cs
@@ -222,7 +222,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Fruit fruit, JsonSerializerOptions jsonSerializerOptions)
         {
             if (fruit.ColorOption.IsSet && fruit.Color == null)
-                throw new ArgumentNullException(nameof(fruit.Color), "Property is required for class Fruit.");
+                throw new JsonException("Cannot write null property Fruit.Color to non-nullable JSON property 'color'.");
 
             if (fruit.ColorOption.IsSet)
                 writer.WriteString("color", fruit.Color);

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -239,7 +239,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, GmFruit gmFruit, JsonSerializerOptions jsonSerializerOptions)
         {
             if (gmFruit.ColorOption.IsSet && gmFruit.Color == null)
-                throw new ArgumentNullException(nameof(gmFruit.Color), "Property is required for class GmFruit.");
+                throw new JsonException("Cannot write null property GmFruit.Color to non-nullable JSON property 'color'.");
 
             if (gmFruit.ColorOption.IsSet)
                 writer.WriteString("color", gmFruit.Color);

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -242,10 +242,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, HasOnlyReadOnly hasOnlyReadOnly, JsonSerializerOptions jsonSerializerOptions)
         {
             if (hasOnlyReadOnly.BarOption.IsSet && hasOnlyReadOnly.Bar == null)
-                throw new ArgumentNullException(nameof(hasOnlyReadOnly.Bar), "Property is required for class HasOnlyReadOnly.");
+                throw new JsonException("Cannot write null property HasOnlyReadOnly.Bar to non-nullable JSON property 'bar'.");
 
             if (hasOnlyReadOnly.FooOption.IsSet && hasOnlyReadOnly.Foo == null)
-                throw new ArgumentNullException(nameof(hasOnlyReadOnly.Foo), "Property is required for class HasOnlyReadOnly.");
+                throw new JsonException("Cannot write null property HasOnlyReadOnly.Foo to non-nullable JSON property 'foo'.");
 
             if (hasOnlyReadOnly.BarOption.IsSet)
                 writer.WriteString("bar", hasOnlyReadOnly.Bar);

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
@@ -340,22 +340,22 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, InjectedVendorExtensionsTest injectedVendorExtensionsTest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessorOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor to non-nullable JSON property 'potentiallyOverriddenPropertyAccessor'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternalOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternal == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternal), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternal to non-nullable JSON property 'potentiallyOverriddenPropertyToInternal'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivateOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivate == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivate), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivate to non-nullable JSON property 'potentiallyOverriddenPropertyToPrivate'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublicOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublic == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublic), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublic to non-nullable JSON property 'potentiallyOverriddenPropertyToPublic'.");
 
             if (injectedVendorExtensionsTest.UnalteredPropertyOption.IsSet && injectedVendorExtensionsTest.UnalteredProperty == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.UnalteredProperty), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.UnalteredProperty to non-nullable JSON property 'unalteredProperty'.");
 
             if (injectedVendorExtensionsTest.UnalteredPropertyAccessorOption.IsSet && injectedVendorExtensionsTest.UnalteredPropertyAccessor == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.UnalteredPropertyAccessor), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.UnalteredPropertyAccessor to non-nullable JSON property 'unalteredPropertyAccessor'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessorOption.IsSet)
                 writer.WriteString("potentiallyOverriddenPropertyAccessor", injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor);

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
@@ -185,12 +185,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, IsoscelesTriangle isoscelesTriangle, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (isoscelesTriangle.ShapeType == null)
-                throw new ArgumentNullException(nameof(isoscelesTriangle.ShapeType), "Property is required for class IsoscelesTriangle.");
-
-            if (isoscelesTriangle.TriangleType == null)
-                throw new ArgumentNullException(nameof(isoscelesTriangle.TriangleType), "Property is required for class IsoscelesTriangle.");
-
             writer.WriteString("shapeType", isoscelesTriangle.ShapeType);
 
             writer.WriteString("triangleType", isoscelesTriangle.TriangleType);

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/List.cs
@@ -178,7 +178,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, List list, JsonSerializerOptions jsonSerializerOptions)
         {
             if (list.Var123ListOption.IsSet && list.Var123List == null)
-                throw new ArgumentNullException(nameof(list.Var123List), "Property is required for class List.");
+                throw new JsonException("Cannot write null property List.Var123List to non-nullable JSON property '123-list'.");
 
             if (list.Var123ListOption.IsSet)
                 writer.WriteString("123-list", list.Var123List);

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -201,10 +201,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, LiteralStringClass literalStringClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (literalStringClass.EscapedLiteralStringOption.IsSet && literalStringClass.EscapedLiteralString == null)
-                throw new ArgumentNullException(nameof(literalStringClass.EscapedLiteralString), "Property is required for class LiteralStringClass.");
+                throw new JsonException("Cannot write null property LiteralStringClass.EscapedLiteralString to non-nullable JSON property 'escapedLiteralString'.");
 
             if (literalStringClass.UnescapedLiteralStringOption.IsSet && literalStringClass.UnescapedLiteralString == null)
-                throw new ArgumentNullException(nameof(literalStringClass.UnescapedLiteralString), "Property is required for class LiteralStringClass.");
+                throw new JsonException("Cannot write null property LiteralStringClass.UnescapedLiteralString to non-nullable JSON property 'unescapedLiteralString'.");
 
             if (literalStringClass.EscapedLiteralStringOption.IsSet)
                 writer.WriteString("escapedLiteralString", literalStringClass.EscapedLiteralString);

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/MapTest.cs
@@ -313,16 +313,16 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MapTest mapTest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mapTest.DirectMapOption.IsSet && mapTest.DirectMap == null)
-                throw new ArgumentNullException(nameof(mapTest.DirectMap), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.DirectMap to non-nullable JSON property 'direct_map'.");
 
             if (mapTest.IndirectMapOption.IsSet && mapTest.IndirectMap == null)
-                throw new ArgumentNullException(nameof(mapTest.IndirectMap), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.IndirectMap to non-nullable JSON property 'indirect_map'.");
 
             if (mapTest.MapMapOfStringOption.IsSet && mapTest.MapMapOfString == null)
-                throw new ArgumentNullException(nameof(mapTest.MapMapOfString), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.MapMapOfString to non-nullable JSON property 'map_map_of_string'.");
 
             if (mapTest.MapOfEnumStringOption.IsSet && mapTest.MapOfEnumString == null)
-                throw new ArgumentNullException(nameof(mapTest.MapOfEnumString), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.MapOfEnumString to non-nullable JSON property 'map_of_enum_string'.");
 
             if (mapTest.DirectMapOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/MixedAnyOf.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/MixedAnyOf.cs
@@ -178,7 +178,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedAnyOf mixedAnyOf, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedAnyOf.ContentOption.IsSet && mixedAnyOf.Content == null)
-                throw new ArgumentNullException(nameof(mixedAnyOf.Content), "Property is required for class MixedAnyOf.");
+                throw new JsonException("Cannot write null property MixedAnyOf.Content to non-nullable JSON property 'content'.");
 
             if (mixedAnyOf.ContentOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/MixedOneOf.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/MixedOneOf.cs
@@ -178,7 +178,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedOneOf mixedOneOf, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedOneOf.ContentOption.IsSet && mixedOneOf.Content == null)
-                throw new ArgumentNullException(nameof(mixedOneOf.Content), "Property is required for class MixedOneOf.");
+                throw new JsonException("Cannot write null property MixedOneOf.Content to non-nullable JSON property 'content'.");
 
             if (mixedOneOf.ContentOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -258,8 +258,17 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, MixedPropertiesAndAdditionalPropertiesClass mixedPropertiesAndAdditionalPropertiesClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.DateTime == null)
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.DateTime to non-nullable JSON property 'dateTime'.");
+
             if (mixedPropertiesAndAdditionalPropertiesClass.MapOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.Map == null)
                 throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.Map to non-nullable JSON property 'map'.");
+
+            if (mixedPropertiesAndAdditionalPropertiesClass.UuidOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.Uuid == null)
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.Uuid to non-nullable JSON property 'uuid'.");
+
+            if (mixedPropertiesAndAdditionalPropertiesClass.UuidWithPatternOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.UuidWithPattern == null)
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.UuidWithPattern to non-nullable JSON property 'uuid_with_pattern'.");
 
             if (mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.IsSet)
                 writer.WriteString("dateTime", mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.Value!.Value.ToString(DateTimeFormat));

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -259,7 +259,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedPropertiesAndAdditionalPropertiesClass mixedPropertiesAndAdditionalPropertiesClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedPropertiesAndAdditionalPropertiesClass.MapOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.Map == null)
-                throw new ArgumentNullException(nameof(mixedPropertiesAndAdditionalPropertiesClass.Map), "Property is required for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.Map to non-nullable JSON property 'map'.");
 
             if (mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.IsSet)
                 writer.WriteString("dateTime", mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.Value!.Value.ToString(DateTimeFormat));

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/MixedSubId.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/MixedSubId.cs
@@ -178,7 +178,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedSubId mixedSubId, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedSubId.IdOption.IsSet && mixedSubId.Id == null)
-                throw new ArgumentNullException(nameof(mixedSubId.Id), "Property is required for class MixedSubId.");
+                throw new JsonException("Cannot write null property MixedSubId.Id to non-nullable JSON property 'id'.");
 
             if (mixedSubId.IdOption.IsSet)
                 writer.WriteString("id", mixedSubId.Id);

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -201,7 +201,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Model200Response model200Response, JsonSerializerOptions jsonSerializerOptions)
         {
             if (model200Response.ClassOption.IsSet && model200Response.Class == null)
-                throw new ArgumentNullException(nameof(model200Response.Class), "Property is required for class Model200Response.");
+                throw new JsonException("Cannot write null property Model200Response.Class to non-nullable JSON property 'class'.");
 
             if (model200Response.ClassOption.IsSet)
                 writer.WriteString("class", model200Response.Class);

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -203,6 +203,9 @@ namespace Org.OpenAPITools.Model
             if (model200Response.ClassOption.IsSet && model200Response.Class == null)
                 throw new JsonException("Cannot write null property Model200Response.Class to non-nullable JSON property 'class'.");
 
+            if (model200Response.NameOption.IsSet && model200Response.Name == null)
+                throw new JsonException("Cannot write null property Model200Response.Name to non-nullable JSON property 'name'.");
+
             if (model200Response.ClassOption.IsSet)
                 writer.WriteString("class", model200Response.Class);
 

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -178,7 +178,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ModelClient modelClient, JsonSerializerOptions jsonSerializerOptions)
         {
             if (modelClient.VarClientOption.IsSet && modelClient.VarClient == null)
-                throw new ArgumentNullException(nameof(modelClient.VarClient), "Property is required for class ModelClient.");
+                throw new JsonException("Cannot write null property ModelClient.VarClient to non-nullable JSON property 'client'.");
 
             if (modelClient.VarClientOption.IsSet)
                 writer.WriteString("client", modelClient.VarClient);

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Name.cs
@@ -284,7 +284,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Name name, JsonSerializerOptions jsonSerializerOptions)
         {
             if (name.PropertyOption.IsSet && name.Property == null)
-                throw new ArgumentNullException(nameof(name.Property), "Property is required for class Name.");
+                throw new JsonException("Cannot write null property Name.Property to non-nullable JSON property 'property'.");
 
             writer.WriteNumber("name", name.VarName);
 

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Name.cs
@@ -286,6 +286,12 @@ namespace Org.OpenAPITools.Model
             if (name.PropertyOption.IsSet && name.Property == null)
                 throw new JsonException("Cannot write null property Name.Property to non-nullable JSON property 'property'.");
 
+            if (name.SnakeCaseOption.IsSet && name.SnakeCase == null)
+                throw new JsonException("Cannot write null property Name.SnakeCase to non-nullable JSON property 'snake_case'.");
+
+            if (name.Var123NumberOption.IsSet && name.Var123Number == null)
+                throw new JsonException("Cannot write null property Name.Var123Number to non-nullable JSON property '123Number'.");
+
             writer.WriteNumber("name", name.VarName);
 
             if (name.PropertyOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
@@ -192,9 +192,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, NotificationtestGetElementsV1ResponseMPayload notificationtestGetElementsV1ResponseMPayload, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (notificationtestGetElementsV1ResponseMPayload.AObjVariableobject == null)
-                throw new ArgumentNullException(nameof(notificationtestGetElementsV1ResponseMPayload.AObjVariableobject), "Property is required for class NotificationtestGetElementsV1ResponseMPayload.");
-
             writer.WritePropertyName("a_objVariableobject");
             JsonSerializer.Serialize(writer, notificationtestGetElementsV1ResponseMPayload.AObjVariableobject, jsonSerializerOptions);
             writer.WriteNumber("pkiNotificationtestID", notificationtestGetElementsV1ResponseMPayload.PkiNotificationtestID);

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -411,10 +411,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, NullableClass nullableClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (nullableClass.ArrayItemsNullableOption.IsSet && nullableClass.ArrayItemsNullable == null)
-                throw new ArgumentNullException(nameof(nullableClass.ArrayItemsNullable), "Property is required for class NullableClass.");
+                throw new JsonException("Cannot write null property NullableClass.ArrayItemsNullable to non-nullable JSON property 'array_items_nullable'.");
 
             if (nullableClass.ObjectItemsNullableOption.IsSet && nullableClass.ObjectItemsNullable == null)
-                throw new ArgumentNullException(nameof(nullableClass.ObjectItemsNullable), "Property is required for class NullableClass.");
+                throw new JsonException("Cannot write null property NullableClass.ObjectItemsNullable to non-nullable JSON property 'object_items_nullable'.");
 
             if (nullableClass.ArrayAndItemsNullablePropOption.IsSet)
                 if (nullableClass.ArrayAndItemsNullablePropOption.Value != null)

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -177,6 +177,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, NumberOnly numberOnly, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (numberOnly.JustNumberOption.IsSet && numberOnly.JustNumber == null)
+                throw new JsonException("Cannot write null property NumberOnly.JustNumber to non-nullable JSON property 'JustNumber'.");
+
             if (numberOnly.JustNumberOption.IsSet)
                 writer.WriteNumber("JustNumber", numberOnly.JustNumberOption.Value!.Value);
         }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -250,13 +250,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ObjectWithDeprecatedFields objectWithDeprecatedFields, JsonSerializerOptions jsonSerializerOptions)
         {
             if (objectWithDeprecatedFields.BarsOption.IsSet && objectWithDeprecatedFields.Bars == null)
-                throw new ArgumentNullException(nameof(objectWithDeprecatedFields.Bars), "Property is required for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Bars to non-nullable JSON property 'bars'.");
 
             if (objectWithDeprecatedFields.DeprecatedRefOption.IsSet && objectWithDeprecatedFields.DeprecatedRef == null)
-                throw new ArgumentNullException(nameof(objectWithDeprecatedFields.DeprecatedRef), "Property is required for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.DeprecatedRef to non-nullable JSON property 'deprecatedRef'.");
 
             if (objectWithDeprecatedFields.UuidOption.IsSet && objectWithDeprecatedFields.Uuid == null)
-                throw new ArgumentNullException(nameof(objectWithDeprecatedFields.Uuid), "Property is required for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Uuid to non-nullable JSON property 'uuid'.");
 
             if (objectWithDeprecatedFields.BarsOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -255,6 +255,9 @@ namespace Org.OpenAPITools.Model
             if (objectWithDeprecatedFields.DeprecatedRefOption.IsSet && objectWithDeprecatedFields.DeprecatedRef == null)
                 throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.DeprecatedRef to non-nullable JSON property 'deprecatedRef'.");
 
+            if (objectWithDeprecatedFields.IdOption.IsSet && objectWithDeprecatedFields.Id == null)
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Id to non-nullable JSON property 'id'.");
+
             if (objectWithDeprecatedFields.UuidOption.IsSet && objectWithDeprecatedFields.Uuid == null)
                 throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Uuid to non-nullable JSON property 'uuid'.");
 

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Order.cs
@@ -387,6 +387,24 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Order order, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (order.CompleteOption.IsSet && order.Complete == null)
+                throw new JsonException("Cannot write null property Order.Complete to non-nullable JSON property 'complete'.");
+
+            if (order.IdOption.IsSet && order.Id == null)
+                throw new JsonException("Cannot write null property Order.Id to non-nullable JSON property 'id'.");
+
+            if (order.PetIdOption.IsSet && order.PetId == null)
+                throw new JsonException("Cannot write null property Order.PetId to non-nullable JSON property 'petId'.");
+
+            if (order.QuantityOption.IsSet && order.Quantity == null)
+                throw new JsonException("Cannot write null property Order.Quantity to non-nullable JSON property 'quantity'.");
+
+            if (order.ShipDateOption.IsSet && order.ShipDate == null)
+                throw new JsonException("Cannot write null property Order.ShipDate to non-nullable JSON property 'shipDate'.");
+
+            if (order.StatusOption.IsSet && order.Status == null)
+                throw new JsonException("Cannot write null property Order.Status to non-nullable JSON property 'status'.");
+
             if (order.CompleteOption.IsSet)
                 writer.WriteBoolean("complete", order.CompleteOption.Value!.Value);
 

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -224,7 +224,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, OuterComposite outerComposite, JsonSerializerOptions jsonSerializerOptions)
         {
             if (outerComposite.MyStringOption.IsSet && outerComposite.MyString == null)
-                throw new ArgumentNullException(nameof(outerComposite.MyString), "Property is required for class OuterComposite.");
+                throw new JsonException("Cannot write null property OuterComposite.MyString to non-nullable JSON property 'my_string'.");
 
             if (outerComposite.MyBooleanOption.IsSet)
                 writer.WriteBoolean("my_boolean", outerComposite.MyBooleanOption.Value!.Value);

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -223,6 +223,12 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, OuterComposite outerComposite, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (outerComposite.MyBooleanOption.IsSet && outerComposite.MyBoolean == null)
+                throw new JsonException("Cannot write null property OuterComposite.MyBoolean to non-nullable JSON property 'my_boolean'.");
+
+            if (outerComposite.MyNumberOption.IsSet && outerComposite.MyNumber == null)
+                throw new JsonException("Cannot write null property OuterComposite.MyNumber to non-nullable JSON property 'my_number'.");
+
             if (outerComposite.MyStringOption.IsSet && outerComposite.MyString == null)
                 throw new JsonException("Cannot write null property OuterComposite.MyString to non-nullable JSON property 'my_string'.");
 

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Pet.cs
@@ -374,17 +374,11 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Pet pet, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (pet.Name == null)
-                throw new ArgumentNullException(nameof(pet.Name), "Property is required for class Pet.");
-
-            if (pet.PhotoUrls == null)
-                throw new ArgumentNullException(nameof(pet.PhotoUrls), "Property is required for class Pet.");
-
             if (pet.CategoryOption.IsSet && pet.Category == null)
-                throw new ArgumentNullException(nameof(pet.Category), "Property is required for class Pet.");
+                throw new JsonException("Cannot write null property Pet.Category to non-nullable JSON property 'category'.");
 
             if (pet.TagsOption.IsSet && pet.Tags == null)
-                throw new ArgumentNullException(nameof(pet.Tags), "Property is required for class Pet.");
+                throw new JsonException("Cannot write null property Pet.Tags to non-nullable JSON property 'tags'.");
 
             writer.WriteString("name", pet.Name);
 

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Pet.cs
@@ -377,6 +377,12 @@ namespace Org.OpenAPITools.Model
             if (pet.CategoryOption.IsSet && pet.Category == null)
                 throw new JsonException("Cannot write null property Pet.Category to non-nullable JSON property 'category'.");
 
+            if (pet.IdOption.IsSet && pet.Id == null)
+                throw new JsonException("Cannot write null property Pet.Id to non-nullable JSON property 'id'.");
+
+            if (pet.StatusOption.IsSet && pet.Status == null)
+                throw new JsonException("Cannot write null property Pet.Status to non-nullable JSON property 'status'.");
+
             if (pet.TagsOption.IsSet && pet.Tags == null)
                 throw new JsonException("Cannot write null property Pet.Tags to non-nullable JSON property 'tags'.");
 

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
@@ -173,9 +173,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, QuadrilateralInterface quadrilateralInterface, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (quadrilateralInterface.QuadrilateralType == null)
-                throw new ArgumentNullException(nameof(quadrilateralInterface.QuadrilateralType), "Property is required for class QuadrilateralInterface.");
-
             writer.WriteString("quadrilateralType", quadrilateralInterface.QuadrilateralType);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -239,10 +239,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ReadOnlyFirst readOnlyFirst, JsonSerializerOptions jsonSerializerOptions)
         {
             if (readOnlyFirst.BarOption.IsSet && readOnlyFirst.Bar == null)
-                throw new ArgumentNullException(nameof(readOnlyFirst.Bar), "Property is required for class ReadOnlyFirst.");
+                throw new JsonException("Cannot write null property ReadOnlyFirst.Bar to non-nullable JSON property 'bar'.");
 
             if (readOnlyFirst.BazOption.IsSet && readOnlyFirst.Baz == null)
-                throw new ArgumentNullException(nameof(readOnlyFirst.Baz), "Property is required for class ReadOnlyFirst.");
+                throw new JsonException("Cannot write null property ReadOnlyFirst.Baz to non-nullable JSON property 'baz'.");
 
             if (readOnlyFirst.BarOption.IsSet)
                 writer.WriteString("bar", readOnlyFirst.Bar);

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -2238,11 +2238,38 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, RequiredClass requiredClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (requiredClass.NotRequiredNotnullableDatePropOption.IsSet && requiredClass.NotRequiredNotnullableDateProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotRequiredNotnullableDateProp to non-nullable JSON property 'not_required_notnullable_date_prop'.");
+
+            if (requiredClass.NotRequiredNotnullableintegerPropOption.IsSet && requiredClass.NotRequiredNotnullableintegerProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotRequiredNotnullableintegerProp to non-nullable JSON property 'not_required_notnullableinteger_prop'.");
+
             if (requiredClass.NotrequiredNotnullableArrayOfStringOption.IsSet && requiredClass.NotrequiredNotnullableArrayOfString == null)
                 throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableArrayOfString to non-nullable JSON property 'notrequired_notnullable_array_of_string'.");
 
+            if (requiredClass.NotrequiredNotnullableBooleanPropOption.IsSet && requiredClass.NotrequiredNotnullableBooleanProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableBooleanProp to non-nullable JSON property 'notrequired_notnullable_boolean_prop'.");
+
+            if (requiredClass.NotrequiredNotnullableDatetimePropOption.IsSet && requiredClass.NotrequiredNotnullableDatetimeProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableDatetimeProp to non-nullable JSON property 'notrequired_notnullable_datetime_prop'.");
+
+            if (requiredClass.NotrequiredNotnullableEnumIntegerOption.IsSet && requiredClass.NotrequiredNotnullableEnumInteger == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableEnumInteger to non-nullable JSON property 'notrequired_notnullable_enum_integer'.");
+
+            if (requiredClass.NotrequiredNotnullableEnumIntegerOnlyOption.IsSet && requiredClass.NotrequiredNotnullableEnumIntegerOnly == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableEnumIntegerOnly to non-nullable JSON property 'notrequired_notnullable_enum_integer_only'.");
+
+            if (requiredClass.NotrequiredNotnullableEnumStringOption.IsSet && requiredClass.NotrequiredNotnullableEnumString == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableEnumString to non-nullable JSON property 'notrequired_notnullable_enum_string'.");
+
+            if (requiredClass.NotrequiredNotnullableOuterEnumDefaultValueOption.IsSet && requiredClass.NotrequiredNotnullableOuterEnumDefaultValue == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableOuterEnumDefaultValue to non-nullable JSON property 'notrequired_notnullable_outerEnumDefaultValue'.");
+
             if (requiredClass.NotrequiredNotnullableStringPropOption.IsSet && requiredClass.NotrequiredNotnullableStringProp == null)
                 throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableStringProp to non-nullable JSON property 'notrequired_notnullable_string_prop'.");
+
+            if (requiredClass.NotrequiredNotnullableUuidOption.IsSet && requiredClass.NotrequiredNotnullableUuid == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableUuid to non-nullable JSON property 'notrequired_notnullable_uuid'.");
 
             writer.WriteString("required_not_nullable_date_prop", requiredClass.RequiredNotNullableDateProp.ToString(RequiredNotNullableDatePropFormat));
 

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -2238,17 +2238,11 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, RequiredClass requiredClass, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (requiredClass.RequiredNotnullableArrayOfString == null)
-                throw new ArgumentNullException(nameof(requiredClass.RequiredNotnullableArrayOfString), "Property is required for class RequiredClass.");
-
-            if (requiredClass.RequiredNotnullableStringProp == null)
-                throw new ArgumentNullException(nameof(requiredClass.RequiredNotnullableStringProp), "Property is required for class RequiredClass.");
-
             if (requiredClass.NotrequiredNotnullableArrayOfStringOption.IsSet && requiredClass.NotrequiredNotnullableArrayOfString == null)
-                throw new ArgumentNullException(nameof(requiredClass.NotrequiredNotnullableArrayOfString), "Property is required for class RequiredClass.");
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableArrayOfString to non-nullable JSON property 'notrequired_notnullable_array_of_string'.");
 
             if (requiredClass.NotrequiredNotnullableStringPropOption.IsSet && requiredClass.NotrequiredNotnullableStringProp == null)
-                throw new ArgumentNullException(nameof(requiredClass.NotrequiredNotnullableStringProp), "Property is required for class RequiredClass.");
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableStringProp to non-nullable JSON property 'notrequired_notnullable_string_prop'.");
 
             writer.WriteString("required_not_nullable_date_prop", requiredClass.RequiredNotNullableDateProp.ToString(RequiredNotNullableDatePropFormat));
 

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Result.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Result.cs
@@ -227,13 +227,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Result result, JsonSerializerOptions jsonSerializerOptions)
         {
             if (result.CodeOption.IsSet && result.Code == null)
-                throw new ArgumentNullException(nameof(result.Code), "Property is required for class Result.");
+                throw new JsonException("Cannot write null property Result.Code to non-nullable JSON property 'code'.");
 
             if (result.DataOption.IsSet && result.Data == null)
-                throw new ArgumentNullException(nameof(result.Data), "Property is required for class Result.");
+                throw new JsonException("Cannot write null property Result.Data to non-nullable JSON property 'data'.");
 
             if (result.UuidOption.IsSet && result.Uuid == null)
-                throw new ArgumentNullException(nameof(result.Uuid), "Property is required for class Result.");
+                throw new JsonException("Cannot write null property Result.Uuid to non-nullable JSON property 'uuid'.");
 
             if (result.CodeOption.IsSet)
                 writer.WriteString("code", result.Code);

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Return.cs
@@ -235,11 +235,8 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Return varReturn, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (varReturn.Lock == null)
-                throw new ArgumentNullException(nameof(varReturn.Lock), "Property is required for class Return.");
-
             if (varReturn.UnsafeOption.IsSet && varReturn.Unsafe == null)
-                throw new ArgumentNullException(nameof(varReturn.Unsafe), "Property is required for class Return.");
+                throw new JsonException("Cannot write null property Return.Unsafe to non-nullable JSON property 'unsafe'.");
 
             writer.WriteString("lock", varReturn.Lock);
 

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Return.cs
@@ -235,6 +235,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Return varReturn, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (varReturn.VarReturnOption.IsSet && varReturn.VarReturn == null)
+                throw new JsonException("Cannot write null property Return.VarReturn to non-nullable JSON property 'return'.");
+
             if (varReturn.UnsafeOption.IsSet && varReturn.Unsafe == null)
                 throw new JsonException("Cannot write null property Return.Unsafe to non-nullable JSON property 'unsafe'.");
 

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -203,6 +203,9 @@ namespace Org.OpenAPITools.Model
             if (rolesReportsHash.RoleOption.IsSet && rolesReportsHash.Role == null)
                 throw new JsonException("Cannot write null property RolesReportsHash.Role to non-nullable JSON property 'role'.");
 
+            if (rolesReportsHash.RoleUuidOption.IsSet && rolesReportsHash.RoleUuid == null)
+                throw new JsonException("Cannot write null property RolesReportsHash.RoleUuid to non-nullable JSON property 'role_uuid'.");
+
             if (rolesReportsHash.RoleOption.IsSet)
             {
                 writer.WritePropertyName("role");

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -201,7 +201,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, RolesReportsHash rolesReportsHash, JsonSerializerOptions jsonSerializerOptions)
         {
             if (rolesReportsHash.RoleOption.IsSet && rolesReportsHash.Role == null)
-                throw new ArgumentNullException(nameof(rolesReportsHash.Role), "Property is required for class RolesReportsHash.");
+                throw new JsonException("Cannot write null property RolesReportsHash.Role to non-nullable JSON property 'role'.");
 
             if (rolesReportsHash.RoleOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
@@ -178,7 +178,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, RolesReportsHashRole rolesReportsHashRole, JsonSerializerOptions jsonSerializerOptions)
         {
             if (rolesReportsHashRole.NameOption.IsSet && rolesReportsHashRole.Name == null)
-                throw new ArgumentNullException(nameof(rolesReportsHashRole.Name), "Property is required for class RolesReportsHashRole.");
+                throw new JsonException("Cannot write null property RolesReportsHashRole.Name to non-nullable JSON property 'name'.");
 
             if (rolesReportsHashRole.NameOption.IsSet)
                 writer.WriteString("name", rolesReportsHashRole.Name);

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
@@ -192,12 +192,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ScaleneTriangle scaleneTriangle, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (scaleneTriangle.ShapeType == null)
-                throw new ArgumentNullException(nameof(scaleneTriangle.ShapeType), "Property is required for class ScaleneTriangle.");
-
-            if (scaleneTriangle.TriangleType == null)
-                throw new ArgumentNullException(nameof(scaleneTriangle.TriangleType), "Property is required for class ScaleneTriangle.");
-
             writer.WriteString("shapeType", scaleneTriangle.ShapeType);
 
             writer.WriteString("triangleType", scaleneTriangle.TriangleType);

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ShapeInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ShapeInterface.cs
@@ -173,9 +173,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ShapeInterface shapeInterface, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (shapeInterface.ShapeType == null)
-                throw new ArgumentNullException(nameof(shapeInterface.ShapeType), "Property is required for class ShapeInterface.");
-
             writer.WriteString("shapeType", shapeInterface.ShapeType);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
@@ -192,12 +192,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, SimpleQuadrilateral simpleQuadrilateral, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (simpleQuadrilateral.QuadrilateralType == null)
-                throw new ArgumentNullException(nameof(simpleQuadrilateral.QuadrilateralType), "Property is required for class SimpleQuadrilateral.");
-
-            if (simpleQuadrilateral.ShapeType == null)
-                throw new ArgumentNullException(nameof(simpleQuadrilateral.ShapeType), "Property is required for class SimpleQuadrilateral.");
-
             writer.WriteString("quadrilateralType", simpleQuadrilateral.QuadrilateralType);
 
             writer.WriteString("shapeType", simpleQuadrilateral.ShapeType);

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -203,6 +203,9 @@ namespace Org.OpenAPITools.Model
             if (specialModelName.VarSpecialModelNameOption.IsSet && specialModelName.VarSpecialModelName == null)
                 throw new JsonException("Cannot write null property SpecialModelName.VarSpecialModelName to non-nullable JSON property '_special_model.name_'.");
 
+            if (specialModelName.SpecialPropertyNameOption.IsSet && specialModelName.SpecialPropertyName == null)
+                throw new JsonException("Cannot write null property SpecialModelName.SpecialPropertyName to non-nullable JSON property '$special[property.name]'.");
+
             if (specialModelName.VarSpecialModelNameOption.IsSet)
                 writer.WriteString("_special_model.name_", specialModelName.VarSpecialModelName);
 

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -201,7 +201,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, SpecialModelName specialModelName, JsonSerializerOptions jsonSerializerOptions)
         {
             if (specialModelName.VarSpecialModelNameOption.IsSet && specialModelName.VarSpecialModelName == null)
-                throw new ArgumentNullException(nameof(specialModelName.VarSpecialModelName), "Property is required for class SpecialModelName.");
+                throw new JsonException("Cannot write null property SpecialModelName.VarSpecialModelName to non-nullable JSON property '_special_model.name_'.");
 
             if (specialModelName.VarSpecialModelNameOption.IsSet)
                 writer.WriteString("_special_model.name_", specialModelName.VarSpecialModelName);

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Tag.cs
@@ -200,6 +200,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Tag tag, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (tag.IdOption.IsSet && tag.Id == null)
+                throw new JsonException("Cannot write null property Tag.Id to non-nullable JSON property 'id'.");
+
             if (tag.NameOption.IsSet && tag.Name == null)
                 throw new JsonException("Cannot write null property Tag.Name to non-nullable JSON property 'name'.");
 

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Tag.cs
@@ -201,7 +201,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Tag tag, JsonSerializerOptions jsonSerializerOptions)
         {
             if (tag.NameOption.IsSet && tag.Name == null)
-                throw new ArgumentNullException(nameof(tag.Name), "Property is required for class Tag.");
+                throw new JsonException("Cannot write null property Tag.Name to non-nullable JSON property 'name'.");
 
             if (tag.IdOption.IsSet)
                 writer.WriteNumber("id", tag.IdOption.Value!.Value);

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -178,7 +178,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestCollectionEndingWithWordList testCollectionEndingWithWordList, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testCollectionEndingWithWordList.ValueOption.IsSet && testCollectionEndingWithWordList.Value == null)
-                throw new ArgumentNullException(nameof(testCollectionEndingWithWordList.Value), "Property is required for class TestCollectionEndingWithWordList.");
+                throw new JsonException("Cannot write null property TestCollectionEndingWithWordList.Value to non-nullable JSON property 'value'.");
 
             if (testCollectionEndingWithWordList.ValueOption.IsSet)
                 writer.WriteString("value", testCollectionEndingWithWordList.Value);

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -178,7 +178,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestCollectionEndingWithWordListObject testCollectionEndingWithWordListObject, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testCollectionEndingWithWordListObject.TestCollectionEndingWithWordListOption.IsSet && testCollectionEndingWithWordListObject.TestCollectionEndingWithWordList == null)
-                throw new ArgumentNullException(nameof(testCollectionEndingWithWordListObject.TestCollectionEndingWithWordList), "Property is required for class TestCollectionEndingWithWordListObject.");
+                throw new JsonException("Cannot write null property TestCollectionEndingWithWordListObject.TestCollectionEndingWithWordList to non-nullable JSON property 'TestCollectionEndingWithWordList'.");
 
             if (testCollectionEndingWithWordListObject.TestCollectionEndingWithWordListOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/TestDescendants.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/TestDescendants.cs
@@ -292,9 +292,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, TestDescendants testDescendants, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (testDescendants.AlternativeName == null)
-                throw new ArgumentNullException(nameof(testDescendants.AlternativeName), "Property is required for class TestDescendants.");
-
             writer.WriteString("alternativeName", testDescendants.AlternativeName);
 
             writer.WriteString("objectType", TestDescendants.ObjectTypeEnumToJsonValue(testDescendants.ObjectType));

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
@@ -178,7 +178,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestInlineFreeformAdditionalPropertiesRequest testInlineFreeformAdditionalPropertiesRequest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testInlineFreeformAdditionalPropertiesRequest.SomePropertyOption.IsSet && testInlineFreeformAdditionalPropertiesRequest.SomeProperty == null)
-                throw new ArgumentNullException(nameof(testInlineFreeformAdditionalPropertiesRequest.SomeProperty), "Property is required for class TestInlineFreeformAdditionalPropertiesRequest.");
+                throw new JsonException("Cannot write null property TestInlineFreeformAdditionalPropertiesRequest.SomeProperty to non-nullable JSON property 'someProperty'.");
 
             if (testInlineFreeformAdditionalPropertiesRequest.SomePropertyOption.IsSet)
                 writer.WriteString("someProperty", testInlineFreeformAdditionalPropertiesRequest.SomeProperty);

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/TestResult.cs
@@ -225,6 +225,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, TestResult testResult, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (testResult.CodeOption.IsSet && testResult.Code == null)
+                throw new JsonException("Cannot write null property TestResult.Code to non-nullable JSON property 'code'.");
+
             if (testResult.DataOption.IsSet && testResult.Data == null)
                 throw new JsonException("Cannot write null property TestResult.Data to non-nullable JSON property 'data'.");
 

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/TestResult.cs
@@ -226,10 +226,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestResult testResult, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testResult.DataOption.IsSet && testResult.Data == null)
-                throw new ArgumentNullException(nameof(testResult.Data), "Property is required for class TestResult.");
+                throw new JsonException("Cannot write null property TestResult.Data to non-nullable JSON property 'data'.");
 
             if (testResult.UuidOption.IsSet && testResult.Uuid == null)
-                throw new ArgumentNullException(nameof(testResult.Uuid), "Property is required for class TestResult.");
+                throw new JsonException("Cannot write null property TestResult.Uuid to non-nullable JSON property 'uuid'.");
 
             if (testResult.CodeOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/TriangleInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/TriangleInterface.cs
@@ -173,9 +173,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, TriangleInterface triangleInterface, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (triangleInterface.TriangleType == null)
-                throw new ArgumentNullException(nameof(triangleInterface.TriangleType), "Property is required for class TriangleInterface.");
-
             writer.WriteString("triangleType", triangleInterface.TriangleType);
         }
     }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/User.cs
@@ -427,25 +427,25 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, User user, JsonSerializerOptions jsonSerializerOptions)
         {
             if (user.EmailOption.IsSet && user.Email == null)
-                throw new ArgumentNullException(nameof(user.Email), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Email to non-nullable JSON property 'email'.");
 
             if (user.FirstNameOption.IsSet && user.FirstName == null)
-                throw new ArgumentNullException(nameof(user.FirstName), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.FirstName to non-nullable JSON property 'firstName'.");
 
             if (user.LastNameOption.IsSet && user.LastName == null)
-                throw new ArgumentNullException(nameof(user.LastName), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.LastName to non-nullable JSON property 'lastName'.");
 
             if (user.ObjectWithNoDeclaredPropsOption.IsSet && user.ObjectWithNoDeclaredProps == null)
-                throw new ArgumentNullException(nameof(user.ObjectWithNoDeclaredProps), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.ObjectWithNoDeclaredProps to non-nullable JSON property 'objectWithNoDeclaredProps'.");
 
             if (user.PasswordOption.IsSet && user.Password == null)
-                throw new ArgumentNullException(nameof(user.Password), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Password to non-nullable JSON property 'password'.");
 
             if (user.PhoneOption.IsSet && user.Phone == null)
-                throw new ArgumentNullException(nameof(user.Phone), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Phone to non-nullable JSON property 'phone'.");
 
             if (user.UsernameOption.IsSet && user.Username == null)
-                throw new ArgumentNullException(nameof(user.Username), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Username to non-nullable JSON property 'username'.");
 
             if (user.AnyTypePropOption.IsSet)
                 if (user.AnyTypePropOption.Value != null)

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/User.cs
@@ -432,6 +432,9 @@ namespace Org.OpenAPITools.Model
             if (user.FirstNameOption.IsSet && user.FirstName == null)
                 throw new JsonException("Cannot write null property User.FirstName to non-nullable JSON property 'firstName'.");
 
+            if (user.IdOption.IsSet && user.Id == null)
+                throw new JsonException("Cannot write null property User.Id to non-nullable JSON property 'id'.");
+
             if (user.LastNameOption.IsSet && user.LastName == null)
                 throw new JsonException("Cannot write null property User.LastName to non-nullable JSON property 'lastName'.");
 
@@ -443,6 +446,9 @@ namespace Org.OpenAPITools.Model
 
             if (user.PhoneOption.IsSet && user.Phone == null)
                 throw new JsonException("Cannot write null property User.Phone to non-nullable JSON property 'phone'.");
+
+            if (user.UserStatusOption.IsSet && user.UserStatus == null)
+                throw new JsonException("Cannot write null property User.UserStatus to non-nullable JSON property 'userStatus'.");
 
             if (user.UsernameOption.IsSet && user.Username == null)
                 throw new JsonException("Cannot write null property User.Username to non-nullable JSON property 'username'.");

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Whale.cs
@@ -219,9 +219,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Whale whale, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (whale.ClassName == null)
-                throw new ArgumentNullException(nameof(whale.ClassName), "Property is required for class Whale.");
-
             writer.WriteString("className", whale.ClassName);
 
             if (whale.HasBaleenOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Whale.cs
@@ -219,6 +219,12 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Whale whale, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (whale.HasBaleenOption.IsSet && whale.HasBaleen == null)
+                throw new JsonException("Cannot write null property Whale.HasBaleen to non-nullable JSON property 'hasBaleen'.");
+
+            if (whale.HasTeethOption.IsSet && whale.HasTeeth == null)
+                throw new JsonException("Cannot write null property Whale.HasTeeth to non-nullable JSON property 'hasTeeth'.");
+
             writer.WriteString("className", whale.ClassName);
 
             if (whale.HasBaleenOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Zebra.cs
@@ -283,9 +283,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Zebra zebra, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (zebra.ClassName == null)
-                throw new ArgumentNullException(nameof(zebra.ClassName), "Property is required for class Zebra.");
-
             writer.WriteString("className", zebra.ClassName);
 
             var typeRawValue = Zebra.TypeEnumToJsonValue(zebra.TypeOption.Value!.Value);

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Zebra.cs
@@ -283,6 +283,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Zebra zebra, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (zebra.TypeOption.IsSet && zebra.Type == null)
+                throw new JsonException("Cannot write null property Zebra.Type to non-nullable JSON property 'type'.");
+
             writer.WriteString("className", zebra.ClassName);
 
             var typeRawValue = Zebra.TypeEnumToJsonValue(zebra.TypeOption.Value!.Value);

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
@@ -250,6 +250,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ZeroBasedEnumClass zeroBasedEnumClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (zeroBasedEnumClass.ZeroBasedEnumOption.IsSet && zeroBasedEnumClass.ZeroBasedEnum == null)
+                throw new JsonException("Cannot write null property ZeroBasedEnumClass.ZeroBasedEnum to non-nullable JSON property 'ZeroBasedEnum'.");
+
             var zeroBasedEnumRawValue = ZeroBasedEnumClass.ZeroBasedEnumEnumToJsonValue(zeroBasedEnumClass.ZeroBasedEnumOption.Value!.Value);
             writer.WriteString("ZeroBasedEnum", zeroBasedEnumRawValue);
         }

--- a/samples/client/petstore/csharp/generichost/net9/UseDateTimeForDate/src/Org.OpenAPITools/Model/NowGet200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net9/UseDateTimeForDate/src/Org.OpenAPITools/Model/NowGet200Response.cs
@@ -201,6 +201,12 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, NowGet200Response nowGet200Response, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (nowGet200Response.NowOption.IsSet && nowGet200Response.Now == null)
+                throw new JsonException("Cannot write null property NowGet200Response.Now to non-nullable JSON property 'now'.");
+
+            if (nowGet200Response.TodayOption.IsSet && nowGet200Response.Today == null)
+                throw new JsonException("Cannot write null property NowGet200Response.Today to non-nullable JSON property 'today'.");
+
             if (nowGet200Response.NowOption.IsSet)
                 writer.WriteString("now", nowGet200Response.NowOption.Value!.Value.ToString(NowFormat));
 

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Activity.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Activity activity, JsonSerializerOptions jsonSerializerOptions)
         {
             if (activity.ActivityOutputsOption.IsSet && activity.ActivityOutputs == null)
-                throw new ArgumentNullException(nameof(activity.ActivityOutputs), "Property is required for class Activity.");
+                throw new JsonException("Cannot write null property Activity.ActivityOutputs to non-nullable JSON property 'activity_outputs'.");
 
             if (activity.ActivityOutputsOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -198,10 +198,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ActivityOutputElementRepresentation activityOutputElementRepresentation, JsonSerializerOptions jsonSerializerOptions)
         {
             if (activityOutputElementRepresentation.Prop1Option.IsSet && activityOutputElementRepresentation.Prop1 == null)
-                throw new ArgumentNullException(nameof(activityOutputElementRepresentation.Prop1), "Property is required for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Cannot write null property ActivityOutputElementRepresentation.Prop1 to non-nullable JSON property 'prop1'.");
 
             if (activityOutputElementRepresentation.Prop2Option.IsSet && activityOutputElementRepresentation.Prop2 == null)
-                throw new ArgumentNullException(nameof(activityOutputElementRepresentation.Prop2), "Property is required for class ActivityOutputElementRepresentation.");
+                throw new JsonException("Cannot write null property ActivityOutputElementRepresentation.Prop2 to non-nullable JSON property 'prop2'.");
 
             if (activityOutputElementRepresentation.Prop1Option.IsSet)
                 writer.WriteString("prop1", activityOutputElementRepresentation.Prop1);

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -334,25 +334,25 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, AdditionalPropertiesClass additionalPropertiesClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (additionalPropertiesClass.EmptyMapOption.IsSet && additionalPropertiesClass.EmptyMap == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.EmptyMap), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.EmptyMap to non-nullable JSON property 'empty_map'.");
 
             if (additionalPropertiesClass.MapOfMapPropertyOption.IsSet && additionalPropertiesClass.MapOfMapProperty == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapOfMapProperty), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapOfMapProperty to non-nullable JSON property 'map_of_map_property'.");
 
             if (additionalPropertiesClass.MapPropertyOption.IsSet && additionalPropertiesClass.MapProperty == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapProperty), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapProperty to non-nullable JSON property 'map_property'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1Option.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1 == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesAnytype1 to non-nullable JSON property 'map_with_undeclared_properties_anytype_1'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2Option.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2 == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesAnytype2 to non-nullable JSON property 'map_with_undeclared_properties_anytype_2'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3Option.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3 == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesAnytype3 to non-nullable JSON property 'map_with_undeclared_properties_anytype_3'.");
 
             if (additionalPropertiesClass.MapWithUndeclaredPropertiesStringOption.IsSet && additionalPropertiesClass.MapWithUndeclaredPropertiesString == null)
-                throw new ArgumentNullException(nameof(additionalPropertiesClass.MapWithUndeclaredPropertiesString), "Property is required for class AdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property AdditionalPropertiesClass.MapWithUndeclaredPropertiesString to non-nullable JSON property 'map_with_undeclared_properties_string'.");
 
             if (additionalPropertiesClass.Anytype1Option.IsSet)
                 if (additionalPropertiesClass.Anytype1Option.Value != null)

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Animal.cs
@@ -221,7 +221,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Animal animal, JsonSerializerOptions jsonSerializerOptions)
         {
             if (animal.ColorOption.IsSet && animal.Color == null)
-                throw new ArgumentNullException(nameof(animal.Color), "Property is required for class Animal.");
+                throw new JsonException("Cannot write null property Animal.Color to non-nullable JSON property 'color'.");
 
             writer.WriteString("className", animal.ClassName);
 

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -221,10 +221,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ApiResponse apiResponse, JsonSerializerOptions jsonSerializerOptions)
         {
             if (apiResponse.MessageOption.IsSet && apiResponse.Message == null)
-                throw new ArgumentNullException(nameof(apiResponse.Message), "Property is required for class ApiResponse.");
+                throw new JsonException("Cannot write null property ApiResponse.Message to non-nullable JSON property 'message'.");
 
             if (apiResponse.TypeOption.IsSet && apiResponse.Type == null)
-                throw new ArgumentNullException(nameof(apiResponse.Type), "Property is required for class ApiResponse.");
+                throw new JsonException("Cannot write null property ApiResponse.Type to non-nullable JSON property 'type'.");
 
             if (apiResponse.CodeOption.IsSet)
                 writer.WriteNumber("code", apiResponse.CodeOption.Value.Value);

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -220,6 +220,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ApiResponse apiResponse, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (apiResponse.CodeOption.IsSet && apiResponse.Code == null)
+                throw new JsonException("Cannot write null property ApiResponse.Code to non-nullable JSON property 'code'.");
+
             if (apiResponse.MessageOption.IsSet && apiResponse.Message == null)
                 throw new JsonException("Cannot write null property ApiResponse.Message to non-nullable JSON property 'message'.");
 

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Apple.cs
@@ -251,13 +251,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Apple apple, JsonSerializerOptions jsonSerializerOptions)
         {
             if (apple.ColorCodeOption.IsSet && apple.ColorCode == null)
-                throw new ArgumentNullException(nameof(apple.ColorCode), "Property is required for class Apple.");
+                throw new JsonException("Cannot write null property Apple.ColorCode to non-nullable JSON property 'color_code'.");
 
             if (apple.CultivarOption.IsSet && apple.Cultivar == null)
-                throw new ArgumentNullException(nameof(apple.Cultivar), "Property is required for class Apple.");
+                throw new JsonException("Cannot write null property Apple.Cultivar to non-nullable JSON property 'cultivar'.");
 
             if (apple.OriginOption.IsSet && apple.Origin == null)
-                throw new ArgumentNullException(nameof(apple.Origin), "Property is required for class Apple.");
+                throw new JsonException("Cannot write null property Apple.Origin to non-nullable JSON property 'origin'.");
 
             if (apple.ColorCodeOption.IsSet)
                 writer.WriteString("color_code", apple.ColorCode);

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -186,9 +186,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, AppleReq appleReq, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (appleReq.Cultivar == null)
-                throw new ArgumentNullException(nameof(appleReq.Cultivar), "Property is required for class AppleReq.");
-
             writer.WriteString("cultivar", appleReq.Cultivar);
 
             if (appleReq.MealyOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -186,6 +186,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, AppleReq appleReq, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (appleReq.MealyOption.IsSet && appleReq.Mealy == null)
+                throw new JsonException("Cannot write null property AppleReq.Mealy to non-nullable JSON property 'mealy'.");
+
             writer.WriteString("cultivar", appleReq.Cultivar);
 
             if (appleReq.MealyOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ArrayOfArrayOfNumberOnly arrayOfArrayOfNumberOnly, JsonSerializerOptions jsonSerializerOptions)
         {
             if (arrayOfArrayOfNumberOnly.ArrayArrayNumberOption.IsSet && arrayOfArrayOfNumberOnly.ArrayArrayNumber == null)
-                throw new ArgumentNullException(nameof(arrayOfArrayOfNumberOnly.ArrayArrayNumber), "Property is required for class ArrayOfArrayOfNumberOnly.");
+                throw new JsonException("Cannot write null property ArrayOfArrayOfNumberOnly.ArrayArrayNumber to non-nullable JSON property 'ArrayArrayNumber'.");
 
             if (arrayOfArrayOfNumberOnly.ArrayArrayNumberOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ArrayOfNumberOnly arrayOfNumberOnly, JsonSerializerOptions jsonSerializerOptions)
         {
             if (arrayOfNumberOnly.ArrayNumberOption.IsSet && arrayOfNumberOnly.ArrayNumber == null)
-                throw new ArgumentNullException(nameof(arrayOfNumberOnly.ArrayNumber), "Property is required for class ArrayOfNumberOnly.");
+                throw new JsonException("Cannot write null property ArrayOfNumberOnly.ArrayNumber to non-nullable JSON property 'ArrayNumber'.");
 
             if (arrayOfNumberOnly.ArrayNumberOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -221,13 +221,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ArrayTest arrayTest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (arrayTest.ArrayArrayOfIntegerOption.IsSet && arrayTest.ArrayArrayOfInteger == null)
-                throw new ArgumentNullException(nameof(arrayTest.ArrayArrayOfInteger), "Property is required for class ArrayTest.");
+                throw new JsonException("Cannot write null property ArrayTest.ArrayArrayOfInteger to non-nullable JSON property 'array_array_of_integer'.");
 
             if (arrayTest.ArrayArrayOfModelOption.IsSet && arrayTest.ArrayArrayOfModel == null)
-                throw new ArgumentNullException(nameof(arrayTest.ArrayArrayOfModel), "Property is required for class ArrayTest.");
+                throw new JsonException("Cannot write null property ArrayTest.ArrayArrayOfModel to non-nullable JSON property 'array_array_of_model'.");
 
             if (arrayTest.ArrayOfStringOption.IsSet && arrayTest.ArrayOfString == null)
-                throw new ArgumentNullException(nameof(arrayTest.ArrayOfString), "Property is required for class ArrayTest.");
+                throw new JsonException("Cannot write null property ArrayTest.ArrayOfString to non-nullable JSON property 'array_of_string'.");
 
             if (arrayTest.ArrayArrayOfIntegerOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Banana.cs
@@ -174,6 +174,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Banana banana, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (banana.LengthCmOption.IsSet && banana.LengthCm == null)
+                throw new JsonException("Cannot write null property Banana.LengthCm to non-nullable JSON property 'lengthCm'.");
+
             if (banana.LengthCmOption.IsSet)
                 writer.WriteNumber("lengthCm", banana.LengthCmOption.Value.Value);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -186,6 +186,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, BananaReq bananaReq, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (bananaReq.SweetOption.IsSet && bananaReq.Sweet == null)
+                throw new JsonException("Cannot write null property BananaReq.Sweet to non-nullable JSON property 'sweet'.");
+
             writer.WriteNumber("lengthCm", bananaReq.LengthCm);
 
             if (bananaReq.SweetOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/BasquePig.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/BasquePig.cs
@@ -170,9 +170,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, BasquePig basquePig, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (basquePig.ClassName == null)
-                throw new ArgumentNullException(nameof(basquePig.ClassName), "Property is required for class BasquePig.");
-
             writer.WriteString("className", basquePig.ClassName);
         }
     }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -291,22 +291,22 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Capitalization capitalization, JsonSerializerOptions jsonSerializerOptions)
         {
             if (capitalization.ATT_NAMEOption.IsSet && capitalization.ATT_NAME == null)
-                throw new ArgumentNullException(nameof(capitalization.ATT_NAME), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.ATT_NAME to non-nullable JSON property 'ATT_NAME'.");
 
             if (capitalization.CapitalCamelOption.IsSet && capitalization.CapitalCamel == null)
-                throw new ArgumentNullException(nameof(capitalization.CapitalCamel), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.CapitalCamel to non-nullable JSON property 'CapitalCamel'.");
 
             if (capitalization.CapitalSnakeOption.IsSet && capitalization.CapitalSnake == null)
-                throw new ArgumentNullException(nameof(capitalization.CapitalSnake), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.CapitalSnake to non-nullable JSON property 'Capital_Snake'.");
 
             if (capitalization.SCAETHFlowPointsOption.IsSet && capitalization.SCAETHFlowPoints == null)
-                throw new ArgumentNullException(nameof(capitalization.SCAETHFlowPoints), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.SCAETHFlowPoints to non-nullable JSON property 'SCA_ETH_Flow_Points'.");
 
             if (capitalization.SmallCamelOption.IsSet && capitalization.SmallCamel == null)
-                throw new ArgumentNullException(nameof(capitalization.SmallCamel), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.SmallCamel to non-nullable JSON property 'smallCamel'.");
 
             if (capitalization.SmallSnakeOption.IsSet && capitalization.SmallSnake == null)
-                throw new ArgumentNullException(nameof(capitalization.SmallSnake), "Property is required for class Capitalization.");
+                throw new JsonException("Cannot write null property Capitalization.SmallSnake to non-nullable JSON property 'small_Snake'.");
 
             if (capitalization.ATT_NAMEOption.IsSet)
                 writer.WriteString("ATT_NAME", capitalization.ATT_NAME);

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Cat.cs
@@ -179,6 +179,9 @@ namespace Org.OpenAPITools.Model
             if (cat.ColorOption.IsSet && cat.Color == null)
                 throw new JsonException("Cannot write null property Cat.Color to non-nullable JSON property 'color'.");
 
+            if (cat.DeclawedOption.IsSet && cat.Declawed == null)
+                throw new JsonException("Cannot write null property Cat.Declawed to non-nullable JSON property 'declawed'.");
+
             writer.WriteString("className", cat.ClassName);
 
             if (cat.ColorOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Cat.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Cat cat, JsonSerializerOptions jsonSerializerOptions)
         {
             if (cat.ColorOption.IsSet && cat.Color == null)
-                throw new ArgumentNullException(nameof(cat.Color), "Property is required for class Cat.");
+                throw new JsonException("Cannot write null property Cat.Color to non-nullable JSON property 'color'.");
 
             writer.WriteString("className", cat.ClassName);
 

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Category.cs
@@ -193,9 +193,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Category category, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (category.Name == null)
-                throw new ArgumentNullException(nameof(category.Name), "Property is required for class Category.");
-
             if (category.IdOption.IsSet)
                 writer.WriteNumber("id", category.IdOption.Value.Value);
 

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Category.cs
@@ -193,6 +193,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Category category, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (category.IdOption.IsSet && category.Id == null)
+                throw new JsonException("Cannot write null property Category.Id to non-nullable JSON property 'id'.");
+
             if (category.IdOption.IsSet)
                 writer.WriteNumber("id", category.IdOption.Value.Value);
 

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -236,7 +236,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ChildCat childCat, JsonSerializerOptions jsonSerializerOptions)
         {
             if (childCat.NameOption.IsSet && childCat.Name == null)
-                throw new ArgumentNullException(nameof(childCat.Name), "Property is required for class ChildCat.");
+                throw new JsonException("Cannot write null property ChildCat.Name to non-nullable JSON property 'name'.");
 
             if (childCat.NameOption.IsSet)
                 writer.WriteString("name", childCat.Name);

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ClassModel classModel, JsonSerializerOptions jsonSerializerOptions)
         {
             if (classModel.ClassOption.IsSet && classModel.Class == null)
-                throw new ArgumentNullException(nameof(classModel.Class), "Property is required for class ClassModel.");
+                throw new JsonException("Cannot write null property ClassModel.Class to non-nullable JSON property '_class'.");
 
             if (classModel.ClassOption.IsSet)
                 writer.WriteString("_class", classModel.Class);

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
@@ -189,12 +189,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ComplexQuadrilateral complexQuadrilateral, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (complexQuadrilateral.QuadrilateralType == null)
-                throw new ArgumentNullException(nameof(complexQuadrilateral.QuadrilateralType), "Property is required for class ComplexQuadrilateral.");
-
-            if (complexQuadrilateral.ShapeType == null)
-                throw new ArgumentNullException(nameof(complexQuadrilateral.ShapeType), "Property is required for class ComplexQuadrilateral.");
-
             writer.WriteString("quadrilateralType", complexQuadrilateral.QuadrilateralType);
 
             writer.WriteString("shapeType", complexQuadrilateral.ShapeType);

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/CopyActivity.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/CopyActivity.cs
@@ -231,9 +231,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, CopyActivity copyActivity, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (copyActivity.CopyActivitytt == null)
-                throw new ArgumentNullException(nameof(copyActivity.CopyActivitytt), "Property is required for class CopyActivity.");
-
             writer.WriteString("copyActivitytt", copyActivity.CopyActivitytt);
 
             writer.WriteString("$schema", CopyActivity.SchemaEnumToJsonValue(copyActivity.Schema));

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/DanishPig.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/DanishPig.cs
@@ -170,9 +170,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, DanishPig danishPig, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (danishPig.ClassName == null)
-                throw new ArgumentNullException(nameof(danishPig.ClassName), "Property is required for class DanishPig.");
-
             writer.WriteString("className", danishPig.ClassName);
         }
     }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -180,6 +180,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, DateOnlyClass dateOnlyClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (dateOnlyClass.DateOnlyPropertyOption.IsSet && dateOnlyClass.DateOnlyProperty == null)
+                throw new JsonException("Cannot write null property DateOnlyClass.DateOnlyProperty to non-nullable JSON property 'dateOnlyProperty'.");
+
             if (dateOnlyClass.DateOnlyPropertyOption.IsSet)
                 writer.WriteString("dateOnlyProperty", dateOnlyClass.DateOnlyPropertyOption.Value.Value.ToString(DateOnlyPropertyFormat));
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, DeprecatedObject deprecatedObject, JsonSerializerOptions jsonSerializerOptions)
         {
             if (deprecatedObject.NameOption.IsSet && deprecatedObject.Name == null)
-                throw new ArgumentNullException(nameof(deprecatedObject.Name), "Property is required for class DeprecatedObject.");
+                throw new JsonException("Cannot write null property DeprecatedObject.Name to non-nullable JSON property 'name'.");
 
             if (deprecatedObject.NameOption.IsSet)
                 writer.WriteString("name", deprecatedObject.Name);

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Descendant1.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Descendant1.cs
@@ -182,12 +182,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Descendant1 descendant1, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (descendant1.AlternativeName == null)
-                throw new ArgumentNullException(nameof(descendant1.AlternativeName), "Property is required for class Descendant1.");
-
-            if (descendant1.DescendantName == null)
-                throw new ArgumentNullException(nameof(descendant1.DescendantName), "Property is required for class Descendant1.");
-
             writer.WriteString("alternativeName", descendant1.AlternativeName);
 
             writer.WriteString("descendantName", descendant1.DescendantName);

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Descendant2.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Descendant2.cs
@@ -182,12 +182,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Descendant2 descendant2, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (descendant2.AlternativeName == null)
-                throw new ArgumentNullException(nameof(descendant2.AlternativeName), "Property is required for class Descendant2.");
-
-            if (descendant2.Confidentiality == null)
-                throw new ArgumentNullException(nameof(descendant2.Confidentiality), "Property is required for class Descendant2.");
-
             writer.WriteString("alternativeName", descendant2.AlternativeName);
 
             writer.WriteString("confidentiality", descendant2.Confidentiality);

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Dog.cs
@@ -177,10 +177,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Dog dog, JsonSerializerOptions jsonSerializerOptions)
         {
             if (dog.BreedOption.IsSet && dog.Breed == null)
-                throw new ArgumentNullException(nameof(dog.Breed), "Property is required for class Dog.");
+                throw new JsonException("Cannot write null property Dog.Breed to non-nullable JSON property 'breed'.");
 
             if (dog.ColorOption.IsSet && dog.Color == null)
-                throw new ArgumentNullException(nameof(dog.Color), "Property is required for class Dog.");
+                throw new JsonException("Cannot write null property Dog.Color to non-nullable JSON property 'color'.");
 
             writer.WriteString("className", dog.ClassName);
 

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Drawing.cs
@@ -238,10 +238,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Drawing drawing, JsonSerializerOptions jsonSerializerOptions)
         {
             if (drawing.MainShapeOption.IsSet && drawing.MainShape == null)
-                throw new ArgumentNullException(nameof(drawing.MainShape), "Property is required for class Drawing.");
+                throw new JsonException("Cannot write null property Drawing.MainShape to non-nullable JSON property 'mainShape'.");
 
             if (drawing.ShapesOption.IsSet && drawing.Shapes == null)
-                throw new ArgumentNullException(nameof(drawing.Shapes), "Property is required for class Drawing.");
+                throw new JsonException("Cannot write null property Drawing.Shapes to non-nullable JSON property 'shapes'.");
 
             if (drawing.MainShapeOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -337,7 +337,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, EnumArrays enumArrays, JsonSerializerOptions jsonSerializerOptions)
         {
             if (enumArrays.ArrayEnumOption.IsSet && enumArrays.ArrayEnum == null)
-                throw new ArgumentNullException(nameof(enumArrays.ArrayEnum), "Property is required for class EnumArrays.");
+                throw new JsonException("Cannot write null property EnumArrays.ArrayEnum to non-nullable JSON property 'array_enum'.");
 
             if (enumArrays.ArrayEnumOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -339,6 +339,9 @@ namespace Org.OpenAPITools.Model
             if (enumArrays.ArrayEnumOption.IsSet && enumArrays.ArrayEnum == null)
                 throw new JsonException("Cannot write null property EnumArrays.ArrayEnum to non-nullable JSON property 'array_enum'.");
 
+            if (enumArrays.JustSymbolOption.IsSet && enumArrays.JustSymbol == null)
+                throw new JsonException("Cannot write null property EnumArrays.JustSymbol to non-nullable JSON property 'just_symbol'.");
+
             if (enumArrays.ArrayEnumOption.IsSet)
             {
                 writer.WritePropertyName("array_enum");

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -875,6 +875,27 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, EnumTest enumTest, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (enumTest.EnumIntegerOption.IsSet && enumTest.EnumInteger == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumInteger to non-nullable JSON property 'enum_integer'.");
+
+            if (enumTest.EnumIntegerOnlyOption.IsSet && enumTest.EnumIntegerOnly == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumIntegerOnly to non-nullable JSON property 'enum_integer_only'.");
+
+            if (enumTest.EnumNumberOption.IsSet && enumTest.EnumNumber == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumNumber to non-nullable JSON property 'enum_number'.");
+
+            if (enumTest.EnumStringOption.IsSet && enumTest.EnumString == null)
+                throw new JsonException("Cannot write null property EnumTest.EnumString to non-nullable JSON property 'enum_string'.");
+
+            if (enumTest.OuterEnumDefaultValueOption.IsSet && enumTest.OuterEnumDefaultValue == null)
+                throw new JsonException("Cannot write null property EnumTest.OuterEnumDefaultValue to non-nullable JSON property 'outerEnumDefaultValue'.");
+
+            if (enumTest.OuterEnumIntegerOption.IsSet && enumTest.OuterEnumInteger == null)
+                throw new JsonException("Cannot write null property EnumTest.OuterEnumInteger to non-nullable JSON property 'outerEnumInteger'.");
+
+            if (enumTest.OuterEnumIntegerDefaultValueOption.IsSet && enumTest.OuterEnumIntegerDefaultValue == null)
+                throw new JsonException("Cannot write null property EnumTest.OuterEnumIntegerDefaultValue to non-nullable JSON property 'outerEnumIntegerDefaultValue'.");
+
             var enumStringRequiredRawValue = EnumTest.EnumStringRequiredEnumToJsonValue(enumTest.EnumStringRequired);
             writer.WriteString("enum_string_required", enumStringRequiredRawValue);
             if (enumTest.EnumIntegerOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
@@ -189,12 +189,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, EquilateralTriangle equilateralTriangle, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (equilateralTriangle.ShapeType == null)
-                throw new ArgumentNullException(nameof(equilateralTriangle.ShapeType), "Property is required for class EquilateralTriangle.");
-
-            if (equilateralTriangle.TriangleType == null)
-                throw new ArgumentNullException(nameof(equilateralTriangle.TriangleType), "Property is required for class EquilateralTriangle.");
-
             writer.WriteString("shapeType", equilateralTriangle.ShapeType);
 
             writer.WriteString("triangleType", equilateralTriangle.TriangleType);

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/File.cs
@@ -176,7 +176,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, File file, JsonSerializerOptions jsonSerializerOptions)
         {
             if (file.SourceURIOption.IsSet && file.SourceURI == null)
-                throw new ArgumentNullException(nameof(file.SourceURI), "Property is required for class File.");
+                throw new JsonException("Cannot write null property File.SourceURI to non-nullable JSON property 'sourceURI'.");
 
             if (file.SourceURIOption.IsSet)
                 writer.WriteString("sourceURI", file.SourceURI);

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -198,10 +198,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, FileSchemaTestClass fileSchemaTestClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (fileSchemaTestClass.FileOption.IsSet && fileSchemaTestClass.File == null)
-                throw new ArgumentNullException(nameof(fileSchemaTestClass.File), "Property is required for class FileSchemaTestClass.");
+                throw new JsonException("Cannot write null property FileSchemaTestClass.File to non-nullable JSON property 'file'.");
 
             if (fileSchemaTestClass.FilesOption.IsSet && fileSchemaTestClass.Files == null)
-                throw new ArgumentNullException(nameof(fileSchemaTestClass.Files), "Property is required for class FileSchemaTestClass.");
+                throw new JsonException("Cannot write null property FileSchemaTestClass.Files to non-nullable JSON property 'files'.");
 
             if (fileSchemaTestClass.FileOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Foo.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Foo foo, JsonSerializerOptions jsonSerializerOptions)
         {
             if (foo.BarOption.IsSet && foo.Bar == null)
-                throw new ArgumentNullException(nameof(foo.Bar), "Property is required for class Foo.");
+                throw new JsonException("Cannot write null property Foo.Bar to non-nullable JSON property 'bar'.");
 
             if (foo.BarOption.IsSet)
                 writer.WriteString("bar", foo.Bar);

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, FooGetDefaultResponse fooGetDefaultResponse, JsonSerializerOptions jsonSerializerOptions)
         {
             if (fooGetDefaultResponse.StringOption.IsSet && fooGetDefaultResponse.String == null)
-                throw new ArgumentNullException(nameof(fooGetDefaultResponse.String), "Property is required for class FooGetDefaultResponse.");
+                throw new JsonException("Cannot write null property FooGetDefaultResponse.String to non-nullable JSON property 'string'.");
 
             if (fooGetDefaultResponse.StringOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -954,11 +954,47 @@ namespace Org.OpenAPITools.Model
             if (formatTest.BinaryOption.IsSet && formatTest.Binary == null)
                 throw new JsonException("Cannot write null property FormatTest.Binary to non-nullable JSON property 'binary'.");
 
+            if (formatTest.DateTimeOption.IsSet && formatTest.DateTime == null)
+                throw new JsonException("Cannot write null property FormatTest.DateTime to non-nullable JSON property 'dateTime'.");
+
+            if (formatTest.DecimalOption.IsSet && formatTest.Decimal == null)
+                throw new JsonException("Cannot write null property FormatTest.Decimal to non-nullable JSON property 'decimal'.");
+
+            if (formatTest.DoubleOption.IsSet && formatTest.Double == null)
+                throw new JsonException("Cannot write null property FormatTest.Double to non-nullable JSON property 'double'.");
+
             if (formatTest.DuplicatePropertyName2Option.IsSet && formatTest.DuplicatePropertyName2 == null)
                 throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName2 to non-nullable JSON property 'duplicate_property_name'.");
 
             if (formatTest.DuplicatePropertyNameOption.IsSet && formatTest.DuplicatePropertyName == null)
                 throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName to non-nullable JSON property '@duplicate_property_name'.");
+
+            if (formatTest.FloatOption.IsSet && formatTest.Float == null)
+                throw new JsonException("Cannot write null property FormatTest.Float to non-nullable JSON property 'float'.");
+
+            if (formatTest.Int32Option.IsSet && formatTest.Int32 == null)
+                throw new JsonException("Cannot write null property FormatTest.Int32 to non-nullable JSON property 'int32'.");
+
+            if (formatTest.Int32RangeOption.IsSet && formatTest.Int32Range == null)
+                throw new JsonException("Cannot write null property FormatTest.Int32Range to non-nullable JSON property 'int32Range'.");
+
+            if (formatTest.Int64Option.IsSet && formatTest.Int64 == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64 to non-nullable JSON property 'int64'.");
+
+            if (formatTest.Int64NegativeOption.IsSet && formatTest.Int64Negative == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64Negative to non-nullable JSON property 'int64Negative'.");
+
+            if (formatTest.Int64NegativeExclusiveOption.IsSet && formatTest.Int64NegativeExclusive == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64NegativeExclusive to non-nullable JSON property 'int64NegativeExclusive'.");
+
+            if (formatTest.Int64PositiveOption.IsSet && formatTest.Int64Positive == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64Positive to non-nullable JSON property 'int64Positive'.");
+
+            if (formatTest.Int64PositiveExclusiveOption.IsSet && formatTest.Int64PositiveExclusive == null)
+                throw new JsonException("Cannot write null property FormatTest.Int64PositiveExclusive to non-nullable JSON property 'int64PositiveExclusive'.");
+
+            if (formatTest.IntegerOption.IsSet && formatTest.Integer == null)
+                throw new JsonException("Cannot write null property FormatTest.Integer to non-nullable JSON property 'integer'.");
 
             if (formatTest.PatternWithBackslashOption.IsSet && formatTest.PatternWithBackslash == null)
                 throw new JsonException("Cannot write null property FormatTest.PatternWithBackslash to non-nullable JSON property 'pattern_with_backslash'.");
@@ -971,6 +1007,18 @@ namespace Org.OpenAPITools.Model
 
             if (formatTest.StringOption.IsSet && formatTest.String == null)
                 throw new JsonException("Cannot write null property FormatTest.String to non-nullable JSON property 'string'.");
+
+            if (formatTest.StringFormattedAsDecimalOption.IsSet && formatTest.StringFormattedAsDecimal == null)
+                throw new JsonException("Cannot write null property FormatTest.StringFormattedAsDecimal to non-nullable JSON property 'string_formatted_as_decimal'.");
+
+            if (formatTest.UnsignedIntegerOption.IsSet && formatTest.UnsignedInteger == null)
+                throw new JsonException("Cannot write null property FormatTest.UnsignedInteger to non-nullable JSON property 'unsigned_integer'.");
+
+            if (formatTest.UnsignedLongOption.IsSet && formatTest.UnsignedLong == null)
+                throw new JsonException("Cannot write null property FormatTest.UnsignedLong to non-nullable JSON property 'unsigned_long'.");
+
+            if (formatTest.UuidOption.IsSet && formatTest.Uuid == null)
+                throw new JsonException("Cannot write null property FormatTest.Uuid to non-nullable JSON property 'uuid'.");
 
             writer.WritePropertyName("byte");
             JsonSerializer.Serialize(writer, formatTest.Byte, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -951,32 +951,26 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, FormatTest formatTest, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (formatTest.Byte == null)
-                throw new ArgumentNullException(nameof(formatTest.Byte), "Property is required for class FormatTest.");
-
-            if (formatTest.Password == null)
-                throw new ArgumentNullException(nameof(formatTest.Password), "Property is required for class FormatTest.");
-
             if (formatTest.BinaryOption.IsSet && formatTest.Binary == null)
-                throw new ArgumentNullException(nameof(formatTest.Binary), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.Binary to non-nullable JSON property 'binary'.");
 
             if (formatTest.DuplicatePropertyName2Option.IsSet && formatTest.DuplicatePropertyName2 == null)
-                throw new ArgumentNullException(nameof(formatTest.DuplicatePropertyName2), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName2 to non-nullable JSON property 'duplicate_property_name'.");
 
             if (formatTest.DuplicatePropertyNameOption.IsSet && formatTest.DuplicatePropertyName == null)
-                throw new ArgumentNullException(nameof(formatTest.DuplicatePropertyName), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.DuplicatePropertyName to non-nullable JSON property '@duplicate_property_name'.");
 
             if (formatTest.PatternWithBackslashOption.IsSet && formatTest.PatternWithBackslash == null)
-                throw new ArgumentNullException(nameof(formatTest.PatternWithBackslash), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.PatternWithBackslash to non-nullable JSON property 'pattern_with_backslash'.");
 
             if (formatTest.PatternWithDigitsOption.IsSet && formatTest.PatternWithDigits == null)
-                throw new ArgumentNullException(nameof(formatTest.PatternWithDigits), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.PatternWithDigits to non-nullable JSON property 'pattern_with_digits'.");
 
             if (formatTest.PatternWithDigitsAndDelimiterOption.IsSet && formatTest.PatternWithDigitsAndDelimiter == null)
-                throw new ArgumentNullException(nameof(formatTest.PatternWithDigitsAndDelimiter), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.PatternWithDigitsAndDelimiter to non-nullable JSON property 'pattern_with_digits_and_delimiter'.");
 
             if (formatTest.StringOption.IsSet && formatTest.String == null)
-                throw new ArgumentNullException(nameof(formatTest.String), "Property is required for class FormatTest.");
+                throw new JsonException("Cannot write null property FormatTest.String to non-nullable JSON property 'string'.");
 
             writer.WritePropertyName("byte");
             JsonSerializer.Serialize(writer, formatTest.Byte, jsonSerializerOptions);

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
@@ -219,7 +219,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Fruit fruit, JsonSerializerOptions jsonSerializerOptions)
         {
             if (fruit.ColorOption.IsSet && fruit.Color == null)
-                throw new ArgumentNullException(nameof(fruit.Color), "Property is required for class Fruit.");
+                throw new JsonException("Cannot write null property Fruit.Color to non-nullable JSON property 'color'.");
 
             if (fruit.ColorOption.IsSet)
                 writer.WriteString("color", fruit.Color);

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -236,7 +236,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, GmFruit gmFruit, JsonSerializerOptions jsonSerializerOptions)
         {
             if (gmFruit.ColorOption.IsSet && gmFruit.Color == null)
-                throw new ArgumentNullException(nameof(gmFruit.Color), "Property is required for class GmFruit.");
+                throw new JsonException("Cannot write null property GmFruit.Color to non-nullable JSON property 'color'.");
 
             if (gmFruit.ColorOption.IsSet)
                 writer.WriteString("color", gmFruit.Color);

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -239,10 +239,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, HasOnlyReadOnly hasOnlyReadOnly, JsonSerializerOptions jsonSerializerOptions)
         {
             if (hasOnlyReadOnly.BarOption.IsSet && hasOnlyReadOnly.Bar == null)
-                throw new ArgumentNullException(nameof(hasOnlyReadOnly.Bar), "Property is required for class HasOnlyReadOnly.");
+                throw new JsonException("Cannot write null property HasOnlyReadOnly.Bar to non-nullable JSON property 'bar'.");
 
             if (hasOnlyReadOnly.FooOption.IsSet && hasOnlyReadOnly.Foo == null)
-                throw new ArgumentNullException(nameof(hasOnlyReadOnly.Foo), "Property is required for class HasOnlyReadOnly.");
+                throw new JsonException("Cannot write null property HasOnlyReadOnly.Foo to non-nullable JSON property 'foo'.");
 
             if (hasOnlyReadOnly.BarOption.IsSet)
                 writer.WriteString("bar", hasOnlyReadOnly.Bar);

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/InjectedVendorExtensionsTest.cs
@@ -337,22 +337,22 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, InjectedVendorExtensionsTest injectedVendorExtensionsTest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessorOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor to non-nullable JSON property 'potentiallyOverriddenPropertyAccessor'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternalOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternal == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternal), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyToInternal to non-nullable JSON property 'potentiallyOverriddenPropertyToInternal'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivateOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivate == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivate), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPrivate to non-nullable JSON property 'potentiallyOverriddenPropertyToPrivate'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublicOption.IsSet && injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublic == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublic), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.PotentiallyOverriddenPropertyToPublic to non-nullable JSON property 'potentiallyOverriddenPropertyToPublic'.");
 
             if (injectedVendorExtensionsTest.UnalteredPropertyOption.IsSet && injectedVendorExtensionsTest.UnalteredProperty == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.UnalteredProperty), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.UnalteredProperty to non-nullable JSON property 'unalteredProperty'.");
 
             if (injectedVendorExtensionsTest.UnalteredPropertyAccessorOption.IsSet && injectedVendorExtensionsTest.UnalteredPropertyAccessor == null)
-                throw new ArgumentNullException(nameof(injectedVendorExtensionsTest.UnalteredPropertyAccessor), "Property is required for class InjectedVendorExtensionsTest.");
+                throw new JsonException("Cannot write null property InjectedVendorExtensionsTest.UnalteredPropertyAccessor to non-nullable JSON property 'unalteredPropertyAccessor'.");
 
             if (injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessorOption.IsSet)
                 writer.WriteString("potentiallyOverriddenPropertyAccessor", injectedVendorExtensionsTest.PotentiallyOverriddenPropertyAccessor);

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
@@ -182,12 +182,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, IsoscelesTriangle isoscelesTriangle, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (isoscelesTriangle.ShapeType == null)
-                throw new ArgumentNullException(nameof(isoscelesTriangle.ShapeType), "Property is required for class IsoscelesTriangle.");
-
-            if (isoscelesTriangle.TriangleType == null)
-                throw new ArgumentNullException(nameof(isoscelesTriangle.TriangleType), "Property is required for class IsoscelesTriangle.");
-
             writer.WriteString("shapeType", isoscelesTriangle.ShapeType);
 
             writer.WriteString("triangleType", isoscelesTriangle.TriangleType);

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/List.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, List list, JsonSerializerOptions jsonSerializerOptions)
         {
             if (list.Var123ListOption.IsSet && list.Var123List == null)
-                throw new ArgumentNullException(nameof(list.Var123List), "Property is required for class List.");
+                throw new JsonException("Cannot write null property List.Var123List to non-nullable JSON property '123-list'.");
 
             if (list.Var123ListOption.IsSet)
                 writer.WriteString("123-list", list.Var123List);

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -198,10 +198,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, LiteralStringClass literalStringClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (literalStringClass.EscapedLiteralStringOption.IsSet && literalStringClass.EscapedLiteralString == null)
-                throw new ArgumentNullException(nameof(literalStringClass.EscapedLiteralString), "Property is required for class LiteralStringClass.");
+                throw new JsonException("Cannot write null property LiteralStringClass.EscapedLiteralString to non-nullable JSON property 'escapedLiteralString'.");
 
             if (literalStringClass.UnescapedLiteralStringOption.IsSet && literalStringClass.UnescapedLiteralString == null)
-                throw new ArgumentNullException(nameof(literalStringClass.UnescapedLiteralString), "Property is required for class LiteralStringClass.");
+                throw new JsonException("Cannot write null property LiteralStringClass.UnescapedLiteralString to non-nullable JSON property 'unescapedLiteralString'.");
 
             if (literalStringClass.EscapedLiteralStringOption.IsSet)
                 writer.WriteString("escapedLiteralString", literalStringClass.EscapedLiteralString);

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/MapTest.cs
@@ -310,16 +310,16 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MapTest mapTest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mapTest.DirectMapOption.IsSet && mapTest.DirectMap == null)
-                throw new ArgumentNullException(nameof(mapTest.DirectMap), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.DirectMap to non-nullable JSON property 'direct_map'.");
 
             if (mapTest.IndirectMapOption.IsSet && mapTest.IndirectMap == null)
-                throw new ArgumentNullException(nameof(mapTest.IndirectMap), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.IndirectMap to non-nullable JSON property 'indirect_map'.");
 
             if (mapTest.MapMapOfStringOption.IsSet && mapTest.MapMapOfString == null)
-                throw new ArgumentNullException(nameof(mapTest.MapMapOfString), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.MapMapOfString to non-nullable JSON property 'map_map_of_string'.");
 
             if (mapTest.MapOfEnumStringOption.IsSet && mapTest.MapOfEnumString == null)
-                throw new ArgumentNullException(nameof(mapTest.MapOfEnumString), "Property is required for class MapTest.");
+                throw new JsonException("Cannot write null property MapTest.MapOfEnumString to non-nullable JSON property 'map_of_enum_string'.");
 
             if (mapTest.DirectMapOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/MixedAnyOf.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/MixedAnyOf.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedAnyOf mixedAnyOf, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedAnyOf.ContentOption.IsSet && mixedAnyOf.Content == null)
-                throw new ArgumentNullException(nameof(mixedAnyOf.Content), "Property is required for class MixedAnyOf.");
+                throw new JsonException("Cannot write null property MixedAnyOf.Content to non-nullable JSON property 'content'.");
 
             if (mixedAnyOf.ContentOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/MixedOneOf.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/MixedOneOf.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedOneOf mixedOneOf, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedOneOf.ContentOption.IsSet && mixedOneOf.Content == null)
-                throw new ArgumentNullException(nameof(mixedOneOf.Content), "Property is required for class MixedOneOf.");
+                throw new JsonException("Cannot write null property MixedOneOf.Content to non-nullable JSON property 'content'.");
 
             if (mixedOneOf.ContentOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -255,8 +255,17 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, MixedPropertiesAndAdditionalPropertiesClass mixedPropertiesAndAdditionalPropertiesClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.DateTime == null)
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.DateTime to non-nullable JSON property 'dateTime'.");
+
             if (mixedPropertiesAndAdditionalPropertiesClass.MapOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.Map == null)
                 throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.Map to non-nullable JSON property 'map'.");
+
+            if (mixedPropertiesAndAdditionalPropertiesClass.UuidOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.Uuid == null)
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.Uuid to non-nullable JSON property 'uuid'.");
+
+            if (mixedPropertiesAndAdditionalPropertiesClass.UuidWithPatternOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.UuidWithPattern == null)
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.UuidWithPattern to non-nullable JSON property 'uuid_with_pattern'.");
 
             if (mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.IsSet)
                 writer.WriteString("dateTime", mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.Value.Value.ToString(DateTimeFormat));

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -256,7 +256,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedPropertiesAndAdditionalPropertiesClass mixedPropertiesAndAdditionalPropertiesClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedPropertiesAndAdditionalPropertiesClass.MapOption.IsSet && mixedPropertiesAndAdditionalPropertiesClass.Map == null)
-                throw new ArgumentNullException(nameof(mixedPropertiesAndAdditionalPropertiesClass.Map), "Property is required for class MixedPropertiesAndAdditionalPropertiesClass.");
+                throw new JsonException("Cannot write null property MixedPropertiesAndAdditionalPropertiesClass.Map to non-nullable JSON property 'map'.");
 
             if (mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.IsSet)
                 writer.WriteString("dateTime", mixedPropertiesAndAdditionalPropertiesClass.DateTimeOption.Value.Value.ToString(DateTimeFormat));

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/MixedSubId.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/MixedSubId.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, MixedSubId mixedSubId, JsonSerializerOptions jsonSerializerOptions)
         {
             if (mixedSubId.IdOption.IsSet && mixedSubId.Id == null)
-                throw new ArgumentNullException(nameof(mixedSubId.Id), "Property is required for class MixedSubId.");
+                throw new JsonException("Cannot write null property MixedSubId.Id to non-nullable JSON property 'id'.");
 
             if (mixedSubId.IdOption.IsSet)
                 writer.WriteString("id", mixedSubId.Id);

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -198,7 +198,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Model200Response model200Response, JsonSerializerOptions jsonSerializerOptions)
         {
             if (model200Response.ClassOption.IsSet && model200Response.Class == null)
-                throw new ArgumentNullException(nameof(model200Response.Class), "Property is required for class Model200Response.");
+                throw new JsonException("Cannot write null property Model200Response.Class to non-nullable JSON property 'class'.");
 
             if (model200Response.ClassOption.IsSet)
                 writer.WriteString("class", model200Response.Class);

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -200,6 +200,9 @@ namespace Org.OpenAPITools.Model
             if (model200Response.ClassOption.IsSet && model200Response.Class == null)
                 throw new JsonException("Cannot write null property Model200Response.Class to non-nullable JSON property 'class'.");
 
+            if (model200Response.NameOption.IsSet && model200Response.Name == null)
+                throw new JsonException("Cannot write null property Model200Response.Name to non-nullable JSON property 'name'.");
+
             if (model200Response.ClassOption.IsSet)
                 writer.WriteString("class", model200Response.Class);
 

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ModelClient modelClient, JsonSerializerOptions jsonSerializerOptions)
         {
             if (modelClient.VarClientOption.IsSet && modelClient.VarClient == null)
-                throw new ArgumentNullException(nameof(modelClient.VarClient), "Property is required for class ModelClient.");
+                throw new JsonException("Cannot write null property ModelClient.VarClient to non-nullable JSON property 'client'.");
 
             if (modelClient.VarClientOption.IsSet)
                 writer.WriteString("client", modelClient.VarClient);

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Name.cs
@@ -281,7 +281,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Name name, JsonSerializerOptions jsonSerializerOptions)
         {
             if (name.PropertyOption.IsSet && name.Property == null)
-                throw new ArgumentNullException(nameof(name.Property), "Property is required for class Name.");
+                throw new JsonException("Cannot write null property Name.Property to non-nullable JSON property 'property'.");
 
             writer.WriteNumber("name", name.VarName);
 

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Name.cs
@@ -283,6 +283,12 @@ namespace Org.OpenAPITools.Model
             if (name.PropertyOption.IsSet && name.Property == null)
                 throw new JsonException("Cannot write null property Name.Property to non-nullable JSON property 'property'.");
 
+            if (name.SnakeCaseOption.IsSet && name.SnakeCase == null)
+                throw new JsonException("Cannot write null property Name.SnakeCase to non-nullable JSON property 'snake_case'.");
+
+            if (name.Var123NumberOption.IsSet && name.Var123Number == null)
+                throw new JsonException("Cannot write null property Name.Var123Number to non-nullable JSON property '123Number'.");
+
             writer.WriteNumber("name", name.VarName);
 
             if (name.PropertyOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
@@ -189,9 +189,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, NotificationtestGetElementsV1ResponseMPayload notificationtestGetElementsV1ResponseMPayload, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (notificationtestGetElementsV1ResponseMPayload.AObjVariableobject == null)
-                throw new ArgumentNullException(nameof(notificationtestGetElementsV1ResponseMPayload.AObjVariableobject), "Property is required for class NotificationtestGetElementsV1ResponseMPayload.");
-
             writer.WritePropertyName("a_objVariableobject");
             JsonSerializer.Serialize(writer, notificationtestGetElementsV1ResponseMPayload.AObjVariableobject, jsonSerializerOptions);
             writer.WriteNumber("pkiNotificationtestID", notificationtestGetElementsV1ResponseMPayload.PkiNotificationtestID);

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -408,10 +408,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, NullableClass nullableClass, JsonSerializerOptions jsonSerializerOptions)
         {
             if (nullableClass.ArrayItemsNullableOption.IsSet && nullableClass.ArrayItemsNullable == null)
-                throw new ArgumentNullException(nameof(nullableClass.ArrayItemsNullable), "Property is required for class NullableClass.");
+                throw new JsonException("Cannot write null property NullableClass.ArrayItemsNullable to non-nullable JSON property 'array_items_nullable'.");
 
             if (nullableClass.ObjectItemsNullableOption.IsSet && nullableClass.ObjectItemsNullable == null)
-                throw new ArgumentNullException(nameof(nullableClass.ObjectItemsNullable), "Property is required for class NullableClass.");
+                throw new JsonException("Cannot write null property NullableClass.ObjectItemsNullable to non-nullable JSON property 'object_items_nullable'.");
 
             if (nullableClass.ArrayAndItemsNullablePropOption.IsSet)
                 if (nullableClass.ArrayAndItemsNullablePropOption.Value != null)

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -174,6 +174,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, NumberOnly numberOnly, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (numberOnly.JustNumberOption.IsSet && numberOnly.JustNumber == null)
+                throw new JsonException("Cannot write null property NumberOnly.JustNumber to non-nullable JSON property 'JustNumber'.");
+
             if (numberOnly.JustNumberOption.IsSet)
                 writer.WriteNumber("JustNumber", numberOnly.JustNumberOption.Value.Value);
         }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -247,13 +247,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ObjectWithDeprecatedFields objectWithDeprecatedFields, JsonSerializerOptions jsonSerializerOptions)
         {
             if (objectWithDeprecatedFields.BarsOption.IsSet && objectWithDeprecatedFields.Bars == null)
-                throw new ArgumentNullException(nameof(objectWithDeprecatedFields.Bars), "Property is required for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Bars to non-nullable JSON property 'bars'.");
 
             if (objectWithDeprecatedFields.DeprecatedRefOption.IsSet && objectWithDeprecatedFields.DeprecatedRef == null)
-                throw new ArgumentNullException(nameof(objectWithDeprecatedFields.DeprecatedRef), "Property is required for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.DeprecatedRef to non-nullable JSON property 'deprecatedRef'.");
 
             if (objectWithDeprecatedFields.UuidOption.IsSet && objectWithDeprecatedFields.Uuid == null)
-                throw new ArgumentNullException(nameof(objectWithDeprecatedFields.Uuid), "Property is required for class ObjectWithDeprecatedFields.");
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Uuid to non-nullable JSON property 'uuid'.");
 
             if (objectWithDeprecatedFields.BarsOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -252,6 +252,9 @@ namespace Org.OpenAPITools.Model
             if (objectWithDeprecatedFields.DeprecatedRefOption.IsSet && objectWithDeprecatedFields.DeprecatedRef == null)
                 throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.DeprecatedRef to non-nullable JSON property 'deprecatedRef'.");
 
+            if (objectWithDeprecatedFields.IdOption.IsSet && objectWithDeprecatedFields.Id == null)
+                throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Id to non-nullable JSON property 'id'.");
+
             if (objectWithDeprecatedFields.UuidOption.IsSet && objectWithDeprecatedFields.Uuid == null)
                 throw new JsonException("Cannot write null property ObjectWithDeprecatedFields.Uuid to non-nullable JSON property 'uuid'.");
 

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Order.cs
@@ -384,6 +384,24 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Order order, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (order.CompleteOption.IsSet && order.Complete == null)
+                throw new JsonException("Cannot write null property Order.Complete to non-nullable JSON property 'complete'.");
+
+            if (order.IdOption.IsSet && order.Id == null)
+                throw new JsonException("Cannot write null property Order.Id to non-nullable JSON property 'id'.");
+
+            if (order.PetIdOption.IsSet && order.PetId == null)
+                throw new JsonException("Cannot write null property Order.PetId to non-nullable JSON property 'petId'.");
+
+            if (order.QuantityOption.IsSet && order.Quantity == null)
+                throw new JsonException("Cannot write null property Order.Quantity to non-nullable JSON property 'quantity'.");
+
+            if (order.ShipDateOption.IsSet && order.ShipDate == null)
+                throw new JsonException("Cannot write null property Order.ShipDate to non-nullable JSON property 'shipDate'.");
+
+            if (order.StatusOption.IsSet && order.Status == null)
+                throw new JsonException("Cannot write null property Order.Status to non-nullable JSON property 'status'.");
+
             if (order.CompleteOption.IsSet)
                 writer.WriteBoolean("complete", order.CompleteOption.Value.Value);
 

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -220,6 +220,12 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, OuterComposite outerComposite, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (outerComposite.MyBooleanOption.IsSet && outerComposite.MyBoolean == null)
+                throw new JsonException("Cannot write null property OuterComposite.MyBoolean to non-nullable JSON property 'my_boolean'.");
+
+            if (outerComposite.MyNumberOption.IsSet && outerComposite.MyNumber == null)
+                throw new JsonException("Cannot write null property OuterComposite.MyNumber to non-nullable JSON property 'my_number'.");
+
             if (outerComposite.MyStringOption.IsSet && outerComposite.MyString == null)
                 throw new JsonException("Cannot write null property OuterComposite.MyString to non-nullable JSON property 'my_string'.");
 

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -221,7 +221,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, OuterComposite outerComposite, JsonSerializerOptions jsonSerializerOptions)
         {
             if (outerComposite.MyStringOption.IsSet && outerComposite.MyString == null)
-                throw new ArgumentNullException(nameof(outerComposite.MyString), "Property is required for class OuterComposite.");
+                throw new JsonException("Cannot write null property OuterComposite.MyString to non-nullable JSON property 'my_string'.");
 
             if (outerComposite.MyBooleanOption.IsSet)
                 writer.WriteBoolean("my_boolean", outerComposite.MyBooleanOption.Value.Value);

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Pet.cs
@@ -371,17 +371,11 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Pet pet, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (pet.Name == null)
-                throw new ArgumentNullException(nameof(pet.Name), "Property is required for class Pet.");
-
-            if (pet.PhotoUrls == null)
-                throw new ArgumentNullException(nameof(pet.PhotoUrls), "Property is required for class Pet.");
-
             if (pet.CategoryOption.IsSet && pet.Category == null)
-                throw new ArgumentNullException(nameof(pet.Category), "Property is required for class Pet.");
+                throw new JsonException("Cannot write null property Pet.Category to non-nullable JSON property 'category'.");
 
             if (pet.TagsOption.IsSet && pet.Tags == null)
-                throw new ArgumentNullException(nameof(pet.Tags), "Property is required for class Pet.");
+                throw new JsonException("Cannot write null property Pet.Tags to non-nullable JSON property 'tags'.");
 
             writer.WriteString("name", pet.Name);
 

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Pet.cs
@@ -374,6 +374,12 @@ namespace Org.OpenAPITools.Model
             if (pet.CategoryOption.IsSet && pet.Category == null)
                 throw new JsonException("Cannot write null property Pet.Category to non-nullable JSON property 'category'.");
 
+            if (pet.IdOption.IsSet && pet.Id == null)
+                throw new JsonException("Cannot write null property Pet.Id to non-nullable JSON property 'id'.");
+
+            if (pet.StatusOption.IsSet && pet.Status == null)
+                throw new JsonException("Cannot write null property Pet.Status to non-nullable JSON property 'status'.");
+
             if (pet.TagsOption.IsSet && pet.Tags == null)
                 throw new JsonException("Cannot write null property Pet.Tags to non-nullable JSON property 'tags'.");
 

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
@@ -170,9 +170,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, QuadrilateralInterface quadrilateralInterface, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (quadrilateralInterface.QuadrilateralType == null)
-                throw new ArgumentNullException(nameof(quadrilateralInterface.QuadrilateralType), "Property is required for class QuadrilateralInterface.");
-
             writer.WriteString("quadrilateralType", quadrilateralInterface.QuadrilateralType);
         }
     }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -236,10 +236,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, ReadOnlyFirst readOnlyFirst, JsonSerializerOptions jsonSerializerOptions)
         {
             if (readOnlyFirst.BarOption.IsSet && readOnlyFirst.Bar == null)
-                throw new ArgumentNullException(nameof(readOnlyFirst.Bar), "Property is required for class ReadOnlyFirst.");
+                throw new JsonException("Cannot write null property ReadOnlyFirst.Bar to non-nullable JSON property 'bar'.");
 
             if (readOnlyFirst.BazOption.IsSet && readOnlyFirst.Baz == null)
-                throw new ArgumentNullException(nameof(readOnlyFirst.Baz), "Property is required for class ReadOnlyFirst.");
+                throw new JsonException("Cannot write null property ReadOnlyFirst.Baz to non-nullable JSON property 'baz'.");
 
             if (readOnlyFirst.BarOption.IsSet)
                 writer.WriteString("bar", readOnlyFirst.Bar);

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -2235,17 +2235,11 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, RequiredClass requiredClass, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (requiredClass.RequiredNotnullableArrayOfString == null)
-                throw new ArgumentNullException(nameof(requiredClass.RequiredNotnullableArrayOfString), "Property is required for class RequiredClass.");
-
-            if (requiredClass.RequiredNotnullableStringProp == null)
-                throw new ArgumentNullException(nameof(requiredClass.RequiredNotnullableStringProp), "Property is required for class RequiredClass.");
-
             if (requiredClass.NotrequiredNotnullableArrayOfStringOption.IsSet && requiredClass.NotrequiredNotnullableArrayOfString == null)
-                throw new ArgumentNullException(nameof(requiredClass.NotrequiredNotnullableArrayOfString), "Property is required for class RequiredClass.");
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableArrayOfString to non-nullable JSON property 'notrequired_notnullable_array_of_string'.");
 
             if (requiredClass.NotrequiredNotnullableStringPropOption.IsSet && requiredClass.NotrequiredNotnullableStringProp == null)
-                throw new ArgumentNullException(nameof(requiredClass.NotrequiredNotnullableStringProp), "Property is required for class RequiredClass.");
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableStringProp to non-nullable JSON property 'notrequired_notnullable_string_prop'.");
 
             writer.WriteString("required_not_nullable_date_prop", requiredClass.RequiredNotNullableDateProp.ToString(RequiredNotNullableDatePropFormat));
 

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -2235,11 +2235,38 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, RequiredClass requiredClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (requiredClass.NotRequiredNotnullableDatePropOption.IsSet && requiredClass.NotRequiredNotnullableDateProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotRequiredNotnullableDateProp to non-nullable JSON property 'not_required_notnullable_date_prop'.");
+
+            if (requiredClass.NotRequiredNotnullableintegerPropOption.IsSet && requiredClass.NotRequiredNotnullableintegerProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotRequiredNotnullableintegerProp to non-nullable JSON property 'not_required_notnullableinteger_prop'.");
+
             if (requiredClass.NotrequiredNotnullableArrayOfStringOption.IsSet && requiredClass.NotrequiredNotnullableArrayOfString == null)
                 throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableArrayOfString to non-nullable JSON property 'notrequired_notnullable_array_of_string'.");
 
+            if (requiredClass.NotrequiredNotnullableBooleanPropOption.IsSet && requiredClass.NotrequiredNotnullableBooleanProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableBooleanProp to non-nullable JSON property 'notrequired_notnullable_boolean_prop'.");
+
+            if (requiredClass.NotrequiredNotnullableDatetimePropOption.IsSet && requiredClass.NotrequiredNotnullableDatetimeProp == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableDatetimeProp to non-nullable JSON property 'notrequired_notnullable_datetime_prop'.");
+
+            if (requiredClass.NotrequiredNotnullableEnumIntegerOption.IsSet && requiredClass.NotrequiredNotnullableEnumInteger == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableEnumInteger to non-nullable JSON property 'notrequired_notnullable_enum_integer'.");
+
+            if (requiredClass.NotrequiredNotnullableEnumIntegerOnlyOption.IsSet && requiredClass.NotrequiredNotnullableEnumIntegerOnly == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableEnumIntegerOnly to non-nullable JSON property 'notrequired_notnullable_enum_integer_only'.");
+
+            if (requiredClass.NotrequiredNotnullableEnumStringOption.IsSet && requiredClass.NotrequiredNotnullableEnumString == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableEnumString to non-nullable JSON property 'notrequired_notnullable_enum_string'.");
+
+            if (requiredClass.NotrequiredNotnullableOuterEnumDefaultValueOption.IsSet && requiredClass.NotrequiredNotnullableOuterEnumDefaultValue == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableOuterEnumDefaultValue to non-nullable JSON property 'notrequired_notnullable_outerEnumDefaultValue'.");
+
             if (requiredClass.NotrequiredNotnullableStringPropOption.IsSet && requiredClass.NotrequiredNotnullableStringProp == null)
                 throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableStringProp to non-nullable JSON property 'notrequired_notnullable_string_prop'.");
+
+            if (requiredClass.NotrequiredNotnullableUuidOption.IsSet && requiredClass.NotrequiredNotnullableUuid == null)
+                throw new JsonException("Cannot write null property RequiredClass.NotrequiredNotnullableUuid to non-nullable JSON property 'notrequired_notnullable_uuid'.");
 
             writer.WriteString("required_not_nullable_date_prop", requiredClass.RequiredNotNullableDateProp.ToString(RequiredNotNullableDatePropFormat));
 

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Result.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Result.cs
@@ -224,13 +224,13 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Result result, JsonSerializerOptions jsonSerializerOptions)
         {
             if (result.CodeOption.IsSet && result.Code == null)
-                throw new ArgumentNullException(nameof(result.Code), "Property is required for class Result.");
+                throw new JsonException("Cannot write null property Result.Code to non-nullable JSON property 'code'.");
 
             if (result.DataOption.IsSet && result.Data == null)
-                throw new ArgumentNullException(nameof(result.Data), "Property is required for class Result.");
+                throw new JsonException("Cannot write null property Result.Data to non-nullable JSON property 'data'.");
 
             if (result.UuidOption.IsSet && result.Uuid == null)
-                throw new ArgumentNullException(nameof(result.Uuid), "Property is required for class Result.");
+                throw new JsonException("Cannot write null property Result.Uuid to non-nullable JSON property 'uuid'.");
 
             if (result.CodeOption.IsSet)
                 writer.WriteString("code", result.Code);

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Return.cs
@@ -232,11 +232,8 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Return varReturn, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (varReturn.Lock == null)
-                throw new ArgumentNullException(nameof(varReturn.Lock), "Property is required for class Return.");
-
             if (varReturn.UnsafeOption.IsSet && varReturn.Unsafe == null)
-                throw new ArgumentNullException(nameof(varReturn.Unsafe), "Property is required for class Return.");
+                throw new JsonException("Cannot write null property Return.Unsafe to non-nullable JSON property 'unsafe'.");
 
             writer.WriteString("lock", varReturn.Lock);
 

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Return.cs
@@ -232,6 +232,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Return varReturn, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (varReturn.VarReturnOption.IsSet && varReturn.VarReturn == null)
+                throw new JsonException("Cannot write null property Return.VarReturn to non-nullable JSON property 'return'.");
+
             if (varReturn.UnsafeOption.IsSet && varReturn.Unsafe == null)
                 throw new JsonException("Cannot write null property Return.Unsafe to non-nullable JSON property 'unsafe'.");
 

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -198,7 +198,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, RolesReportsHash rolesReportsHash, JsonSerializerOptions jsonSerializerOptions)
         {
             if (rolesReportsHash.RoleOption.IsSet && rolesReportsHash.Role == null)
-                throw new ArgumentNullException(nameof(rolesReportsHash.Role), "Property is required for class RolesReportsHash.");
+                throw new JsonException("Cannot write null property RolesReportsHash.Role to non-nullable JSON property 'role'.");
 
             if (rolesReportsHash.RoleOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -200,6 +200,9 @@ namespace Org.OpenAPITools.Model
             if (rolesReportsHash.RoleOption.IsSet && rolesReportsHash.Role == null)
                 throw new JsonException("Cannot write null property RolesReportsHash.Role to non-nullable JSON property 'role'.");
 
+            if (rolesReportsHash.RoleUuidOption.IsSet && rolesReportsHash.RoleUuid == null)
+                throw new JsonException("Cannot write null property RolesReportsHash.RoleUuid to non-nullable JSON property 'role_uuid'.");
+
             if (rolesReportsHash.RoleOption.IsSet)
             {
                 writer.WritePropertyName("role");

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, RolesReportsHashRole rolesReportsHashRole, JsonSerializerOptions jsonSerializerOptions)
         {
             if (rolesReportsHashRole.NameOption.IsSet && rolesReportsHashRole.Name == null)
-                throw new ArgumentNullException(nameof(rolesReportsHashRole.Name), "Property is required for class RolesReportsHashRole.");
+                throw new JsonException("Cannot write null property RolesReportsHashRole.Name to non-nullable JSON property 'name'.");
 
             if (rolesReportsHashRole.NameOption.IsSet)
                 writer.WriteString("name", rolesReportsHashRole.Name);

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
@@ -189,12 +189,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ScaleneTriangle scaleneTriangle, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (scaleneTriangle.ShapeType == null)
-                throw new ArgumentNullException(nameof(scaleneTriangle.ShapeType), "Property is required for class ScaleneTriangle.");
-
-            if (scaleneTriangle.TriangleType == null)
-                throw new ArgumentNullException(nameof(scaleneTriangle.TriangleType), "Property is required for class ScaleneTriangle.");
-
             writer.WriteString("shapeType", scaleneTriangle.ShapeType);
 
             writer.WriteString("triangleType", scaleneTriangle.TriangleType);

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ShapeInterface.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ShapeInterface.cs
@@ -170,9 +170,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ShapeInterface shapeInterface, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (shapeInterface.ShapeType == null)
-                throw new ArgumentNullException(nameof(shapeInterface.ShapeType), "Property is required for class ShapeInterface.");
-
             writer.WriteString("shapeType", shapeInterface.ShapeType);
         }
     }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
@@ -189,12 +189,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, SimpleQuadrilateral simpleQuadrilateral, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (simpleQuadrilateral.QuadrilateralType == null)
-                throw new ArgumentNullException(nameof(simpleQuadrilateral.QuadrilateralType), "Property is required for class SimpleQuadrilateral.");
-
-            if (simpleQuadrilateral.ShapeType == null)
-                throw new ArgumentNullException(nameof(simpleQuadrilateral.ShapeType), "Property is required for class SimpleQuadrilateral.");
-
             writer.WriteString("quadrilateralType", simpleQuadrilateral.QuadrilateralType);
 
             writer.WriteString("shapeType", simpleQuadrilateral.ShapeType);

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -200,6 +200,9 @@ namespace Org.OpenAPITools.Model
             if (specialModelName.VarSpecialModelNameOption.IsSet && specialModelName.VarSpecialModelName == null)
                 throw new JsonException("Cannot write null property SpecialModelName.VarSpecialModelName to non-nullable JSON property '_special_model.name_'.");
 
+            if (specialModelName.SpecialPropertyNameOption.IsSet && specialModelName.SpecialPropertyName == null)
+                throw new JsonException("Cannot write null property SpecialModelName.SpecialPropertyName to non-nullable JSON property '$special[property.name]'.");
+
             if (specialModelName.VarSpecialModelNameOption.IsSet)
                 writer.WriteString("_special_model.name_", specialModelName.VarSpecialModelName);
 

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -198,7 +198,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, SpecialModelName specialModelName, JsonSerializerOptions jsonSerializerOptions)
         {
             if (specialModelName.VarSpecialModelNameOption.IsSet && specialModelName.VarSpecialModelName == null)
-                throw new ArgumentNullException(nameof(specialModelName.VarSpecialModelName), "Property is required for class SpecialModelName.");
+                throw new JsonException("Cannot write null property SpecialModelName.VarSpecialModelName to non-nullable JSON property '_special_model.name_'.");
 
             if (specialModelName.VarSpecialModelNameOption.IsSet)
                 writer.WriteString("_special_model.name_", specialModelName.VarSpecialModelName);

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Tag.cs
@@ -198,7 +198,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, Tag tag, JsonSerializerOptions jsonSerializerOptions)
         {
             if (tag.NameOption.IsSet && tag.Name == null)
-                throw new ArgumentNullException(nameof(tag.Name), "Property is required for class Tag.");
+                throw new JsonException("Cannot write null property Tag.Name to non-nullable JSON property 'name'.");
 
             if (tag.IdOption.IsSet)
                 writer.WriteNumber("id", tag.IdOption.Value.Value);

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Tag.cs
@@ -197,6 +197,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Tag tag, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (tag.IdOption.IsSet && tag.Id == null)
+                throw new JsonException("Cannot write null property Tag.Id to non-nullable JSON property 'id'.");
+
             if (tag.NameOption.IsSet && tag.Name == null)
                 throw new JsonException("Cannot write null property Tag.Name to non-nullable JSON property 'name'.");
 

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestCollectionEndingWithWordList testCollectionEndingWithWordList, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testCollectionEndingWithWordList.ValueOption.IsSet && testCollectionEndingWithWordList.Value == null)
-                throw new ArgumentNullException(nameof(testCollectionEndingWithWordList.Value), "Property is required for class TestCollectionEndingWithWordList.");
+                throw new JsonException("Cannot write null property TestCollectionEndingWithWordList.Value to non-nullable JSON property 'value'.");
 
             if (testCollectionEndingWithWordList.ValueOption.IsSet)
                 writer.WriteString("value", testCollectionEndingWithWordList.Value);

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestCollectionEndingWithWordListObject testCollectionEndingWithWordListObject, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testCollectionEndingWithWordListObject.TestCollectionEndingWithWordListOption.IsSet && testCollectionEndingWithWordListObject.TestCollectionEndingWithWordList == null)
-                throw new ArgumentNullException(nameof(testCollectionEndingWithWordListObject.TestCollectionEndingWithWordList), "Property is required for class TestCollectionEndingWithWordListObject.");
+                throw new JsonException("Cannot write null property TestCollectionEndingWithWordListObject.TestCollectionEndingWithWordList to non-nullable JSON property 'TestCollectionEndingWithWordList'.");
 
             if (testCollectionEndingWithWordListObject.TestCollectionEndingWithWordListOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/TestDescendants.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/TestDescendants.cs
@@ -289,9 +289,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, TestDescendants testDescendants, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (testDescendants.AlternativeName == null)
-                throw new ArgumentNullException(nameof(testDescendants.AlternativeName), "Property is required for class TestDescendants.");
-
             writer.WriteString("alternativeName", testDescendants.AlternativeName);
 
             writer.WriteString("objectType", TestDescendants.ObjectTypeEnumToJsonValue(testDescendants.ObjectType));

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
@@ -175,7 +175,7 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestInlineFreeformAdditionalPropertiesRequest testInlineFreeformAdditionalPropertiesRequest, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testInlineFreeformAdditionalPropertiesRequest.SomePropertyOption.IsSet && testInlineFreeformAdditionalPropertiesRequest.SomeProperty == null)
-                throw new ArgumentNullException(nameof(testInlineFreeformAdditionalPropertiesRequest.SomeProperty), "Property is required for class TestInlineFreeformAdditionalPropertiesRequest.");
+                throw new JsonException("Cannot write null property TestInlineFreeformAdditionalPropertiesRequest.SomeProperty to non-nullable JSON property 'someProperty'.");
 
             if (testInlineFreeformAdditionalPropertiesRequest.SomePropertyOption.IsSet)
                 writer.WriteString("someProperty", testInlineFreeformAdditionalPropertiesRequest.SomeProperty);

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/TestResult.cs
@@ -222,6 +222,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, TestResult testResult, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (testResult.CodeOption.IsSet && testResult.Code == null)
+                throw new JsonException("Cannot write null property TestResult.Code to non-nullable JSON property 'code'.");
+
             if (testResult.DataOption.IsSet && testResult.Data == null)
                 throw new JsonException("Cannot write null property TestResult.Data to non-nullable JSON property 'data'.");
 

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/TestResult.cs
@@ -223,10 +223,10 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, TestResult testResult, JsonSerializerOptions jsonSerializerOptions)
         {
             if (testResult.DataOption.IsSet && testResult.Data == null)
-                throw new ArgumentNullException(nameof(testResult.Data), "Property is required for class TestResult.");
+                throw new JsonException("Cannot write null property TestResult.Data to non-nullable JSON property 'data'.");
 
             if (testResult.UuidOption.IsSet && testResult.Uuid == null)
-                throw new ArgumentNullException(nameof(testResult.Uuid), "Property is required for class TestResult.");
+                throw new JsonException("Cannot write null property TestResult.Uuid to non-nullable JSON property 'uuid'.");
 
             if (testResult.CodeOption.IsSet)
             {

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/TriangleInterface.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/TriangleInterface.cs
@@ -170,9 +170,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, TriangleInterface triangleInterface, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (triangleInterface.TriangleType == null)
-                throw new ArgumentNullException(nameof(triangleInterface.TriangleType), "Property is required for class TriangleInterface.");
-
             writer.WriteString("triangleType", triangleInterface.TriangleType);
         }
     }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/User.cs
@@ -429,6 +429,9 @@ namespace Org.OpenAPITools.Model
             if (user.FirstNameOption.IsSet && user.FirstName == null)
                 throw new JsonException("Cannot write null property User.FirstName to non-nullable JSON property 'firstName'.");
 
+            if (user.IdOption.IsSet && user.Id == null)
+                throw new JsonException("Cannot write null property User.Id to non-nullable JSON property 'id'.");
+
             if (user.LastNameOption.IsSet && user.LastName == null)
                 throw new JsonException("Cannot write null property User.LastName to non-nullable JSON property 'lastName'.");
 
@@ -440,6 +443,9 @@ namespace Org.OpenAPITools.Model
 
             if (user.PhoneOption.IsSet && user.Phone == null)
                 throw new JsonException("Cannot write null property User.Phone to non-nullable JSON property 'phone'.");
+
+            if (user.UserStatusOption.IsSet && user.UserStatus == null)
+                throw new JsonException("Cannot write null property User.UserStatus to non-nullable JSON property 'userStatus'.");
 
             if (user.UsernameOption.IsSet && user.Username == null)
                 throw new JsonException("Cannot write null property User.Username to non-nullable JSON property 'username'.");

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/User.cs
@@ -424,25 +424,25 @@ namespace Org.OpenAPITools.Model
         public void WriteProperties(Utf8JsonWriter writer, User user, JsonSerializerOptions jsonSerializerOptions)
         {
             if (user.EmailOption.IsSet && user.Email == null)
-                throw new ArgumentNullException(nameof(user.Email), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Email to non-nullable JSON property 'email'.");
 
             if (user.FirstNameOption.IsSet && user.FirstName == null)
-                throw new ArgumentNullException(nameof(user.FirstName), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.FirstName to non-nullable JSON property 'firstName'.");
 
             if (user.LastNameOption.IsSet && user.LastName == null)
-                throw new ArgumentNullException(nameof(user.LastName), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.LastName to non-nullable JSON property 'lastName'.");
 
             if (user.ObjectWithNoDeclaredPropsOption.IsSet && user.ObjectWithNoDeclaredProps == null)
-                throw new ArgumentNullException(nameof(user.ObjectWithNoDeclaredProps), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.ObjectWithNoDeclaredProps to non-nullable JSON property 'objectWithNoDeclaredProps'.");
 
             if (user.PasswordOption.IsSet && user.Password == null)
-                throw new ArgumentNullException(nameof(user.Password), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Password to non-nullable JSON property 'password'.");
 
             if (user.PhoneOption.IsSet && user.Phone == null)
-                throw new ArgumentNullException(nameof(user.Phone), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Phone to non-nullable JSON property 'phone'.");
 
             if (user.UsernameOption.IsSet && user.Username == null)
-                throw new ArgumentNullException(nameof(user.Username), "Property is required for class User.");
+                throw new JsonException("Cannot write null property User.Username to non-nullable JSON property 'username'.");
 
             if (user.AnyTypePropOption.IsSet)
                 if (user.AnyTypePropOption.Value != null)

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Whale.cs
@@ -216,9 +216,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Whale whale, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (whale.ClassName == null)
-                throw new ArgumentNullException(nameof(whale.ClassName), "Property is required for class Whale.");
-
             writer.WriteString("className", whale.ClassName);
 
             if (whale.HasBaleenOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Whale.cs
@@ -216,6 +216,12 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Whale whale, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (whale.HasBaleenOption.IsSet && whale.HasBaleen == null)
+                throw new JsonException("Cannot write null property Whale.HasBaleen to non-nullable JSON property 'hasBaleen'.");
+
+            if (whale.HasTeethOption.IsSet && whale.HasTeeth == null)
+                throw new JsonException("Cannot write null property Whale.HasTeeth to non-nullable JSON property 'hasTeeth'.");
+
             writer.WriteString("className", whale.ClassName);
 
             if (whale.HasBaleenOption.IsSet)

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Zebra.cs
@@ -280,6 +280,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Zebra zebra, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (zebra.TypeOption.IsSet && zebra.Type == null)
+                throw new JsonException("Cannot write null property Zebra.Type to non-nullable JSON property 'type'.");
+
             writer.WriteString("className", zebra.ClassName);
 
             var typeRawValue = Zebra.TypeEnumToJsonValue(zebra.TypeOption.Value.Value);

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Zebra.cs
@@ -280,9 +280,6 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Zebra zebra, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (zebra.ClassName == null)
-                throw new ArgumentNullException(nameof(zebra.ClassName), "Property is required for class Zebra.");
-
             writer.WriteString("className", zebra.ClassName);
 
             var typeRawValue = Zebra.TypeEnumToJsonValue(zebra.TypeOption.Value.Value);

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
@@ -247,6 +247,9 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ZeroBasedEnumClass zeroBasedEnumClass, JsonSerializerOptions jsonSerializerOptions)
         {
+            if (zeroBasedEnumClass.ZeroBasedEnumOption.IsSet && zeroBasedEnumClass.ZeroBasedEnum == null)
+                throw new JsonException("Cannot write null property ZeroBasedEnumClass.ZeroBasedEnum to non-nullable JSON property 'ZeroBasedEnum'.");
+
             var zeroBasedEnumRawValue = ZeroBasedEnumClass.ZeroBasedEnumEnumToJsonValue(zeroBasedEnumClass.ZeroBasedEnumOption.Value.Value);
             writer.WriteString("ZeroBasedEnum", zeroBasedEnumRawValue);
         }


### PR DESCRIPTION
The error message incorrectly said property is required instead of property is not nullable. Also changed to only check ^required because we can trust the NRT. Also removed the reference type check because the validation is good on nullable value types as well.

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the misleading serialization error message in the C# generichost client when writing null to a non-nullable property.

- Changes the error message to state the actual problem and includes the JSON property name.
- Switches the thrown exception from `ArgumentNullException` to `JsonException`.
- Removes null checks on required properties because they are already non-nullable.

<sup>Written for commit 1d1cb76413099c98be7fd866288a759100566453. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24933?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

