### PR TITLE
[Java] fix: map the OAS 3.1 null type to Object, not a never-generated ModelNull

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -304,6 +304,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
         typeMapping.put("date", "Date");
         typeMapping.put("file", "File");
         typeMapping.put("AnyType", "Object");
+        typeMapping.put("null", "Object");
         typeMapping.put("enum", "Enum");
 
         importMapping.put("BigDecimal", "java.math.BigDecimal");

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/AbstractJavaCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/AbstractJavaCodegenTest.java
@@ -1114,4 +1114,13 @@ public class AbstractJavaCodegenTest {
     public void testSanitizedDataType() {
         assertThat(codegen.sanitizeDataType("org.somepkg.DataType")).isEqualTo("orgsomepkgDataType");
     }
+
+    @Test(description = "the OAS 3.1 null type maps to Object instead of a never-generated ModelNull (issue 24520)")
+    public void testNullTypeMapsToObject() {
+        Schema<?> nullSchema = new Schema<>().type("null");
+
+        assertThat(codegen.getSchemaType(nullSchema)).isEqualTo("Object");
+        assertThat(codegen.getTypeDeclaration(nullSchema)).isEqualTo("Object");
+        assertThat(codegen.getTypeDeclaration(new ArraySchema().items(nullSchema))).isEqualTo("List<Object>");
+    }
 }

--- a/modules/openapi-generator/src/test/resources/3_1/java/petstore.yaml
+++ b/modules/openapi-generator/src/test/resources/3_1/java/petstore.yaml
@@ -1135,3 +1135,6 @@ components:
         second_property:
           description: just null type
           type: null
+        third_property:
+          description: null type declared as the OAS 3.1 quoted string
+          type: 'null'

--- a/samples/client/petstore/java/okhttp-gson-3.1/api/openapi.yaml
+++ b/samples/client/petstore/java/okhttp-gson-3.1/api/openapi.yaml
@@ -1215,6 +1215,8 @@ components:
           $ref: "#/components/schemas/Pet"
         second_property:
           description: just null type
+        third_property:
+          description: null type declared as the OAS 3.1 quoted string
     updatePetWithForm_request:
       properties:
         name:

--- a/samples/client/petstore/java/okhttp-gson-3.1/docs/PetWithTypesObjectNullAndRef.md
+++ b/samples/client/petstore/java/okhttp-gson-3.1/docs/PetWithTypesObjectNullAndRef.md
@@ -9,6 +9,7 @@
 |------------ | ------------- | ------------- | -------------|
 |**firstProperty** | [**Pet**](Pet.md) |  |  [optional] |
 |**secondProperty** | **Object** | just null type |  [optional] |
+|**thirdProperty** | **Object** | null type declared as the OAS 3.1 quoted string |  [optional] |
 
 
 

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/PetWithTypesObjectNullAndRef.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/PetWithTypesObjectNullAndRef.java
@@ -63,6 +63,11 @@ public class PetWithTypesObjectNullAndRef {
   @javax.annotation.Nullable
   private Object secondProperty = null;
 
+  public static final String SERIALIZED_NAME_THIRD_PROPERTY = "third_property";
+  @SerializedName(SERIALIZED_NAME_THIRD_PROPERTY)
+  @javax.annotation.Nullable
+  private Object thirdProperty = null;
+
   public PetWithTypesObjectNullAndRef() {
   }
 
@@ -101,6 +106,25 @@ public class PetWithTypesObjectNullAndRef {
 
   public void setSecondProperty(@javax.annotation.Nullable Object secondProperty) {
     this.secondProperty = secondProperty;
+  }
+
+
+  public PetWithTypesObjectNullAndRef thirdProperty(@javax.annotation.Nullable Object thirdProperty) {
+    this.thirdProperty = thirdProperty;
+    return this;
+  }
+
+  /**
+   * null type declared as the OAS 3.1 quoted string
+   * @return thirdProperty
+   */
+  @javax.annotation.Nullable
+  public Object getThirdProperty() {
+    return thirdProperty;
+  }
+
+  public void setThirdProperty(@javax.annotation.Nullable Object thirdProperty) {
+    this.thirdProperty = thirdProperty;
   }
 
   /**
@@ -159,7 +183,8 @@ public class PetWithTypesObjectNullAndRef {
     }
     PetWithTypesObjectNullAndRef petWithTypesObjectNullAndRef = (PetWithTypesObjectNullAndRef) o;
     return Objects.equals(this.firstProperty, petWithTypesObjectNullAndRef.firstProperty) &&
-        Objects.equals(this.secondProperty, petWithTypesObjectNullAndRef.secondProperty)&&
+        Objects.equals(this.secondProperty, petWithTypesObjectNullAndRef.secondProperty) &&
+        Objects.equals(this.thirdProperty, petWithTypesObjectNullAndRef.thirdProperty)&&
         Objects.equals(this.additionalProperties, petWithTypesObjectNullAndRef.additionalProperties);
   }
 
@@ -169,7 +194,7 @@ public class PetWithTypesObjectNullAndRef {
 
   @Override
   public int hashCode() {
-    return Objects.hash(firstProperty, secondProperty, additionalProperties);
+    return Objects.hash(firstProperty, secondProperty, thirdProperty, additionalProperties);
   }
 
   private static <T> int hashCodeNullable(JsonNullable<T> a) {
@@ -185,6 +210,7 @@ public class PetWithTypesObjectNullAndRef {
     sb.append("class PetWithTypesObjectNullAndRef {\n");
     sb.append("    firstProperty: ").append(toIndentedString(firstProperty)).append("\n");
     sb.append("    secondProperty: ").append(toIndentedString(secondProperty)).append("\n");
+    sb.append("    thirdProperty: ").append(toIndentedString(thirdProperty)).append("\n");
     sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
@@ -204,7 +230,7 @@ public class PetWithTypesObjectNullAndRef {
 
   static {
     // a set of all properties/fields (JSON key names)
-    openapiFields = new HashSet<String>(Arrays.asList("first_property", "second_property"));
+    openapiFields = new HashSet<String>(Arrays.asList("first_property", "second_property", "third_property"));
 
     // a set of required properties/fields (JSON key names)
     openapiRequiredFields = new HashSet<String>(0);


### PR DESCRIPTION
A Java property declared `type: 'null'` becomes `ModelNull`, which is never emitted, so generated clients fail to compile (regression in 7.17.0).

`AbstractJavaCodegen` lacks a `null` `typeMapping`, so `getSchemaType` falls through to `toModelName("null")`, where the reserved-word rule prefixes `Model`. Python, Go, Elixir, and Xojo already map `null`.

#24701 used unquoted `type: null`, which YAML parses as a null scalar, so it did not exercise this path. `third_property` adds the quoted form. Reverting the mapping makes the new unit test and sample compilation fail; patched, the sample compiles and the module suite passes 4,985 tests.

TypeScript still has this gap, so Ref #24520, not Fixes.

- [x] Read contribution guidelines.
- [x] Built and regenerated affected samples.
- [x] Java TC: /cc @xhh


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Maps the OAS 3.1 `null` type to `Object` in Java codegen so properties declared `type: 'null'` no longer generate a reference to `ModelNull`, a class the generator never emits. This was a regression in 7.17.0 that made generated clients fail to compile; Python, Go, Elixir, and Xojo already map `null`.

**Bug Fixes**
- The previous fixture used unquoted `type: null`, which YAML parses as a null scalar, so it didn't exercise this path; the new `third_property` uses the quoted form.
- TypeScript still has this gap, so this addresses but does not close issue 24520.

<sup>Written for commit 412e049ac8bf454d966afacdd1d1a95bbfafca5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24935?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

