### PR TITLE
fix(java): don't emit unqualified enum default for discriminator ref-to-property

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -7155,7 +7155,18 @@ public class DefaultCodegen implements CodegenConfig {
                 }
             }
             if (enumName != null) {
-                var.defaultValue = toEnumDefaultValue(var, enumName);
+                if (var.isEnum || referencedSchema.isPresent()) {
+                    var.defaultValue = toEnumDefaultValue(var, enumName);
+                } else {
+                    // Neither an inline nested enum (var.isEnum) nor a ref to a named enum
+                    // schema (referencedSchema): var.datatypeWithEnum is just the raw scalar
+                    // type (e.g. a discriminator property that is a `$ref` into another
+                    // schema's property rather than a ref to the enum schema itself).
+                    // allowableValues/enum matching still ran, but there's no enum constant to
+                    // qualify the value with. Drop the default rather than emit a bare,
+                    // unqualified token that would not compile (see #24874).
+                    var.defaultValue = null;
+                }
             }
         }
     }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -1870,6 +1870,27 @@ public class JavaClientCodegenTest {
     }
 
     @Test
+    public void testDiscriminatorPropertyRefToEnumDoesNotEmitInvalidDefault_issue24874() {
+        final Path output = newTempFolder();
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName(JAVA_GENERATOR)
+                .setInputSpec("src/test/resources/bugs/issue_24874.yaml")
+                .setAdditionalProperties(Map.of(MODEL_NAME_PREFIX, "Stock"))
+                .setOutputDir(output.toString().replace("\\", "/"));
+
+        Map<String, File> files = new DefaultGenerator().opts(configurator.toClientOptInput()).generate().stream()
+                .collect(Collectors.toMap(File::getName, Function.identity()));
+
+        // CategoryEvent.category is a discriminator property that is a `$ref` to another schema's
+        // (CategorySource) inline enum property, not to a named enum schema and not an inline enum
+        // itself. There is no enum type at this use site to qualify the discriminator mapping value
+        // with, so no default must be emitted here; previously this rendered the uncompilable
+        // `this.category = String.ARCHIVE;` (see #24874).
+        JavaFileAssert.assertThat(files.get("StockArchiveCategoryEvent.java"))
+                .fileDoesNotContain("String.ARCHIVE");
+    }
+
+    @Test
     public void testWebClientJsonCreatorWithNullable_issue12790() {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()

--- a/modules/openapi-generator/src/test/resources/bugs/issue_24874.yaml
+++ b/modules/openapi-generator/src/test/resources/bugs/issue_24874.yaml
@@ -1,0 +1,35 @@
+openapi: "3.1.0"
+info:
+  title: Shared category discriminator
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    CategorySource:
+      type: object
+      required:
+        - category
+      properties:
+        category:
+          type: string
+          enum:
+            - ARCHIVE
+    CategoryEvent:
+      type: object
+      required:
+        - category
+      properties:
+        category:
+          description: Event category
+          $ref: "#/components/schemas/CategorySource/properties/category"
+      discriminator:
+        propertyName: category
+        mapping:
+          ARCHIVE: "#/components/schemas/ArchiveCategoryEvent"
+    ArchiveCategoryEvent:
+      allOf:
+        - $ref: "#/components/schemas/CategoryEvent"
+        - type: object
+          properties:
+            value:
+              type: string


### PR DESCRIPTION
Fixes #24874

## Bug
The Java client generator (default library: okhttp-gson) produced non-compiling code when a discriminator property is a `$ref` directly into another schema's inline enum property, rather than a `$ref` to a named enum schema:

```java
this.category = String.ARCHIVE;
```

`String.ARCHIVE` does not exist, so the generated client fails to compile.

## Root cause
`DefaultCodegen#updateCodegenPropertyEnum` resolves the enum default value and, whenever a matching enum entry is found, unconditionally calls `toEnumDefaultValue(var, enumName)` to qualify it with the property's datatype. That qualification is only meaningful when the property is itself an inline enum (`var.isEnum`) or resolves to a named enum schema (`referencedSchema`). For a discriminator property that is a `$ref` into another schema's *property* (not the enum schema itself), neither is true — `var.datatypeWithEnum` is just the raw scalar type (`String`) — yet the enum-matching logic still ran and produced a bogus qualified token.

This is exercised by okhttp-gson's `pojo.mustache`, which assigns the discriminator's default value in the generated subtype's constructor (other Java libraries don't emit this constructor-level assignment, which is why @jpfinne's comment on the issue pinned it to okhttp-gson specifically — the underlying bad value is computed generically in `DefaultCodegen`, okhttp-gson is just the template that surfaces it as a compile error).

## Fix
Only call `toEnumDefaultValue` when `var.isEnum || referencedSchema.isPresent()`. Otherwise, drop the default (`null`) rather than emit an unqualified token that won't compile. The field is simply left unset in this edge case, which is the same as any other discriminator property whose caller must set it explicitly — no compile error, no incorrect value.

## Test evidence
- Added `modules/openapi-generator/src/test/resources/bugs/issue_24874.yaml` (the exact spec from the issue).
- Added `JavaClientCodegenTest#testDiscriminatorPropertyRefToEnumDoesNotEmitInvalidDefault_issue24874`, which fails on current master (reproduces `this.category = String.ARCHIVE;` via `fileDoesNotContain` assertion) and passes with this fix.
- Ran the full `java-*` sample set (`bin/configs/java-*.yaml`, 136 generators via `bin/generate-samples.sh`) — zero model/pojo diffs, confirming no existing committed sample exercises this narrow edge case and this change is safe.

## Verification done
1. No in-flight PR/linked branch for #24874 (checked via `gh issue view` / `gh api .../timeline`).
2. No active assignee/self-claim.
3. Code-focused change (.java + test fixture only).
4. Confirmed the bug still reproduces on latest `upstream/master` before the fix, and is resolved after.
5. N/A (no parent epic).
6. N/A (not spring-projects/*, no triage-pending gate).

Verification done: reproduced the exact compile failure from the issue on latest master using the issue's own minimal spec, confirmed root cause in `DefaultCodegen#updateCodegenPropertyEnum`, added a regression test that is red before / green after the fix, and confirmed zero sample diffs across the full java-* config set.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #24874. Stops the Java generator from emitting uncompilable defaults like `this.category = String.ARCHIVE;` in okhttp-gson when a discriminator property is a `$ref` to another schema's inline enum property. The default is now left unset instead of qualified with the raw scalar type.

- `toEnumDefaultValue` is now skipped for properties that aren't inline enums and whose datatype is a language-specific primitive; those properties get `null`.
- The guard checks `languageSpecificPrimitives` rather than `referencedSchema`, so package-qualified datatypes (for example PHP) keep valid defaults for named enum refs.
- Adds a regression test using the issue's spec; it failed before this change.
- The full `java-*` sample set regenerates with zero diffs, so no existing sample is affected.

<sup>Written for commit 77718a38a3acc9b222bb7f9421b46166de16d485. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24934?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

