### PR TITLE
[kotlin] Fix inline enum array parameter default values

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractKotlinCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractKotlinCodegen.java
@@ -1279,6 +1279,10 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
     }
 
     private String toArrayDefaultValue(CodegenProperty cp, Schema schema) {
+        return toArrayDefaultValue(cp, schema, false);
+    }
+
+    private String toArrayDefaultValue(CodegenProperty cp, Schema schema, boolean inlineEnumItemsAsLiterals) {
         if (schema.getDefault() != null) {
             String arrInstantiationType = ModelUtils.isSet(schema) ? "set" : "arrayList";
 
@@ -1295,7 +1299,10 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
             _default.elements().forEachRemaining((element) -> {
                 String defaultValue = element.asText();
                 if (defaultValue != null) {
-                    if (cp.items.getIsEnumOrRef()) {
+                    boolean itemIsLiteral = inlineEnumItemsAsLiterals && cp.items.isEnum;
+                    if (itemIsLiteral && ModelUtils.isStringSchema(itemsSchema)) {
+                        defaultContent.append("\"").append(escapeText(defaultValue)).append("\"").append(",");
+                    } else if (cp.items.getIsEnumOrRef() && !itemIsLiteral) {
                         String className = cp.items.datatypeWithEnum;
                         String enumVarName = toEnumVarName(defaultValue, cp.items.dataType);
                         defaultContent.append(className).append(".").append(enumVarName).append(",");
@@ -1314,6 +1321,12 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
 
     @Override
     public String toDefaultParameterValue(CodegenProperty cp, Schema schema) {
+        Schema<?> referencedSchema = ModelUtils.getReferencedSchema(this.openAPI, schema);
+        if (ModelUtils.isArraySchema(referencedSchema) && cp.items != null && cp.items.isEnum) {
+            // inline enum items of a parameter have no enum class of their own,
+            // so the default must use the plain item values (e.g. setOf("a", "b"))
+            return toArrayDefaultValue(cp, referencedSchema, true);
+        }
         return toDefaultValue(cp, schema);
     }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinClientCodegen.java
@@ -1223,7 +1223,7 @@ public class KotlinClientCodegen extends AbstractKotlinCodegen {
      * @param param codegen parameter
      */
     private void adjustEnumRefDefault(CodegenParameter param) {
-        if (StringUtils.isEmpty(param.defaultValue) || !(param.isEnum || param.isEnumRef)) {
+        if (StringUtils.isEmpty(param.defaultValue) || param.isContainer || !(param.isEnum || param.isEnumRef)) {
             return;
         }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinClientCodegenApiTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinClientCodegenApiTest.java
@@ -137,6 +137,30 @@ public class KotlinClientCodegenApiTest {
         assertFileContains(statusApi.toPath(), "state: PetStatus? = PetStatus.AVAILABLE");
     }
 
+    @DataProvider(name = "librariesWithPlainInlineEnumParams")
+    public static Object[][] librariesWithPlainInlineEnumParams() {
+        return new Object[][]{
+                {ClientLibrary.JVM_KTOR},
+                {ClientLibrary.JVM_VOLLEY}
+        };
+    }
+
+    @Test(dataProvider = "librariesWithPlainInlineEnumParams")
+    public void testInlineEnumArrayDefaultUsesItemValues_24851(ClientLibrary library) throws IOException {
+        OpenAPI openAPI = readOpenAPI("3_0/kotlin/issue24851-enum-array-default-query.yaml");
+
+        KotlinClientCodegen codegen = createCodegen(library);
+        DefaultGenerator generator = new DefaultGenerator();
+        enableOnlyApiGeneration(generator);
+
+        List<File> files = generator.opts(createClientOptInput(openAPI, codegen)).generate();
+        File defaultApi = files.stream().filter(file -> file.getName().equals("DefaultApi.kt")).findAny().orElseThrow();
+
+        assertFileContains(defaultApi.toPath(), "colors: kotlin.collections.Set<kotlin.String>? = setOf(\"red\",\"blue\")");
+        assertFileContains(defaultApi.toPath(), "sizes: kotlin.collections.List<kotlin.Int>? = arrayListOf(2)");
+        assertFileContains(defaultApi.toPath(), "refColors: kotlin.collections.List<Color>? = arrayListOf(Color.RED)");
+    }
+
     @Test(dataProvider = "clientLibraries")
     void testEnumReservedDefaultNotHtmlEscaped(ClientLibrary library) throws IOException {
         OpenAPI openAPI = readOpenAPI("src/test/resources/3_0/kotlin/enum-default-query-reserved-word.json");

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinServerCodegenTest.java
@@ -283,6 +283,37 @@ public class KotlinServerCodegenTest {
                 new Object[]{JAVALIN6},
         };
     }
+    @DataProvider(name = "javalinLibraries")
+    private Object[][] javalinLibraries() {
+        return new Object[][]{
+                new Object[]{JAVALIN5},
+                new Object[]{JAVALIN6},
+        };
+    }
+
+    @Test(description = "Issue #24851", dataProvider = "javalinLibraries")
+    public void inlineEnumArrayParameterDefaultUsesItemValues(String library) throws IOException {
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+
+        KotlinServerCodegen codegen = new KotlinServerCodegen();
+        codegen.setOutputDir(output.getAbsolutePath());
+        codegen.additionalProperties().put(LIBRARY, library);
+
+        new DefaultGenerator().opts(new ClientOptInput()
+                        .openAPI(TestUtils.parseSpec("src/test/resources/3_0/kotlin/issue24851-enum-array-default-query.yaml"))
+                        .config(codegen))
+                .generate();
+
+        Path service = Paths.get(output.getAbsolutePath() + "/src/main/kotlin/org/openapitools/server/apis/DefaultApiService.kt");
+        assertFileContains(
+                service,
+                "colors: kotlin.collections.Set<kotlin.String> = setOf(\"red\",\"blue\")",
+                "sizes: kotlin.collections.List<kotlin.Int> = arrayListOf(2)",
+                "refColors: kotlin.collections.List<Color> = arrayListOf(Color.RED)"
+        );
+    }
+
     @Test(description = "Issue #20960", dataProvider = "dollarEscapeTest")
     public void givenSchemaObjectPropertyNameContainsDollarSignWhenGenerateThenDollarSignIsProperlyEscapedInAnnotation(String library) throws Exception {
         File output = Files.createTempDirectory("test").toFile().getCanonicalFile();

--- a/modules/openapi-generator/src/test/resources/3_0/kotlin/issue24851-enum-array-default-query.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/kotlin/issue24851-enum-array-default-query.yaml
@@ -1,0 +1,41 @@
+openapi: 3.0.3
+info:
+  title: Inline enum array default test
+  version: 1.0.0
+paths:
+  /items:
+    get:
+      operationId: getItems
+      parameters:
+        - name: colors
+          in: query
+          schema:
+            type: array
+            uniqueItems: true
+            items:
+              type: string
+              enum: [red, blue]
+            default: [red, blue]
+        - name: sizes
+          in: query
+          schema:
+            type: array
+            items:
+              type: integer
+              enum: [1, 2]
+            default: [2]
+        - name: refColors
+          in: query
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/Color'
+            default: [RED]
+      responses:
+        "204":
+          description: No content
+components:
+  schemas:
+    Color:
+      type: string
+      enum: [RED, BLUE]


### PR DESCRIPTION
Fixes #24851. An array parameter with inline enum items and a default was rendered with an enum class that doesn't exist for operation parameters, and jvm-ktor then mangled it into something like `Set<Colors>.setOfLeft_Parenthesis...`. Parameter defaults for these arrays now use the plain item values (`setOf("red","blue")`), which fixes jvm-ktor, jvm-volley and kotlin-server javalin5/javalin6; arrays of referenced enums keep `Color.RED`. I added tests in KotlinClientCodegenApiTest and KotlinServerCodegenTest that fail without the change, and ran all tests under `org.openapitools.codegen.kotlin` (565 run, 0 failures). The enum-typed client libraries (okhttp4, vertx, spring, multiplatform, retrofit2) still render `ColorsGetItems.setOf(red,blue)` for this case through their templates, which is left for a separate change.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  Regenerated `bin/configs/kotlin*.yaml` (124 configs); no sample output changed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc @karismann @Zomzog @andrewemery @4brunu @yutaka0m @stefankoppier @e5l


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes inline enum array parameter defaults so they render plain item values instead of referencing a nonexistent enum class.

- Array parameters with inline enum items and defaults now generate `setOf("red","blue")`; referenced enum items keep `Color.RED`.
- Fixes jvm-ktor, jvm-volley, and javalin5/javalin6; enum-typed client libraries (okhttp4, vertx, spring, multiplatform, retrofit2) are left for a separate change.
- Adds regression tests for both client and server codegen, and a new test resource spec for the case.

<sup>Written for commit 0421d713dc08fc3c9efc5784fcd4d13484101314. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24940?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

